### PR TITLE
fix: stream switch failure + transcript UI cleanup

### DIFF
--- a/frontend/src/components/screens/TranscriptScreen.vue
+++ b/frontend/src/components/screens/TranscriptScreen.vue
@@ -9,11 +9,10 @@
         <div>
           <div class="flex justify-between items-center mb-3">
             <div class="font-mono text-[10px] text-atc-faint tracking-[1.5px] uppercase">FEEDS · {{ channels?.length || 0 }}</div>
-            <button class="bg-transparent border border-atc-line rounded-full px-2.5 py-1 text-atc-text text-[11px] cursor-pointer font-sans">+ Add</button>
           </div>
           <div class="flex flex-col gap-0.5">
             <button
-              v-for="ch in (channels || []).slice(0, 7)"
+              v-for="ch in (channels || [])"
               :key="ch.id"
               @click="$emit('switch-feed', ch)"
               class="flex items-center gap-2.5 px-3 py-2.5 rounded-xl border text-left cursor-pointer transition-colors font-sans"
@@ -182,16 +181,6 @@
           </div>
         </div>
 
-        <!-- Runway diagram -->
-        <div class="p-4 rounded-2xl bg-atc-card border border-atc-line">
-          <div class="font-mono text-[10px] text-atc-faint tracking-[1.5px] uppercase mb-3.5">RUNWAY · {{ icao }}</div>
-          <RunwayDiagram :size="260" accent="#FF5A1F" />
-          <div class="grid grid-cols-2 gap-1.5 mt-2.5 font-mono text-[12px] tracking-[0.3px]">
-            <div><span class="text-atc-faint text-[10px] block uppercase tracking-[1px] mb-0.5">ACTIVE</span><b class="text-atc-orange">25L · 25R</b></div>
-            <div><span class="text-atc-faint text-[10px] block uppercase tracking-[1px] mb-0.5">WIND</span><b>{{ metar?.wind || '—' }}</b></div>
-          </div>
-        </div>
-
         <!-- Model info -->
         <div class="p-4 rounded-2xl bg-atc-card border border-atc-line">
           <div class="font-mono text-[10px] text-atc-faint tracking-[1.5px] uppercase mb-3.5">TRANSCRIPTION MODEL</div>
@@ -263,8 +252,6 @@
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import TopBar from '../ui/TopBar.vue'
 import Waveform from '../ui/Waveform.vue'
-import RunwayDiagram from '../ui/RunwayDiagram.vue'
-import { useMetar } from '../../composables/useMetar.js'
 
 const props = defineProps({
   icao:            { type: String,  default: '' },
@@ -282,10 +269,6 @@ const streamEl  = ref(null)
 const streamEnd = ref(null)
 
 const activeFeed = computed(() => props.channels?.find(c => c.id === props.activeFeedId) || props.channels?.[0] || null)
-
-// METAR for right rail wind
-const icaoRef = computed(() => props.icao)
-const { parsed: metar } = useMetar(icaoRef)
 
 // Speaker metadata
 const SPEAKERS = {
@@ -386,8 +369,8 @@ onUnmounted(() => { clearInterval(sessionTimer); clearInterval(typeTimer) })
 const sessionStats = computed(() => [
   { label: 'UPTIME',   value: sessionElapsed.value },
   { label: 'SEGMENTS', value: counts.value.all },
-  { label: 'LATENCY',  value: '184ms' },
-  { label: 'VAD',      value: '82%', accent: true },
+  { label: 'TOWER',    value: counts.value.atc },
+  { label: 'AIRCRAFT', value: counts.value.plane, accent: true },
 ])
 
 // Zulu time formatter

--- a/frontend/src/composables/useLiveATC.js
+++ b/frontend/src/composables/useLiveATC.js
@@ -283,25 +283,31 @@ export function useLiveATC() {
         const proxyUrl = `${API_BASE}/proxy/${activeChannel.value.id}`
         const audio = audioRef.value
 
+        // Resume AudioContext first — browsers suspend it on pause; resuming before
+        // play() avoids "AudioContext was not allowed to start" on stream switches.
+        const ctx = initAudioContext()
+        if (ctx.state === 'suspended') {
+            await ctx.resume().catch(() => { })
+        }
+
         audio.crossOrigin = "anonymous"
         audio.src = proxyUrl
+        audio.load()  // explicit reset so the element is clean after src change
 
         try {
             await audio.play()
             error.value = null
         } catch (e) {
-            console.error("Auto-play failed", e)
-            if (e.name === "NotAllowedError") {
+            if (e.name === "AbortError") {
+                // AbortError is expected when src changes mid-load (e.g., rapid
+                // stream switches). The audio element will recover on its own.
+                console.warn("Audio load aborted (stream switching), ignoring")
+            } else if (e.name === "NotAllowedError") {
                 error.value = "Click Play to enable audio."
             } else {
-                error.value = "Audio stream failed. Check connection."
+                console.error("Auto-play failed", e)
+                error.value = "Click Play to start stream."
             }
-            // We stay isConnected=true so UI shows Player, allowing user to retry
-        }
-
-        const ctx = initAudioContext()
-        if (ctx.state === 'suspended') {
-            await ctx.resume().catch(() => { })
         }
 
         if (!mediaSourceRef.value) {


### PR DESCRIPTION
## Issue 1: "Audio stream failed" toast on every stream switch

**Root cause:** `AudioContext.resume()` was called *after* `audio.play()`. On stream switches, the browser suspends the AudioContext when audio is paused. Calling `play()` before resuming the context causes it to throw a non-`NotAllowedError`, which was displayed as the "Audio stream failed" toast.

**Fix (in `useLiveATC.js`):**
- Move `initAudioContext()` + `ctx.resume()` to *before* `audio.play()` — the context must be active before playback can start
- Add `audio.load()` after `audio.src` change to explicitly reset the element, preventing stale `AbortError` from a previous in-flight load being interrupted
- Catch `AbortError` silently (expected during rapid stream switches, the element self-recovers). All other errors now say "Click Play to start stream." instead of the misleading "Check connection"

## Issue 2: Fake data in transcript UI

**Removed:**
- **Runway diagram** — showed hardcoded "25L · 25R" active runways with no real data
- **LATENCY: 184ms** — hardcoded, not measured
- **VAD: 82%** — hardcoded, not measured
- **"+ Add" feed button** — non-functional placeholder
- **7-feed cap** in sidebar — all feeds now visible

**Replaced with real data:**
- Session stats now show TOWER count and AIRCRAFT count, computed from actual caption results

## Files changed
- `frontend/src/composables/useLiveATC.js` — stream switch connect() fix
- `frontend/src/components/screens/TranscriptScreen.vue` — UI cleanup + fake data removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)