### PR TITLE
[codex] rename project to ADSBao

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# LiveATC Caption — Codex Guide
+# ADSBao — Codex Guide
 
 ## Dev environment
 
@@ -14,7 +14,7 @@ Backend runs on `http://localhost:8000`, frontend on `http://localhost:5173`. Ct
 
 - **Backend**: FastAPI + uvicorn, managed by `uv`. Entry point: `backend/main.py`.
 - **Frontend**: Vue 3 + Vite + Tailwind + DaisyUI, managed by `pnpm` (installed via Homebrew).
-- **Audio pipeline**: PyAV decodes the LiveATC stream → webrtcvad VAD → faster-whisper STT → Codex Haiku parsing. All runs server-side; PCM audio and captions flow over a single WebSocket to the browser.
+- **Audio pipeline**: Web-delivered airport metadata, METAR, and ADS-B context flow through the backend; live audio streaming is currently disabled in this build.
 
 ## Key paths
 
@@ -24,9 +24,9 @@ Backend runs on `http://localhost:8000`, frontend on `http://localhost:5173`. Ct
 | `backend/services/base_transcriber.py` | Shared VAD loop, audio queues, stream_audio() |
 | `backend/services/claude_transcriber.py` | Whisper STT + Codex Haiku parsing |
 | `backend/services/rag_service.py` | Airport context: runways, callsigns, METAR |
-| `frontend/src/composables/useLiveATC.js` | All audio/WebSocket/caption state |
-| `frontend/public/playback-processor.js` | AudioWorklet ring-buffer PCM player |
-| `frontend/src/views/SettingsView.vue` | Settings: API key + transcription params |
+| `frontend/src/views/HomeView.vue` | Search-to-airport route flow |
+| `frontend/src/components/screens/AirportCaptionScreen.vue` | Airport explorer map + METAR screen |
+| `frontend/src/views/SettingsView.vue` | Lightweight frontend runtime/settings copy |
 
 ## Linting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# LiveATC Caption — Claude Code Guide
+# ADSBao — Claude Code Guide
 
 ## Dev environment
 
@@ -14,7 +14,7 @@ Backend runs on `http://localhost:8000`, frontend on `http://localhost:5173`. Ct
 
 - **Backend**: FastAPI + uvicorn, managed by `uv`. Entry point: `backend/main.py`.
 - **Frontend**: Vue 3 + Vite + Tailwind + DaisyUI, managed by `pnpm` (installed via Homebrew).
-- **Audio pipeline**: PyAV decodes the LiveATC stream → webrtcvad VAD → faster-whisper STT → Claude Haiku parsing. All runs server-side; PCM audio and captions flow over a single WebSocket to the browser.
+- **Audio pipeline**: Web-delivered airport metadata, METAR, and ADS-B context flow through the backend; live audio streaming is currently disabled in this build.
 
 ## Key paths
 
@@ -24,9 +24,9 @@ Backend runs on `http://localhost:8000`, frontend on `http://localhost:5173`. Ct
 | `backend/services/base_transcriber.py` | Shared VAD loop, audio queues, stream_audio() |
 | `backend/services/claude_transcriber.py` | Whisper STT + Claude Haiku parsing |
 | `backend/services/rag_service.py` | Airport context: runways, callsigns, METAR |
-| `frontend/src/composables/useLiveATC.js` | All audio/WebSocket/caption state |
-| `frontend/public/playback-processor.js` | AudioWorklet ring-buffer PCM player |
-| `frontend/src/views/SettingsView.vue` | Settings: API key + transcription params |
+| `frontend/src/views/HomeView.vue` | Search-to-airport route flow |
+| `frontend/src/components/screens/AirportCaptionScreen.vue` | Airport explorer map + METAR screen |
+| `frontend/src/views/SettingsView.vue` | Lightweight frontend runtime/settings copy |
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# LiveATC Caption
+# ADSBao
 
