### PR TITLE
[codex] Add browseable OurAirports catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **/.ruff_cache
 
 docs/superpowers
+backend/data

--- a/backend/api/router/airport_catalog.py
+++ b/backend/api/router/airport_catalog.py
@@ -1,0 +1,217 @@
+import csv
+import io
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+_OURAIRPORTS_CSV_URL = "https://davidmegginson.github.io/ourairports-data/airports.csv"
+_TIMEOUT = 20.0
+_CACHE_TTL_SECONDS = 24 * 60 * 60
+_CACHE_PATH = (
+    Path(__file__).resolve().parents[2] / "data" / "ourairports" / "airports.csv"
+)
+_CATALOG: list[dict[str, Any]] | None = None
+_CATALOG_LOADED_AT = 0.0
+
+_TYPE_LABELS = {
+    "large_airport": "Large Airport",
+    "medium_airport": "Medium Airport",
+    "small_airport": "Small Airport",
+    "heliport": "Heliport",
+    "seaplane_base": "Seaplane Base",
+    "balloonport": "Balloonport",
+}
+_TYPE_RANK = {
+    "large_airport": 0,
+    "medium_airport": 1,
+    "small_airport": 2,
+    "seaplane_base": 3,
+    "heliport": 4,
+    "balloonport": 5,
+}
+
+
+async def _download_ourairports_csv() -> str:
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        response = await client.get(_OURAIRPORTS_CSV_URL, follow_redirects=True)
+        response.raise_for_status()
+        return response.text
+
+
+def clear_catalog_cache() -> None:
+    global _CATALOG, _CATALOG_LOADED_AT
+    _CATALOG = None
+    _CATALOG_LOADED_AT = 0.0
+
+
+def _cache_is_fresh() -> bool:
+    if not _CACHE_PATH.exists():
+        return False
+    age_seconds = time.time() - _CACHE_PATH.stat().st_mtime
+    return age_seconds <= _CACHE_TTL_SECONDS
+
+
+def _read_cached_csv() -> str | None:
+    if not _CACHE_PATH.exists():
+        return None
+    return _CACHE_PATH.read_text(encoding="utf-8")
+
+
+def _write_cached_csv(csv_text: str) -> None:
+    _CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _CACHE_PATH.write_text(csv_text, encoding="utf-8")
+
+
+async def _load_csv_text() -> str:
+    cached_csv = _read_cached_csv()
+    if cached_csv is not None and _cache_is_fresh():
+        return cached_csv
+
+    try:
+        downloaded_csv = await _download_ourairports_csv()
+        _write_cached_csv(downloaded_csv)
+        return downloaded_csv
+    except Exception:
+        if cached_csv is not None:
+            return cached_csv
+        raise
+
+
+def _to_float(value: str) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_row(row: dict[str, str]) -> dict[str, Any] | None:
+    airport_type = row.get("type") or ""
+    if airport_type == "closed":
+        return None
+
+    ident = row.get("ident") or ""
+    gps_code = row.get("gps_code") or ""
+    local_code = row.get("local_code") or ""
+    iata = row.get("iata_code") or ""
+    code = gps_code or ident or local_code
+    name = row.get("name") or code
+
+    if not code or not name:
+        return None
+
+    return {
+        "icao": code,
+        "iata": iata,
+        "name": name,
+        "city": row.get("municipality") or "",
+        "country": row.get("iso_country") or "",
+        "region": row.get("iso_region") or "",
+        "continent": row.get("continent") or "",
+        "lat": _to_float(row.get("latitude_deg") or ""),
+        "lon": _to_float(row.get("longitude_deg") or ""),
+        "type": airport_type,
+        "type_label": _TYPE_LABELS.get(
+            airport_type, airport_type.replace("_", " ").title()
+        ),
+        "code": code,
+        "scheduled_service": row.get("scheduled_service") == "yes",
+        "source": "ourairports",
+    }
+
+
+def _parse_catalog(csv_text: str) -> list[dict[str, Any]]:
+    airports = []
+    reader = csv.DictReader(io.StringIO(csv_text))
+    for row in reader:
+        airport = _normalize_row(row)
+        if airport:
+            airports.append(airport)
+    return airports
+
+
+async def _load_catalog() -> list[dict[str, Any]]:
+    global _CATALOG, _CATALOG_LOADED_AT
+    if _CATALOG is None or time.time() - _CATALOG_LOADED_AT > _CACHE_TTL_SECONDS:
+        _CATALOG = _parse_catalog(await _load_csv_text())
+        _CATALOG_LOADED_AT = time.time()
+    return _CATALOG
+
+
+def _browse_score(airport: dict[str, Any]) -> tuple[int, int, int, str]:
+    type_rank = _TYPE_RANK.get(airport.get("type") or "", 9)
+    scheduled_rank = 0 if airport.get("scheduled_service") else 1
+    iata_rank = 0 if airport.get("iata") else 1
+    return (type_rank, scheduled_rank, iata_rank, airport.get("name") or "")
+
+
+def _query_score(
+    query: str, airport: dict[str, Any]
+) -> tuple[int, tuple[int, int, int, str], int]:
+    normalized_query = query.strip().upper()
+    code = (airport.get("icao") or airport.get("code") or "").upper()
+    iata = (airport.get("iata") or "").upper()
+    name = (airport.get("name") or "").upper()
+    city = (airport.get("city") or "").upper()
+
+    if code == normalized_query or iata == normalized_query:
+        return (0, _browse_score(airport), 0)
+    if code.startswith(normalized_query) or iata.startswith(normalized_query):
+        return (1, _browse_score(airport), 0)
+    if name.startswith(normalized_query) or city.startswith(normalized_query):
+        return (2, _browse_score(airport), 0)
+    if normalized_query in name or normalized_query in city:
+        return (2, _browse_score(airport), 1)
+    return (9, _browse_score(airport), 0)
+
+
+def _matches_query(query: str, airport: dict[str, Any]) -> bool:
+    normalized_query = query.strip().upper()
+    if not normalized_query:
+        return True
+    haystack = " ".join(
+        str(airport.get(field) or "")
+        for field in ("icao", "iata", "name", "city", "country", "region")
+    ).upper()
+    return normalized_query in haystack
+
+
+def _matches_kind(kind: str, airport: dict[str, Any]) -> bool:
+    if not kind or kind == "all":
+        return True
+    return airport.get("type") == kind
+
+
+async def search_ourairports(
+    query: str = "",
+    *,
+    country: str = "",
+    kind: str = "all",
+    limit: int = 48,
+) -> list[dict[str, Any]]:
+    catalog = await _load_catalog()
+    normalized_country = country.strip().upper()
+    bounded_limit = max(1, min(limit, 100))
+
+    results = [
+        airport
+        for airport in catalog
+        if _matches_query(query, airport)
+        and _matches_kind(kind, airport)
+        and (
+            not normalized_country
+            or (airport.get("country") or "").upper() == normalized_country
+        )
+    ]
+
+    if query.strip():
+        results.sort(key=lambda airport: _query_score(query, airport))
+    else:
+        results.sort(key=_browse_score)
+
+    return results[:bounded_limit]
+
+
+async def catalog_count() -> int:
+    return len(await _load_catalog())

