### PR TITLE
Fix Vercel production proxy errors for METAR and aircraft endpoints

### DIFF
--- a/api/proxy/aircraft/positions/[...params].js
+++ b/api/proxy/aircraft/positions/[...params].js
@@ -1,9 +1,22 @@
 export const config = { runtime: 'edge' }
 
 export default async function handler(request) {
-  const url = new URL(request.url)
+  const requestUrl = typeof request?.url === 'string' ? request.url : ''
+  const url = requestUrl.startsWith('http')
+    ? new URL(requestUrl)
+    : new URL(requestUrl, 'https://adsbao.vercel.app')
   const segments = url.pathname.split('/').filter(Boolean)
-  const [lat, lon, dist] = segments.slice(-3).map(decodeURIComponent)
+  const [rawLat, rawLon, rawDist] = segments.slice(-3)
+  const safeDecode = (value = '') => {
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  }
+  const lat = safeDecode(rawLat)
+  const lon = safeDecode(rawLon)
+  const dist = safeDecode(rawDist)
   const start = Date.now()
 
   try {

--- a/api/proxy/metar/[icao].js
+++ b/api/proxy/metar/[icao].js
@@ -1,8 +1,17 @@
 export const config = { runtime: 'edge' }
 
 export default async function handler(request) {
-  const url = new URL(request.url)
-  const icao = decodeURIComponent(url.pathname.split('/').pop())
+  const requestUrl = typeof request?.url === 'string' ? request.url : ''
+  const url = requestUrl.startsWith('http')
+    ? new URL(requestUrl)
+    : new URL(requestUrl, 'https://adsbao.vercel.app')
+  const rawIcao = url.pathname.split('/').filter(Boolean).pop() || ''
+  let icao = rawIcao
+  try {
+    icao = decodeURIComponent(rawIcao)
+  } catch {
+    // Keep raw ICAO when decode fails instead of crashing the edge function.
+  }
   const start = Date.now()
 
   try {

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "buildCommand": "pnpm build",
   "outputDirectory": "dist",
   "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
### Motivation
- Production Vercel deployments intermittently crashed the Edge proxy handlers due to fragile `request.url` parsing and malformed percent-encoding in path segments.  
- API proxy routes could also be routed through the SPA catch-all rewrite and therefore not reach the proxy handlers.

### Description
- Hardened `api/proxy/metar/[icao].js` to safely resolve `request.url` in relative-URL Edge contexts and to avoid throwing on `decodeURIComponent` failures by falling back to the raw path segment.  
- Applied the same defensive URL resolution and safe decoding to `api/proxy/aircraft/positions/[...params].js` for `lat`, `lon`, and `dist` segments.  
- Updated `vercel.json` rewrites to preserve `/api/*` routes before the SPA fallback so proxy endpoints are not swallowed by `index.html` rewriting.  

### Testing
- Ran `pnpm build`, which completed successfully.  
- Ran `pnpm -s test:aviation-data`, which completed successfully and exercised the proxy handlers (observed upstream 200 audit logs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd6851aa08331bf2786be865b915a)