-A modern, real-time transcription HUD for LiveATC audio feeds, powered by Google's Gemini AI.
+A modern airport-monitoring HUD with dynamic airport search, METAR context, and preview caption workflows.
 
 ![Live App Screenshot](screenshot.png)
 
 ## Overview
-LiveATC Caption captures live air traffic control audio streams and provides real-time, HUD-style transcriptions. It uses Voice Activity Detection (VAD) to identify speech and sends filtered audio segments to Gemini for high-accuracy aviation transcription.
+ADSBao provides a search-first airport operations view with weather context, aircraft position overlays, and preview caption workflows. Airport search results are fetched dynamically from a public airport-data service.
 
 ## Tech Stack
 - **AI**: Google Gemini (3.0 Flash Preview) and Anthropic Claude
@@ -20,24 +20,24 @@ LiveATC Caption captures live air traffic control audio streams and provides rea
 
 ```bash
 # Add the tap once
-brew tap orriduck/liveatc-caption https://github.com/orriduck/liveatc-caption
+brew tap orriduck/adsbao https://github.com/orriduck/ADSBao
 
 # Install
-brew install --cask liveatc-caption
+brew install --cask adsbao
 
 # Stay up to date — run after any new release
-brew upgrade --cask liveatc-caption
+brew upgrade --cask adsbao
 ```
 
 ### Direct download
 
