### PR TITLE
Format backend files for CI

### DIFF
--- a/backend/api/router/caption.py
+++ b/backend/api/router/caption.py
@@ -55,9 +55,7 @@ async def websocket_caption(
 
         while transcriber.is_running:
             try:
-                chunk = await asyncio.to_thread(
-                    transcriber.audio_queue.get, True, 0.05
-                )
+                chunk = await asyncio.to_thread(transcriber.audio_queue.get, True, 0.05)
             except queue.Empty:
                 continue
 
@@ -108,7 +106,9 @@ async def websocket_caption(
                 while len(buf) >= frame_bytes:
                     frame, buf = buf[:frame_bytes], buf[frame_bytes:]
                     try:
-                        is_speech = vad_instance.is_speech(frame, transcriber.SAMPLE_RATE)
+                        is_speech = vad_instance.is_speech(
+                            frame, transcriber.SAMPLE_RATE
+                        )
                     except Exception:
                         is_speech = False
 
@@ -127,8 +127,12 @@ async def websocket_caption(
                         ):
                             if len(speech_buf) > transcriber.MIN_SPEECH_BYTES:
                                 print("  <<< [TRANSCRIBING]")
-                                end_offset = transcriber.bytes_queued / 32000 + sync_offset
-                                asyncio.create_task(_process(bytes(speech_buf), end_offset))
+                                end_offset = (
+                                    transcriber.bytes_queued / 32000 + sync_offset
+                                )
+                                asyncio.create_task(
+                                    _process(bytes(speech_buf), end_offset)
+                                )
                             speech_buf = b""
                             in_speech = False
                             silence_n = 0
@@ -166,7 +170,9 @@ async def websocket_caption(
             t.cancel()
         for t in done:
             exc = t.exception()
-            if exc and not isinstance(exc, (WebSocketDisconnect, asyncio.CancelledError)):
+            if exc and not isinstance(
+                exc, (WebSocketDisconnect, asyncio.CancelledError)
+            ):
                 print(f"[WS] task error: {exc}")
                 try:
                     await websocket.send_json({"type": "error", "message": str(exc)})

--- a/backend/services/base_transcriber.py
+++ b/backend/services/base_transcriber.py
@@ -4,6 +4,7 @@ BaseTranscriber — shared audio streaming, VAD, and prompt loading.
 Both ClaudeTranscriber and GeminiTranscriber extend this class and only need
 to implement _transcribe_chunk() and transcribe_segment().
 """
+
 import os
 import queue
 import threading

--- a/backend/services/claude_transcriber.py
+++ b/backend/services/claude_transcriber.py
@@ -51,7 +51,9 @@ class ClaudeTranscriber(BaseTranscriber):
         # cases where no server-side key is configured (e.g. personal dev setup).
         resolved = (os.environ.get("ANTHROPIC_API_KEY", "") or api_key or "").strip()
         super().__init__(api_key=resolved)
-        self.client = anthropic.Anthropic(api_key=self.api_key) if self.api_key else None
+        self.client = (
+            anthropic.Anthropic(api_key=self.api_key) if self.api_key else None
+        )
         self._whisper = None
         self._model_size = model_size or WHISPER_MODEL_SIZE
 

--- a/backend/services/gemini_transcriber.py
+++ b/backend/services/gemini_transcriber.py
@@ -37,9 +37,7 @@ class GeminiTranscriber(BaseTranscriber):
                     response_schema=TranscriptionResponse,
                     temperature=0.1,
                 ),
-                contents=[
-                    types.Part.from_bytes(data=wav_data, mime_type="audio/wav")
-                ],
+                contents=[types.Part.from_bytes(data=wav_data, mime_type="audio/wav")],
             )
             if response.text:
                 data = json.loads(response.text)

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -39,7 +39,7 @@ class RAGService:
         self.data = self._load_kb()
 
         # Per-ICAO caches
-        self._airport_ctx: dict[str, str] = {}   # icao → context string
+        self._airport_ctx: dict[str, str] = {}  # icao → context string
         self._runways: dict[str, list[str]] = {}  # icao → ["27L", "09R", …]
         self._coords: dict[str, tuple[float, float]] = {}  # icao → (lat, lon)
         self._callsigns: dict[str, list[str]] = {}  # icao → ["UAL276", …]
@@ -251,9 +251,7 @@ class RAGService:
         if "waypoint_rules" in kb:
             synonyms = kb["waypoint_rules"].get("synonyms", [])
             if not text_hint or any(s.lower() in text_hint.lower() for s in synonyms):
-                parts.append(
-                    f"WAYPOINT RULES: {kb['waypoint_rules']['description']}"
-                )
+                parts.append(f"WAYPOINT RULES: {kb['waypoint_rules']['description']}")
                 for p in kb["waypoint_rules"]["patterns"]:
                     if "instruction" in p:
                         parts.append(f"- {p['instruction']}")
@@ -281,15 +279,23 @@ class RAGService:
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+
 def _runway_spoken(rwy_id: str) -> str:
     """
     Convert a runway identifier to its spoken form.
     "27L" → "TWO SEVEN LEFT", "09" → "ZERO NINER"
     """
     _digit_map = {
-        "0": "ZERO", "1": "ONE", "2": "TWO", "3": "THREE",
-        "4": "FOUR", "5": "FIFE", "6": "SIX", "7": "SEVEN",
-        "8": "EIGHT", "9": "NINER",
+        "0": "ZERO",
+        "1": "ONE",
+        "2": "TWO",
+        "3": "THREE",
+        "4": "FOUR",
+        "5": "FIFE",
+        "6": "SIX",
+        "7": "SEVEN",
+        "8": "EIGHT",
+        "9": "NINER",
     }
     _suffix_map = {"L": "LEFT", "R": "RIGHT", "C": "CENTER"}
 

--- a/backend/tests/test_base_transcriber.py
+++ b/backend/tests/test_base_transcriber.py
@@ -7,6 +7,7 @@ def _make_transcriber():
     # WhisperModel is imported lazily inside _get_whisper(); patch at the source module.
     with patch("faster_whisper.WhisperModel", MagicMock()):
         from services.claude_transcriber import ClaudeTranscriber
+
         t = ClaudeTranscriber(api_key="dummy")
         t.is_running = False
         return t
@@ -44,8 +45,10 @@ def test_stream_audio_pushes_to_both_queues():
     t = _make_transcriber()
     t.is_running = True  # stream_audio() sets this False on completion
 
-    with patch("av.open", return_value=mock_container), \
-         patch("av.AudioResampler", return_value=mock_resampler):
+    with (
+        patch("av.open", return_value=mock_container),
+        patch("av.AudioResampler", return_value=mock_resampler),
+    ):
         t.stream_audio("fake_url")
 
     assert t.chunk_queue.get() == fake_pcm
@@ -61,5 +64,6 @@ def test_model_size_default():
 def test_model_size_override():
     with patch("faster_whisper.WhisperModel", MagicMock()):
         from services.claude_transcriber import ClaudeTranscriber
+
         t = ClaudeTranscriber(api_key="dummy", model_size="small.en")
         assert t._model_size == "small.en"


### PR DESCRIPTION
## Summary
- run Ruff format on backend files that failed CI format check

## Verification
- cd backend && uvx ruff check .
- cd backend && uvx ruff format --check .

Backend tests were not run locally because backend/.venv does not have pytest installed.