### PR TITLE
[codex] Narrow airport dashboard cards

### DIFF
--- a/frontend/src/components/screens/AirportCaptionScreen.vue
+++ b/frontend/src/components/screens/AirportCaptionScreen.vue
@@ -425,7 +425,9 @@ const formatObsTime = (value) => {
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-inline: auto;
   padding-bottom: 16px;
+  width: min(75vw, 1280px);
 }
 
 .glass-panel {
@@ -580,6 +582,7 @@ const formatObsTime = (value) => {
 @media (max-width: 1180px) {
   .airport-dashboard {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: min(86vw, 960px);
   }
 
   .traffic-panel {
@@ -611,6 +614,7 @@ const formatObsTime = (value) => {
 
   .airport-dashboard {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
   }
 
   .raw-metar-panel {


### PR DESCRIPTION
## Summary
- constrain the airport bottom dashboard to about 75% of desktop viewport width
- keep intermediate and mobile breakpoints preserving progressive card hiding

## Validation
- pnpm --dir frontend build
- pnpm --dir frontend test:home-airport-directory && pnpm --dir frontend test:airport-directory && pnpm --dir frontend test:aviation-data && pnpm --dir frontend test:airport-wiki && pnpm --dir frontend test:metar && pnpm --dir frontend test:aircraft-motion && pnpm --dir frontend test:aircraft-traffic-intent
- browser check at http://127.0.0.1:5174/KATL