### PR TITLE
Switch homepage airport directory to airportsapi.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Backend runs on `http://localhost:8000`, frontend on `http://localhost:5173`. Ct
 
 - **Backend**: FastAPI + uvicorn, managed by `uv`. Entry point: `backend/main.py`.
 - **Frontend**: Vue 3 + Vite + Tailwind + DaisyUI, managed by `pnpm` (installed via Homebrew).
-- **Airport data**: OurAirports-backed airport catalog, AviationWeather METAR proxy, and ADS-B position proxy.
+- **Airport data**: Homepage airport directory is fetched live from airportsapi.com with frontend caching; backend airport lookup still keeps the OurAirports-backed catalog plus AviationWeather METAR and ADS-B proxies.
 - **Live audio**: Streaming/transcription has been removed from this build; the caption WebSocket only returns a disabled-streaming error.
 
 ## Key paths
@@ -26,7 +26,7 @@ Backend runs on `http://localhost:8000`, frontend on `http://localhost:5173`. Ct
 | `backend/api/router/proxy.py` | METAR and nearby aircraft proxy endpoints |
 | `backend/api/router/caption.py` | Disabled live-streaming WebSocket response |
 | `frontend/src/views/HomeView.vue` | Search-to-airport route flow |
-| `frontend/src/components/screens/SearchScreen.vue` | Browseable airport catalog UI |
+| `frontend/src/components/screens/SearchScreen.vue` | Live airport directory UI backed by airportsapi.com + frontend cache |
 | `frontend/src/components/screens/AirportCaptionScreen.vue` | Airport explorer map + METAR screen |
 
 ## Linting

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test:airport-directory": "node src/services/airportDirectory.test.js",
     "test:aircraft-motion": "node src/utils/aircraftMotion.test.js",
     "test:aircraft-traffic-intent": "node src/utils/aircraftTrafficIntent.test.js",
     "preview": "vite preview"

--- a/frontend/src/components/screens/SearchScreen.vue
+++ b/frontend/src/components/screens/SearchScreen.vue
@@ -9,7 +9,7 @@
       <div class="max-w-3xl relative z-10">
         <div class="inline-flex items-center gap-2.5 px-3.5 py-1.5 rounded-full border border-atc-line bg-atc-card font-mono text-[11px] tracking-[0.5px] text-atc-dim mb-7">
           <span class="w-1.5 h-1.5 rounded-full bg-atc-mint flex-shrink-0 animate-pulse-dot" style="box-shadow:0 0 8px #34d399" />
-          OURAIRPORTS CATALOG · {{ catalogLabel }}
+          LIVE DIRECTORY · {{ catalogLabel }}
         </div>
 
         <h1 class="font-sans text-[clamp(54px,9vw,88px)] leading-[0.95] font-bold text-atc-text m-0" style="letter-spacing:-3.2px">
@@ -17,8 +17,8 @@
           <span class="font-display italic font-normal text-atc-orange" style="letter-spacing:-2px">traffic</span> fast.
         </h1>
         <p class="mt-6 text-lg leading-relaxed text-atc-dim max-w-xl font-normal">
-          Search the public OurAirports catalog by ICAO, IATA, city, or airport name.
-          Narrow the catalog before opening the weather and nearby-traffic explorer.
+          Search airportsapi.com by ICAO, IATA, city, or airport name.
+          Results are fetched live, then cached in the browser for faster follow-up lookups.
         </p>
 
         <div
@@ -88,7 +88,7 @@
           <button class="px-3.5 py-2 rounded-lg bg-atc-card border border-atc-line text-atc-text text-[13px] cursor-pointer font-sans">
             {{ sourceLabel }}
           </button>
-          <span class="text-atc-faint">airportsapi.com kept as fallback</span>
+          <span class="text-atc-faint">{{ cacheStatusLabel }}</span>
         </div>
       </div>
 
@@ -122,8 +122,8 @@
       </div>
       <div class="flex gap-6 text-[13px] text-atc-dim">
         <span class="cursor-pointer hover:text-atc-text transition-colors">About</span>
