### PR TITLE
fix: caption stream-switch races and vad_filter NO_SPEECH

### DIFF
--- a/backend/services/claude_transcriber.py
+++ b/backend/services/claude_transcriber.py
@@ -102,7 +102,8 @@ class ClaudeTranscriber:
             beam_size=5,
             language="en",
             initial_prompt=_ATC_INITIAL_PROMPT,
-            vad_filter=True,  # silero-VAD skips silence, reducing hallucinations
+            # vad_filter omitted: audio is pre-segmented by frontend VAD; Silero
+            # rejects short clips with no leading silence → NO_SPEECH every time.
             condition_on_previous_text=False,  # each segment is independent
         )
         return " ".join(s.text.strip() for s in segments).strip()

--- a/frontend/src/components/screens/TranscriptScreen.vue
+++ b/frontend/src/components/screens/TranscriptScreen.vue
@@ -203,8 +203,8 @@
               </svg>
             </div>
             <div>
-              <div class="text-[15px] font-semibold" style="letter-spacing:-0.2px">Gemini 3.0 Flash</div>
-              <div class="text-[11px] text-atc-dim mt-0.5">Aviation-tuned · preview</div>
+              <div class="text-[15px] font-semibold" style="letter-spacing:-0.2px">Claude Haiku 4.5</div>
+              <div class="text-[11px] text-atc-dim mt-0.5">Aviation-tuned · whisper small.en</div>
             </div>
           </div>
           <p class="text-[12.5px] text-atc-dim leading-relaxed m-0">
@@ -373,7 +373,7 @@ watch(visible, async (newCaps) => {
 
 // Session elapsed
 const sessionElapsed = ref('00:00')
-const sessionStart = ref(Date.now() - 73000)
+const sessionStart = ref(Date.now())
 let sessionTimer = null
 const tickSession = () => {
   const s = Math.floor((Date.now() - sessionStart.value) / 1000)

--- a/frontend/src/composables/useLiveATC.js
+++ b/frontend/src/composables/useLiveATC.js
@@ -36,6 +36,8 @@ export function useLiveATC() {
     let silenceStart = null
     let speechStart = null
     let rafId = null
+    let transcribeAbort = null  // AbortController for in-flight transcription requests
+    let connectionId = 0        // increments on every connect(); guards stale finalize() calls
 
     // Monitor Audio State
     watch(audioRef, (audio) => {
@@ -158,12 +160,18 @@ export function useLiveATC() {
 
         recorderRef.value.stop()
 
+        const capturedId = connectionId  // snapshot epoch at call time
+
         const finalize = async () => {
+            if (connectionId !== capturedId) return  // stale — new connection started
+
             const blob = new Blob(audioChunks, { type: 'audio/webm' })
 
             if (blob.size > 5000) {
                 await sendToTranscribe(blob, startTime)
             }
+
+            if (connectionId !== capturedId) return  // disconnected during transcription
 
             audioChunks = []
             connectionState.value = 'LISTENING'
@@ -177,6 +185,9 @@ export function useLiveATC() {
     }
 
     const sendToTranscribe = async (audioBlob, startTime) => {
+        const abort = new AbortController()
+        transcribeAbort = abort
+
         try {
             const formData = new FormData()
             formData.append("file", audioBlob)
@@ -203,7 +214,8 @@ export function useLiveATC() {
             const resp = await fetch(url, {
                 method: 'POST',
                 headers,
-                body: formData
+                body: formData,
+                signal: abort.signal
             })
 
             if (!resp.ok) throw new Error("Transcription failed")
@@ -230,8 +242,11 @@ export function useLiveATC() {
             }
 
         } catch (e) {
+            if (e.name === 'AbortError') return  // intentional cancel on stream switch
             console.error("Transcription send error", e)
             captions.value = captions.value.filter(c => !c.isTemp)
+        } finally {
+            if (transcribeAbort === abort) transcribeAbort = null
         }
     }
 
@@ -318,6 +333,12 @@ export function useLiveATC() {
     }
 
     const disconnect = () => {
+        connectionId++                          // invalidate any pending finalize() calls
+        if (transcribeAbort) {
+            transcribeAbort.abort()
+            transcribeAbort = null
+        }
+
         isConnected.value = false
         connectionState.value = 'IDLE'
         if (audioRef.value) {


### PR DESCRIPTION
## Root Cause Analysis

Systematic debugging found two independent root causes for the two reported issues.

### Issue 1: Captions not appearing (NO_SPEECH every time)

**Root cause:** `vad_filter=True` in faster-whisper uses Silero VAD internally. Silero requires leading silence before speech onset to detect a speech segment. The frontend AnalyserNode pipeline pre-segments audio — clips begin mid-transmission with no leading silence. Result: Silero emits NO_SPEECH on every clip.

**Fix:** Remove `vad_filter` from `_stt()` in `claude_transcriber.py`. Audio is already segmented by the frontend; double-VAD is both redundant and destructive here.

### Issue 2: Stream switch — stale captions / wrong state

Two race conditions:

**a) Stale fetch completing after switch:**
In-flight `fetch()` POST to `/caption/transcribe` from the old stream could complete after `connect()` cleared `captions.value = []`, injecting old-stream transcription results into the new feed.

**Fix:** Create an `AbortController` per request in `sendToTranscribe()`, store it in `transcribeAbort`. `disconnect()` calls `transcribeAbort.abort()` before clearing state. Catch `AbortError` silently (it's intentional).

**b) Stale `setTimeout(finalize)` firing after switch:**
`stopRecordingAndTranscribe()` schedules `setTimeout(finalize, 50)` to wait for the recorder's final `ondataavailable`. After `disconnect()` + `connect()`, the new recorder is running. The stale `finalize()` then calls `recorderRef.value.start(100)` on the already-running recorder (silent failure) and sets `connectionState = 'LISTENING'` at the wrong time.

**Fix:** Capture `connectionId` (a monotonic counter incremented on each `disconnect()`) at call time. `finalize()` bails if the captured ID no longer matches the current `connectionId`.

## Additional fixes

- `TranscriptScreen.vue`: model label "Gemini 3.0 Flash" → "Claude Haiku 4.5" with correct subtitle
- `TranscriptScreen.vue`: session timer no longer starts at 1:13 due to hardcoded `-73000ms` offset removed

## Test plan

- [ ] Connect to a feed → transmissions appear as captions within a few seconds
- [ ] Switch to a different feed → old captions clear, new captions appear (no bleed-through from old stream)
- [ ] Session timer starts at 0:00 when entering transcript view
- [ ] Model info panel shows "Claude Haiku 4.5"

🤖 Generated with [Claude Code](https://claude.com/claude-code)