### PR TITLE
feat: audit logging for external API fetches

### DIFF
--- a/src/services/airportDirectory.js
+++ b/src/services/airportDirectory.js
@@ -1,4 +1,5 @@
 import { toFiniteNumber } from '../utils/math.js'
+import { withAuditLogging } from '../utils/apiLogger.js'
 
 const API_BASE_URL = 'https://airportsapi.com/api'
 const CACHE_PREFIX = 'adsbao:airport-directory:v1:'
@@ -140,6 +141,8 @@ export const createAirportDirectoryClient = ({
 
   const resolvedStorage = resolveStorage(storage)
 
+  const auditedFetch = withAuditLogging(fetchImpl, { service: 'airportsapi.com' })
+
   const getCached = (cacheKey) => {
     const memoryEntry = memoryCache.get(cacheKey)
     if (memoryEntry && memoryEntry.expiresAt > now()) {
@@ -174,7 +177,7 @@ export const createAirportDirectoryClient = ({
   }
 
   const fetchJson = async (url, { allow404 = false } = {}) => {
-    const response = await fetchImpl(url, {
+    const response = await auditedFetch(url, {
       headers: {
         Accept: 'application/json, application/vnd.api+json',
       },

--- a/src/services/airportWiki.js
+++ b/src/services/airportWiki.js
@@ -1,3 +1,5 @@
+import { withAuditLogging } from '../utils/apiLogger.js'
+
 const WIKIPEDIA_SUMMARY_BASE = 'https://en.wikipedia.org/api/rest_v1/page/summary'
 
 const cleanText = (value) => String(value || '').replace(/\s+/g, ' ').trim()
@@ -53,10 +55,17 @@ export const normalizeWikipediaSummary = (payload) => {
 
 export const fetchAirportWikiSummary = async (airport, fetchImpl = fetch) => {
   const candidates = getAirportWikiTitleCandidates(airport)
+  const auditedFetch = withAuditLogging(fetchImpl, {
+    service: 'Wikipedia',
+    getParams(url) {
+      const title = decodeURIComponent(url.split('/').pop() || '')
+      return { title }
+    },
+  })
 
   for (const title of candidates) {
     try {
-      const response = await fetchImpl(getWikipediaSummaryUrl(title), {
+      const response = await auditedFetch(getWikipediaSummaryUrl(title), {
         headers: { Accept: 'application/json' },
       })
       if (!response.ok) continue

--- a/src/services/aviationData.js
+++ b/src/services/aviationData.js
@@ -1,3 +1,5 @@
+import { withAuditLogging } from '../utils/apiLogger.js'
+
 const env = import.meta.env ?? {}
 
 export const DEFAULT_AIRCRAFT_POLL_MS = 3_000
@@ -29,11 +31,19 @@ export const createMetarClient = ({
 } = {}) => {
   if (!fetchImpl) throw new Error('METAR client requires fetch support')
 
+  const auditedFetch = withAuditLogging(fetchImpl, {
+    service: 'AviationWeather/METAR',
+    getParams(url) {
+      const icao = decodeURIComponent(url.split('/').pop() || '')
+      return { icao }
+    },
+  })
+
   return {
     fetchMetar(icao) {
       const normalized = String(icao || '').trim().toUpperCase()
       if (!normalized) return []
-      return fetchJson(fetchImpl, `${baseUrl}/${encodeURIComponent(normalized)}`, {
+      return fetchJson(auditedFetch, `${baseUrl}/${encodeURIComponent(normalized)}`, {
         timeoutMs: 10_000,
       })
     },
@@ -46,12 +56,24 @@ export const createAircraftPositionClient = ({
 } = {}) => {
   if (!fetchImpl) throw new Error('Aircraft position client requires fetch support')
 
+  const auditedFetch = withAuditLogging(fetchImpl, {
+    service: 'adsb.lol/Aircraft',
+    getParams(url) {
+      const parts = url.split('/')
+      return {
+        lat: decodeURIComponent(parts[parts.length - 3] ?? ''),
+        lon: decodeURIComponent(parts[parts.length - 2] ?? ''),
+        distNm: decodeURIComponent(parts[parts.length - 1] ?? ''),
+      }
+    },
+  })
+
   return {
     fetchNearbyAircraft({ lat, lon, distNm = DEFAULT_AIRCRAFT_DIST_NM }) {
       const encodedLat = encodeURIComponent(String(lat))
       const encodedLon = encodeURIComponent(String(lon))
       const encodedDist = encodeURIComponent(String(distNm))
-      return fetchJson(fetchImpl, `${baseUrl}/${encodedLat}/${encodedLon}/${encodedDist}`, {
+      return fetchJson(auditedFetch, `${baseUrl}/${encodedLat}/${encodedLon}/${encodedDist}`, {
         timeoutMs: 14_000,
       })
     },

--- a/src/utils/apiLogger.js
+++ b/src/utils/apiLogger.js
@@ -1,0 +1,34 @@
+const parseQueryParams = (url) => {
+  try {
+    const parsed = new URL(url, 'http://localhost')
+    const result = {}
+    for (const [k, v] of parsed.searchParams) result[k] = v
+    return Object.keys(result).length ? result : null
+  } catch {
+    return null
+  }
+}
+
+export const withAuditLogging = (fetchImpl, { service = 'API', getParams } = {}) => {
+  return async (url, options) => {
+    const params = typeof getParams === 'function' ? getParams(url) : parseQueryParams(url)
+    const start = performance.now()
+    try {
+      const response = await fetchImpl(url, options)
+      const ms = Math.round(performance.now() - start)
+      console.group(`[audit:api] ${service}  HTTP ${response.status}  +${ms}ms`)
+      console.log('url:   ', url)
+      if (params) console.log('params:', params)
+      console.groupEnd()
+      return response
+    } catch (err) {
+      const ms = Math.round(performance.now() - start)
+      console.group(`[audit:api] ${service}  ERROR  +${ms}ms`)
+      console.log('url:   ', url)
+      if (params) console.log('params:', params)
+      console.error('error: ', err.message)
+      console.groupEnd()
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/utils/apiLogger.js` — a `withAuditLogging(fetchImpl, opts)` wrapper that logs every outbound fetch as a `[audit:api]` console group
- Each log entry reports: service name, URL, parsed parameters, HTTP status, and elapsed time (or error message on failure)
- Wired into all four external API clients:
  - **AviationWeather/METAR** — logs `{ icao }` extracted from path
  - **adsb.lol/Aircraft** — logs `{ lat, lon, distNm }` extracted from path segments
  - **airportsapi.com** — logs query-string params (`filter[type]`, `filter[code]`, `filter[name]`, `page[cursor]`)
  - **Wikipedia** — logs `{ title }` decoded from the summary URL path

## Test plan

- [x] `pnpm test:aviation-data` — METAR and ADS-B audit lines visible in output
- [x] `pnpm test:airport-directory` — airportsapi.com audit lines visible for all browse/search/resolve calls
- [x] `pnpm test:airport-wiki` — passes (wiki uses a mocked fetch in tests)
- [x] `pnpm test:metar` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)