### PR TITLE
Restore aircraft polling cadence

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,11 @@
+.git
+.vercel
+dist
+screenshot.png
+
+frontend/.vercel
+frontend/dist
+frontend/node_modules
+
+packaging/electron/dist
+packaging/electron/node_modules

--- a/frontend/src/services/aviationData.js
+++ b/frontend/src/services/aviationData.js
@@ -1,6 +1,6 @@
 const env = import.meta.env ?? {}
 
-export const DEFAULT_AIRCRAFT_POLL_MS = 15_000
+export const DEFAULT_AIRCRAFT_POLL_MS = 3_000
 export const DEFAULT_AIRCRAFT_DIST_NM = 20
 
 const DEFAULT_METAR_BASE = '/api/proxy/metar'

--- a/frontend/src/services/aviationData.test.js
+++ b/frontend/src/services/aviationData.test.js
@@ -47,5 +47,5 @@ const createJsonResponse = (payload, status = 200) => ({
 }
 
 {
-  assert.equal(DEFAULT_AIRCRAFT_POLL_MS, 15_000)
+  assert.equal(DEFAULT_AIRCRAFT_POLL_MS, 3_000)
 }


### PR DESCRIPTION
## Summary
- restore the aircraft positions polling constant to 3 seconds
- add a root .vercelignore so manual root deployments do not upload local build artifacts

## Validation
- pnpm --dir frontend test:aviation-data
- pnpm --dir frontend build
- pnpm build
- deployed production to https://adsbao.vercel.app/
- verified https://adsbao.vercel.app/ and /KBOS return 200
- verified /api/proxy/metar/KBOS returns data
- observed repeated aircraft positions requests on https://adsbao.vercel.app/KBOS

Co-authored-by: Codex <codex@openai.com>