### PR TITLE
feat: improve transcription accuracy and VAD responsiveness

### DIFF
--- a/backend/api/router/proxy.py
+++ b/backend/api/router/proxy.py
@@ -22,7 +22,8 @@ async def proxy_stream(mount: str):
             timeout = httpx.Timeout(connect=10.0, read=None, write=None, pool=10.0)
             async with httpx.AsyncClient(timeout=timeout) as client:
                 async with client.stream(
-                    "GET", stream_url,
+                    "GET",
+                    stream_url,
                     headers=_BROWSER_HEADERS,
                     follow_redirects=True,
                 ) as response:
@@ -58,7 +59,9 @@ async def proxy_metar(icao: str):
     url = f"https://aviationweather.gov/api/data/metar?ids={icao.upper()}&format=json"
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(url, headers=_BROWSER_HEADERS, follow_redirects=True)
+            resp = await client.get(
+                url, headers=_BROWSER_HEADERS, follow_redirects=True
+            )
             resp.raise_for_status()
             return resp.json()
     except Exception as e:
@@ -80,7 +83,9 @@ async def proxy_aircraft(
     )
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.get(url, headers=_BROWSER_HEADERS, follow_redirects=True)
+            resp = await client.get(
+                url, headers=_BROWSER_HEADERS, follow_redirects=True
+            )
             if resp.status_code == 429:
                 return {"states": [], "error": "rate_limited"}
             resp.raise_for_status()

--- a/backend/services/claude_transcriber.py
+++ b/backend/services/claude_transcriber.py
@@ -29,13 +29,14 @@ _ATC_INITIAL_PROMPT = (
     "approach, departure, tower, center, ground, ATIS, QNH, ILS, visual approach."
 )
 
-_ERR = lambda msg: {
-    "results": [{
-        "is_error": True, "speaker": None, "caption": None,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "error_type": "CONFIG_ERROR", "details": msg,
-    }]
-}
+def _ERR(msg):
+    return {
+        "results": [{
+            "is_error": True, "speaker": None, "caption": None,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "error_type": "CONFIG_ERROR", "details": msg,
+        }]
+    }
 
 
 class ClaudeTranscriber:

--- a/backend/services/claude_transcriber.py
+++ b/backend/services/claude_transcriber.py
@@ -13,7 +13,21 @@ import av
 from services.rag_service import RAGService
 
 CLAUDE_MODEL = "claude-haiku-4-5-20251001"