-        <span class="cursor-pointer hover:text-atc-text transition-colors">OurAirports</span>
-        <span class="cursor-pointer hover:text-atc-text transition-colors">Browseable airport catalog</span>
+        <span class="cursor-pointer hover:text-atc-text transition-colors">airportsapi.com</span>
+        <span class="cursor-pointer hover:text-atc-text transition-colors">Live airport directory</span>
       </div>
     </footer>
   </div>
@@ -134,6 +134,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import TopBar from '../ui/TopBar.vue'
 import Wordmark from '../ui/Wordmark.vue'
 import AirportCard from '../ui/AirportCard.vue'
+import { airportDirectoryClient } from '../../services/airportDirectory.js'
 
 const emit = defineEmits(['open-airport'])
 
@@ -144,8 +145,7 @@ const focused = ref(false)
 const results = ref([])
 const searchLoading = ref(false)
 const searchError = ref(null)
-const source = ref('ourairports')
-const catalogCount = ref(0)
+const cacheState = ref('cold')
 
 const kindOptions = [
   { id: 'all', label: 'All airports' },
@@ -165,14 +165,23 @@ const countryOptions = [
 ]
 
 let searchTimer = null
+let activeRequestId = 0
 
 const filtered = computed(() => results.value)
 
 const catalogLabel = computed(() => (
-  catalogCount.value ? `${catalogCount.value.toLocaleString()} airports indexed` : `${results.value.length} loaded`
+  cacheState.value === 'hit'
+    ? `${results.value.length.toLocaleString()} cached locally`
+    : `${results.value.length.toLocaleString()} live results`
 ))
 
-const sourceLabel = computed(() => source.value === 'airportsapi.com' ? 'airportsapi.com fallback' : 'OurAirports CSV')
+const sourceLabel = computed(() => (
+  cacheState.value === 'hit' ? 'airportsapi.com · cached' : 'airportsapi.com · live'
+))
+
+const cacheStatusLabel = computed(() => (
+  cacheState.value === 'hit' ? 'frontend cache hit' : 'frontend cache warming'
+))
 
 const browseTitle = computed(() => {
   const selectedKind = kindOptions.find((option) => option.id === kind.value)?.label || 'All airports'
@@ -181,29 +190,32 @@ const browseTitle = computed(() => {
 })
 
 const loadAirports = async (query = '') => {
+  const requestId = ++activeRequestId
   searchLoading.value = true
   searchError.value = null
   try {
-    const params = new URLSearchParams()
-    if (query.trim()) params.set('query', query.trim())
-    if (kind.value !== 'all') params.set('kind', kind.value)
-    if (country.value) params.set('country', country.value)
-    params.set('limit', '60')
-    const url = `/api/search/airports?${params.toString()}`
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(response.status >= 500 ? 'Airport search is unavailable right now' : `Airport search failed (${response.status})`)
+    const payload = await airportDirectoryClient.loadAirports({
+      query,
+      kind: kind.value,
+      country: country.value,
+      limit: 60,
+    })
+    if (requestId !== activeRequestId) {
+      return
     }
-    const payload = await response.json()
     results.value = payload.airports || []
-    source.value = payload.source || 'ourairports'
-    catalogCount.value = payload.catalog_count || catalogCount.value
+    cacheState.value = payload.cache || 'miss'
   } catch (err) {
+    if (requestId !== activeRequestId) {
+      return
+    }
     console.error('Airport search failed', err)
     results.value = []
-    searchError.value = err?.message || 'Airport search failed'
+    searchError.value = err?.message || 'Airport directory is unavailable right now'
   } finally {
-    searchLoading.value = false
+    if (requestId === activeRequestId) {
+      searchLoading.value = false
+    }
   }
 }
 

--- a/frontend/src/services/airportDirectory.js
+++ b/frontend/src/services/airportDirectory.js
@@ -1,0 +1,336 @@
+const API_BASE_URL = 'https://airportsapi.com/api'
+const CACHE_PREFIX = 'adsbao:airport-directory:v1:'
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1000
+const API_PAGE_SIZE = 30
+
+const TYPE_RANK = {
+  large_airport: 0,
+  medium_airport: 1,
+  small_airport: 2,
+  heliport: 3,
+}
+
+const ALL_KIND_SEQUENCE = [
+  'large_airport',
+  'medium_airport',
+  'small_airport',
+  'heliport',
+]
+
+const memoryCache = new Map()
+
+const toFiniteNumber = (value) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+const normalizeAirport = (record) => {
+  const attrs = record?.attributes || record || {}
+  const code = attrs.icao_code || attrs.gps_code || attrs.code || attrs.local_code || ''
+  const type = attrs.type || ''
+
+  return {
+    icao: code,
+    iata: attrs.iata_code || attrs.local_code || '',
+    name: attrs.name || code,
+    city: attrs.municipality || '',
+    country: attrs.country_code || attrs.iso_country || '',
+    lat: toFiniteNumber(attrs.latitude),
+    lon: toFiniteNumber(attrs.longitude),
+    type,
+    type_label: type ? type.replaceAll('_', ' ').replace(/\b\w/g, (char) => char.toUpperCase()) : '',
+    code: attrs.code || code,
+    source: 'airportsapi.com',
+  }
+}
+
+const makeAirportKey = (airport) => (
+  String(airport.icao || airport.code || airport.name || '').trim().toUpperCase()
+)
+
+const dedupeAirports = (airports) => {
+  const seen = new Set()
+  return airports.filter((airport) => {
+    const key = makeAirportKey(airport)
+    if (!key || seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+const matchesKind = (airport, kind) => kind === 'all' || !kind || airport.type === kind
+
+const matchesCountry = (airport, country) => !country || String(airport.country || '').toUpperCase() === country
+
+const matchesQuery = (airport, query) => {
+  const normalizedQuery = query.trim().toUpperCase()
+  if (!normalizedQuery) return true
+
+  const haystack = [
+    airport.icao,
+    airport.iata,
+    airport.code,
+    airport.name,
+    airport.city,
+    airport.country,
+  ].join(' ').toUpperCase()
+
+  return haystack.includes(normalizedQuery)
+}
+
+const browseScore = (airport) => ([
+  TYPE_RANK[airport.type] ?? 9,
+  airport.iata ? 0 : 1,
+  String(airport.name || ''),
+])
+
+const queryScore = (airport, query) => {
+  const normalizedQuery = query.trim().toUpperCase()
+  const code = String(airport.icao || airport.code || '').toUpperCase()
+  const iata = String(airport.iata || '').toUpperCase()
+  const name = String(airport.name || '').toUpperCase()
+  const city = String(airport.city || '').toUpperCase()
+
+  if (code === normalizedQuery || iata === normalizedQuery) return [0, browseScore(airport)]
+  if (code.startsWith(normalizedQuery) || iata.startsWith(normalizedQuery)) return [1, browseScore(airport)]
+  if (name.startsWith(normalizedQuery) || city.startsWith(normalizedQuery)) return [2, browseScore(airport)]
+  if (name.includes(normalizedQuery) || city.includes(normalizedQuery)) return [3, browseScore(airport)]
+  return [9, browseScore(airport)]
+}
+
+const resolveStorage = (storage) => {
+  if (storage) return storage
+  if (typeof window !== 'undefined' && window.localStorage) return window.localStorage
+  return null
+}
+
+const safeParse = (rawValue) => {
+  try {
+    return JSON.parse(rawValue)
+  } catch {
+    return null
+  }
+}
+
+const getNextLink = (payload) => {
+  const links = payload?.links
+  if (!links) return null
+  if (typeof links.next === 'string') return links.next
+  if (links.next?.href) return links.next.href
+  return null
+}
+
+const buildEndpoint = ({ country, queryType, queryValue, kind, cursor }) => {
+  const baseUrl = country
+    ? `${API_BASE_URL}/countries/${country}/airports`
+    : `${API_BASE_URL}/airports`
+  const url = new URL(baseUrl)
+  if (queryType && queryValue) url.searchParams.set(`filter[${queryType}]`, queryValue)
+  if (kind && kind !== 'all') url.searchParams.set('filter[type]', kind)
+  if (cursor) url.searchParams.set('page[cursor]', cursor)
+  return url.toString()
+}
+
+export const createAirportDirectoryClient = ({
+  fetchImpl = globalThis.fetch?.bind(globalThis),
+  storage,
+  now = () => Date.now(),
+  ttlMs = DEFAULT_TTL_MS,
+} = {}) => {
+  if (!fetchImpl) {
+    throw new Error('Airport directory client requires fetch support')
+  }
+
+  const resolvedStorage = resolveStorage(storage)
+
+  const getCached = (cacheKey) => {
+    const memoryEntry = memoryCache.get(cacheKey)
+    if (memoryEntry && memoryEntry.expiresAt > now()) {
+      return { ...memoryEntry.payload, cache: 'hit' }
+    }
+    if (memoryEntry) {
+      memoryCache.delete(cacheKey)
+    }
+
+    if (!resolvedStorage) return null
+
+    const parsed = safeParse(resolvedStorage.getItem(`${CACHE_PREFIX}${cacheKey}`))
+    if (!parsed || parsed.expiresAt <= now()) {
+      resolvedStorage.removeItem(`${CACHE_PREFIX}${cacheKey}`)
+      return null
+    }
+
+    memoryCache.set(cacheKey, parsed)
+    return { ...parsed.payload, cache: 'hit' }
+  }
+
+  const setCached = (cacheKey, payload) => {
+    const entry = {
+      expiresAt: now() + ttlMs,
+      payload,
+    }
+    memoryCache.set(cacheKey, entry)
+    if (resolvedStorage) {
+      resolvedStorage.setItem(`${CACHE_PREFIX}${cacheKey}`, JSON.stringify(entry))
+    }
+    return { ...payload, cache: 'miss' }
+  }
+
+  const fetchJson = async (url, { allow404 = false } = {}) => {
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/json, application/vnd.api+json',
+      },
+    })
+
+    if (allow404 && response.status === 404) return null
+    if (!response.ok) {
+      throw new Error(`Airport directory request failed (${response.status})`)
+    }
+    return response.json()
+  }
+
+  const fetchPagedAirports = async ({ country = '', kind = 'all', limit = 60, queryType = '', queryValue = '' }) => {
+    const airports = []
+    let cursor = null
+
+    while (airports.length < limit) {
+      const payload = await fetchJson(buildEndpoint({
+        country,
+        kind,
+        queryType,
+        queryValue,
+        cursor,
+      }))
+      airports.push(
+        ...(payload?.data || [])
+          .map(normalizeAirport)
+          .filter((airport) => airport.icao || airport.code || airport.name),
+      )
+
+      const nextLink = getNextLink(payload)
+      if (!nextLink) break
+
+      const nextUrl = new URL(nextLink)
+      cursor = nextUrl.searchParams.get('page[cursor]')
+      if (!cursor) break
+    }
+
+    return airports
+  }
+
+  const loadBrowseAirports = async ({ country = '', kind = 'all', limit = 60 }) => {
+    const normalizedCountry = String(country || '').trim().toUpperCase()
+    const normalizedKind = kind || 'all'
+    const cacheKey = `browse:${normalizedCountry}:${normalizedKind}:${limit}`
+    const cached = getCached(cacheKey)
+    if (cached) return cached
+
+    const kindsToLoad = normalizedKind === 'all' ? ALL_KIND_SEQUENCE : [normalizedKind]
+    const collected = []
+
+    for (const nextKind of kindsToLoad) {
+      const remaining = Math.max(limit - collected.length, API_PAGE_SIZE)
+      const airports = await fetchPagedAirports({
+        country: normalizedCountry,
+        kind: nextKind,
+        limit: remaining,
+      })
+      collected.push(...airports)
+      if (dedupeAirports(collected).length >= limit) break
+    }
+
+    const airports = dedupeAirports(collected)
+      .filter((airport) => matchesCountry(airport, normalizedCountry) && matchesKind(airport, normalizedKind))
+      .sort((left, right) => {
+        const [leftType, leftIata, leftName] = browseScore(left)
+        const [rightType, rightIata, rightName] = browseScore(right)
+        return leftType - rightType || leftIata - rightIata || leftName.localeCompare(rightName)
+      })
+      .slice(0, limit)
+
+    return setCached(cacheKey, {
+      airports,
+      source: 'airportsapi.com',
+    })
+  }
+
+  const searchAirports = async ({ query, country = '', kind = 'all', limit = 60 }) => {
+    const trimmed = String(query || '').trim()
+    const normalizedCountry = String(country || '').trim().toUpperCase()
+    const normalizedKind = kind || 'all'
+    const cacheKey = `search:${trimmed}:${normalizedCountry}:${normalizedKind}:${limit}`
+    const cached = getCached(cacheKey)
+    if (cached) return cached
+
+    const upper = trimmed.toUpperCase()
+    const candidates = []
+
+    if (/^[A-Z0-9]{4}$/.test(upper)) {
+      const exactPayload = await fetchJson(`${API_BASE_URL}/airports/${upper}`, { allow404: true })
+      if (exactPayload?.data) {
+        candidates.push(normalizeAirport(exactPayload.data))
+      }
+    }
+
+    const [codeMatches, nameMatches] = await Promise.all([
+      fetchPagedAirports({
+        country: normalizedCountry,
+        kind: normalizedKind === 'all' ? 'all' : normalizedKind,
+        limit,
+        queryType: 'code',
+        queryValue: upper,
+      }),
+      fetchPagedAirports({
+        country: normalizedCountry,
+        kind: normalizedKind === 'all' ? 'all' : normalizedKind,
+        limit,
+        queryType: 'name',
+        queryValue: trimmed,
+      }),
+    ])
+
+    candidates.push(...codeMatches, ...nameMatches)
+
+    if (normalizedCountry) {
+      const browseMatches = await loadBrowseAirports({
+        country: normalizedCountry,
+        kind: normalizedKind,
+        limit: Math.max(limit, 60),
+      })
+      candidates.push(...browseMatches.airports.filter((airport) => matchesQuery(airport, trimmed)))
+    }
+
+    const airports = dedupeAirports(candidates)
+      .filter((airport) => (
+        matchesCountry(airport, normalizedCountry)
+        && matchesKind(airport, normalizedKind)
+        && matchesQuery(airport, trimmed)
+      ))
+      .sort((left, right) => {
+        const [leftRank, leftBrowse] = queryScore(left, trimmed)
+        const [rightRank, rightBrowse] = queryScore(right, trimmed)
+        return leftRank - rightRank
+          || leftBrowse[0] - rightBrowse[0]
+          || leftBrowse[1] - rightBrowse[1]
+          || leftBrowse[2].localeCompare(rightBrowse[2])
+      })
+      .slice(0, limit)
+
+    return setCached(cacheKey, {
+      airports,
+      source: 'airportsapi.com',
+    })
+  }
+
+  return {
+    async loadAirports({ query = '', country = '', kind = 'all', limit = 60 } = {}) {
+      if (String(query || '').trim()) {
+        return searchAirports({ query, country, kind, limit })
+      }
+      return loadBrowseAirports({ country, kind, limit })
+    },
+  }
+}
+
+export const airportDirectoryClient = createAirportDirectoryClient()

--- a/frontend/src/services/airportDirectory.test.js
+++ b/frontend/src/services/airportDirectory.test.js
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+
+import { createAirportDirectoryClient } from './airportDirectory.js'
+
+const createMemoryStorage = () => {
+  const store = new Map()
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null
+    },
+    setItem(key, value) {
+      store.set(key, String(value))
+    },
+    removeItem(key) {
+      store.delete(key)
+    },
+  }
+}
+
+const createJsonResponse = (payload, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  async json() {
+    return payload
+  },
+})
+
+const makeRecord = (code, overrides = {}) => ({
+  id: code,
+  type: 'airports',
+  attributes: {
+    name: overrides.name || `${code} Airport`,
+    code,
+    type: overrides.type || 'large_airport',
+    latitude: overrides.latitude ?? 42.0,
+    longitude: overrides.longitude ?? -71.0,
+    gps_code: overrides.gps_code ?? code,
+    icao_code: overrides.icao_code ?? code,
+    iata_code: overrides.iata_code ?? code.slice(-3),
+    local_code: overrides.local_code ?? null,
+    municipality: overrides.municipality ?? '',
+    country_code: overrides.country_code ?? 'US',
+  },
+})
+
+{
+  const storage = createMemoryStorage()
+  const calls = []
+  const client = createAirportDirectoryClient({
+    fetchImpl: async (url) => {
+      calls.push(url)
+      return createJsonResponse({
+        data: [makeRecord('KBOS', { name: 'Boston Logan International Airport', municipality: 'Boston' })],
+        links: [],
+      })
+    },
+    storage,
+    now: () => 1_000,
+  })
+
+  const first = await client.loadAirports({ country: 'US', kind: 'large_airport', limit: 10 })
+  const second = await client.loadAirports({ country: 'US', kind: 'large_airport', limit: 10 })
+
+  assert.equal(calls.length, 1)
+  assert.match(calls[0], /\/api\/countries\/US\/airports\?/)
+  assert.match(calls[0], /filter%5Btype%5D=large_airport/)
+  assert.equal(first.source, 'airportsapi.com')
+  assert.equal(first.cache, 'miss')
+  assert.equal(second.cache, 'hit')
+  assert.equal(first.airports[0].icao, 'KBOS')
+  assert.equal(first.airports[0].city, 'Boston')
+}
+
+{
+  const storage = createMemoryStorage()
+  const calls = []
+  const client = createAirportDirectoryClient({
+    fetchImpl: async (url) => {
+      calls.push(url)
+      if (url.includes('/api/airports/KBOS')) {
+        return createJsonResponse({ data: makeRecord('KBOS', { name: 'Boston Logan International Airport', municipality: 'Boston' }) })
+      }
+      if (url.includes('filter%5Bcode%5D=KBOS')) {
+        return createJsonResponse({ data: [makeRecord('KBOS', { name: 'Boston Logan International Airport', municipality: 'Boston' })] })
+      }
+      if (url.includes('filter%5Bname%5D=KBOS')) {
+        return createJsonResponse({ data: [makeRecord('KBOS', { name: 'Boston Logan International Airport', municipality: 'Boston' })] })
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    },
+    storage,
+    now: () => 2_000,
+  })
+
+  const result = await client.loadAirports({ query: 'KBOS', limit: 10 })
+
+  assert.equal(calls.length, 3)
+  assert.equal(result.airports.length, 1)
+  assert.equal(result.airports[0].icao, 'KBOS')
+}
+
+{
+  const storage = createMemoryStorage()
+  const client = createAirportDirectoryClient({
+    fetchImpl: async (url) => {
+      if (url.includes('/api/countries/US/airports')) {
+        return createJsonResponse({
+          data: [
+            makeRecord('KBOS', { name: 'Logan International Airport', municipality: 'Boston' }),
+            makeRecord('KJFK', { name: 'John F Kennedy International Airport', municipality: 'New York' }),
+          ],
+          links: [],
+        })
+      }
+      if (url.includes('filter%5Bcode%5D=Boston')) {
+        return createJsonResponse({ data: [] })
+      }
+      if (url.includes('filter%5Bname%5D=Boston')) {
+        return createJsonResponse({ data: [] })
+      }
+      return createJsonResponse({}, 404)
+    },
+    storage,
+    now: () => 3_000,
+  })
+
+  await client.loadAirports({ country: 'US', kind: 'all', limit: 10 })
+  const result = await client.loadAirports({ query: 'Boston', country: 'US', kind: 'all', limit: 10 })
+
+  assert.equal(result.airports.length, 1)
+  assert.equal(result.airports[0].city, 'Boston')
+}


### PR DESCRIPTION
## Summary
- move homepage airport browsing/search off the backend OurAirports CSV path
- fetch live airport directory data from airportsapi.com and cache responses in the frontend
- add focused frontend tests for the new airport directory client and update local agent docs

## Testing
- pnpm test:airport-directory
- pnpm test:aircraft-motion
- pnpm test:aircraft-traffic-intent
- pnpm build