### PR TITLE
[codex] Add aircraft traffic intent classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/__pycache__
 *_backup
 **/.ruff_cache
+**/.zed
 
 docs/superpowers
 backend/data

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "test:aircraft-motion": "node src/utils/aircraftMotion.test.js",
+    "test:aircraft-traffic-intent": "node src/utils/aircraftTrafficIntent.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/components/map/AirportMap.vue
+++ b/frontend/src/components/map/AirportMap.vue
@@ -11,6 +11,15 @@
          style="color:rgba(245,245,247,0.28);text-shadow:0 0 6px #0a0a0b">
       © OpenStreetMap · CartoDB
     </div>
+    <div
+      class="absolute right-3 top-[168px] pointer-events-none flex max-w-[calc(100%-24px)] flex-wrap gap-2 rounded border border-white/10 px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.8px]"
+      style="background:rgba(10,10,11,0.58);backdrop-filter:blur(10px);color:rgba(245,245,247,0.72);text-shadow:0 0 6px #0a0a0b"
+    >
+      <span v-for="item in trafficLegend" :key="item.id" class="inline-flex items-center gap-1.5">
+        <span class="h-1.5 w-1.5 rounded-full" :style="{ background: item.color, boxShadow: `0 0 6px ${item.color}` }" />
+        {{ item.label }}
+      </span>
+    </div>
 
     <!-- Loading state -->
     <div v-if="!mapReady" class="absolute inset-0 flex items-center justify-center bg-atc-card rounded-lg">
@@ -51,6 +60,17 @@ const lonStr = ref('')
 
 // Dead-reckoning: animate aircraft that exceed this speed (knots)
 const ANIMATE_THRESHOLD_KT = 30
+const TRAFFIC_INTENT_COLORS = {
+  arrival: '#38bdf8',
+  departure: '#fb923c',
+  unknown: '#cbd5e1',
+  ground: '#34d399',
+}
+const trafficLegend = [
+  { id: 'arrival', label: 'ARR', color: TRAFFIC_INTENT_COLORS.arrival },
+  { id: 'departure', label: 'DEP', color: TRAFFIC_INTENT_COLORS.departure },
+  { id: 'unknown', label: 'UNK', color: TRAFFIC_INTENT_COLORS.unknown },
+]
 
 // RAF loop — updates visual aircraft positions on a delayed, latency-aware clock
 let rafId = null
@@ -212,6 +232,13 @@ const makeAcIcon = (color, label, rot = 0, showArrow = true, hasTelemetry = fals
   })
 }
 