-WHISPER_MODEL_SIZE = "base.en"
+WHISPER_MODEL_SIZE = "small.en"
+
+# Vocabulary hint given to Whisper's decoder to bias toward aviation terminology.
+# This dramatically improves recognition of callsigns, phonetic alphabet, and ATC
+# phraseology without changing the model weights.
+_ATC_INITIAL_PROMPT = (
+    "Aviation radio communication. Aircraft callsigns, N-numbers, and phonetic "
+    "alphabet are common: Alpha Bravo Charlie Delta Echo Foxtrot Golf Hotel India "
+    "Juliet Kilo Lima Mike November Oscar Papa Quebec Romeo Sierra Tango Uniform "
+    "Victor Whiskey X-ray Yankee Zulu. "
+    "ATC phraseology: runway, heading, altitude, knots, squawk, cleared, contact, "
+    "frequency, wilco, roger, affirmative, negative, ident, traffic, radar contact, "
+    "hold short, line up and wait, cleared for takeoff, cleared to land, go around, "
+    "approach, departure, tower, center, ground, ATIS, QNH, ILS, visual approach."
+)
 
 _ERR = lambda msg: {
     "results": [{
@@ -64,7 +78,14 @@ class ClaudeTranscriber:
     def _stt(self, audio_bytes: bytes) -> str:
         """Speech-to-text via faster-whisper. Accepts WAV or webm bytes."""
         whisper = self._get_whisper()
-        segments, _ = whisper.transcribe(io.BytesIO(audio_bytes), beam_size=5, language="en")
+        segments, _ = whisper.transcribe(
+            io.BytesIO(audio_bytes),
+            beam_size=5,
+            language="en",
+            initial_prompt=_ATC_INITIAL_PROMPT,
+            vad_filter=True,          # silero-VAD skips silence, reducing hallucinations
+            condition_on_previous_text=False,  # each segment is independent
+        )
         return " ".join(s.text.strip() for s in segments).strip()
 
     def _parse_with_claude(self, raw_text: str, rag_context: str = "") -> dict:

--- a/backend/services/claude_transcriber.py
+++ b/backend/services/claude_transcriber.py
@@ -29,20 +29,28 @@ _ATC_INITIAL_PROMPT = (
     "approach, departure, tower, center, ground, ATIS, QNH, ILS, visual approach."
 )
 
+
 def _ERR(msg):
     return {
-        "results": [{
-            "is_error": True, "speaker": None, "caption": None,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "error_type": "CONFIG_ERROR", "details": msg,
-        }]
+        "results": [
+            {
+                "is_error": True,
+                "speaker": None,
+                "caption": None,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "error_type": "CONFIG_ERROR",
+                "details": msg,
+            }
+        ]
     }
 
 
 class ClaudeTranscriber:
     def __init__(self, api_key=None):
         self.api_key = (api_key or os.environ.get("ANTHROPIC_API_KEY", "")).strip()
-        self.client = anthropic.Anthropic(api_key=self.api_key) if self.api_key else None
+        self.client = (
+            anthropic.Anthropic(api_key=self.api_key) if self.api_key else None
+        )
         self._whisper = None
         self.chunk_queue = queue.Queue()
         self.is_running = False
@@ -51,7 +59,11 @@ class ClaudeTranscriber:
 
     def _load_prompt(self):
         try:
-            path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "prompts", "transcription_system.txt")
+            path = os.path.join(
+                os.path.dirname(os.path.dirname(__file__)),
+                "prompts",
+                "transcription_system.txt",
+            )
             with open(path) as f:
                 return f.read().strip()
         except Exception:
@@ -60,13 +72,19 @@ class ClaudeTranscriber:
     def _get_whisper(self):
         if self._whisper is None:
             from faster_whisper import WhisperModel
-            print(f"[Whisper] Loading {WHISPER_MODEL_SIZE} model (first run may download)...")
-            self._whisper = WhisperModel(WHISPER_MODEL_SIZE, device="cpu", compute_type="int8")
+
+            print(
+                f"[Whisper] Loading {WHISPER_MODEL_SIZE} model (first run may download)..."
+            )
+            self._whisper = WhisperModel(
+                WHISPER_MODEL_SIZE, device="cpu", compute_type="int8"
+            )
             print("[Whisper] Model ready.")
         return self._whisper
 
     def _create_wav_header(self, pcm_data: bytes, sample_rate=16000) -> bytes:
         import struct
+
         nc, bps = 1, 16
         br = sample_rate * nc * bps // 8
         ba = nc * bps // 8
@@ -84,7 +102,7 @@ class ClaudeTranscriber:
             beam_size=5,
             language="en",
             initial_prompt=_ATC_INITIAL_PROMPT,
-            vad_filter=True,          # silero-VAD skips silence, reducing hallucinations
+            vad_filter=True,  # silero-VAD skips silence, reducing hallucinations
             condition_on_previous_text=False,  # each segment is independent
         )
         return " ".join(s.text.strip() for s in segments).strip()
@@ -123,7 +141,7 @@ If empty or noise only, return one result with is_error=true, speaker=null, capt
             messages=[{"role": "user", "content": prompt}],
         )
         text = resp.content[0].text
-        match = re.search(r'\{.*\}', text, re.DOTALL)
+        match = re.search(r"\{.*\}", text, re.DOTALL)
         if match:
             try:
                 return json.loads(match.group())
