### PR TITLE
[codex] Add compact ATC control dock

### DIFF
--- a/frontend/src/components/map/AirportMap.vue
+++ b/frontend/src/components/map/AirportMap.vue
@@ -87,7 +87,7 @@ const initMap = () => {
     zoomControl:      false,
     attributionControl: false,
     scrollWheelZoom:  false,
-    dragging:         true,
+    dragging:         false,
   })
 
   // CartoDB Dark Matter — no auth needed

--- a/frontend/src/components/screens/AirportCaptionScreen.vue
+++ b/frontend/src/components/screens/AirportCaptionScreen.vue
@@ -37,18 +37,74 @@
       <!-- KPI strip -->
       <div
         class="grid border border-atc-line rounded-xl overflow-hidden"
-        style="grid-template-columns:repeat(6,1fr);gap:1px;background:rgba(255,255,255,0.07)"
+        style="grid-template-columns:repeat(5,1fr);gap:1px;background:rgba(255,255,255,0.07)"
       >
-        <KPICell label="WIND"       :value="metar?.wind    || '—'" />
-        <KPICell label="VIS"        :value="metar?.vis     || '—'" />
-        <KPICell label="CEILING"    :value="metar?.ceiling || '—'" />
-        <KPICell label="TEMP · DEW" :value="metar ? `${metar.temp} / ${metar.dew}` : '—'" />
-        <KPICell label="ALTIM"      :value="metar?.altim   || '—'" />
-        <KPICell
-          label="STATUS"
-          :value="activeFeed ? activeFeed.name : (channels?.length ? `${channels.length} feeds` : '—')"
-          accent
-        />
+        <KPICell label="WIND">
+          <div class="kpi-value">
+            <template v-if="metar?.rawWspd != null">
+              <NumberFlow
+                v-if="metar.rawWdir != null"
+                class="kpi-number-flow"
+                :value="metar.rawWdir"
+                :format="{ minimumIntegerDigits: 3 }"
+                suffix="°"
+              />
+              <span v-else class="kpi-unit">VRB</span>
+              <span class="kpi-unit px-1.5">/</span>
+              <NumberFlow class="kpi-number-flow" :value="metar.rawWspd" suffix=" kt" />
+              <template v-if="metar.rawWgst">
+                <span class="kpi-unit pl-1">G</span>
+                <NumberFlow class="kpi-number-flow" :value="metar.rawWgst" suffix="kt" />
+              </template>
+            </template>
+            <template v-else>{{ metar?.wind || '—' }}</template>
+          </div>
+        </KPICell>
+        <KPICell label="VIS">
+          <div class="kpi-value">
+            <template v-if="visInfo">
+              <NumberFlow class="kpi-number-flow" :value="visInfo.value" :suffix="visInfo.plus ? '+' : ''" />
+              <span class="kpi-unit pl-1.5">SM</span>
+            </template>
+            <span v-else>{{ metar?.vis || '—' }}</span>
+          </div>
+        </KPICell>
+        <KPICell label="CEILING">
+          <div class="kpi-value">
+            <template v-if="ceilingInfo">
+              <span class="kpi-unit pr-1.5">{{ ceilingInfo.cover }}</span>
+              <NumberFlow
+                class="kpi-number-flow"
+                :value="ceilingInfo.base"
+                :format="{ maximumFractionDigits: 0 }"
+                suffix=" ft"
+              />
+            </template>
+            <span v-else>{{ metar?.ceiling || '—' }}</span>
+          </div>
+        </KPICell>
+        <KPICell label="TEMP · DEW">
+          <div class="kpi-value">
+            <template v-if="metar?.rawTemp != null">
+              <NumberFlow class="kpi-number-flow" :value="metar.rawTemp" suffix="°C" />
+              <span class="kpi-unit px-1.5">/</span>
+              <NumberFlow class="kpi-number-flow" :value="metar.rawDewp ?? 0" suffix="°C" />
+            </template>
+            <span v-else>{{ metar ? `${metar.temp} / ${metar.dew}` : '—' }}</span>
+          </div>
+        </KPICell>
+        <KPICell label="ALTIM">
+          <div class="kpi-value">
+            <NumberFlow
+              v-if="metar?.rawAltim != null"
+              class="kpi-number-flow"
+              :value="metar.rawAltim"
+              :format="{ maximumFractionDigits: 0 }"
+              suffix=" inHg"
+            />
+            <span v-else>{{ metar?.altim || '—' }}</span>
+          </div>
+        </KPICell>
       </div>
     </section>
 
@@ -67,230 +123,150 @@
         />
       </div>
 
-      <!-- Aircraft count (bottom-center) -->
-      <div class="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 flex items-center gap-2 font-mono text-[11px] text-atc-dim pointer-events-none whitespace-nowrap" style="text-shadow:0 0 8px #0a0a0b">
+      <!-- Aircraft count (above bottom dock) -->
+      <div class="absolute bottom-[100px] left-1/2 -translate-x-1/2 z-10 flex items-center gap-2 font-mono text-[11px] text-atc-dim pointer-events-none whitespace-nowrap" style="text-shadow:0 0 8px #0a0a0b">
         <span class="w-1.5 h-1.5 rounded-full bg-atc-orange flex-shrink-0" style="box-shadow:0 0 6px #FF5A1F" />
         {{ aircraft.length }} aircraft in range
         <span class="text-atc-faint">·</span>
         <span class="text-atc-faint">Updated {{ fmtUpdated(lastUpdated) }}</span>
       </div>
 
