### PR TITLE
Handle missing country fields from airportsapi.com

### DIFF
--- a/frontend/src/services/airportDirectory.js
+++ b/frontend/src/services/airportDirectory.js
@@ -24,7 +24,7 @@ const toFiniteNumber = (value) => {
   return Number.isFinite(number) ? number : null
 }
 
-const normalizeAirport = (record) => {
+const normalizeAirport = (record, fallbackCountry = '') => {
   const attrs = record?.attributes || record || {}
   const code = attrs.icao_code || attrs.gps_code || attrs.code || attrs.local_code || ''
   const type = attrs.type || ''
@@ -34,7 +34,7 @@ const normalizeAirport = (record) => {
     iata: attrs.iata_code || attrs.local_code || '',
     name: attrs.name || code,
     city: attrs.municipality || '',
-    country: attrs.country_code || attrs.iso_country || '',
+    country: attrs.country_code || attrs.iso_country || fallbackCountry,
     lat: toFiniteNumber(attrs.latitude),
     lon: toFiniteNumber(attrs.longitude),
     type,
@@ -204,7 +204,7 @@ export const createAirportDirectoryClient = ({
       }))
       airports.push(
         ...(payload?.data || [])
-          .map(normalizeAirport)
+          .map((record) => normalizeAirport(record, country))
           .filter((airport) => airport.icao || airport.code || airport.name),
       )
 

--- a/frontend/src/services/airportDirectory.test.js
+++ b/frontend/src/services/airportDirectory.test.js
@@ -130,3 +130,35 @@ const makeRecord = (code, overrides = {}) => ({
   assert.equal(result.airports.length, 1)
   assert.equal(result.airports[0].city, 'Boston')
 }
+
+{
+  const client = createAirportDirectoryClient({
+    fetchImpl: async () => createJsonResponse({
+      data: [
+        {
+          id: 'KSEA',
+          type: 'airports',
+          attributes: {
+            name: 'Seattle Tacoma International Airport',
+            code: 'KSEA',
+            type: 'large_airport',
+            latitude: 47.449,
+            longitude: -122.309,
+            gps_code: 'KSEA',
+            icao_code: 'KSEA',
+            iata_code: 'SEA',
+            local_code: 'SEA',
+            municipality: 'Seattle',
+          },
+        },
+      ],
+      links: [],
+    }),
+    now: () => 4_000,
+  })
+
+  const result = await client.loadAirports({ country: 'US', kind: 'large_airport', limit: 11 })
+
+  assert.equal(result.airports.length, 1)
+  assert.equal(result.airports[0].country, 'US')
+}


### PR DESCRIPTION
## Summary
- preserve country context when airportsapi country endpoints omit country fields in each airport record
- keep the new US-only homepage browse flow from self-filtering everything down to zero
- add a regression case that mirrors the real airportsapi country endpoint payload shape

## Verification
- confirmed live airportsapi country endpoints return rows for US filters while omitting `country_code` and `iso_country`
- pnpm build