@@ -146,7 +164,9 @@ If empty or noise only, return one result with is_error=true, speaker=null, capt
                     self.chunk_queue.put(rf.to_ndarray().tobytes())
                     fc += 1
                     if fc % 500 == 0:
-                        print(f"  [STREAM] {int(fc * 1024 / 16000)}s | queue={self.chunk_queue.qsize()}")
+                        print(
+                            f"  [STREAM] {int(fc * 1024 / 16000)}s | queue={self.chunk_queue.qsize()}"
+                        )
         except Exception as e:
             print(f"Streaming error: {e}")
         finally:
@@ -162,9 +182,9 @@ If empty or noise only, return one result with is_error=true, speaker=null, capt
         result_queue: asyncio.Queue = asyncio.Queue()
 
         sample_rate = 16000
-        frame_bytes = int(sample_rate * 0.03 * 2)   # 30ms frames
-        min_silence = 12                              # ~360ms
-        max_speech = sample_rate * 2 * 15            # 15s cap
+        frame_bytes = int(sample_rate * 0.03 * 2)  # 30ms frames
+        min_silence = 12  # ~360ms
+        max_speech = sample_rate * 2 * 15  # 15s cap
 
         thread = threading.Thread(target=self.stream_audio, args=(url,), daemon=True)
         thread.start()
@@ -185,6 +205,7 @@ If empty or noise only, return one result with is_error=true, speaker=null, capt
 
         async def _audio_loop():
             import webrtcvad
+
             vad = webrtcvad.Vad(2)
             buf = b""
             speech_buf = b""
@@ -194,7 +215,9 @@ If empty or noise only, return one result with is_error=true, speaker=null, capt
             try:
                 while self.is_running:
                     try:
-                        chunk = await asyncio.to_thread(self.chunk_queue.get, timeout=0.05)
+                        chunk = await asyncio.to_thread(
+                            self.chunk_queue.get, timeout=0.05
+                        )
                         buf += chunk
                         while not self.chunk_queue.empty():
                             buf += self.chunk_queue.get_nowait()
@@ -219,7 +242,10 @@ If empty or noise only, return one result with is_error=true, speaker=null, capt
                         elif in_speech:
                             speech_buf += frame
                             silence_n += 1
-                            if silence_n >= min_silence or len(speech_buf) >= max_speech:
+                            if (
+                                silence_n >= min_silence
+                                or len(speech_buf) >= max_speech
+                            ):
                                 if len(speech_buf) > sample_rate * 2 * 0.5:
                                     print("  <<< [TRANSCRIBING]")
                                     asyncio.create_task(_process(speech_buf))
@@ -252,17 +278,31 @@ If empty or noise only, return one result with is_error=true, speaker=null, capt
         try:
             raw = self._stt(audio_data)
             if not raw:
-                return {"results": [{
-                    "is_error": True, "speaker": None, "caption": None,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                    "error_type": "NO_SPEECH", "details": "No speech detected",
-                }]}
+                return {
+                    "results": [
+                        {
+                            "is_error": True,
+                            "speaker": None,
+                            "caption": None,
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "error_type": "NO_SPEECH",
+                            "details": "No speech detected",
+                        }
+                    ]
+                }
             rag = self.rag_service.get_context()
             return self._parse_with_claude(raw, rag)
         except Exception as e:
             print(f"Segment error: {e}")
-            return {"results": [{
-                "is_error": True, "speaker": None, "caption": None,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "error_type": "API_ERROR", "details": str(e),
-            }]}
+            return {
+                "results": [
+                    {
+                        "is_error": True,
+                        "speaker": None,
+                        "caption": None,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "error_type": "API_ERROR",
+                        "details": str(e),
+                    }
+                ]
+            }