-      <!-- ── LEFT FLOAT: Feed selector ──────────────────────────────────── -->
-      <div
-        class="absolute top-3 left-10 z-10 flex flex-col rounded-2xl border border-white/10 overflow-hidden"
-        style="width:236px;height:calc(100% - 24px);background:rgba(10,10,11,0.82);backdrop-filter:blur(16px)"
-      >
-        <!-- Header: stats + filter dropdown -->
-        <div class="flex-shrink-0 px-3 pt-3 pb-2 border-b border-white/8 flex flex-col gap-1.5">
-          <!-- Stats row -->
-          <div class="flex items-center justify-between font-mono text-[9px]">
-            <span class="text-atc-faint tracking-[1.5px] uppercase">ATC FEEDS</span>
-            <div class="flex gap-2 text-atc-dim">
-              <span><b class="text-atc-text">{{ channels?.filter(c => c.is_up !== false).length || 0 }}</b> live</span>
-              <span><b class="text-atc-text">{{ totalListeners }}</b> listeners</span>
-            </div>
-          </div>
-          <!-- Filter dropdown -->
-          <select
-            v-model="feedFilter"
-            class="w-full rounded px-2 py-1 font-mono text-[10px] text-atc-text border border-white/10 cursor-pointer appearance-none"
-            style="background:rgba(255,255,255,0.05);outline:none"
+      <!-- ── BOTTOM DOCK: compact mobile-friendly controls ──────────────── -->
+      <div class="absolute inset-x-3 bottom-3 z-20 sm:inset-x-4">
+        <Transition name="feed-dropup">
+          <div
+            v-if="feedMenuOpen"
+            class="absolute bottom-[calc(100%+10px)] left-0 right-0 max-h-[min(62vh,420px)] overflow-hidden rounded-[24px] border border-white/15 shadow-2xl sm:right-auto sm:w-[380px]"
+            style="background:rgba(10,10,11,0.94);backdrop-filter:blur(22px);box-shadow:0 22px 70px rgba(0,0,0,0.55)"
           >
-            <option v-for="t in feedTabs" :key="t" :value="t">{{ t === 'All' ? 'All feeds' : feedTabLabels[t] }}</option>
-          </select>
-        </div>
-
-        <!-- Feed list -->
-        <div class="flex-1 overflow-y-auto flex flex-col gap-px p-1.5 min-h-0">
-          <div v-if="!channels?.length" class="flex items-center justify-center py-6">
-            <div class="font-mono text-[10px] text-atc-faint animate-pulse">LOADING FEEDS…</div>
-          </div>
-
-          <button
-            v-for="ch in filteredChannels"
-            :key="ch.id"
-            @click="selectFeed(ch)"
-            class="flex items-center gap-2 px-2.5 py-1 rounded-lg border text-left cursor-pointer transition-all font-sans w-full"
-            :class="ch.id === activeFeedId
-              ? 'border-atc-orange/30 bg-atc-orange/8'
-              : 'border-transparent bg-transparent hover:bg-white/5'"
-          >
-            <!-- Flashing green dot: active=green pulse, others=dim -->
-            <span
-              class="w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors"
-              :class="ch.id === activeFeedId
-                ? 'bg-atc-mint animate-flash-dot'
-                : 'bg-white/20'"
-            />
-            <div class="flex-1 min-w-0">
-              <div
-                class="text-[11px] truncate"
-                :class="isHighTraffic(ch) ? 'font-bold text-atc-text' : 'font-medium text-atc-dim'"
-                style="letter-spacing:-0.1px"
-              >{{ ch.name }}</div>
+          <div class="flex items-center justify-between gap-3 px-4 py-3 border-b border-white/10">
+            <div class="min-w-0">
+              <div class="font-mono text-[9px] text-atc-faint tracking-[1.5px] uppercase">Feed selector</div>
+              <div class="text-[12px] font-bold truncate">{{ activeFeed?.name || 'Choose a frequency' }}</div>
             </div>
