### PR TITLE
[codex] Improve aircraft position smoothing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test:aircraft-motion": "node src/utils/aircraftMotion.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/components/map/AirportMap.vue
+++ b/frontend/src/components/map/AirportMap.vue
@@ -24,6 +24,10 @@ import { createApp, h, ref, shallowRef, onMounted, onUnmounted, watch } from 'vu
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import NumberFlow from '@number-flow/vue'
+import {
+  beginAircraftMotionState,
+  calculateAircraftVisualPosition,
+} from '../../utils/aircraftMotion'
 
 const props = defineProps({
   icao:     { type: String,  default: '' },
@@ -39,7 +43,7 @@ const mapReady = ref(false)
 let map = null
 let sizeObs = null
 // Track markers by icao24 for smooth position updates
-// Entry shape: { marker, color, label, rot, baseLat, baseLon, baseTime, velocity, track, isAnimated }
+// Entry shape: { marker, color, label, lat, lon, positionTime, correctionLat, correctionLon, ... }
 const acMarkersMap = new Map()
 
 const latStr = ref('')
@@ -48,25 +52,15 @@ const lonStr = ref('')
 // Dead-reckoning: animate aircraft that exceed this speed (knots)
 const ANIMATE_THRESHOLD_KT = 30
 
-// RAF loop — updates predicted positions at ~60 fps for fast aircraft
+// RAF loop — updates visual aircraft positions on a delayed, latency-aware clock
 let rafId = null
 
 const animateLoop = () => {
   if (!map) return
   const now = Date.now()
   for (const [, entry] of acMarkersMap) {
-    if (!entry.isAnimated) continue
-    const dt = (now - entry.baseTime) / 1000  // seconds since last poll
-    if (dt <= 0) continue
-
-    // 匀速运动: uniform linear motion in the direction of `track`
-    // 1 knot = 0.514444 m/s; track is degrees clockwise from north
-    const mps = entry.velocity * 0.514444
-    const trackRad = (entry.track * Math.PI) / 180
-    const latRad   = (entry.baseLat * Math.PI) / 180
-    const dLat = (mps * Math.cos(trackRad) * dt) / 111_320
-    const dLon = (mps * Math.sin(trackRad) * dt) / (111_320 * Math.cos(latRad))
-    entry.marker.setLatLng([entry.baseLat + dLat, entry.baseLon + dLon])
+    const position = calculateAircraftVisualPosition(entry, now)
+    entry.marker.setLatLng([position.lat, position.lon])
   }
   rafId = requestAnimationFrame(animateLoop)
 }
@@ -236,14 +230,16 @@ const updateAircraft = () => {
 
     if (acMarkersMap.has(ac.icao24)) {
       const entry = acMarkersMap.get(ac.icao24)
-      // Anchor dead-reckoning to the fresh authoritative position
-      entry.marker.setLatLng([ac.lat, ac.lon])
-      entry.baseLat   = ac.lat
-      entry.baseLon   = ac.lon
-      entry.baseTime  = now
-      entry.velocity  = vel
-      entry.track     = ac.track ?? 0
-      entry.isAnimated = isAnimated
+      const currentLatLng = entry.marker.getLatLng()
+      const motionState = beginAircraftMotionState(ac, now, {
+        lat: currentLatLng.lat,
+        lon: currentLatLng.lng,
+      })
+      Object.assign(entry, motionState, {
+        velocity: vel,
+        track: ac.track ?? 0,
+        isAnimated,
+      })
       // Refresh icon only when appearance changes
       if (color !== entry.color || label !== entry.label || rot !== entry.rot || showArrow !== entry.showArrow || hasTelemetry !== entry.hasTelemetry) {
         unmountAircraftTelemetry(entry.marker)
@@ -253,10 +249,12 @@ const updateAircraft = () => {
       }
       if (hasTelemetry) queueAircraftTelemetrySync(entry.marker, ac)
     } else {
-      const m = L.marker([ac.lat, ac.lon], { icon: makeAcIcon(color, label, rot, showArrow, hasTelemetry) }).addTo(map)
+      const motionState = beginAircraftMotionState(ac, now)
+      const visualPosition = calculateAircraftVisualPosition(motionState, now)
+      const m = L.marker([visualPosition.lat, visualPosition.lon], { icon: makeAcIcon(color, label, rot, showArrow, hasTelemetry) }).addTo(map)
       acMarkersMap.set(ac.icao24, {
         marker: m, color, label, rot, showArrow, hasTelemetry,
-        baseLat: ac.lat, baseLon: ac.lon, baseTime: now,
+        ...motionState,
         velocity: vel, track: ac.track ?? 0,
         isAnimated,
       })

--- a/frontend/src/composables/useAircraftPositions.js
+++ b/frontend/src/composables/useAircraftPositions.js
@@ -1,4 +1,5 @@
 import { ref, watch, onUnmounted } from 'vue'
+import { parseAdsbPositionTime } from '../utils/aircraftMotion'
 
 // Proxied through backend — adsb.lol has no CORS headers for browser requests
 const API = '/api/proxy/aircraft/positions'
@@ -22,6 +23,7 @@ export function useAircraftPositions(icaoRef, latRef, lonRef) {
       const res = await fetch(url, { signal: AbortSignal.timeout(14_000) })
       if (!res.ok) throw new Error(`ADS-B HTTP ${res.status}`)
       const json = await res.json()
+      const receiveTime = Date.now()
 
       // adsb.lol response: { ac: [{ hex, flight, lat, lon, alt_baro, gs, track, gnd, ... }] }
       aircraft.value = (json.ac || [])
@@ -35,6 +37,8 @@ export function useAircraftPositions(icaoRef, latRef, lonRef) {
           onGround: a.gnd ?? false,
           velocity: a.gs ?? null,
           track:    a.track ?? 0,
+          positionTime: parseAdsbPositionTime(a, json.now, receiveTime),
+          receiveTime,
         }))
       lastUpdated.value = new Date()
     } catch (e) {

--- a/frontend/src/utils/aircraftMotion.js
+++ b/frontend/src/utils/aircraftMotion.js
@@ -1,0 +1,99 @@
+const KT_TO_MPS = 0.514444
+const METERS_PER_DEGREE_LAT = 111_320
+
+export const VISUAL_DELAY_MS = 750
+export const CORRECTION_DURATION_MS = 750
+export const SLOW_AIRCRAFT_THRESHOLD_KT = 30
+export const FAST_EXTRAPOLATION_LIMIT_MS = 4_000
+export const SLOW_FULL_SPEED_WINDOW_MS = 500
+export const SLOW_EXTRAPOLATION_SCALE = 0.25
+
+const toFiniteNumber = (value) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+const normalizeEpochMs = (value) => {
+  const number = toFiniteNumber(value)
+  if (number == null) return null
+  return number < 10_000_000_000 ? Math.round(number * 1000) : Math.round(number)
+}
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
+
+export const parseAdsbPositionTime = (aircraft, responseNow, receiveTime = Date.now()) => {
+  const serverNow = normalizeEpochMs(responseNow) ?? normalizeEpochMs(receiveTime) ?? Date.now()
+  const ageSeconds = toFiniteNumber(aircraft?.seen_pos ?? aircraft?.seen)
+  if (ageSeconds == null) return serverNow
+  return serverNow - Math.max(0, ageSeconds) * 1000
+}
+
+export const getAircraftExtrapolationLimitMs = (aircraft) => {
+  const velocity = Math.max(0, toFiniteNumber(aircraft?.velocity) ?? 0)
+  return aircraft?.onGround || velocity < SLOW_AIRCRAFT_THRESHOLD_KT
+    ? FAST_EXTRAPOLATION_LIMIT_MS
+    : FAST_EXTRAPOLATION_LIMIT_MS
+}
+
+const getEffectiveElapsedMs = (aircraft, elapsedMs) => {
+  const boundedElapsedMs = clamp(elapsedMs, 0, getAircraftExtrapolationLimitMs(aircraft))
+  const velocity = Math.max(0, toFiniteNumber(aircraft?.velocity) ?? 0)
+  const isSlow = aircraft?.onGround || velocity < SLOW_AIRCRAFT_THRESHOLD_KT
+
+  if (!isSlow || boundedElapsedMs <= SLOW_FULL_SPEED_WINDOW_MS) return boundedElapsedMs
+
+  return SLOW_FULL_SPEED_WINDOW_MS
+    + (boundedElapsedMs - SLOW_FULL_SPEED_WINDOW_MS) * SLOW_EXTRAPOLATION_SCALE
+}
+
+export const projectAircraftPosition = (aircraft, elapsedMs) => {
+  const lat = toFiniteNumber(aircraft?.lat) ?? 0
+  const lon = toFiniteNumber(aircraft?.lon) ?? 0
+  const velocity = Math.max(0, toFiniteNumber(aircraft?.velocity) ?? 0)
+  const track = toFiniteNumber(aircraft?.track) ?? 0
+  const elapsedSeconds = Math.max(0, elapsedMs) / 1000
+
+  if (!velocity || !elapsedSeconds) return { lat, lon }
+
+  const mps = velocity * KT_TO_MPS
+  const trackRad = (track * Math.PI) / 180
+  const latRad = (lat * Math.PI) / 180
+  const dLat = (mps * Math.cos(trackRad) * elapsedSeconds) / METERS_PER_DEGREE_LAT
+  const lonDivisor = METERS_PER_DEGREE_LAT * Math.cos(latRad)
+  const dLon = lonDivisor === 0 ? 0 : (mps * Math.sin(trackRad) * elapsedSeconds) / lonDivisor
+
+  return { lat: lat + dLat, lon: lon + dLon }
+}
+
+const targetPositionForTime = (state, nowMs) => {
+  const positionTime = toFiniteNumber(state.positionTime) ?? nowMs
+  const renderTime = nowMs - VISUAL_DELAY_MS
+  const elapsedMs = getEffectiveElapsedMs(state, renderTime - positionTime)
+  return projectAircraftPosition(state, elapsedMs)
+}
+
+export const beginAircraftMotionState = (aircraft, nowMs = Date.now(), currentVisualPosition = null) => {
+  const target = targetPositionForTime(aircraft, nowMs)
+  const current = currentVisualPosition ?? target
+
+  return {
+    ...aircraft,
+    correctionLat: current.lat - target.lat,
+    correctionLon: current.lon - target.lon,
+    correctionStartTime: nowMs,
+  }
+}
+
+export const calculateAircraftVisualPosition = (state, nowMs = Date.now()) => {
+  const target = targetPositionForTime(state, nowMs)
+  const correctionStartTime = toFiniteNumber(state.correctionStartTime)
+
+  if (correctionStartTime == null) return target
+
+  const progress = clamp((nowMs - correctionStartTime) / CORRECTION_DURATION_MS, 0, 1)
+  const remaining = 1 - progress
+  return {
+    lat: target.lat + (toFiniteNumber(state.correctionLat) ?? 0) * remaining,
+    lon: target.lon + (toFiniteNumber(state.correctionLon) ?? 0) * remaining,
+  }
+}

--- a/frontend/src/utils/aircraftMotion.test.js
+++ b/frontend/src/utils/aircraftMotion.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+
+import {
+  beginAircraftMotionState,
+  calculateAircraftVisualPosition,
+  parseAdsbPositionTime,
+  projectAircraftPosition,
+} from './aircraftMotion.js'
+
+const nearlyEqual = (actual, expected, tolerance = 1e-8) => {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${actual} to be within ${tolerance} of ${expected}`,
+  )
+}
+
+{
+  const responseNow = 1_700_000_003_000
+  const positionTime = parseAdsbPositionTime({ seen_pos: 1.25 }, responseNow, 1_700_000_003_200)
+  assert.equal(positionTime, 1_700_000_001_750)
+}
+
+{
+  const ac = {
+    lat: 33,
+    lon: -118,
+    onGround: true,
+    velocity: 20,
+    track: 0,
+    positionTime: 0,
+  }
+
+  const earlyPosition = calculateAircraftVisualPosition(ac, 1_500)
+  const laterPosition = calculateAircraftVisualPosition(ac, 3_000)
+  const fullSpeedPosition = projectAircraftPosition(ac, 2_250)
+
+  assert.ok(laterPosition.lat > earlyPosition.lat, 'slow aircraft should keep moving while waiting for the next poll')
+  assert.ok(laterPosition.lat < fullSpeedPosition.lat, 'slow aircraft should use reduced extrapolation after the short confidence window')
+  nearlyEqual(laterPosition.lon, ac.lon)
+}
+
+{
+  const staleVisualPosition = projectAircraftPosition({
+    lat: 33,
+    lon: -118,
+    velocity: 80,
+    track: 0,
+  }, 3_000)
+
+  const newSnapshot = {
+    lat: 33.0005,
+    lon: -118,
+    onGround: true,
+    velocity: 12,
+    track: 0,
+    positionTime: 2_500,
+  }
+
+  const state = beginAircraftMotionState(newSnapshot, 3_000, staleVisualPosition)
+  const immediate = calculateAircraftVisualPosition(state, 3_000)
+  const settled = calculateAircraftVisualPosition(state, 3_900)
+  const target = calculateAircraftVisualPosition(newSnapshot, 3_900)
+
+  nearlyEqual(immediate.lat, staleVisualPosition.lat)
+  assert.ok(settled.lat < immediate.lat, 'settled correction should move back from the stale prediction')
+  nearlyEqual(settled.lat, target.lat)
+}


### PR DESCRIPTION
## Summary
- Add timestamp-aware ADS-B aircraft motion helpers and a focused regression test.
- Preserve ADS-B position timing metadata in the frontend aircraft polling composable.
- Render map markers on a delayed visual timeline with smoothed correction and reduced slow-aircraft extrapolation while waiting for the next poll.

## Root Cause
The map treated each received ADS-B point as current at `Date.now()`, even when the source position was already stale. Slow or ground aircraft could then overshoot and snap back. A first cap-only approach also risked visibly stopping slow aircraft before the next 3-second poll arrived.

## Validation
- `pnpm run test:aircraft-motion`
- `pnpm build`

Fixes #25