### PR TITLE
feat: 3s map poll with RAF dead-reckoning for airborne aircraft

### DIFF
--- a/frontend/src/components/map/AirportMap.vue
+++ b/frontend/src/components/map/AirportMap.vue
@@ -129,17 +129,24 @@ const initMap = () => {
   sizeObs.observe(mapEl.value)
 }
 
-const makeAcIcon = (color, label, rot = 0) => L.divIcon({
-  className: '',
-  html: `<div style="position:relative">
-    <svg width="18" height="18" viewBox="0 0 24 24" style="transform:rotate(${rot}deg);filter:drop-shadow(0 0 4px ${color})">
-      <path d="M12 2L16 20L12 17L8 20Z" fill="${color}"/>
-    </svg>
-    <div style="position:absolute;left:22px;top:2px;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:600;color:${color};white-space:nowrap;text-shadow:0 0 4px #0a0a0b,0 0 6px #0a0a0b;letter-spacing:0.3px">${label}</div>
-  </div>`,
-  iconSize: [18, 18],
-  iconAnchor: [9, 9],
-})
+const makeAcIcon = (color, label, rot = 0, showArrow = true) => {
+  const symbol = showArrow
+    ? `<svg width="18" height="18" viewBox="0 0 24 24" style="transform:rotate(${rot}deg);filter:drop-shadow(0 0 4px ${color})">
+        <path d="M12 2L16 20L12 17L8 20Z" fill="${color}"/>
+       </svg>`
+    : `<svg width="10" height="10" viewBox="0 0 10 10" style="filter:drop-shadow(0 0 4px ${color});margin:4px">
+        <circle cx="5" cy="5" r="5" fill="${color}"/>
+       </svg>`
+  return L.divIcon({
+    className: '',
+    html: `<div style="position:relative;display:flex;align-items:center">
+      ${symbol}
+      <div style="position:absolute;left:${showArrow ? 22 : 18}px;top:2px;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:600;color:${color};white-space:nowrap;text-shadow:0 0 4px #0a0a0b,0 0 6px #0a0a0b;letter-spacing:0.3px">${label}</div>
+    </div>`,
+    iconSize: [18, 18],
+    iconAnchor: [9, 9],
+  })
+}
 
 const updateAircraft = () => {
   if (!map) return
@@ -152,7 +159,9 @@ const updateAircraft = () => {
     const color = ac.onGround ? '#34d399' : props.accent
     const label = (ac.callsign || ac.icao24 || '').trim()
     const rot   = Math.round(ac.track || 0)
-    const isAnimated = !ac.onGround && (ac.velocity ?? 0) >= ANIMATE_THRESHOLD_KT
+    const vel   = ac.velocity ?? 0
+    const isAnimated = !ac.onGround && vel >= ANIMATE_THRESHOLD_KT
+    const showArrow  = vel >= ANIMATE_THRESHOLD_KT
 
     if (acMarkersMap.has(ac.icao24)) {
       const entry = acMarkersMap.get(ac.icao24)
@@ -161,20 +170,20 @@ const updateAircraft = () => {
       entry.baseLat   = ac.lat
       entry.baseLon   = ac.lon
       entry.baseTime  = now
-      entry.velocity  = ac.velocity ?? 0
+      entry.velocity  = vel
       entry.track     = ac.track ?? 0
       entry.isAnimated = isAnimated
       // Refresh icon only when appearance changes
-      if (color !== entry.color || label !== entry.label || rot !== entry.rot) {
-        entry.marker.setIcon(makeAcIcon(color, label, rot))
-        entry.color = color; entry.label = label; entry.rot = rot
+      if (color !== entry.color || label !== entry.label || rot !== entry.rot || showArrow !== entry.showArrow) {
+        entry.marker.setIcon(makeAcIcon(color, label, rot, showArrow))
+        entry.color = color; entry.label = label; entry.rot = rot; entry.showArrow = showArrow
       }
     } else {
-      const m = L.marker([ac.lat, ac.lon], { icon: makeAcIcon(color, label, rot) }).addTo(map)
+      const m = L.marker([ac.lat, ac.lon], { icon: makeAcIcon(color, label, rot, showArrow) }).addTo(map)
       acMarkersMap.set(ac.icao24, {
-        marker: m, color, label, rot,
+        marker: m, color, label, rot, showArrow,
         baseLat: ac.lat, baseLon: ac.lon, baseTime: now,
-        velocity: ac.velocity ?? 0, track: ac.track ?? 0,
+        velocity: vel, track: ac.track ?? 0,
         isAnimated,
       })
     }

--- a/frontend/src/components/map/AirportMap.vue
+++ b/frontend/src/components/map/AirportMap.vue
@@ -134,8 +134,8 @@ const makeAcIcon = (color, label, rot = 0, showArrow = true) => {
     ? `<svg width="18" height="18" viewBox="0 0 24 24" style="transform:rotate(${rot}deg);filter:drop-shadow(0 0 4px ${color})">
         <path d="M12 2L16 20L12 17L8 20Z" fill="${color}"/>
        </svg>`
-    : `<svg width="10" height="10" viewBox="0 0 10 10" style="filter:drop-shadow(0 0 4px ${color});margin:4px">
-        <circle cx="5" cy="5" r="5" fill="${color}"/>
+    : `<svg width="7" height="7" viewBox="0 0 7 7" style="filter:drop-shadow(0 0 3px ${color});margin:5.5px">
+        <circle cx="3.5" cy="3.5" r="3.5" fill="${color}"/>
        </svg>`
   return L.divIcon({
     className: '',
@@ -156,12 +156,12 @@ const updateAircraft = () => {
   props.aircraft.forEach(ac => {
     if (!ac.lat || !ac.lon) return
     seen.add(ac.icao24)
-    const color = ac.onGround ? '#34d399' : props.accent
+    const vel        = ac.velocity ?? 0
+    const showArrow  = vel >= ANIMATE_THRESHOLD_KT
+    const isAnimated = !ac.onGround && showArrow
+    const color = ac.onGround ? '#34d399' : showArrow ? props.accent : '#ffb347'
     const label = (ac.callsign || ac.icao24 || '').trim()
     const rot   = Math.round(ac.track || 0)
-    const vel   = ac.velocity ?? 0
-    const isAnimated = !ac.onGround && vel >= ANIMATE_THRESHOLD_KT
-    const showArrow  = vel >= ANIMATE_THRESHOLD_KT
 
     if (acMarkersMap.has(ac.icao24)) {
       const entry = acMarkersMap.get(ac.icao24)

--- a/frontend/src/components/map/AirportMap.vue
+++ b/frontend/src/components/map/AirportMap.vue
@@ -38,10 +38,45 @@ const mapReady = ref(false)
 let map = null
 let sizeObs = null
 // Track markers by icao24 for smooth position updates
-const acMarkersMap = new Map() // icao24 -> { marker, color, label, rot }
+// Entry shape: { marker, color, label, rot, baseLat, baseLon, baseTime, velocity, track, isAnimated }
+const acMarkersMap = new Map()
 
 const latStr = ref('')
 const lonStr = ref('')
+
+// Dead-reckoning: animate aircraft that exceed this speed (knots)
+const ANIMATE_THRESHOLD_KT = 30
+
+// RAF loop — updates predicted positions at ~60 fps for fast aircraft
+let rafId = null
+
+const animateLoop = () => {
+  if (!map) return
+  const now = Date.now()
+  for (const [, entry] of acMarkersMap) {
+    if (!entry.isAnimated) continue
+    const dt = (now - entry.baseTime) / 1000  // seconds since last poll
+    if (dt <= 0) continue
+
+    // 匀速运动: uniform linear motion in the direction of `track`
+    // 1 knot = 0.514444 m/s; track is degrees clockwise from north
+    const mps = entry.velocity * 0.514444
+    const trackRad = (entry.track * Math.PI) / 180
+    const latRad   = (entry.baseLat * Math.PI) / 180
+    const dLat = (mps * Math.cos(trackRad) * dt) / 111_320
+    const dLon = (mps * Math.sin(trackRad) * dt) / (111_320 * Math.cos(latRad))
+    entry.marker.setLatLng([entry.baseLat + dLat, entry.baseLon + dLon])
+  }
+  rafId = requestAnimationFrame(animateLoop)
+}
+
+const startRaf = () => {
+  if (rafId == null) rafId = requestAnimationFrame(animateLoop)
+}
+
+const stopRaf = () => {
+  if (rafId != null) { cancelAnimationFrame(rafId); rafId = null }
+}
 
 const initMap = () => {
   if (!mapEl.value || map) return
@@ -82,6 +117,7 @@ const initMap = () => {
 
   mapReady.value = true
   updateAircraft()
+  startRaf()
 
   // Observe the container for size changes (flex layout settles asynchronously).
   // Every time the container grows/shrinks, tell Leaflet to recalculate so it
@@ -108,6 +144,7 @@ const makeAcIcon = (color, label, rot = 0) => L.divIcon({
 const updateAircraft = () => {
   if (!map) return
 
+  const now = Date.now()
   const seen = new Set()
   props.aircraft.forEach(ac => {
     if (!ac.lat || !ac.lon) return
@@ -115,11 +152,18 @@ const updateAircraft = () => {
     const color = ac.onGround ? '#34d399' : props.accent
     const label = (ac.callsign || ac.icao24 || '').trim()
     const rot   = Math.round(ac.track || 0)
+    const isAnimated = !ac.onGround && (ac.velocity ?? 0) >= ANIMATE_THRESHOLD_KT
 
     if (acMarkersMap.has(ac.icao24)) {
       const entry = acMarkersMap.get(ac.icao24)
-      // Smooth position update — CSS transition handles the animation
+      // Anchor dead-reckoning to the fresh authoritative position
       entry.marker.setLatLng([ac.lat, ac.lon])
+      entry.baseLat   = ac.lat
+      entry.baseLon   = ac.lon
+      entry.baseTime  = now
+      entry.velocity  = ac.velocity ?? 0
+      entry.track     = ac.track ?? 0
+      entry.isAnimated = isAnimated
       // Refresh icon only when appearance changes
       if (color !== entry.color || label !== entry.label || rot !== entry.rot) {
         entry.marker.setIcon(makeAcIcon(color, label, rot))
@@ -127,7 +171,12 @@ const updateAircraft = () => {
       }
     } else {
       const m = L.marker([ac.lat, ac.lon], { icon: makeAcIcon(color, label, rot) }).addTo(map)
-      acMarkersMap.set(ac.icao24, { marker: m, color, label, rot })
+      acMarkersMap.set(ac.icao24, {
+        marker: m, color, label, rot,
+        baseLat: ac.lat, baseLon: ac.lon, baseTime: now,
+        velocity: ac.velocity ?? 0, track: ac.track ?? 0,
+        isAnimated,
+      })
     }
   })
 
@@ -148,6 +197,7 @@ watch(() => [props.lat, props.lon], ([lat, lon]) => {
 
 onMounted(initMap)
 onUnmounted(() => {
+  stopRaf()
   sizeObs?.disconnect()
   acMarkersMap.clear()
   if (map) { map.remove(); map = null }
@@ -155,8 +205,9 @@ onUnmounted(() => {
 </script>
 
 <style>
-/* Smooth aircraft position updates — Leaflet repositions markers via transform */
+/* No CSS transition — fast aircraft use RAF dead-reckoning; slow/ground aircraft
+   snap on poll which is imperceptible at low speeds. */
 .leaflet-marker-icon {
-  transition: transform 1s ease-out;
+  transition: none;
 }
 </style>

--- a/frontend/src/composables/useAircraftPositions.js
+++ b/frontend/src/composables/useAircraftPositions.js
@@ -2,7 +2,7 @@ import { ref, watch, onUnmounted } from 'vue'
 
 // Proxied through backend — adsb.lol has no CORS headers for browser requests
 const API = '/api/proxy/aircraft/positions'
-const POLL_MS = 1_000
+const POLL_MS = 3_000
 const DIST_NM = 20  // nautical miles radius (~37 km) — catches approach traffic too
 
 export function useAircraftPositions(icaoRef, latRef, lonRef) {


### PR DESCRIPTION
## Summary

- Increase ADS-B position poll interval from 1 s → **3 s** to reduce backend proxy load
- Replace the old CSS `transition: 1s ease-out` with a **`requestAnimationFrame` dead-reckoning loop** that applies 匀速运动 (uniform linear motion) for aircraft flying ≥ 30 kt
- Aircraft markers now move continuously at ~60 fps between polls, extrapolated from last known position + ground speed + track bearing
- Ground/slow aircraft (< 30 kt) snap on each 3 s poll — imperceptible given their low speed

## How dead-reckoning works

\`\`\`
Δt   = (now - lastPollTime) / 1000          // seconds elapsed
mps  = velocity_kts × 0.514444             // knots → m/s
dLat = mps × cos(track_rad) × Δt / 111320
dLon = mps × sin(track_rad) × Δt / (111320 × cos(lat_rad))
marker.setLatLng([baseLat + dLat, baseLon + dLon])
\`\`\`

Each poll resets \`baseLat/baseLon/baseTime\` to the authoritative ADS-B position, so drift never accumulates beyond one 3 s window.

## Test plan

- [ ] Open app on an active airport, confirm markers for airborne aircraft move fluidly without jumps
- [ ] Confirm ground aircraft (green markers) remain stationary between polls
- [ ] Confirm network tab shows ADS-B requests firing every ~3 s (not 1 s)
- [ ] Navigate away and back — confirm RAF loop stops/restarts cleanly (no leaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)