-          </button>
-        </div>
-      </div>
-
-      <!-- ── RIGHT FLOAT: Player + Captions ─────────────────────────────── -->
-      <div
-        class="absolute top-3 right-10 z-10 flex flex-col rounded-2xl border border-white/10 overflow-hidden"
-        style="width:320px;height:calc(100% - 24px);background:rgba(10,10,11,0.82);backdrop-filter:blur(16px)"
-      >
-        <!-- Player card -->
-        <div class="flex-shrink-0 p-4 border-b border-white/8">
-          <!-- No feed selected -->
-          <div v-if="!activeFeedId" class="flex flex-col items-center justify-center py-4 text-center gap-2">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" class="text-atc-faint opacity-40"><polygon points="6 4 20 12 6 20 6 4"/></svg>
-            <div class="text-atc-faint font-mono text-[9px] tracking-widest uppercase">No feed selected</div>
-            <div class="text-atc-dim text-[11px]">Pick a feed on the left</div>
-          </div>
-
-          <!-- Active player -->
-          <template v-else>
-            <div class="flex items-center gap-3 mb-3">
-              <button
-                @click="$emit('toggle-play')"
-                class="w-10 h-10 rounded-full bg-atc-orange text-atc-bg border-none grid place-items-center cursor-pointer flex-shrink-0"
-              >
-                <svg v-if="isPlaying" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="5" y="4" width="5" height="16"/><rect x="14" y="4" width="5" height="16"/></svg>
-                <svg v-else          width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="6 4 20 12 6 20 6 4"/></svg>
-              </button>
-              <div class="flex-1 min-w-0">
-                <div class="text-[13px] font-bold truncate" style="letter-spacing:-0.2px">{{ activeFeed?.name }}</div>
-                <div class="flex items-center gap-1.5 mt-0.5 font-mono text-[10px] text-atc-dim">
-                  <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border text-[8px] font-bold tracking-[1.2px]" style="border-color:rgba(255,59,48,0.4);color:#ff6b62">
-                    <span class="w-1 h-1 rounded-full bg-red-500 animate-pulse-dot" />
-                    LIVE
-                  </span>
-                  <span v-if="activeFeed?.freq">{{ activeFeed.freq }} MHz</span>
-                  <span class="text-atc-faint">·</span>
-                  <span>{{ sessionElapsed }}</span>
-                </div>
-              </div>
-              <div class="flex gap-1 flex-shrink-0">
-                <button @click="$emit('download')" class="w-7 h-7 rounded-full bg-white/8 border border-white/10 text-atc-text cursor-pointer grid place-items-center">
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-                </button>
-                <button @click="$emit('stop')" class="w-7 h-7 rounded-full bg-atc-red border-none text-white cursor-pointer grid place-items-center">
-                  <span class="w-2 h-2 bg-white inline-block" />
-                </button>
-              </div>
-            </div>
-
-            <!-- Waveform -->
-            <Waveform :playing="isPlaying" :bars="50" :height="24" :analyser="analyser" />
-
-            <!-- State row -->
-            <div class="flex items-center justify-between mt-2">
-              <span class="flex items-center gap-1.5 font-mono text-[9px] text-atc-mint tracking-[0.5px]">
-                <span class="w-1.5 h-1.5 rounded-full bg-atc-mint animate-pulse-dot" style="box-shadow:0 0 5px #34d399" />
-                {{ connectionStateLabel }}
-              </span>
-              <span class="font-mono text-[9px] text-atc-faint">{{ activeFeed?.listeners || 0 }} listening</span>
-            </div>
-          </template>
-        </div>
-
-        <!-- Captions header -->
-        <div class="flex-shrink-0 flex items-center justify-between px-4 py-2 border-b border-white/8">
-          <div class="flex items-center gap-2">
-            <span class="font-mono text-[9px] text-atc-faint tracking-[1.5px] uppercase">TRANSCRIPT</span>
-            <button
-              @click="toggleCaption"
-              class="flex items-center gap-1 px-1.5 py-0.5 rounded-full border font-mono text-[8px] font-bold tracking-[1px] uppercase transition-all cursor-pointer"
-              :class="captionEnabled
-                ? 'border-atc-mint/40 text-atc-mint bg-atc-mint/10'
-                : 'border-white/15 text-atc-dim bg-transparent'"
-              :title="captionEnabled ? 'Disable captions' : 'Enable captions'"
+            <select
+              v-model="feedFilter"
+              class="h-9 w-28 rounded-full px-3 font-mono text-[10px] text-atc-text border border-white/10 cursor-pointer appearance-none"
+              style="background:rgba(255,255,255,0.07);outline:none"
             >
-              <span class="w-1 h-1 rounded-full transition-colors" :class="captionEnabled ? 'bg-atc-mint' : 'bg-white/30'" />
-              {{ captionEnabled ? 'ON' : 'OFF' }}
+              <option v-for="t in feedTabs" :key="t" :value="t">{{ t === 'All' ? 'All' : feedTabLabels[t] }}</option>
+            </select>
+          </div>
+
+          <div class="max-h-[calc(min(62vh,420px)-86px)] overflow-y-auto px-2 py-2">
+            <div v-if="!channels?.length" class="flex items-center justify-center py-8">
+              <div class="font-mono text-[10px] text-atc-faint animate-pulse">LOADING FEEDS…</div>
+            </div>
+
+            <button
+              v-for="ch in filteredChannels"
+              :key="ch.id"
+              @click="selectFeed(ch)"
+              class="flex min-h-11 w-full items-center gap-3 rounded-2xl border px-3 py-2 text-left font-sans transition-all"
+              :class="ch.id === activeFeedId
+                ? 'border-atc-orange/35 bg-atc-orange/10 text-atc-text'
+                : 'border-transparent bg-transparent text-atc-dim hover:bg-white/6 hover:text-atc-text'"
+            >
+              <span
+                class="w-2 h-2 rounded-full flex-shrink-0 transition-colors"
+                :class="ch.id === activeFeedId
+                  ? 'bg-atc-mint animate-flash-dot'
+                  : 'bg-white/20'"
+              />
+              <span class="flex-1 min-w-0 text-[13px] font-semibold truncate">{{ ch.name }}</span>
+              <span class="font-mono text-[10px] text-atc-faint tabular-nums">{{ ch.listeners || 0 }}</span>
             </button>
           </div>