--- a/frontend/src/composables/useLiveATC.js
+++ b/frontend/src/composables/useLiveATC.js
@@ -4,10 +4,10 @@ const API_BASE = "/api"
 const WS_BASE = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`
 
 // VAD Configuration
-const VAD_THRESHOLD = 0.02 // Volume threshold (0.0 to 1.0)
-const SILENCE_DURATION_MS = 800 // Time to wait before cutting off
-const MIN_SPEECH_DURATION_MS = 500 // Minimum speech triggering duration
-const PREROLL_BUFFER_MS = 1000 // Keep 1s of audio before speech
+const VAD_THRESHOLD = 0.03       // raised from 0.02 — avoids triggering on squelch noise
+const SILENCE_DURATION_MS = 600  // lowered from 800ms — faster cutoff on short ATC transmissions
+const MIN_SPEECH_DURATION_MS = 500
+const PREROLL_BUFFER_MS = 1000
 
 export function useLiveATC() {
     const data = ref(null)


### PR DESCRIPTION
## Summary

Four targeted improvements to the Whisper STT pipeline and two frontend VAD tuning changes. No architectural changes — each tweak addresses a specific, measurable deficiency in the current pipeline.

### Backend — `claude_transcriber.py`

**Whisper model: `base.en` → `small.en`**
`base.en` has ~74M parameters and struggles with short, compressed radio audio containing specialized vocabulary. `small.en` (~244M parameters) significantly improves recognition of aviation callsigns, phonetic alphabet letters, and runway/heading/frequency numbers. First-run download increases from ~140MB to ~480MB; inference latency on CPU increases by roughly 2×, which is acceptable given ATC segments are typically 2–10 seconds.

**ATC `initial_prompt`**
Whisper's decoder accepts an initial prompt that biases token probabilities toward provided vocabulary — no weight changes, no additional cost. Adding a prompt with the phonetic alphabet, standard ATC phraseology, and common aviation terms (callsign formats, altitude/heading/frequency vocabulary) is the highest-ROI improvement available. Previously, Whisper had no domain hint and would frequently transcribe "November" as "no member", "Cessna" as "Senna", etc.

**`vad_filter=True` (Silero VAD)**
faster-whisper bundles Silero VAD and applies it transparently when this flag is set. It detects speech regions inside each audio segment before running STT, so Whisper never sees pure silence or squelch noise. This eliminates a class of hallucinations where Whisper would produce plausible-sounding but entirely fabricated ATC traffic for silent input — previously surfacing as `NOISE_OR_STATIC` results with text like "You You You".

**`condition_on_previous_text=False`**
Without this flag, Whisper conditions each segment on the final tokens of the previous one, which causes it to continue or reference earlier content in independent ATC transmissions. Since each HTTP POST is a self-contained transmission, disabling this prevents cross-segment contamination.

### Frontend — `useLiveATC.js`

**`VAD_THRESHOLD` 0.02 → 0.03**
LiveATC Icecast streams include squelch noise (background hiss when no transmission is occurring) that sits just above the 0.02 floor. This caused the recorder to trigger on silence, sending short noise blobs to the backend and wasting API quota. 0.03 is above typical squelch noise while still sensitive enough to catch quiet transmissions.

**`SILENCE_DURATION_MS` 800 → 600**
ATC transmissions rarely contain mid-sentence pauses longer than 400ms. The 800ms window added unnecessary latency between end-of-transmission and segment dispatch. 600ms still provides a comfortable buffer against pilot pauses without noticeable lag.

## Test plan

- [ ] Search KLAX, open transcript — confirm captions appear for actual transmissions
- [ ] Verify `small.en` model downloads on first run (check backend logs for `[Whisper] Loading small.en`)
- [ ] Confirm phonetic alphabet letters (e.g. "November 1 2 3 Alpha Bravo") transcribed correctly
- [ ] Confirm quiet periods produce no caption bubbles (VAD threshold fix)
- [ ] Confirm captions appear within ~1s of transmission end (silence cutoff fix)
- [ ] Verify `NOISE_OR_STATIC` results are rare or absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)