--- a/backend/api/router/search.py
+++ b/backend/api/router/search.py
@@ -3,6 +3,8 @@ import asyncio
 import httpx
 from fastapi import APIRouter, HTTPException, Query
 
+from api.router.airport_catalog import catalog_count, search_ourairports
+
 router = APIRouter(prefix="/search", tags=["search"])
 
 _AIRPORTS_API = "https://airportsapi.com/api/airports"
@@ -188,21 +190,63 @@ async def _search_remote_airports(query: str) -> list[dict]:
 
 
 @router.get("/airports")
-async def search_airports(query: str = Query(default="", max_length=80)):
+async def search_airports(
+    query: str = Query(default="", max_length=80),
+    country: str = Query(default="", max_length=2),
+    kind: str = Query(default="all", max_length=40),
+    limit: int = Query(default=48, ge=1, le=100),
+):
     """
-    Search airports by code or name using a public airport data service.
+    Search and browse airports using OurAirports, with airportsapi.com retained
+    as a fallback for lookup gaps.
     """
     try:
         trimmed = query.strip()
-        if trimmed:
-            return {"airports": await _search_remote_airports(trimmed)}
+        airports = await search_ourairports(
+            trimmed,
+            country=country,
+            kind=kind,
+            limit=limit,
+        )
+        if airports or not trimmed:
+            return {
+                "airports": airports,
+                "source": "ourairports",
+                "catalog_count": await catalog_count(),
+            }
 