-          <div class="flex gap-2.5 font-mono text-[10px] text-atc-dim">
-            <span><b class="text-atc-text">{{ counts.atc }}</b> twr</span>
-            <span><b class="text-atc-text">{{ counts.plane }}</b> acft</span>
+
+          <div class="px-4 py-2 border-t border-white/8 flex items-center justify-between font-mono text-[9px] text-atc-dim">
+            <span><b class="text-atc-text">{{ channels?.filter(c => c.is_up !== false).length || 0 }}</b> live</span>
+            <span><b class="text-atc-text">{{ totalListeners }}</b> listening</span>
           </div>
-        </div>
-
-        <!-- Caption stream -->
-        <div ref="streamEl" class="flex-1 min-h-0 overflow-y-auto px-4 py-3 flex flex-col gap-4">
-
-          <!-- Captions disabled state -->
-          <div v-if="!captionEnabled" class="flex flex-col items-center justify-center h-full gap-3 pointer-events-none select-none">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" class="opacity-20">
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><line x1="4" y1="4" x2="20" y2="20"/>
-            </svg>
-            <span class="font-mono text-[9px] tracking-widest uppercase opacity-20">Captions off</span>
-            <!-- Still show live speaking state so user knows audio is active -->
-            <div v-if="connectionState === 'SPEAKING'" class="flex items-center gap-1.5 px-2 py-1 rounded bg-red-500/10 text-red-500 font-mono text-[9px] font-bold uppercase tracking-wider">
-              <div class="flex gap-0.5 items-end h-2">
-                <div v-for="j in 3" :key="j" class="w-0.5 bg-current rounded-full" :style="`height:${[8,5,7][j-1]}px;animation:eqBar ${[1,1.2,0.8][j-1]}s infinite alternate`" />
-              </div>
-              Speaking
-            </div>
-            <div v-else-if="connectionState === 'TRANSCRIBING'" class="flex items-center gap-1.5 px-2 py-1 rounded bg-amber-500/10 text-amber-500 font-mono text-[9px] font-bold uppercase tracking-wider">
-              <div class="flex gap-0.5 items-end h-2">
-                <div v-for="j in 3" :key="j" class="w-0.5 bg-current rounded-full opacity-60" :style="`height:${[8,5,7][j-1]}px;animation:eqBar ${[1,1.2,0.8][j-1]}s infinite alternate`" />
-              </div>
-              Transcribing
-            </div>
           </div>
+        </Transition>
 
-          <div
-            v-for="(cap, i) in visible"
-            :key="cap.id"
-            style="animation:capIn 0.4s cubic-bezier(0.2,0.6,0.2,1)"
-            :class="cap.isTemp ? 'opacity-40' : ''"
+        <div
+          class="bottom-dock flex min-h-[68px] flex-row items-center gap-2 rounded-[26px] border border-white/15 p-2 shadow-2xl"
+          style="background:rgba(10,10,11,0.91);backdrop-filter:blur(22px);box-shadow:0 18px 58px rgba(0,0,0,0.52)"
+        >
+          <button
+            class="bottom-dock-feed flex min-h-11 items-center gap-2.5 rounded-[20px] border border-white/10 bg-white/[0.045] px-3 text-left transition-colors hover:bg-white/8"
+            :aria-expanded="feedMenuOpen"
+            @click="feedMenuOpen = !feedMenuOpen"
           >
-            <div class="flex items-center gap-2 font-mono text-[9px] mb-1">
-              <span class="inline-flex px-1.5 py-0.5 rounded-full border font-bold tracking-[1.2px]" :style="speakerStyle(cap.speaker)">
-                {{ speakerMeta(cap.speaker).label }}
-              </span>
-              <span class="text-atc-faint">{{ fmtZulu(cap.timestamp) }}</span>
-              <span class="text-atc-faint">{{ Math.round((cap.confidence || 0.85) * 100) }}%</span>
-              <template v-if="parseCallsign(cap.caption)">
-                <span class="text-atc-faint">·</span>
-                <span class="font-semibold" :style="{ color: speakerMeta(cap.speaker).color }">{{ parseCallsign(cap.caption) }}</span>
-              </template>
-            </div>
-            <div
-              class="font-sans font-semibold leading-snug"
-              style="font-size:18px;letter-spacing:-0.3px"
-              :style="{
-                color: cap.speaker === 'unknown' ? 'var(--atc-dim)' : 'var(--atc-text)',
-                fontStyle: cap.speaker === 'unknown' ? 'italic' : 'normal',
-              }"
+            <ListFilter class="w-4 h-4 text-atc-orange flex-shrink-0" :stroke-width="2" />
+            <span class="min-w-0 flex-1">
+              <span class="block font-mono text-[9px] tracking-[1.4px] uppercase text-atc-faint">Feed</span>
+              <span class="block truncate text-[13px] font-bold">{{ activeFeed?.name || 'Choose feed' }}</span>
+            </span>
+            <ChevronDown
+              class="w-4 h-4 text-atc-dim transition-transform"
+              :class="feedMenuOpen ? 'rotate-180' : ''"
+              :stroke-width="2"
+            />
+          </button>
+
+          <div class="bottom-dock-transcript flex min-h-11 min-w-0 items-center gap-2.5 rounded-[20px] border border-white/10 bg-white/[0.03] px-3">
+            <button
+              @click="toggleCaption"
+              class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border transition-colors"
+              :class="captionEnabled
+                ? 'border-atc-mint/35 bg-atc-mint/10 text-atc-mint'
+                : 'border-white/15 bg-transparent text-atc-dim'"
+              :title="captionEnabled ? 'Disable captions' : 'Enable captions'"
             >
