### PR TITLE
Use gradient map chrome and fast aircraft telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# LiveATC Caption — Codex Guide
+
+## Dev environment
+
+Start backend + frontend together:
+
+```bash
+make dev
+```
+
+Backend runs on `http://localhost:8000`, frontend on `http://localhost:5173`. Ctrl-C stops both.
+
+## Stack
+
+- **Backend**: FastAPI + uvicorn, managed by `uv`. Entry point: `backend/main.py`.
+- **Frontend**: Vue 3 + Vite + Tailwind + DaisyUI, managed by `pnpm` (installed via Homebrew).
+- **Audio pipeline**: PyAV decodes the LiveATC stream → webrtcvad VAD → faster-whisper STT → Codex Haiku parsing. All runs server-side; PCM audio and captions flow over a single WebSocket to the browser.
+
+## Key paths
+
+| Path | What |
+|---|---|
+| `backend/api/router/caption.py` | WebSocket endpoint — multiplexes PCM audio + JSON captions |
+| `backend/services/base_transcriber.py` | Shared VAD loop, audio queues, stream_audio() |
+| `backend/services/claude_transcriber.py` | Whisper STT + Codex Haiku parsing |
+| `backend/services/rag_service.py` | Airport context: runways, callsigns, METAR |
+| `frontend/src/composables/useLiveATC.js` | All audio/WebSocket/caption state |
+| `frontend/public/playback-processor.js` | AudioWorklet ring-buffer PCM player |
+| `frontend/src/views/SettingsView.vue` | Settings: API key + transcription params |
+
+## Linting
+
+```bash
+cd backend && uvx ruff check . && uvx ruff format --check .
+```
+
+## Tests
+
+```bash
+cd backend && .venv/bin/python -m pytest tests/ -v
+```
+
+## API key
+
+Set `ANTHROPIC_API_KEY` in `backend/.env`. The env var always wins over any frontend-passed key.