-        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            featured = await asyncio.gather(
-                *[_fetch_exact_airport(client, code) for code in _FEATURED_CODES]
-            )
-        return {"airports": [airport for airport in featured if airport]}
+        fallback_airports = await _search_remote_airports(trimmed)
+        return {
+            "airports": fallback_airports[:limit],
+            "source": "airportsapi.com",
+            "catalog_count": await catalog_count(),
+        }
     except httpx.HTTPError as exc:
+        if query.strip():
+            try:
+                return {
+                    "airports": (await _search_remote_airports(query.strip()))[:limit],
+                    "source": "airportsapi.com",
+                    "catalog_count": 0,
+                }
+            except httpx.HTTPError:
+                pass
+        else:
+            try:
+                async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                    featured = await asyncio.gather(
+                        *[
+                            _fetch_exact_airport(client, code)
+                            for code in _FEATURED_CODES
+                        ]
+                    )
+                return {
+                    "airports": [airport for airport in featured if airport][:limit],
+                    "source": "airportsapi.com",
+                    "catalog_count": 0,
+                }
+            except httpx.HTTPError:
+                pass
         raise HTTPException(
             status_code=502, detail="Airport search is unavailable"
         ) from exc
@@ -214,7 +258,9 @@ async def search(icao: str = Query(..., min_length=2, max_length=10)):
     Resolve a single airport and return preview channel metadata.
     """
     try:
-        airports = await _search_remote_airports(icao)
+        airports = await search_ourairports(icao, limit=1)
+        if not airports:
+            airports = await _search_remote_airports(icao)
         if not airports:
             raise HTTPException(status_code=404, detail="Airport not found")
         airport = airports[0]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,3 +21,9 @@ dependencies = [
     "webrtcvad>=2.0.10",
     "websockets>=15.0.1",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+]

--- a/backend/tests/test_airport_catalog.py
+++ b/backend/tests/test_airport_catalog.py
@@ -1,0 +1,129 @@
+import pytest
+
+
+AIRPORTS_CSV = """id,ident,type,name,latitude_deg,longitude_deg,elevation_ft,continent,iso_country,iso_region,municipality,scheduled_service,gps_code,iata_code,local_code,home_link,wikipedia_link,keywords
+3632,KLAX,large_airport,Los Angeles International Airport,33.942501,-118.407997,125,NA,US,US-CA,Los Angeles,yes,KLAX,LAX,LAX,,,
+507,EGLL,large_airport,London Heathrow Airport,51.4706,-0.461941,83,EU,GB,GB-ENG,London,yes,EGLL,LHR,,,
+9999,00AK,small_airport,Low Priority Strip,59.0,-151.0,100,NA,US,US-AK,Remote,no,00AK,,00AK,,,
+10000,TE17,small_airport,Heathrow Airport,31.4,-97.1,100,NA,US,US-TX,Robinson,no,TE17,,TE17,,,
+"""
+
+ALT_AIRPORTS_CSV = """id,ident,type,name,latitude_deg,longitude_deg,elevation_ft,continent,iso_country,iso_region,municipality,scheduled_service,gps_code,iata_code,local_code,home_link,wikipedia_link,keywords
+20000,KSEA,large_airport,Seattle Tacoma International Airport,47.449001,-122.308998,433,NA,US,US-WA,Seattle,yes,KSEA,SEA,SEA,,,
+"""
+
+
+@pytest.mark.asyncio
+async def test_ourairports_catalog_searches_codes_and_names(monkeypatch):
+    from api.router import airport_catalog
+
+    async def fake_download():
+        return AIRPORTS_CSV
+
+    monkeypatch.setattr(airport_catalog, "_download_ourairports_csv", fake_download)
+    airport_catalog.clear_catalog_cache()
+
+    results = await airport_catalog.search_ourairports("heathrow", limit=10)
+
+    assert results[0]["icao"] == "EGLL"
+    assert results[0]["iata"] == "LHR"
+    assert results[0]["name"] == "London Heathrow Airport"
+    assert results[0]["city"] == "London"
+    assert results[0]["country"] == "GB"
+    assert results[0]["source"] == "ourairports"
+
+
+@pytest.mark.asyncio
+async def test_ourairports_catalog_prefers_major_airports_for_text_search(monkeypatch):
+    from api.router import airport_catalog
+
+    async def fake_download():
+        return AIRPORTS_CSV
+
+    monkeypatch.setattr(airport_catalog, "_download_ourairports_csv", fake_download)
+    airport_catalog.clear_catalog_cache()
+
+    results = await airport_catalog.search_ourairports("heathrow", limit=10)
+
+    assert results[0]["icao"] == "EGLL"
+
+
+@pytest.mark.asyncio
+async def test_ourairports_catalog_browses_major_airports_first(monkeypatch):
+    from api.router import airport_catalog
+
+    async def fake_download():
+        return AIRPORTS_CSV
+
+    monkeypatch.setattr(airport_catalog, "_download_ourairports_csv", fake_download)
+    airport_catalog.clear_catalog_cache()
+
+    results = await airport_catalog.search_ourairports("", limit=3)
+
+    assert {airport["icao"] for airport in results[:2]} == {"KLAX", "EGLL"}
+    assert results[2]["type"] == "small_airport"
+
+
+@pytest.mark.asyncio
+async def test_ourairports_catalog_uses_fresh_disk_cache_without_network(
+    monkeypatch, tmp_path
+):
+    from api.router import airport_catalog
+
+    cache_file = tmp_path / "airports.csv"
+    cache_file.write_text(AIRPORTS_CSV, encoding="utf-8")
+
+    async def fail_download():
+        raise AssertionError("fresh disk cache should not hit network")
+
+    monkeypatch.setattr(airport_catalog, "_CACHE_PATH", cache_file)
+    monkeypatch.setattr(airport_catalog, "_CACHE_TTL_SECONDS", 3600)
+    monkeypatch.setattr(airport_catalog, "_download_ourairports_csv", fail_download)
+    airport_catalog.clear_catalog_cache()
+
+    results = await airport_catalog.search_ourairports("LAX", limit=10)
+
+    assert results[0]["icao"] == "KLAX"
+
+
+@pytest.mark.asyncio
+async def test_ourairports_catalog_refreshes_stale_disk_cache(monkeypatch, tmp_path):
+    from api.router import airport_catalog
+
+    cache_file = tmp_path / "airports.csv"
+    cache_file.write_text(AIRPORTS_CSV, encoding="utf-8")
+
+    async def fake_download():
+        return ALT_AIRPORTS_CSV
+
+    monkeypatch.setattr(airport_catalog, "_CACHE_PATH", cache_file)
+    monkeypatch.setattr(airport_catalog, "_CACHE_TTL_SECONDS", -1)
+    monkeypatch.setattr(airport_catalog, "_download_ourairports_csv", fake_download)
+    airport_catalog.clear_catalog_cache()
+
+    results = await airport_catalog.search_ourairports("SEA", limit=10)
+
+    assert results[0]["icao"] == "KSEA"
+    assert cache_file.read_text(encoding="utf-8") == ALT_AIRPORTS_CSV
+
+
+@pytest.mark.asyncio
+async def test_ourairports_catalog_falls_back_to_stale_disk_cache(
+    monkeypatch, tmp_path
+):
+    from api.router import airport_catalog
+
+    cache_file = tmp_path / "airports.csv"
+    cache_file.write_text(AIRPORTS_CSV, encoding="utf-8")
+
+    async def fail_download():
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(airport_catalog, "_CACHE_PATH", cache_file)
+    monkeypatch.setattr(airport_catalog, "_CACHE_TTL_SECONDS", -1)
+    monkeypatch.setattr(airport_catalog, "_download_ourairports_csv", fail_download)
+    airport_catalog.clear_catalog_cache()
+
+    results = await airport_catalog.search_ourairports("LAX", limit=10)
+
+    assert results[0]["icao"] == "KLAX"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -126,6 +126,12 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
@@ -143,6 +149,12 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.38.0" },
     { name = "webrtcvad", specifier = ">=2.0.10" },
     { name = "websockets", specifier = ">=15.0.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]
 
 [[package]]
@@ -522,6 +534,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -721,6 +742,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.2"
 source = { registry = "https://pypi.org/simple" }
@@ -843,6 +873,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyinstaller"
 version = "6.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -890,6 +929,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]

--- a/frontend/src/components/screens/SearchScreen.vue
+++ b/frontend/src/components/screens/SearchScreen.vue
@@ -3,22 +3,22 @@
     <TopBar screen="SEARCH · AIRPORTS" />
 
     <section
-      class="relative px-14 pt-[72px] pb-14 border-b border-atc-line overflow-hidden"
+      class="relative px-6 md:px-14 pt-[72px] pb-14 border-b border-atc-line overflow-hidden"
       style="background:radial-gradient(ellipse at 85% 20%, rgba(255,90,31,0.16), transparent 55%), radial-gradient(ellipse at 10% 90%, rgba(255,90,31,0.08), transparent 50%), #0a0a0b"
     >
       <div class="max-w-3xl relative z-10">
         <div class="inline-flex items-center gap-2.5 px-3.5 py-1.5 rounded-full border border-atc-line bg-atc-card font-mono text-[11px] tracking-[0.5px] text-atc-dim mb-7">
           <span class="w-1.5 h-1.5 rounded-full bg-atc-mint flex-shrink-0 animate-pulse-dot" style="box-shadow:0 0 8px #34d399" />
-          WEB SEARCH · {{ results.length }} airports loaded
+          OURAIRPORTS CATALOG · {{ catalogLabel }}
         </div>
 
-        <h1 class="font-sans text-[88px] leading-[0.95] font-bold text-atc-text m-0" style="letter-spacing:-3.2px">
-          Search airport<br />
+        <h1 class="font-sans text-[clamp(54px,9vw,88px)] leading-[0.95] font-bold text-atc-text m-0" style="letter-spacing:-3.2px">
+          Browse airport<br />
           <span class="font-display italic font-normal text-atc-orange" style="letter-spacing:-2px">traffic</span> fast.
         </h1>
         <p class="mt-6 text-lg leading-relaxed text-atc-dim max-w-xl font-normal">
-          Airport results now load dynamically from a public web data source.
-          Search by ICAO code or airport name, then open the airport explorer view.
+          Search the public OurAirports catalog by ICAO, IATA, city, or airport name.
+          Narrow the catalog before opening the weather and nearby-traffic explorer.
         </p>
 
         <div
@@ -34,7 +34,7 @@
             @focus="focused = true"
             @blur="focused = false"
             @keydown.enter="doSearch"
-            placeholder="KJFK, Heathrow, Boston…"
+            placeholder="KJFK, Heathrow, Boston, LHR…"
             class="flex-1 bg-transparent border-none outline-none text-atc-text text-[17px] font-medium placeholder:text-atc-faint font-sans"
           />
           <button v-if="searchLoading" class="font-mono text-[11px] text-atc-dim tracking-widest">…</button>
@@ -43,39 +43,52 @@
 
         <div class="flex gap-2 mt-4 flex-wrap">
           <button
-            v-for="r in regions"
-            :key="r.id"
-            @click="region = r.id"
+            v-for="option in kindOptions"
+            :key="option.id"
+            @click="kind = option.id"
             class="px-4 py-2 rounded-full border text-[13px] font-medium cursor-pointer transition-all"
-            :class="region === r.id
+            :class="kind === option.id
               ? 'bg-atc-text text-atc-bg border-atc-text'
               : 'bg-transparent border-atc-line text-atc-dim hover:border-atc-line-strong'"
-          >{{ r.label }}</button>
+          >{{ option.label }}</button>
+        </div>
+
+        <div class="mt-4 flex flex-wrap gap-2">
+          <button
+            v-for="option in countryOptions"
+            :key="option.id"
+            @click="country = option.id"
+            class="px-3.5 py-2 rounded-xl border font-mono text-[11px] uppercase tracking-[1px] cursor-pointer transition-all"
+            :class="country === option.id
+              ? 'bg-atc-orange text-atc-bg border-atc-orange'
+              : 'bg-atc-card border-atc-line text-atc-dim hover:border-atc-line-strong'"
+          >{{ option.label }}</button>
         </div>
       </div>
 
-      <div class="absolute top-14 right-14 text-right pointer-events-none">
+      <div class="hidden lg:block absolute top-14 right-14 text-right pointer-events-none">
         <div
           class="font-display italic text-transparent leading-[0.9] select-none"
           style="font-size:140px;font-weight:700;letter-spacing:-6px;-webkit-text-stroke:1px #FF5A1F"
         >
           {{ String(filtered.length).padStart(3, '0') }}
         </div>
-        <div class="font-mono text-[11px] text-atc-orange tracking-[2px] mt-2">{{ q ? 'MATCHES' : 'FEATURED' }}</div>
+        <div class="font-mono text-[11px] text-atc-orange tracking-[2px] mt-2">{{ q ? 'MATCHES' : 'BROWSE SET' }}</div>
       </div>
     </section>
 
-    <section class="px-14 py-12 flex-1">
-      <div class="flex items-baseline justify-between mb-6 pb-4 border-b border-atc-line">
+    <section class="px-6 md:px-14 py-12 flex-1">
+      <div class="flex flex-col lg:flex-row lg:items-baseline justify-between gap-4 mb-6 pb-4 border-b border-atc-line">
         <div class="flex items-baseline gap-3 text-[26px] font-semibold" style="letter-spacing:-0.5px">
-          {{ q ? `Results for "${q}"` : 'Featured airports' }}
+          {{ q ? `Results for "${q}"` : browseTitle }}
           <span class="font-mono text-[13px] text-atc-faint tracking-[0.5px]">{{ filtered.length }}</span>
         </div>
-        <div class="flex items-center gap-2 text-[12px]">
-          <span class="text-atc-faint uppercase tracking-[1px]">Source</span>
+        <div class="flex flex-wrap items-center gap-2 text-[12px]">
+          <span class="text-atc-faint uppercase tracking-[1px]">Primary source</span>
           <button class="px-3.5 py-2 rounded-lg bg-atc-card border border-atc-line text-atc-text text-[13px] cursor-pointer font-sans">
-            airportsapi.com
+            {{ sourceLabel }}
           </button>
+          <span class="text-atc-faint">airportsapi.com kept as fallback</span>
         </div>
       </div>
 
@@ -91,7 +104,7 @@
         <div class="font-mono text-[12px] text-atc-dim">No airports matched the current search.</div>
       </div>
 
-      <div v-else class="grid gap-3.5" style="grid-template-columns:repeat(3,1fr)">
+      <div v-else class="grid gap-3.5 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
         <AirportCard
           v-for="(a, i) in filtered"
           :key="a.icao || a.code || a.name"
@@ -102,15 +115,15 @@
       </div>
     </section>
 
-    <footer class="flex justify-between items-center px-14 py-5 border-t border-atc-line">
+    <footer class="flex flex-col md:flex-row gap-4 md:justify-between md:items-center px-6 md:px-14 py-5 border-t border-atc-line">
       <div class="flex items-center gap-3.5">
         <Wordmark />
         <span class="text-[12px] text-atc-faint">v0.4.0 · ADSBao preview</span>
       </div>
       <div class="flex gap-6 text-[13px] text-atc-dim">
         <span class="cursor-pointer hover:text-atc-text transition-colors">About</span>
-        <span class="cursor-pointer hover:text-atc-text transition-colors">API</span>
-        <span class="cursor-pointer hover:text-atc-text transition-colors">Dynamic airport search</span>
+        <span class="cursor-pointer hover:text-atc-text transition-colors">OurAirports</span>
+        <span class="cursor-pointer hover:text-atc-text transition-colors">Browseable airport catalog</span>
       </div>
     </footer>
   </div>
@@ -125,46 +138,66 @@ import AirportCard from '../ui/AirportCard.vue'
 const emit = defineEmits(['open-airport'])
 
 const q = ref('')
-const region = ref('all')
+const kind = ref('all')
+const country = ref('')
 const focused = ref(false)
 const results = ref([])
 const searchLoading = ref(false)
 const searchError = ref(null)
+const source = ref('ourairports')
+const catalogCount = ref(0)
 
-const regions = [
-  { id: 'all', label: 'All regions' },
-  { id: 'US', label: 'North America' },
-  { id: 'EU', label: 'Europe' },
-  { id: 'AP', label: 'Asia Pacific' },
+const kindOptions = [
+  { id: 'all', label: 'All airports' },
+  { id: 'large_airport', label: 'Large' },
+  { id: 'medium_airport', label: 'Medium' },
+  { id: 'small_airport', label: 'Small' },
+  { id: 'heliport', label: 'Heliports' },
+]
+
+const countryOptions = [
+  { id: '', label: 'World' },
+  { id: 'US', label: 'US' },
+  { id: 'CA', label: 'CA' },
+  { id: 'GB', label: 'GB' },
+  { id: 'JP', label: 'JP' },
+  { id: 'AU', label: 'AU' },
 ]
 
 let searchTimer = null
 
-const airportRegion = (airport) => {
-  const code = String(airport.icao || airport.code || '').toUpperCase()
-  if (/^(K|C|M|P)/.test(code)) return 'US'
-  if (/^(E|L)/.test(code)) return 'EU'
-  if (/^(R|V|W|Y|Z)/.test(code)) return 'AP'
-  return 'all'
-}
+const filtered = computed(() => results.value)
 
-const filtered = computed(() =>
-  results.value.filter((airport) => region.value === 'all' || airportRegion(airport) === region.value)
-)
+const catalogLabel = computed(() => (
+  catalogCount.value ? `${catalogCount.value.toLocaleString()} airports indexed` : `${results.value.length} loaded`
+))
+
+const sourceLabel = computed(() => source.value === 'airportsapi.com' ? 'airportsapi.com fallback' : 'OurAirports CSV')
+
+const browseTitle = computed(() => {
+  const selectedKind = kindOptions.find((option) => option.id === kind.value)?.label || 'All airports'
+  const selectedCountry = countryOptions.find((option) => option.id === country.value)?.label || country.value
+  return country.value ? `${selectedKind} · ${selectedCountry}` : selectedKind
+})
 
 const loadAirports = async (query = '') => {
   searchLoading.value = true
   searchError.value = null
   try {
-    const url = query.trim()
-      ? `/api/search/airports?query=${encodeURIComponent(query.trim())}`
-      : '/api/search/airports'
+    const params = new URLSearchParams()
+    if (query.trim()) params.set('query', query.trim())
+    if (kind.value !== 'all') params.set('kind', kind.value)
+    if (country.value) params.set('country', country.value)
+    params.set('limit', '60')
+    const url = `/api/search/airports?${params.toString()}`
     const response = await fetch(url)
     if (!response.ok) {
       throw new Error(response.status >= 500 ? 'Airport search is unavailable right now' : `Airport search failed (${response.status})`)
     }
     const payload = await response.json()
     results.value = payload.airports || []
+    source.value = payload.source || 'ourairports'
+    catalogCount.value = payload.catalog_count || catalogCount.value
   } catch (err) {
     console.error('Airport search failed', err)
     results.value = []
@@ -212,6 +245,10 @@ watch(q, (value) => {
   searchTimer = setTimeout(() => {
     loadAirports(value)
   }, value.trim() ? 250 : 0)
+})
+
+watch([kind, country], () => {
+  loadAirports(q.value)
 })
 
 onMounted(() => {

--- a/frontend/src/components/ui/AirportCard.vue
+++ b/frontend/src/components/ui/AirportCard.vue
@@ -9,19 +9,23 @@
   >
     <div class="flex items-baseline gap-2.5 mb-2">
       <span class="font-display italic text-[42px] leading-none text-atc-text" style="letter-spacing:-1px">{{ a.iata || a.code }}</span>
-      <span class="font-mono text-[11px] text-atc-faint tracking-[1px]">{{ a.code }}</span>
+      <span class="font-mono text-[11px] text-atc-faint tracking-[1px]">{{ a.icao || a.code }}</span>
     </div>
     <div class="text-[15px] font-semibold text-atc-text" style="letter-spacing:-0.2px">{{ a.name }}</div>
     <div class="text-[13px] text-atc-dim mb-4">{{ subtitle }}</div>
 
     <div class="mt-auto flex items-center gap-4 pt-3.5 border-t border-atc-line">
       <div class="flex flex-col gap-0.5">
-        <span class="font-mono text-[16px] font-semibold">{{ a.code }}</span>
+        <span class="font-mono text-[16px] font-semibold">{{ a.icao || a.code }}</span>
         <span class="text-[10px] text-atc-faint uppercase tracking-[1px]">icao</span>
       </div>
       <div class="flex flex-col gap-0.5">
         <span class="font-mono text-[16px] font-semibold text-atc-mint">{{ a.country }}</span>
-        <span class="text-[10px] text-atc-faint uppercase tracking-[1px]">region</span>
+        <span class="text-[10px] text-atc-faint uppercase tracking-[1px]">country</span>
+      </div>
+      <div class="hidden sm:flex flex-col gap-0.5">
+        <span class="font-mono text-[16px] font-semibold text-atc-dim">{{ typeShort }}</span>
+        <span class="text-[10px] text-atc-faint uppercase tracking-[1px]">class</span>
       </div>
       <div class="ml-auto w-8 h-8 rounded-full bg-atc-high text-atc-text grid place-items-center">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -46,5 +50,13 @@ const subtitle = computed(() => {
   if (props.a.city) return props.a.city
   if (props.a.country) return props.a.country
   return props.a.type_label || props.a.type || 'Airport data'
+})
+
+const typeShort = computed(() => {
+  if (props.a.type === 'large_airport') return 'L'
+  if (props.a.type === 'medium_airport') return 'M'
+  if (props.a.type === 'small_airport') return 'S'
+  if (props.a.type === 'heliport') return 'H'
+  return '—'
 })
 </script>


### PR DESCRIPTION
## Summary
- Replace fixed featured-airport behavior with an OurAirports-backed searchable and browseable airport catalog.
- Keep airportsapi.com as a fallback path for lookup/search gaps.
- Add persisted OurAirports CSV caching with a 24-hour TTL and stale-cache fallback when refresh fails.
- Update the index UI with type/country filters, catalog metadata, source labels, and responsive airport cards.

## Validation
- `cd backend && .venv/bin/python -m pytest tests/ -v`
- `cd backend && uvx ruff check . && uvx ruff format --check .`
- `cd frontend && pnpm build`