-              <template v-if="cap.isTemp">
-                <span class="animate-pulse text-atc-faint text-[12px]">Transcribing…</span>
-              </template>
-              <template v-else>
-                {{ i === visible.length - 1 ? displayedText : (cap.caption || cap.details || 'UNINTELLIGIBLE') }}
-                <span v-if="i === visible.length - 1 && typing" class="inline-block ml-0.5 text-atc-orange animate-caret">▍</span>
-              </template>
-            </div>
-          </div>
-
-          <!-- Speaking indicator -->
-          <div v-if="connectionState === 'SPEAKING'" class="flex items-center gap-2">
-            <div class="flex items-center gap-1.5 px-2 py-1 rounded bg-red-500/10 text-red-500 font-mono text-[9px] font-bold uppercase tracking-wider">
-              <div class="flex gap-0.5 items-end h-2">
-                <div v-for="j in 3" :key="j" class="w-0.5 bg-current rounded-full" :style="`height:${[8,5,7][j-1]}px;animation:eqBar ${[1,1.2,0.8][j-1]}s infinite alternate`" />
+              <MessageSquare v-if="captionEnabled" class="w-4 h-4" :stroke-width="2" />
+              <MessageSquareOff v-else class="w-4 h-4" :stroke-width="2" />
+            </button>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2 font-mono text-[9px] tracking-[1.4px] uppercase text-atc-faint">
+                <span>Transcript</span>
+                <span class="text-atc-dim">{{ counts.atc }} twr</span>
+                <span class="text-atc-dim">{{ counts.plane }} acft</span>
               </div>
-              Speaking
+              <div class="truncate text-[13px] font-semibold text-atc-text">
+                {{ transcriptPreview }}
+              </div>
             </div>
           </div>
 
-          <!-- Empty state -->
-          <div v-if="visible.length === 0 && connectionState !== 'SPEAKING' && activeFeedId" class="flex flex-col items-center justify-center py-8 opacity-20">
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" class="mb-2 animate-pulse"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-            <p class="font-sans italic text-[12px]">Awaiting Transmission</p>
-          </div>
+          <section class="bottom-dock-player flex min-h-11 items-center gap-2.5 rounded-[20px] border border-white/10 bg-white/[0.045] px-2.5">
+            <div class="player-copy min-w-0 flex-1">
+              <div class="truncate text-[13px] font-bold">{{ activeFeed?.name || 'No feed selected' }}</div>
+              <div class="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-atc-dim">
+                <span class="inline-flex items-center gap-1 text-atc-mint">
+                  <span class="w-1.5 h-1.5 rounded-full bg-atc-mint animate-pulse-dot" />
+                  {{ connectionStateLabel }}
+                </span>
+                <span class="player-time inline-flex items-baseline justify-end tabular-nums">
+                  <NumberFlow
+                    class="player-time-flow"
+                    :value="sessionMinutes"
+                    :format="{ minimumIntegerDigits: 2, maximumFractionDigits: 0 }"
+                  /><span class="player-time-separator">:</span><NumberFlow
+                    class="player-time-flow"
+                    :value="sessionSeconds"
+                    :format="{ minimumIntegerDigits: 2, maximumFractionDigits: 0 }"
+                  />
+                </span>
+              </div>
+            </div>
 
-          <div ref="streamEnd" />
+            <div class="flex flex-shrink-0 gap-1">
+              <button
+                @click="togglePlayback"
+                class="transport-button grid h-9 w-9 place-items-center rounded-full shadow-lg disabled:cursor-default disabled:opacity-50"
+                :class="isPlaying ? 'transport-button--stop' : 'transport-button--play'"
+                :disabled="!isPlaying && !activeFeed"
+                :title="isPlaying ? 'Stop audio' : 'Start audio'"
+              >
+                <Transition name="transport-icon" mode="out-in">
+                  <Square v-if="isPlaying" key="stop" class="w-3 h-3 fill-current" :stroke-width="0" />
+                  <Play v-else key="play" class="w-4 h-4 fill-current" :stroke-width="0" />
+                </Transition>
+              </button>
+            </div>
+          </section>
         </div>
       </div>
 