-Download the latest `.dmg` or `.app.zip` from the [Releases](https://github.com/orriduck/liveatc-caption/releases) page.
+Download the latest `.dmg` or `.app.zip` from the [Releases](https://github.com/orriduck/ADSBao/releases) page.
 
-> **Note** — LiveATC Caption is not code-signed with an Apple Developer certificate.
+> **Note** — ADSBao is not code-signed with an Apple Developer certificate.
 > On first launch macOS will show a Gatekeeper warning.
 > Open **System Settings → Privacy & Security** and click **Open Anyway**, or run:
 > ```bash
-> xattr -dr com.apple.quarantine "/Applications/LiveATC Caption.app"
+> xattr -dr com.apple.quarantine "/Applications/ADSBao.app"
 > ```
 
 ## Getting Started
@@ -74,7 +74,7 @@ pnpm run dev
 
 The dev server starts on `http://localhost:5173`.
 
-Open [http://localhost:5173](http://localhost:5173) to start listening.
+Open [http://localhost:5173](http://localhost:5173) to start exploring.
 
 ---
 
@@ -91,8 +91,8 @@ We welcome contributions! Here's how to set up the full development environment:
 
 **1. Clone the repo**
 ```bash
-git clone https://github.com/orriduck/liveatc-caption.git
-cd liveatc-caption
+git clone https://github.com/orriduck/ADSBao.git
+cd ADSBao
 ```
 
 **2. Start the backend** (from the repo root)
@@ -127,7 +127,7 @@ Keys can also be entered through the in-app Settings panel without restarting th
 
 ### Project structure
 ```
-liveatc-caption/
+ADSBao/
 ├── backend/          # FastAPI app (Python)
 │   ├── api/          # Route handlers
 │   ├── services/     # Transcription, audio streaming

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from api.router.caption import router as caption_router
 from api.router.proxy import router as proxy_router
 from services.config_store import load_into_env, set_api_key, get_api_key
 
-app = FastAPI(title="LiveATC Caption App")
+app = FastAPI(title="ADSBao App")
 
 # Allow CORS for development
 app.add_middleware(
@@ -23,10 +23,7 @@ app.add_middleware(
 )
 
 app.include_router(search_router, prefix="/api")
-app.include_router(
-    caption_router, prefix="/ws"
-)  # Keep old prefix for now or move transcribe to /api?
-# Ideally transcribe should be under /api/caption
+app.include_router(caption_router, prefix="/ws")
 app.include_router(proxy_router, prefix="/api")
 
 # Serve static files from the frontend build

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ATC Caption</title>
+  <title>ADSBao</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet" />

--- a/frontend/src/components/screens/SearchScreen.vue
+++ b/frontend/src/components/screens/SearchScreen.vue
@@ -105,7 +105,7 @@
     <footer class="flex justify-between items-center px-14 py-5 border-t border-atc-line">
       <div class="flex items-center gap-3.5">
         <Wordmark />
-        <span class="text-[12px] text-atc-faint">v0.4.0 · Airport explorer preview</span>
+        <span class="text-[12px] text-atc-faint">v0.4.0 · ADSBao preview</span>
       </div>
       <div class="flex gap-6 text-[13px] text-atc-dim">
         <span class="cursor-pointer hover:text-atc-text transition-colors">About</span>

--- a/frontend/src/components/ui/Wordmark.vue
+++ b/frontend/src/components/ui/Wordmark.vue
@@ -9,7 +9,7 @@
     </div>
     <div class="leading-none">
       <div class="text-base font-bold tracking-tight text-atc-text" style="letter-spacing:-0.3px">
-        ATC<span class="text-atc-orange">·</span>Caption
+        ADSBao
       </div>
     </div>
   </div>

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -10,10 +10,10 @@
 
       <div class="space-y-8">
         <div class="space-y-4">
-          <h2 class="text-xl uppercase">Airport Explorer</h2>
+          <h2 class="text-xl uppercase">ADSBao</h2>
           <p class="text-sm leading-relaxed opacity-60">
-            This frontend is now an airport explorer focused on airport lookup, weather context, and nearby traffic visualization.
-            The LiveATC player, feed selector, and transcription presentation have been removed from the UI.
+            ADSBao is an airport explorer focused on airport lookup, weather context, and nearby traffic visualization.
+            The previous LiveATC player, feed selector, and transcription presentation have been removed from the UI.
           </p>
         </div>
 
@@ -30,7 +30,7 @@
 
         <div class="flex flex-col gap-4 border-t pt-8">
           <a
-            href="https://github.com/orriduck/liveatc-caption"
+            href="https://github.com/orriduck/ADSBao"
             target="_blank"
             rel="noreferrer"
             class="group flex items-center justify-between rounded-2xl border p-4 transition-all hover:bg-current/5"

--- a/pack_and_run.sh
+++ b/pack_and_run.sh
@@ -21,13 +21,13 @@ npm run dist
 cd ../..
 
 echo "${GREEN}Build Complete!${NC}"
-echo "The app is located at: ${BLUE}packaging/electron/dist/mac-arm64/LiveATC Caption.app${NC}"
+echo "The app is located at: ${BLUE}packaging/electron/dist/mac-arm64/ADSBao.app${NC}"
 
 # Ask to run the app
 read -p "Would you like to run the app now? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    echo "${BLUE}Launching LiveATC Caption...${NC}"
-    open "packaging/electron/dist/mac-arm64/LiveATC Caption.app"
+    echo "${BLUE}Launching ADSBao...${NC}"
+    open "packaging/electron/dist/mac-arm64/ADSBao.app"
 fi

--- a/packaging/electron/package.json
+++ b/packaging/electron/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "liveatc-caption",
-    "version": "0.1.0",
-    "description": "LiveATC Real-time Captioning App",
+    "name": "adsbao",
+    "version": "0.4.0",
+    "description": "ADSBao airport explorer app",
     "author": "orriduck",
     "repository": {
         "type": "git",
-        "url": "https://github.com/orriduck/liveatc-caption.git"
+        "url": "https://github.com/orriduck/ADSBao.git"
     },
     "main": "main.js",
     "scripts": {
@@ -20,8 +20,8 @@
         "get-port": "^5.1.1"
     },
     "build": {
-        "appId": "com.liveatc.caption",
-        "productName": "LiveATC Caption",
+        "appId": "com.adsbao.app",
+        "productName": "ADSBao",
         "mac": {
             "category": "public.app-category.utilities",
             "target": [


### PR DESCRIPTION
## Summary
- rename the active app and project surfaces from ATC Caption / LiveATC references to ADSBao
- update frontend branding, repo URLs, and Electron packaging metadata to match the new name
- refresh the local developer docs and run script so the renamed app path is consistent

## Validation
- pnpm --dir frontend build