+const getTrafficIntentColor = (ac, showArrow) => {
+  if (ac.onGround) return TRAFFIC_INTENT_COLORS.ground
+  if (ac.trafficIntent === 'arrival') return TRAFFIC_INTENT_COLORS.arrival
+  if (ac.trafficIntent === 'departure') return TRAFFIC_INTENT_COLORS.departure
+  return showArrow ? TRAFFIC_INTENT_COLORS.unknown : '#ffb347'
+}
+
 const updateAircraft = () => {
   if (!map) return
 
@@ -223,7 +250,7 @@ const updateAircraft = () => {
     const vel        = ac.velocity ?? 0
     const showArrow  = vel >= ANIMATE_THRESHOLD_KT
     const isAnimated = !ac.onGround && showArrow
-    const color = ac.onGround ? '#34d399' : showArrow ? props.accent : '#ffb347'
+    const color = getTrafficIntentColor(ac, showArrow)
     const label = (ac.callsign || ac.icao24 || '').trim()
     const rot   = Math.round(ac.track || 0)
     const hasTelemetry = !ac.onGround && showArrow && formatTelemetryValue(ac.velocity) != null && formatTelemetryValue(ac.altitude) != null
@@ -241,11 +268,15 @@ const updateAircraft = () => {
         isAnimated,
       })
       // Refresh icon only when appearance changes
-      if (color !== entry.color || label !== entry.label || rot !== entry.rot || showArrow !== entry.showArrow || hasTelemetry !== entry.hasTelemetry) {
+      if (color !== entry.color || label !== entry.label || rot !== entry.rot || showArrow !== entry.showArrow || hasTelemetry !== entry.hasTelemetry || ac.trafficIntent !== entry.trafficIntent) {
         unmountAircraftTelemetry(entry.marker)
         entry.marker.setIcon(makeAcIcon(color, label, rot, showArrow, hasTelemetry))
-        entry.color = color; entry.label = label; entry.rot = rot; entry.showArrow = showArrow
+        entry.color = color
+        entry.label = label
+        entry.rot = rot
+        entry.showArrow = showArrow
         entry.hasTelemetry = hasTelemetry
+        entry.trafficIntent = ac.trafficIntent
       }
       if (hasTelemetry) queueAircraftTelemetrySync(entry.marker, ac)
     } else {
@@ -253,7 +284,7 @@ const updateAircraft = () => {
       const visualPosition = calculateAircraftVisualPosition(motionState, now)
       const m = L.marker([visualPosition.lat, visualPosition.lon], { icon: makeAcIcon(color, label, rot, showArrow, hasTelemetry) }).addTo(map)
       acMarkersMap.set(ac.icao24, {
-        marker: m, color, label, rot, showArrow, hasTelemetry,
+        marker: m, color, label, rot, showArrow, hasTelemetry, trafficIntent: ac.trafficIntent,
         ...motionState,
         velocity: vel, track: ac.track ?? 0,
         isAnimated,

--- a/frontend/src/composables/useAircraftPositions.js
+++ b/frontend/src/composables/useAircraftPositions.js
@@ -1,5 +1,6 @@
 import { ref, watch, onUnmounted } from 'vue'
 import { parseAdsbPositionTime } from '../utils/aircraftMotion'
+import { createAircraftIntentTracker } from '../utils/aircraftTrafficIntent.js'
 
 // Proxied through backend — adsb.lol has no CORS headers for browser requests
 const API = '/api/proxy/aircraft/positions'
@@ -10,6 +11,7 @@ export function useAircraftPositions(icaoRef, latRef, lonRef) {
   const aircraft    = ref([])
   const loading     = ref(false)
   const lastUpdated = ref(null)
+  const intentTracker = createAircraftIntentTracker()
   let timer = null
 
   const poll = async () => {
@@ -26,7 +28,7 @@ export function useAircraftPositions(icaoRef, latRef, lonRef) {
       const receiveTime = Date.now()
 
       // adsb.lol response: { ac: [{ hex, flight, lat, lon, alt_baro, gs, track, gnd, ... }] }
-      aircraft.value = (json.ac || [])
+      const snapshots = (json.ac || [])
         .filter(a => a.lat != null && a.lon != null)
         .map(a => ({
           icao24:   a.hex || '',
@@ -40,6 +42,7 @@ export function useAircraftPositions(icaoRef, latRef, lonRef) {
           positionTime: parseAdsbPositionTime(a, json.now, receiveTime),
           receiveTime,
         }))
+      aircraft.value = intentTracker.update(snapshots, { lat, lon }, receiveTime)
       lastUpdated.value = new Date()
     } catch (e) {
       console.warn('ADS-B fetch failed:', e.message)
@@ -50,12 +53,14 @@ export function useAircraftPositions(icaoRef, latRef, lonRef) {
 
   const start = () => {
     stop()
+    intentTracker.clear()
     poll()
     timer = setInterval(poll, POLL_MS)
   }
 
   const stop = () => {
     if (timer) { clearInterval(timer); timer = null }
+    intentTracker.clear()
     aircraft.value = []
   }
 

--- a/frontend/src/utils/aircraftTrafficIntent.js
+++ b/frontend/src/utils/aircraftTrafficIntent.js
@@ -1,0 +1,137 @@
+const EARTH_RADIUS_NM = 3440.065
+const MIN_SAMPLE_SPAN_MS = 2_000
+const MIN_DISTANCE_DELTA_NM = 0.08
+const MIN_ALTITUDE_DELTA_FT = 75
+
+const toFiniteNumber = (value) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+const toRadians = (degrees) => (degrees * Math.PI) / 180
+
+export const getDistanceNm = (fromLat, fromLon, toLat, toLon) => {
+  const lat1 = toFiniteNumber(fromLat)
+  const lon1 = toFiniteNumber(fromLon)
+  const lat2 = toFiniteNumber(toLat)
+  const lon2 = toFiniteNumber(toLon)
+  if (lat1 == null || lon1 == null || lat2 == null || lon2 == null) return null
+
+  const dLat = toRadians(lat2 - lat1)
+  const dLon = toRadians(lon2 - lon1)
+  const rLat1 = toRadians(lat1)
+  const rLat2 = toRadians(lat2)
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos(rLat1) * Math.cos(rLat2) * Math.sin(dLon / 2) ** 2
+  return 2 * EARTH_RADIUS_NM * Math.asin(Math.sqrt(a))
+}
+
+const classifyConfidence = (distanceDeltaNm, altitudeDeltaFt) => {
+  const distanceConfidence = Math.min(Math.abs(distanceDeltaNm) / 2.5, 0.75)
+  const altitudeConfidence = altitudeDeltaFt == null
+    ? 0
+    : Math.min(Math.abs(altitudeDeltaFt) / 2_000, 0.25)
+  return Math.round((0.2 + distanceConfidence + altitudeConfidence) * 100) / 100
+}
+
+export const inferAircraftTrafficIntent = (previousSample, currentSample) => {
+  const previousDistance = toFiniteNumber(previousSample?.distanceNm)
+  const currentDistance = toFiniteNumber(currentSample?.distanceNm)
+  const previousTime = toFiniteNumber(previousSample?.time)
+  const currentTime = toFiniteNumber(currentSample?.time)
+
+  if (
+    previousDistance == null
+    || currentDistance == null
+    || previousTime == null
+    || currentTime == null
+    || currentTime - previousTime < MIN_SAMPLE_SPAN_MS
+  ) {
+    return { state: 'unknown', confidence: 0 }
+  }
+
+  const distanceDelta = currentDistance - previousDistance
+  if (Math.abs(distanceDelta) < MIN_DISTANCE_DELTA_NM) {
+    return { state: 'unknown', confidence: 0 }
+  }
+
+  const previousAltitude = toFiniteNumber(previousSample?.altitude)
+  const currentAltitude = toFiniteNumber(currentSample?.altitude)
+  const altitudeDelta = previousAltitude == null || currentAltitude == null
+    ? null
+    : currentAltitude - previousAltitude
+  const hasAltitudeSignal = altitudeDelta != null && Math.abs(altitudeDelta) >= MIN_ALTITUDE_DELTA_FT
+
+  if (distanceDelta < 0 && hasAltitudeSignal && altitudeDelta < 0) {
+    return {
+      state: 'arrival',
+      confidence: classifyConfidence(distanceDelta, altitudeDelta),
+    }
+  }
+
+  const groundLaunch = previousSample?.onGround && !currentSample?.onGround
+  if (distanceDelta > 0 && (groundLaunch || (hasAltitudeSignal && altitudeDelta > 0))) {
+    return {
+      state: 'departure',
+      confidence: classifyConfidence(distanceDelta, altitudeDelta),
+    }
+  }
+
+  return { state: 'unknown', confidence: 0 }
+}
+
+export const createAircraftIntentTracker = ({
+  maxSamples = 5,
+  maxAgeMs = 18_000,
+} = {}) => {
+  const histories = new Map()
+
+  const update = (aircraft, airport, nowMs = Date.now()) => {
+    const airportLat = toFiniteNumber(airport?.lat)
+    const airportLon = toFiniteNumber(airport?.lon)
+    const activeIds = new Set()
+
+    const enriched = aircraft.map((item) => {
+      const id = item.icao24 || item.callsign
+      const distanceNm = getDistanceNm(item.lat, item.lon, airportLat, airportLon)
+      if (!id || distanceNm == null) {
+        return { ...item, distanceNm, trafficIntent: 'unknown', trafficIntentConfidence: 0 }
+      }
+
+      activeIds.add(id)
+      const sample = {
+        time: nowMs,
+        lat: item.lat,
+        lon: item.lon,
+        altitude: item.altitude,
+        velocity: item.velocity,
+        onGround: item.onGround,
+        distanceNm,
+      }
+      const history = (histories.get(id) || [])
+        .filter((entry) => nowMs - entry.time <= maxAgeMs)
+      history.push(sample)
+      histories.set(id, history.slice(-maxSamples))
+
+      const baseline = histories.get(id)[0]
+      const intent = inferAircraftTrafficIntent(baseline, sample)
+
+      return {
+        ...item,
+        distanceNm,
+        trafficIntent: intent.state,
+        trafficIntentConfidence: intent.confidence,
+      }
+    })
+
+    for (const id of histories.keys()) {
+      if (!activeIds.has(id)) histories.delete(id)
+    }
+
+    return enriched
+  }
+
+  const clear = () => histories.clear()
+
+  return { update, clear }
+}

--- a/frontend/src/utils/aircraftTrafficIntent.test.js
+++ b/frontend/src/utils/aircraftTrafficIntent.test.js
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+
+import {
+  createAircraftIntentTracker,
+  inferAircraftTrafficIntent,
+} from './aircraftTrafficIntent.js'
+
+const airport = { lat: 42.3656, lon: -71.0096 }
+
+{
+  const intent = inferAircraftTrafficIntent(
+    { time: 0, lat: 42.60, lon: -71.10, altitude: 5_000, distanceNm: 14 },
+    { time: 9_000, lat: 42.40, lon: -71.03, altitude: 2_400, distanceNm: 3 },
+  )
+
+  assert.equal(intent.state, 'arrival')
+  assert.ok(intent.confidence > 0.5)
+}
+
+{
+  const intent = inferAircraftTrafficIntent(
+    { time: 0, lat: 42.36, lon: -71.02, altitude: 300, onGround: true, distanceNm: 0.5 },
+    { time: 9_000, lat: 42.48, lon: -70.92, altitude: 3_200, velocity: 190, distanceNm: 9 },
+  )
+
+  assert.equal(intent.state, 'departure')
+  assert.ok(intent.confidence > 0.5)
+}
+
+{
+  const intent = inferAircraftTrafficIntent(
+    { time: 0, lat: 42.50, lon: -71.10, altitude: 6_000, distanceNm: 8 },
+    { time: 9_000, lat: 42.44, lon: -71.06, altitude: 6_300, distanceNm: 5 },
+  )
+
+  assert.equal(intent.state, 'unknown')
+  assert.equal(intent.confidence, 0)
+}
+
+{
+  const intent = inferAircraftTrafficIntent(
+    { time: 0, lat: 42.60, lon: -71.10, distanceNm: 14 },
+    { time: 9_000, lat: 42.40, lon: -71.03, distanceNm: 3 },
+  )
+
+  assert.equal(intent.state, 'unknown')
+}
+
+{
+  const tracker = createAircraftIntentTracker({ maxSamples: 3, maxAgeMs: 20_000 })
+  let [aircraft] = tracker.update([
+    { icao24: 'a1', lat: 42.60, lon: -71.10, altitude: 5_000, velocity: 180 },
+  ], airport, 1_000)
+
+  assert.equal(aircraft.trafficIntent, 'unknown')
+
+  ;[aircraft] = tracker.update([
+    { icao24: 'a1', lat: 42.45, lon: -71.04, altitude: 3_000, velocity: 170 },
+  ], airport, 7_000)
+
+  assert.equal(aircraft.trafficIntent, 'arrival')
+  assert.ok(aircraft.distanceNm < 6)
+}


### PR DESCRIPTION
## Summary
- add a bounded aircraft intent tracker that caches recent ADS-B positions and classifies traffic as arrival, departure, or unknown
- enrich aircraft snapshots in the frontend data flow with distance and intent metadata
- color map markers by inferred traffic intent and add an ARR/DEP/UNK legend
- ignore local `.zed` editor state

## Validation
- `pnpm run test:aircraft-motion`
- `pnpm run test:aircraft-traffic-intent`
- `pnpm run build`
- checked the local KLAX page in the in-app browser

Closes #36
