### PR TITLE
docs: add make dev command and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# LiveATC Caption — Claude Code Guide
+
+## Dev environment
+
+Start backend + frontend together:
+
+```bash
+make dev
+```
+
+Backend runs on `http://localhost:8000`, frontend on `http://localhost:5173`. Ctrl-C stops both.
+
+## Stack
+
+- **Backend**: FastAPI + uvicorn, managed by `uv`. Entry point: `backend/main.py`.
+- **Frontend**: Vue 3 + Vite + Tailwind + DaisyUI, managed by `pnpm` (installed via Homebrew).
+- **Audio pipeline**: PyAV decodes the LiveATC stream → webrtcvad VAD → faster-whisper STT → Claude Haiku parsing. All runs server-side; PCM audio and captions flow over a single WebSocket to the browser.
+
+## Key paths
+
+| Path | What |
+|---|---|
+| `backend/api/router/caption.py` | WebSocket endpoint — multiplexes PCM audio + JSON captions |
+| `backend/services/base_transcriber.py` | Shared VAD loop, audio queues, stream_audio() |
+| `backend/services/claude_transcriber.py` | Whisper STT + Claude Haiku parsing |
+| `backend/services/rag_service.py` | Airport context: runways, callsigns, METAR |
+| `frontend/src/composables/useLiveATC.js` | All audio/WebSocket/caption state |
+| `frontend/public/playback-processor.js` | AudioWorklet ring-buffer PCM player |
+| `frontend/src/views/SettingsView.vue` | Settings: API key + transcription params |
+
+## Linting
+
+```bash
+cd backend && uvx ruff check . && uvx ruff format --check .
+```
+
+## Tests
+
+```bash
+cd backend && .venv/bin/python -m pytest tests/ -v
+```
+
+## API key
+
+Set `ANTHROPIC_API_KEY` in `backend/.env`. The env var always wins over any frontend-passed key.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: dev
+
+# Start backend (port 8000) and frontend (port 5173) together.
+# Ctrl-C stops both.
+dev:
+	@(cd backend && uv run uvicorn main:app --host 0.0.0.0 --port 8000 --reload) & \
+	trap "kill %1 2>/dev/null" EXIT; \
+	PATH="/opt/homebrew/bin:$$PATH" pnpm --dir frontend dev


### PR DESCRIPTION
## Summary
- \`make dev\` starts backend (port 8000) + frontend (port 5173) together; Ctrl-C stops both
- \`CLAUDE.md\` documents the dev command, stack overview, key paths, linting, and tests for future Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)