@@ -299,10 +275,11 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ChevronDown, ListFilter, MessageSquare, MessageSquareOff, Play, Square } from 'lucide-vue-next'
+import NumberFlow from '@number-flow/vue'
 import KPICell from '../ui/KPICell.vue'
 import AirportMap from '../map/AirportMap.vue'
-import Waveform from '../ui/Waveform.vue'
 import { useMetar } from '../../composables/useMetar.js'
 import { useAircraftPositions } from '../../composables/useAircraftPositions.js'
 
@@ -317,12 +294,13 @@ const props = defineProps({
   analyser:        { type: Object,  default: null },
 })
 
-const emit = defineEmits(['back', 'select-feed', 'toggle-play', 'stop', 'download'])
+const emit = defineEmits(['back', 'select-feed', 'toggle-play', 'stop'])
 
 // ── Feed filter ────────────────────────────────────────────────────────────
 const feedTabs      = ['All', 'Twr', 'Gnd', 'App', 'Ctr']
 const feedTabLabels = { Twr: 'Tower', Gnd: 'Ground', App: 'Approach', Ctr: 'Center' }
 const feedFilter    = ref('All')
+const feedMenuOpen  = ref(false)
 
 const filteredChannels = computed(() => {
   if (feedFilter.value === 'All') return props.channels
@@ -341,7 +319,10 @@ const isHighTraffic = (ch) => {
 }
 
 const activeFeed = computed(() => props.channels?.find(c => c.id === props.activeFeedId) || null)
-const selectFeed = (ch) => emit('select-feed', ch)
+const selectFeed = (ch) => {
+  feedMenuOpen.value = false
+  emit('select-feed', ch)
+}
 
 // ── METAR ──────────────────────────────────────────────────────────────────
 const icaoRef = computed(() => props.icao)
@@ -369,23 +350,28 @@ const fmtUpdated = (d) => {
 
 const mapContainerEl = ref(null)
 
-// ── Speaker metadata ───────────────────────────────────────────────────────
-const SPEAKERS = {
-  atc:     { label: 'ATC',  color: '#FF5A1F' },
-  ATC:     { label: 'ATC',  color: '#FF5A1F' },
-  plane:   { label: 'ACFT', color: '#34d399' },
-  PLANE:   { label: 'ACFT', color: '#34d399' },
-  unknown: { label: 'UNK',  color: '#8aa0b4' },
-}
-const speakerMeta  = (s) => SPEAKERS[s] || SPEAKERS.unknown
-const speakerStyle = (s) => {
-  const c = speakerMeta(s).color
-  return { color: c, borderColor: `${c}55`, background: `${c}10` }
-}
-
 const connectionStateLabel = computed(() => ({
   IDLE: 'Idle', LISTENING: 'Streaming', SPEAKING: 'Speaking', TRANSCRIBING: 'Transcribing…',
 }[props.connectionState] || 'Connecting…'))
+
+const ceilingInfo = computed(() => {
+  const match = metar.value?.ceiling?.match(/^([A-Z]+)\s+([\d,]+)\s+ft$/)
+  if (!match) return null
+  return {
+    cover: match[1],
+    base: Number(match[2].replaceAll(',', '')),
+  }
+})
+
+const visInfo = computed(() => {
+  const raw = metar.value?.vis
+  const match = raw?.match(/^(\d+(?:\.\d+)?)(\+)?\s*SM$/)
+  if (!match) return null
+  return {
+    value: Number(match[1]),
+    plus: Boolean(match[2]),
+  }
+})
 
 // ── Caption toggle ──────────────────────────────────────────────────────────
 const captionEnabled = ref(localStorage.getItem('caption_enabled') !== 'false')
@@ -398,68 +384,298 @@ const toggleCaption = () => {
 const realCaptions = computed(() => props.captions || [])
 const visible      = computed(() => captionEnabled.value ? realCaptions.value : [])
 
+const latestCaption = computed(() => visible.value[visible.value.length - 1] || null)
+const transcriptPreview = computed(() => {
+  if (!captionEnabled.value) return 'Captions off'
+  if (props.connectionState === 'SPEAKING') return 'Speaking...'
+  if (props.connectionState === 'TRANSCRIBING') return 'Transcribing...'
+  const cap = latestCaption.value
+  if (!cap) return activeFeed.value ? 'Awaiting transmission' : 'Select a feed to begin'
+  if (cap.isTemp) return 'Transcribing...'
+  return displayedText.value || cap.caption || cap.details || 'Unintelligible'
+})
+
 const counts = computed(() => ({
   all:   realCaptions.value.length,
   atc:   realCaptions.value.filter(c => ['atc','ATC'].includes(c.speaker)).length,
   plane: realCaptions.value.filter(c => ['plane','PLANE'].includes(c.speaker)).length,
 }))
 
-// ── Callsign parser ────────────────────────────────────────────────────────
-const AIRLINES = ['DELTA','UNITED','SOUTHWEST','AMERICAN','ALASKA','JETBLUE','FEDEX','UPS','HAWAIIAN','CACTUS','SKYWEST']
-const parseCallsign = (text) => {
-  if (!text) return null
-  const m = text.match(new RegExp(`\\b(${AIRLINES.join('|')})\\b\\s+([0-9A-Z]+)`, 'i'))
-  return m ? `${m[1]} ${m[2]}`.toUpperCase() : null
-}
-
-// ── Typewriter effect ──────────────────────────────────────────────────────
-const streamEl      = ref(null)
-const streamEnd     = ref(null)
+// ── Typewriter preview ─────────────────────────────────────────────────────
 const displayedText = ref('')
-const typing        = ref(false)
 let typeTimer = null
 
-watch(visible, async (newCaps) => {
+watch(visible, (newCaps) => {
   const last = newCaps[newCaps.length - 1]
   if (!last || last.isTemp) return
   const text = last.caption || last.details || ''
   if (!text) return
   clearInterval(typeTimer)
   displayedText.value = ''
-  typing.value = true
   let i = 0
   typeTimer = setInterval(() => {
     i++
     displayedText.value = text.slice(0, i)
-    if (i >= text.length) { clearInterval(typeTimer); typing.value = false }
+    if (i >= text.length) clearInterval(typeTimer)
   }, 18)
-  await nextTick()
-  streamEnd.value?.scrollIntoView({ behavior: 'smooth' })
 }, { deep: true })
 
 // ── Session timer ──────────────────────────────────────────────────────────
-const sessionElapsed = ref('00:00')
-const sessionStart   = ref(Date.now())
+const sessionElapsedSeconds = ref(0)
+const sessionStart          = ref(Date.now())
 let sessionTimer = null
 
 const tickSession = () => {
-  const s = Math.floor((Date.now() - sessionStart.value) / 1000)
-  sessionElapsed.value = `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`
+  if (!props.isPlaying) return
+  sessionElapsedSeconds.value = Math.floor((Date.now() - sessionStart.value) / 1000)
 }
 
-watch(() => props.activeFeedId, () => { sessionStart.value = Date.now(); sessionElapsed.value = '00:00' })
+const sessionMinutes = computed(() => Math.floor(sessionElapsedSeconds.value / 60))
+const sessionSeconds = computed(() => sessionElapsedSeconds.value % 60)
+
+const resetSessionTimer = () => {
+  sessionStart.value = Date.now()
+  sessionElapsedSeconds.value = 0
+}
+
+const startPlayback = () => {
+  if (props.isPlaying) return
+  resetSessionTimer()
+  emit('toggle-play')
+}
+
+const stopPlayback = () => {
+  resetSessionTimer()
+  emit('stop')
+}
+
+const togglePlayback = () => {
+  if (props.isPlaying) {
+    stopPlayback()
+    return
+  }
+  startPlayback()
+}
+
+watch(() => props.activeFeedId, () => {
+  resetSessionTimer()
+})
+
+watch(() => props.isPlaying, (playing, wasPlaying) => {
+  if (playing && !wasPlaying) {
+    sessionStart.value = Date.now() - sessionElapsedSeconds.value * 1000
+    tickSession()
+  }
+  if (!playing && wasPlaying) {
+    resetSessionTimer()
+  }
+})
 
 onMounted(() => { tickSession(); sessionTimer = setInterval(tickSession, 1000) })
 onUnmounted(() => {
   clearInterval(sessionTimer)
   clearInterval(typeTimer)
 })
-
-// ── Zulu time formatter ────────────────────────────────────────────────────
-const fmtZulu = (ts) => {
-  if (!ts) return ''
-  const d = new Date(ts)
-  const pad = n => String(n).padStart(2, '0')
-  return `${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
-}
 </script>
+
+<style scoped>
+.kpi-value {
+  align-items: baseline;
+  color: var(--atc-text);
+  display: flex;
+  flex-wrap: wrap;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 21px;
+  font-weight: 700;
+  line-height: 1.05;
+  min-width: 0;
+}
+
+.kpi-number-flow {
+  font-variant-numeric: tabular-nums;
+  line-height: 0.9;
+}
+
+.bottom-dock-feed {
+  flex: 1 1 210px;
+  min-width: 132px;
+  max-width: 245px;
+}
+
+.bottom-dock-transcript {
+  flex: 2 2 260px;
+  min-width: 142px;
+}
+
+.bottom-dock-player {
+  flex: 1 1 285px;
+  min-width: 224px;
+}
+
+.player-time {
+  min-width: 4.4ch;
+}
+
+.player-time-flow {
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.player-time-separator {
+  color: var(--atc-faint);
+  padding: 0 0.5px;
+}
+
+.kpi-number-flow::part(suffix),
+.kpi-unit {
+  color: var(--atc-dim);
+  font-size: 0.58em;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.player-time-flow::part(suffix) {
+  display: none;
+}
+
+.transport-button {
+  transition:
+    background-color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 140ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.transport-button:not(:disabled):active {
+  transform: scale(0.94);
+}
+
+.transport-button--play {
+  background: rgba(250, 250, 250, 0.96);
+  box-shadow: 0 10px 28px rgba(255, 255, 255, 0.16), 0 0 0 1px rgba(255, 255, 255, 0.55) inset;
+  color: #0a0a0b;
+}
+
+.transport-button--play:not(:disabled):hover {
+  background: #ffffff;
+  box-shadow: 0 12px 32px rgba(255, 255, 255, 0.22), 0 0 0 1px rgba(255, 255, 255, 0.7) inset;
+}
+
+.transport-button--play:disabled {
+  background: rgba(250, 250, 250, 0.9);
+  color: #0a0a0b;
+  opacity: 0.72;
+}
+
+.transport-button--stop {
+  background: var(--atc-red);
+  box-shadow: 0 10px 28px rgba(255, 59, 48, 0.28), 0 0 0 1px rgba(255, 255, 255, 0.16) inset;
+  color: #ffffff;
+}
+
+.transport-button--stop:hover {
+  box-shadow: 0 12px 34px rgba(255, 59, 48, 0.36), 0 0 0 1px rgba(255, 255, 255, 0.2) inset;
+  filter: brightness(1.06);
+}
+
+.transport-icon-enter-active,
+.transport-icon-leave-active {
+  transition:
+    opacity 120ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 120ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.transport-icon-enter-from {
+  opacity: 0;
+  transform: scale(0.72) rotate(-18deg);
+}
+
+.transport-icon-leave-to {
+  opacity: 0;
+  transform: scale(0.72) rotate(18deg);
+}
+
+.feed-dropup-enter-active,
+.feed-dropup-leave-active {
+  transition:
+    opacity 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: bottom left;
+}
+
+.feed-dropup-enter-from,
+.feed-dropup-leave-to {
+  opacity: 0;
+  transform: translateY(14px) scale(0.985);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feed-dropup-enter-active,
+  .feed-dropup-leave-active,
+  .transport-button,
+  .transport-icon-enter-active,
+  .transport-icon-leave-active {
+    transition-duration: 1ms;
+  }
+}
+
+@media (max-width: 940px) {
+  .bottom-dock {
+    gap: 6px;
+    padding: 6px;
+  }
+
+  .bottom-dock-feed {
+    flex-basis: 150px;
+    max-width: 210px;
+  }
+
+  .bottom-dock-transcript {
+    flex-basis: 170px;
+    flex-shrink: 3;
+  }
+
+  .bottom-dock-player {
+    flex-basis: 230px;
+    min-width: 196px;
+  }
+}
+
+@media (max-width: 720px) {
+  .bottom-dock {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .bottom-dock-feed,
+  .bottom-dock-transcript,
+  .bottom-dock-player {
+    max-width: none;
+  }
+
+  .bottom-dock-feed {
+    flex: 1 1 128px;
+  }
+
+  .bottom-dock-transcript {
+    flex: 999 1 190px;
+    order: 3;
+    width: 100%;
+  }
+
+  .bottom-dock-player {
+    flex: 1 1 210px;
+  }
+}
+
+@media (max-width: 520px) {
+  .player-copy > div:first-child,
+  .player-copy .text-atc-mint {
+    display: none;
+  }
+
+  .bottom-dock-player {
+    min-width: 168px;
+  }
+}
+</style>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -23,9 +23,8 @@
       :analyser="analyserRef"
       @back="handleBack"
       @select-feed="handleSelectFeed"
-      @toggle-play="togglePlay"
+      @toggle-play="handleStart"
       @stop="handleStop"
-      @download="handleDownload"
     />
   </transition>
 </template>
@@ -52,7 +51,6 @@ const {
   handleSearch,
   connect,
   disconnect,
-  togglePlay,
 } = inject('liveATC')
 
 const currentIcao = ref('')
@@ -79,6 +77,12 @@ const handleSelectFeed = async (channel) => {
 
 const handleStop = () => {
   disconnect()
+}
+
+const handleStart = async () => {
+  if (!activeChannel.value) return
+  disconnect()
+  await connect()
 }
 
 const handleBack = () => {
@@ -118,26 +122,4 @@ watch(() => route.params, ({ icao, channel }) => {
   }
 })
 
-// ── Download ──────────────────────────────────────────────────────────────
-
-const handleDownload = () => {
-  if (!captions.value?.length) return
-  const lines = captions.value
-    .filter(c => !c.isTemp && (c.caption || c.details))
-    .map(c => {
-      const ts      = new Date(c.timestamp).toISOString()
-      const speaker = c.speaker || 'UNK'
-      const text    = c.caption || c.details || ''
-      return `[${ts}] ${speaker}: ${text}`
-    })
-    .join('\n')
-
-  const blob = new Blob([lines], { type: 'text/plain' })
-  const url  = URL.createObjectURL(blob)
-  const a    = document.createElement('a')
-  a.href     = url
-  a.download = `${currentIcao.value}_captions_${Date.now()}.txt`
-  a.click()
-  URL.revokeObjectURL(url)
-}
 </script>


### PR DESCRIPTION
## Summary
- Move feed selection, transcript preview, and player into a compact bottom dock
- Simplify playback into a single start/stop control with animated states and fresh-start semantics
- Polish METAR formatting with NumberFlow, remove the status KPI, and disable map dragging

## Verification
- Browser refresh on local Vite app: no console errors
- Player stop preserves feed selection and resets elapsed time
- `git diff --check`
- `pnpm --dir frontend build` currently blocked locally by missing optional Rollup package `@rollup/rollup-darwin-x64`