--- a/frontend/src/components/map/AirportMap.vue
+++ b/frontend/src/components/map/AirportMap.vue
@@ -20,9 +20,10 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { createApp, h, ref, shallowRef, onMounted, onUnmounted, watch } from 'vue'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
+import NumberFlow from '@number-flow/vue'
 
 const props = defineProps({
   icao:     { type: String,  default: '' },
@@ -129,7 +130,63 @@ const initMap = () => {
   sizeObs.observe(mapEl.value)
 }
 
-const makeAcIcon = (color, label, rot = 0, showArrow = true) => {
+const wholeNumberFormat = { maximumFractionDigits: 0 }
+
+const escapeHtml = (value) => String(value)
+  .replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;')
+  .replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;')
+  .replaceAll("'", '&#39;')
+
+const formatTelemetryValue = (value) => {
+  if (value == null || value === '' || value === 'ground') return null
+  const number = Number(value)
+  return Number.isFinite(number) ? Math.round(number) : null
+}
+
+const syncNumberFlow = (root, selector, value, suffix) => {
+  const host = root?.querySelector(selector)
+  if (!host || value == null) return
+
+  if (!host.__numberFlowApp) {
+    const currentValue = shallowRef(value)
+    const app = createApp({
+      render: () => h(NumberFlow, {
+        class: 'aircraft-number-flow',
+        value: currentValue.value,
+        suffix,
+        format: wholeNumberFormat,
+      }),
+    })
+    app.mount(host)
+    host.__numberFlowApp = app
+    host.__numberFlowValue = currentValue
+  } else {
+    host.__numberFlowValue.value = value
+  }
+}
+
+const unmountAircraftTelemetry = (marker) => {
+  marker?.getElement()?.querySelectorAll('[data-aircraft-flow]').forEach((host) => {
+    host.__numberFlowApp?.unmount()
+    delete host.__numberFlowApp
+    delete host.__numberFlowValue
+  })
+}
+
+const syncAircraftTelemetry = (marker, ac) => {
+  const root = marker?.getElement()
+  if (!root) return
+  syncNumberFlow(root, '[data-aircraft-flow="speed"]', formatTelemetryValue(ac.velocity), 'kt')
+  syncNumberFlow(root, '[data-aircraft-flow="altitude"]', formatTelemetryValue(ac.altitude), 'ft')
+}
+
+const queueAircraftTelemetrySync = (marker, ac) => {
+  requestAnimationFrame(() => syncAircraftTelemetry(marker, ac))
+}
+
+const makeAcIcon = (color, label, rot = 0, showArrow = true, hasTelemetry = false) => {
   const symbol = showArrow
     ? `<svg width="18" height="18" viewBox="0 0 24 24" style="transform:rotate(${rot}deg);filter:drop-shadow(0 0 4px ${color})">
         <path d="M12 2L16 20L12 17L8 20Z" fill="${color}"/>
@@ -137,11 +194,24 @@ const makeAcIcon = (color, label, rot = 0, showArrow = true) => {
     : `<svg width="7" height="7" viewBox="0 0 7 7" style="filter:drop-shadow(0 0 3px ${color});margin:5.5px">
         <circle cx="3.5" cy="3.5" r="3.5" fill="${color}"/>
        </svg>`
+  const safeLabel = escapeHtml(label)
+  const labelTop = showArrow && hasTelemetry ? '-4px' : '2px'
+  const telemetryLine = showArrow && hasTelemetry
+    ? `<div class="aircraft-telemetry">
+        <span data-aircraft-flow="speed"></span>
+        <span class="aircraft-telemetry-separator">|</span>
+        <span data-aircraft-flow="altitude"></span>
+      </div>`
+    : ''
+
   return L.divIcon({
     className: '',
     html: `<div style="position:relative;display:flex;align-items:center">
       ${symbol}
-      <div style="position:absolute;left:${showArrow ? 22 : 18}px;top:2px;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:600;color:${color};white-space:nowrap;text-shadow:0 0 4px #0a0a0b,0 0 6px #0a0a0b;letter-spacing:0.3px">${label}</div>
+      <div class="aircraft-label" style="left:${showArrow ? 22 : 18}px;top:${labelTop};color:${color}">
+        <div class="aircraft-label-title">${safeLabel}</div>
+        ${telemetryLine}
+      </div>
     </div>`,
     iconSize: [18, 18],
     iconAnchor: [9, 9],
@@ -162,6 +232,7 @@ const updateAircraft = () => {
     const color = ac.onGround ? '#34d399' : showArrow ? props.accent : '#ffb347'
     const label = (ac.callsign || ac.icao24 || '').trim()
     const rot   = Math.round(ac.track || 0)
+    const hasTelemetry = !ac.onGround && showArrow && formatTelemetryValue(ac.velocity) != null && formatTelemetryValue(ac.altitude) != null
 
     if (acMarkersMap.has(ac.icao24)) {
       const entry = acMarkersMap.get(ac.icao24)
@@ -174,24 +245,32 @@ const updateAircraft = () => {
       entry.track     = ac.track ?? 0
       entry.isAnimated = isAnimated
       // Refresh icon only when appearance changes
-      if (color !== entry.color || label !== entry.label || rot !== entry.rot || showArrow !== entry.showArrow) {
-        entry.marker.setIcon(makeAcIcon(color, label, rot, showArrow))
+      if (color !== entry.color || label !== entry.label || rot !== entry.rot || showArrow !== entry.showArrow || hasTelemetry !== entry.hasTelemetry) {
+        unmountAircraftTelemetry(entry.marker)
+        entry.marker.setIcon(makeAcIcon(color, label, rot, showArrow, hasTelemetry))
         entry.color = color; entry.label = label; entry.rot = rot; entry.showArrow = showArrow
+        entry.hasTelemetry = hasTelemetry
       }
+      if (hasTelemetry) queueAircraftTelemetrySync(entry.marker, ac)
     } else {
-      const m = L.marker([ac.lat, ac.lon], { icon: makeAcIcon(color, label, rot, showArrow) }).addTo(map)
+      const m = L.marker([ac.lat, ac.lon], { icon: makeAcIcon(color, label, rot, showArrow, hasTelemetry) }).addTo(map)
       acMarkersMap.set(ac.icao24, {
-        marker: m, color, label, rot, showArrow,
+        marker: m, color, label, rot, showArrow, hasTelemetry,
         baseLat: ac.lat, baseLon: ac.lon, baseTime: now,
         velocity: vel, track: ac.track ?? 0,
         isAnimated,
       })
+      if (hasTelemetry) queueAircraftTelemetrySync(m, ac)
     }
   })
 
   // Remove stale markers
   for (const [id, entry] of acMarkersMap) {
-    if (!seen.has(id)) { entry.marker.remove(); acMarkersMap.delete(id) }
+    if (!seen.has(id)) {
+      unmountAircraftTelemetry(entry.marker)
+      entry.marker.remove()
+      acMarkersMap.delete(id)
+    }
   }
 }
 
@@ -208,6 +287,7 @@ onMounted(initMap)
 onUnmounted(() => {
   stopRaf()
   sizeObs?.disconnect()
+  for (const [, entry] of acMarkersMap) unmountAircraftTelemetry(entry.marker)
   acMarkersMap.clear()
   if (map) { map.remove(); map = null }
 })
@@ -218,5 +298,48 @@ onUnmounted(() => {
    snap on poll which is imperceptible at low speeds. */
 .leaflet-marker-icon {
   transition: none;
+}
+
+.aircraft-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  line-height: 1.05;
+  position: absolute;
+  text-shadow: 0 0 4px #0a0a0b, 0 0 7px #0a0a0b;
+  white-space: nowrap;
+}
+
+.aircraft-label-title {
+  font-size: 10px;
+}
+
+.aircraft-telemetry {
+  align-items: baseline;
+  color: rgba(245, 245, 247, 0.86);
+  display: flex;
+  font-size: 8.5px;
+  font-weight: 700;
+  gap: 3px;
+  letter-spacing: 0;
+  margin-top: 1px;
+  text-shadow: 0 0 4px #0a0a0b, 0 0 8px #0a0a0b;
+}
+
+.aircraft-number-flow {
+  font-variant-numeric: tabular-nums;
+}
+
+.aircraft-number-flow::part(suffix) {
+  color: rgba(245, 245, 247, 0.54);
+  font-size: 0.86em;
+  font-weight: 700;
+  margin-left: 1px;
+}
+
+.aircraft-telemetry-separator {
+  color: rgba(255, 90, 31, 0.72);
+  font-size: 0.9em;
 }
 </style>

--- a/frontend/src/components/screens/AirportCaptionScreen.vue
+++ b/frontend/src/components/screens/AirportCaptionScreen.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="flex flex-col h-screen bg-atc-bg text-atc-text font-sans overflow-hidden">
+  <div class="relative flex flex-col h-screen bg-atc-bg text-atc-text font-sans overflow-hidden">
 
     <!-- ─── MASTHEAD ─────────────────────────────────────────────────────── -->
     <section
-      class="flex-shrink-0 px-10 py-4 border-b border-atc-line"
-      style="background:radial-gradient(ellipse at 90% 0%, rgba(255,90,31,0.07), transparent 45%), #0a0a0b"
+      class="absolute inset-x-0 top-0 z-20 px-10 pt-4 pb-10 pointer-events-none"
+      style="background:linear-gradient(to bottom, rgba(10,10,11,0.98) 0%, rgba(10,10,11,0.88) 58%, rgba(10,10,11,0) 100%)"
     >
       <!-- Breadcrumb / back + title on one line -->
-      <div class="flex items-center gap-4 mb-3">
+      <div class="flex items-center gap-4 mb-3 pointer-events-auto">
         <button
           class="flex items-center gap-1.5 hover:text-atc-text transition-colors cursor-pointer bg-transparent border-none p-0 font-mono text-[11px] tracking-[0.5px] uppercase text-atc-dim flex-shrink-0"
           @click="$emit('back')"
@@ -36,7 +36,7 @@
 
       <!-- KPI strip -->
       <div
-        class="grid border border-atc-line rounded-xl overflow-hidden"
+        class="grid border border-atc-line rounded-xl overflow-hidden pointer-events-auto"
         style="grid-template-columns:repeat(5,1fr);gap:1px;background:rgba(255,255,255,0.07)"
       >
         <KPICell label="WIND">
@@ -132,7 +132,11 @@
       </div>
 
       <!-- ── BOTTOM DOCK: compact mobile-friendly controls ──────────────── -->
-      <div class="absolute inset-x-3 bottom-3 z-20 sm:inset-x-4">
+      <div
+        class="absolute inset-x-0 bottom-0 z-20 px-3 pt-14 pb-3 sm:px-4"
+        style="background:linear-gradient(to top, rgba(10,10,11,0.98) 0%, rgba(10,10,11,0.82) 48%, rgba(10,10,11,0) 100%)"
+      >
+        <div class="relative">
         <Transition name="feed-dropup">
           <div
             v-if="feedMenuOpen"
@@ -186,8 +190,7 @@
         </Transition>
 
         <div
-          class="bottom-dock flex min-h-[68px] flex-row items-center gap-2 rounded-[26px] border border-white/15 p-2 shadow-2xl"
-          style="background:rgba(10,10,11,0.91);backdrop-filter:blur(22px);box-shadow:0 18px 58px rgba(0,0,0,0.52)"
+          class="bottom-dock flex min-h-[68px] flex-row items-center gap-2"
         >
           <button
             class="bottom-dock-feed flex min-h-11 items-center gap-2.5 rounded-[20px] border border-white/10 bg-white/[0.045] px-3 text-left transition-colors hover:bg-white/8"
@@ -267,6 +270,7 @@
               </button>
             </div>
           </section>
+        </div>
         </div>
       </div>
 
@@ -622,7 +626,6 @@ onUnmounted(() => {
 @media (max-width: 940px) {
   .bottom-dock {
     gap: 6px;
-    padding: 6px;
   }
 
   .bottom-dock-feed {


### PR DESCRIPTION
## Summary
- fade the top masthead and bottom dock chrome into the map instead of solid/rounded containers
- add NumberFlow speed and altitude readouts under fast airborne aircraft labels
- include the repo AGENTS.md guide

## Verification
- git diff --check
- Vite dev server transforms AirportMap.vue successfully

Note: frontend build is still blocked locally by missing optional Rollup package @rollup/rollup-darwin-x64 in node_modules.