### PR TITLE
[codex] Add airport-aware flight route labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ pnpm build
 ## Tests
 
 ```bash
-pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
+pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
 ```
 
 ## Runtime config

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:aviation-data": "node src/services/aviationData.test.js",
     "test:vercel-routing": "node src/config/vercelRouting.test.js",
     "test:airport-wiki": "node src/services/airportWiki.test.js",
+    "test:flight-route-display": "node src/utils/flightRouteDisplay.test.js",
+    "test:airport-map-display": "node src/utils/airportMapDisplay.test.js",
     "test:metar": "node src/composables/useMetar.test.js",
     "test:aircraft-motion": "node src/utils/aircraftMotion.test.js",
     "test:aircraft-traffic-intent": "node src/utils/aircraftTrafficIntent.test.js",

--- a/src/components/map/AirportMap.vue
+++ b/src/components/map/AirportMap.vue
@@ -77,6 +77,10 @@ import {
     calculateAircraftVisualPosition,
     SLOW_AIRCRAFT_THRESHOLD_KT,
 } from "../../utils/aircraftMotion";
+import {
+    countGroundAircraft,
+    shouldShowAirportArea,
+} from "../../utils/airportMapDisplay.js";
 import { AIRCRAFT_COLORS, BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft";
 
 const props = defineProps({
@@ -92,6 +96,7 @@ const mapEl = ref(null);
 const mapReady = ref(false);
 let map = null;
 let sizeObs = null;
+let airportAreaLayer = null;
 // Track markers by icao24 for smooth position updates
 // Entry shape: { marker, color, label, lat, lon, positionTime, correctionLat, correctionLon, ... }
 const acMarkersMap = new Map();
@@ -158,25 +163,7 @@ const initMap = () => {
         },
     ).addTo(map);
 
-    // Airport perimeter box (approx ±0.03° from center)
-    if (props.lat && props.lon) {
-        const d = 0.032;
-        L.polygon(
-            [
-                [props.lat + d, props.lon - d],
-                [props.lat + d, props.lon + d],
-                [props.lat - d, props.lon + d],
-                [props.lat - d, props.lon - d],
-            ],
-            {
-                color: "rgba(255,255,255,0.2)",
-                weight: 1,
-                dashArray: "4 4",
-                fillColor: "rgba(255,255,255,0.02)",
-                fillOpacity: 1,
-            },
-        ).addTo(map);
-    }
+    updateAirportArea();
 
     latStr.value = props.lat
         ? `${Math.abs(props.lat).toFixed(2)}°${props.lat >= 0 ? "N" : "S"}`
@@ -270,12 +257,54 @@ const queueAircraftTelemetrySync = (marker, ac) => {
     requestAnimationFrame(() => syncAircraftTelemetry(marker, ac));
 };
 
+const makeAirportAreaIcon = (groundCount) =>
+    L.divIcon({
+        className: "airport-area-count-icon",
+        html: `<div class="airport-area-count">
+      <span>Ground</span>
+      <strong>${groundCount}</strong>
+    </div>`,
+        iconSize: [76, 38],
+        iconAnchor: [38, 19],
+    });
+
+const updateAirportArea = () => {
+    if (!map) return;
+
+    airportAreaLayer?.removeFrom(map);
+    airportAreaLayer = null;
+
+    if (!props.lat || !props.lon || !shouldShowAirportArea(props.zoom)) return;
+
+    const d = 0.032;
+    const bounds = [
+        [props.lat + d, props.lon - d],
+        [props.lat + d, props.lon + d],
+        [props.lat - d, props.lon + d],
+        [props.lat - d, props.lon - d],
+    ];
+    airportAreaLayer = L.layerGroup([
+        L.polygon(bounds, {
+            color: "rgba(255,255,255,0.2)",
+            weight: 1,
+            dashArray: "4 4",
+            fillColor: "rgba(255,255,255,0.02)",
+            fillOpacity: 1,
+        }),
+        L.marker([props.lat, props.lon], {
+            icon: makeAirportAreaIcon(countGroundAircraft(props.aircraft)),
+            interactive: false,
+        }),
+    ]).addTo(map);
+};
+
 const makeAcIcon = (
     color,
     label,
     rot = 0,
     showArrow = true,
     hasTelemetry = false,
+    routeLabel = "",
 ) => {
     const symbol = showArrow
         ? `<svg width="18" height="18" viewBox="0 0 24 24" style="transform:rotate(${rot}deg);filter:drop-shadow(0 0 4px ${color})">
@@ -285,6 +314,7 @@ const makeAcIcon = (
         <circle cx="3.5" cy="3.5" r="3.5" fill="${color}"/>
        </svg>`;
     const safeLabel = escapeHtml(label);
+    const safeRouteLabel = escapeHtml(routeLabel);
     const labelTop = showArrow && hasTelemetry ? "-4px" : "2px";
     const telemetryLine =
         showArrow && hasTelemetry
@@ -294,13 +324,25 @@ const makeAcIcon = (
         <span data-aircraft-flow="altitude"></span>
       </div>`
             : "";
+    const routeLine = safeRouteLabel
+        ? `<div class="aircraft-route-label">${safeRouteLabel}</div>`
+        : "";
+    const labelClass = safeRouteLabel
+        ? "aircraft-label aircraft-label--route-cycle"
+        : "aircraft-label";
+    const titleLine = safeRouteLabel
+        ? `<div class="aircraft-title-cycle">
+          <div class="aircraft-label-title aircraft-callsign-state">${safeLabel}</div>
+          ${routeLine}
+        </div>`
+        : `<div class="aircraft-label-title">${safeLabel}</div>`;
 
     return L.divIcon({
         className: "",
         html: `<div style="position:relative;display:flex;align-items:center">
       ${symbol}
-      <div class="aircraft-label" style="left:${showArrow ? 22 : 18}px;top:${labelTop};color:${color}">
-        <div class="aircraft-label-title">${safeLabel}</div>
+      <div class="${labelClass}" style="left:${showArrow ? 22 : 18}px;top:${labelTop};color:${color}">
+        ${titleLine}
         ${telemetryLine}
       </div>
     </div>`,
@@ -332,6 +374,7 @@ const updateAircraft = () => {
         const isAnimated = !ac.onGround && showArrow;
         const color = getAircraftColor(ac, showArrow);
         const label = (ac.callsign || ac.icao24 || "").trim();
+        const routeLabel = (ac.flightRouteLabel || "").trim();
         const rot = Math.round(ac.track || 0);
         const hasTelemetry =
             !ac.onGround &&
@@ -357,17 +400,26 @@ const updateAircraft = () => {
                 label !== entry.label ||
                 rot !== entry.rot ||
                 showArrow !== entry.showArrow ||
-                hasTelemetry !== entry.hasTelemetry
+                hasTelemetry !== entry.hasTelemetry ||
+                routeLabel !== entry.routeLabel
             ) {
                 unmountAircraftTelemetry(entry.marker);
                 entry.marker.setIcon(
-                    makeAcIcon(color, label, rot, showArrow, hasTelemetry),
+                    makeAcIcon(
+                        color,
+                        label,
+                        rot,
+                        showArrow,
+                        hasTelemetry,
+                        routeLabel,
+                    ),
                 );
                 entry.color = color;
                 entry.label = label;
                 entry.rot = rot;
                 entry.showArrow = showArrow;
                 entry.hasTelemetry = hasTelemetry;
+                entry.routeLabel = routeLabel;
             }
             if (hasTelemetry) queueAircraftTelemetrySync(entry.marker, ac);
         } else {
@@ -377,7 +429,14 @@ const updateAircraft = () => {
                 now,
             );
             const m = L.marker([visualPosition.lat, visualPosition.lon], {
-                icon: makeAcIcon(color, label, rot, showArrow, hasTelemetry),
+                icon: makeAcIcon(
+                    color,
+                    label,
+                    rot,
+                    showArrow,
+                    hasTelemetry,
+                    routeLabel,
+                ),
             }).addTo(map);
             acMarkersMap.set(ac.icao24, {
                 marker: m,
@@ -386,6 +445,7 @@ const updateAircraft = () => {
                 rot,
                 showArrow,
                 hasTelemetry,
+                routeLabel,
                 ...motionState,
                 velocity: vel,
                 track: ac.track ?? 0,
@@ -403,6 +463,8 @@ const updateAircraft = () => {
             acMarkersMap.delete(id);
         }
     }
+
+    updateAirportArea();
 };
 
 watch(() => props.aircraft, updateAircraft, { deep: true });
@@ -413,13 +475,17 @@ watch(
             map.setView([lat, lon], props.zoom);
             latStr.value = `${Math.abs(lat).toFixed(2)}°${lat >= 0 ? "N" : "S"}`;
             lonStr.value = `${Math.abs(lon).toFixed(2)}°${lon >= 0 ? "E" : "W"}`;
+            updateAirportArea();
         }
     },
 );
 watch(
     () => props.zoom,
     (zoom) => {
-        if (map) map.setZoom(zoom);
+        if (map) {
+            map.setZoom(zoom);
+            updateAirportArea();
+        }
     },
 );
 
@@ -430,6 +496,8 @@ onUnmounted(() => {
     for (const [, entry] of acMarkersMap)
         unmountAircraftTelemetry(entry.marker);
     acMarkersMap.clear();
+    airportAreaLayer?.removeFrom(map);
+    airportAreaLayer = null;
     if (map) {
         map.remove();
         map = null;
@@ -461,6 +529,69 @@ onUnmounted(() => {
     font-size: 10px;
 }
 
+.aircraft-label--route-cycle {
+    min-height: 20px;
+    min-width: 74px;
+}
+
+.aircraft-title-cycle {
+    min-height: 11px;
+    min-width: 74px;
+    position: relative;
+}
+
+.aircraft-callsign-state,
+.aircraft-route-label {
+    transition: opacity 0.32s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.aircraft-label--route-cycle .aircraft-callsign-state {
+    animation: aircraft-callsign-fade 7.2s infinite;
+}
+
+.aircraft-route-label {
+    color: inherit;
+    font-size: 9px;
+    font-weight: 800;
+    left: 0;
+    letter-spacing: 0.4px;
+    line-height: 1.05;
+    opacity: 0;
+    position: absolute;
+    text-shadow:
+        0 0 4px #0a0a0b,
+        0 0 8px #0a0a0b;
+    top: 0;
+}
+
+.aircraft-label--route-cycle .aircraft-route-label {
+    animation: aircraft-route-fade 7.2s infinite;
+}
+
+@keyframes aircraft-callsign-fade {
+    0%,
+    42%,
+    100% {
+        opacity: 1;
+    }
+    50%,
+    84% {
+        opacity: 0;
+    }
+}
+
+@keyframes aircraft-route-fade {
+    0%,
+    42%,
+    100% {
+        opacity: 0;
+    }
+    50%,
+    84% {
+        opacity: 1;
+    }
+}
+
 .aircraft-telemetry {
     align-items: baseline;
     color: rgba(245, 245, 247, 0.86);
@@ -489,5 +620,52 @@ onUnmounted(() => {
 .aircraft-telemetry-separator {
     color: rgba(255, 90, 31, 0.72);
     font-size: 0.9em;
+}
+
+.airport-area-count {
+    align-items: center;
+    background: rgba(10, 10, 11, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 10px;
+    box-shadow:
+        0 8px 24px rgba(0, 0, 0, 0.26),
+        inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    color: rgba(245, 245, 247, 0.86);
+    display: flex;
+    font-family: "JetBrains Mono", monospace;
+    gap: 7px;
+    justify-content: center;
+    min-width: 76px;
+    padding: 7px 8px;
+    text-shadow: 0 0 7px #0a0a0b;
+}
+
+.airport-area-count span {
+    color: rgba(245, 245, 247, 0.46);
+    font-size: 8px;
+    font-weight: 800;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.airport-area-count strong {
+    color: var(--atc-mint);
+    font-size: 15px;
+    line-height: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .aircraft-label--route-cycle .aircraft-callsign-state,
+    .aircraft-label--route-cycle .aircraft-route-label {
+        animation: none;
+    }
+
+    .aircraft-label--route-cycle .aircraft-callsign-state {
+        opacity: 1;
+    }
+
+    .aircraft-label--route-cycle .aircraft-route-label {
+        display: none;
+    }
 }
 </style>

--- a/src/components/screens/AirportCaptionScreen.vue
+++ b/src/components/screens/AirportCaptionScreen.vue
@@ -17,7 +17,7 @@
                 :lon="airportLon"
                 :zoom="mapZoom"
                 accent="#FF5A1F"
-                :aircraft="aircraft"
+                :aircraft="aircraftWithRoutes"
             />
         </div>
 
@@ -277,9 +277,12 @@ import MapControlBar from "../ui/MapControlBar.vue";
 import AirportMap from "../map/AirportMap.vue";
 import { useAircraftPositions } from "../../composables/useAircraftPositions.js";
 import { useAirportWiki } from "../../composables/useAirportWiki.js";
+import { useFlightRoutes } from "../../composables/useFlightRoutes.js";
 import { useMetar } from "../../composables/useMetar.js";
 import { AIRCRAFT_COLORS, BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft.js";
 import { SLOW_AIRCRAFT_THRESHOLD_KT } from "../../utils/aircraftMotion.js";
+import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
+import { formatLocalFlightRouteLabel } from "../../utils/flightRouteDisplay.js";
 import { AIRPORT_FALLBACKS, COORDS } from "../../data/airportFallbacks.js";
 
 const props = defineProps({
@@ -291,7 +294,7 @@ const props = defineProps({
 
 defineEmits(["back"]);
 
-const mapZoom = ref(13);
+const mapZoom = ref(ZOOM_APPROACH);
 const activeWeatherView = ref("parsed");
 const mobileMapDim = ref(0);
 const mobileBreadcrumbOpacity = ref(1);
@@ -383,6 +386,30 @@ const airportLon = computed(
 const latRef = computed(() => airportLat.value);
 const lonRef = computed(() => airportLon.value);
 const { aircraft, lastUpdated } = useAircraftPositions(icaoRef, latRef, lonRef);
+const { routesByCallsign } = useFlightRoutes(aircraft);
+
+const normalizeCallsign = (callsign) =>
+    String(callsign || "").trim().toUpperCase().replace(/\s+/g, "");
+
+const aircraftWithRoutes = computed(() =>
+    aircraft.value.map((item) => {
+        const key = normalizeCallsign(item.callsign);
+        const route = routesByCallsign.value[key] || null;
+        const localAirport = {
+            iata: airportCodeLabel.value,
+            icao: props.airport?.icao || props.icao,
+        };
+        return {
+            ...item,
+            flightRoute: route,
+            flightRouteLabel: formatLocalFlightRouteLabel(
+                route,
+                localAirport,
+                item.trafficIntent,
+            ),
+        };
+    }),
+);
 
 const wikiAirport = computed(() => ({
     name: airportName.value,

--- a/src/components/ui/MapControlBar.vue
+++ b/src/components/ui/MapControlBar.vue
@@ -200,10 +200,11 @@
 
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from "vue";
-
-const ZOOM_APPROACH = 10;
-const ZOOM_AIRPORT = 13;
-const ZOOM_DETAIL = 14;
+import {
+    ZOOM_AIRPORT,
+    ZOOM_APPROACH,
+    ZOOM_DETAIL,
+} from "../../utils/airportMapDisplay.js";
 
 const VIDEO_ID = "JDQiaRYmTGk";
 

--- a/src/composables/useFlightRoutes.js
+++ b/src/composables/useFlightRoutes.js
@@ -1,0 +1,99 @@
+import { computed, onUnmounted, shallowRef, watch } from 'vue'
+
+import { flightRouteClient } from '../services/aviationData.js'
+
+const HIT_CACHE_MS = 6 * 60 * 60 * 1000
+const MISS_CACHE_MS = 30 * 60 * 1000
+const MAX_LOOKUPS_PER_PASS = 6
+
+const routeCache = new Map()
+const inFlight = new Set()
+
+const normalizeCallsign = (callsign) =>
+  String(callsign || '').trim().toUpperCase().replace(/\s+/g, '')
+
+const isLookupCandidate = (callsign) => /^[A-Z0-9]{2,8}$/.test(callsign)
+
+const getFreshCacheEntry = (callsign, now = Date.now()) => {
+  const cached = routeCache.get(callsign)
+  if (!cached) return null
+
+  const maxAge = cached.route ? HIT_CACHE_MS : MISS_CACHE_MS
+  if (now - cached.time <= maxAge) return cached
+
+  routeCache.delete(callsign)
+  return null
+}
+
+export function useFlightRoutes(aircraftRef) {
+  const version = shallowRef(0)
+  const loadingCount = shallowRef(0)
+  let disposed = false
+
+  const bump = () => {
+    version.value += 1
+  }
+
+  const lookup = async (callsign) => {
+    inFlight.add(callsign)
+    loadingCount.value = inFlight.size
+    try {
+      const route = await flightRouteClient.fetchFlightRoute(callsign)
+      routeCache.set(callsign, {
+        route,
+        time: Date.now(),
+      })
+    } catch (error) {
+      console.warn(`Flight route lookup failed for ${callsign}:`, error.message)
+    } finally {
+      inFlight.delete(callsign)
+      loadingCount.value = inFlight.size
+      if (!disposed) bump()
+    }
+  }
+
+  watch(
+    aircraftRef,
+    (aircraft = []) => {
+      const now = Date.now()
+      const callsigns = [
+        ...new Set(
+          aircraft
+            .map((item) => normalizeCallsign(item.callsign))
+            .filter(isLookupCandidate),
+        ),
+      ]
+
+      const pending = callsigns
+        .filter((callsign) => !getFreshCacheEntry(callsign, now) && !inFlight.has(callsign))
+        .slice(0, MAX_LOOKUPS_PER_PASS)
+
+      pending.forEach(lookup)
+      bump()
+    },
+    { immediate: true },
+  )
+
+  const routesByCallsign = computed(() => {
+    version.value
+    const routes = {}
+    const now = Date.now()
+
+    for (const item of aircraftRef.value || []) {
+      const callsign = normalizeCallsign(item.callsign)
+      const cached = getFreshCacheEntry(callsign, now)
+      if (cached?.route) routes[callsign] = cached.route
+    }
+
+    return routes
+  })
+
+  onUnmounted(() => {
+    disposed = true
+  })
+
+  return {
+    routesByCallsign,
+    loadingCount,
+  }
+}

--- a/src/config/vercelRouting.test.js
+++ b/src/config/vercelRouting.test.js
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'node:fs'
 
 const config = JSON.parse(readFileSync(new URL('../../vercel.json', import.meta.url), 'utf8'))
 
-assert.deepEqual(config.rewrites?.slice(0, 2), [
+assert.deepEqual(config.rewrites?.slice(0, 3), [
   {
     source: '/api/proxy/metar/:icao',
     destination: 'https://aviationweather.gov/api/data/metar?ids=:icao&format=json',
@@ -12,8 +12,13 @@ assert.deepEqual(config.rewrites?.slice(0, 2), [
     source: '/api/proxy/aircraft/positions/:lat/:lon/:dist',
     destination: 'https://api.adsb.lol/v2/lat/:lat/lon/:lon/dist/:dist',
   },
+  {
+    source: '/api/proxy/flight-routes/callsign/:callsign',
+    destination: 'https://api.adsbdb.com/v0/callsign/:callsign',
+  },
 ])
 
 assert.equal(config.rewrites?.at(-1)?.destination, '/index.html')
 assert.equal(existsSync(new URL('../../api/proxy/metar/[icao].js', import.meta.url)), false)
 assert.equal(existsSync(new URL('../../api/proxy/aircraft/positions/[...params].js', import.meta.url)), false)
+assert.equal(existsSync(new URL('../../api/proxy/flight-routes/callsign/[callsign].js', import.meta.url)), false)

--- a/src/services/aviationData.js
+++ b/src/services/aviationData.js
@@ -7,6 +7,7 @@ export const DEFAULT_AIRCRAFT_DIST_NM = 20
 
 const DEFAULT_METAR_BASE = '/api/proxy/metar'
 const DEFAULT_AIRCRAFT_POSITIONS_BASE = '/api/proxy/aircraft/positions'
+const DEFAULT_FLIGHT_ROUTE_BASE = '/api/proxy/flight-routes/callsign'
 
 const createTimeoutSignal = (timeoutMs) => (
   typeof AbortSignal !== 'undefined' && AbortSignal.timeout
@@ -80,5 +81,88 @@ export const createAircraftPositionClient = ({
   }
 }
 
+const normalizeAirport = (airport) => {
+  if (!airport) return null
+  const lat = Number(airport.latitude)
+  const lon = Number(airport.longitude)
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null
+
+  return {
+    icao: String(airport.icao_code || '').trim().toUpperCase(),
+    iata: String(airport.iata_code || '').trim().toUpperCase(),
+    name: String(airport.name || '').trim(),
+    municipality: String(airport.municipality || '').trim(),
+    country: String(airport.country_name || '').trim(),
+    lat,
+    lon,
+  }
+}
+
+export const normalizeFlightRoute = (payload) => {
+  const route = payload?.response?.flightroute
+  if (!route) return null
+
+  const origin = normalizeAirport(route.origin)
+  const destination = normalizeAirport(route.destination)
+  if (!origin || !destination || !origin.icao || !destination.icao) return null
+
+  const callsign = String(route.callsign || route.callsign_icao || '').trim().toUpperCase()
+  if (!callsign) return null
+
+  return {
+    callsign,
+    callsignIcao: String(route.callsign_icao || '').trim().toUpperCase(),
+    callsignIata: String(route.callsign_iata || '').trim().toUpperCase(),
+    airlineName: String(route.airline?.name || '').trim(),
+    airlineIcao: String(route.airline?.icao || '').trim().toUpperCase(),
+    airlineIata: String(route.airline?.iata || '').trim().toUpperCase(),
+    origin,
+    destination,
+    source: 'adsbdb',
+  }
+}
+
+const normalizeCallsign = (callsign) =>
+  String(callsign || '').trim().toUpperCase().replace(/\s+/g, '')
+
+export const createFlightRouteClient = ({
+  fetchImpl = globalThis.fetch?.bind(globalThis),
+  baseUrl = env.VITE_FLIGHT_ROUTE_BASE || DEFAULT_FLIGHT_ROUTE_BASE,
+} = {}) => {
+  if (!fetchImpl) throw new Error('Flight route client requires fetch support')
+
+  const auditedFetch = withAuditLogging(fetchImpl, {
+    service: 'adsbdb/FlightRoute',
+    getParams(url) {
+      return { callsign: decodeURIComponent(url.split('/').pop() || '') }
+    },
+  })
+
+  return {
+    async fetchFlightRoute(callsign) {
+      const normalized = normalizeCallsign(callsign)
+      if (!normalized) return null
+
+      const response = await auditedFetch(`${baseUrl}/${encodeURIComponent(normalized)}`, {
+        signal: createTimeoutSignal(10_000),
+        headers: {
+          Accept: 'application/json',
+        },
+      })
+
+      if (response.status === 400 || response.status === 404) return null
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+
+      const body = await response.text()
+      try {
+        return normalizeFlightRoute(JSON.parse(body))
+      } catch {
+        throw new Error(`Expected JSON from ${baseUrl}/${normalized}`)
+      }
+    },
+  }
+}
+
 export const metarClient = createMetarClient()
 export const aircraftPositionClient = createAircraftPositionClient()
+export const flightRouteClient = createFlightRouteClient()

--- a/src/services/aviationData.test.js
+++ b/src/services/aviationData.test.js
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict'
 
 import {
   createAircraftPositionClient,
+  createFlightRouteClient,
   createMetarClient,
   DEFAULT_AIRCRAFT_POLL_MS,
+  normalizeFlightRoute,
 } from './aviationData.js'
 
 const createJsonResponse = (payload, status = 200) => ({
@@ -61,6 +63,91 @@ const createTextResponse = (payload, status = 200, contentType = 'text/html') =>
 
 {
   assert.equal(DEFAULT_AIRCRAFT_POLL_MS, 3_000)
+}
+
+{
+  const route = normalizeFlightRoute({
+    response: {
+      flightroute: {
+        callsign: 'DAL123',
+        callsign_icao: 'DAL123',
+        callsign_iata: 'DL123',
+        airline: {
+          name: 'Delta Air Lines',
+          icao: 'DAL',
+          iata: 'DL',
+        },
+        origin: {
+          icao_code: 'EGPH',
+          iata_code: 'EDI',
+          name: 'Edinburgh Airport',
+          municipality: 'Edinburgh',
+          country_name: 'United Kingdom',
+          latitude: 55.950145,
+          longitude: -3.372288,
+        },
+        destination: {
+          icao_code: 'KBOS',
+          iata_code: 'BOS',
+          name: 'Logan International Airport',
+          municipality: 'Boston',
+          country_name: 'United States',
+          latitude: 42.3643,
+          longitude: -71.005203,
+        },
+      },
+    },
+  })
+
+  assert.equal(route.callsign, 'DAL123')
+  assert.equal(route.airlineName, 'Delta Air Lines')
+  assert.equal(route.origin.icao, 'EGPH')
+  assert.equal(route.destination.iata, 'BOS')
+}
+
+{
+  const calls = []
+  const client = createFlightRouteClient({
+    fetchImpl: async (url) => {
+      calls.push(url)
+      return createJsonResponse({
+        response: {
+          flightroute: {
+            callsign: 'BAW213',
+            origin: {
+              icao_code: 'EGLL',
+              iata_code: 'LHR',
+              name: 'Heathrow Airport',
+              latitude: 51.4706,
+              longitude: -0.461941,
+            },
+            destination: {
+              icao_code: 'KBOS',
+              iata_code: 'BOS',
+              name: 'Logan International Airport',
+              latitude: 42.3643,
+              longitude: -71.005203,
+            },
+          },
+        },
+      })
+    },
+  })
+
+  const route = await client.fetchFlightRoute(' baw213 ')
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0], '/api/proxy/flight-routes/callsign/BAW213')
+  assert.equal(route.origin.iata, 'LHR')
+  assert.equal(route.destination.icao, 'KBOS')
+}
+
+{
+  const client = createFlightRouteClient({
+    fetchImpl: async () => createJsonResponse({ response: 'unknown callsign' }, 404),
+  })
+
+  assert.equal(await client.fetchFlightRoute('NOPE123'), null)
 }
 
 {

--- a/src/utils/airportMapDisplay.js
+++ b/src/utils/airportMapDisplay.js
@@ -1,0 +1,8 @@
+export const ZOOM_APPROACH = 10
+export const ZOOM_AIRPORT = 13
+export const ZOOM_DETAIL = 14
+
+export const shouldShowAirportArea = (zoom) => Number(zoom) >= ZOOM_AIRPORT
+
+export const countGroundAircraft = (aircraft = []) =>
+  aircraft.filter((item) => item?.onGround).length

--- a/src/utils/airportMapDisplay.test.js
+++ b/src/utils/airportMapDisplay.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+
+import { countGroundAircraft, shouldShowAirportArea } from './airportMapDisplay.js'
+
+assert.equal(shouldShowAirportArea(10), false)
+assert.equal(shouldShowAirportArea(13), true)
+assert.equal(shouldShowAirportArea(14), true)
+
+assert.equal(
+  countGroundAircraft([
+    { onGround: true },
+    { onGround: false },
+    { onGround: true },
+    {},
+  ]),
+  2,
+)

--- a/src/utils/flightRouteDisplay.js
+++ b/src/utils/flightRouteDisplay.js
@@ -1,0 +1,45 @@
+const airportCode = (airport) =>
+  String(airport?.iata || airport?.icao || '').trim().toUpperCase()
+
+const airportCodes = (airport) =>
+  new Set(
+    [airport?.iata, airport?.icao]
+      .map((code) => String(code || '').trim().toUpperCase())
+      .filter(Boolean),
+  )
+
+const airportMatches = (routeAirport, airport) => {
+  const localCodes = airportCodes(airport)
+  return [routeAirport?.iata, routeAirport?.icao]
+    .map((code) => String(code || '').trim().toUpperCase())
+    .some((code) => localCodes.has(code))
+}
+
+export const formatFlightRouteLabel = (route) => {
+  const origin = airportCode(route?.origin)
+  const destination = airportCode(route?.destination)
+  return origin && destination ? `${origin} -> ${destination}` : ''
+}
+
+export const formatLocalFlightRouteLabel = (route, airport, trafficIntent) => {
+  if (!route || !airport) return ''
+
+  if (trafficIntent === 'arrival' && !airportMatches(route.destination, airport)) {
+    return ''
+  }
+
+  if (trafficIntent === 'departure' && !airportMatches(route.origin, airport)) {
+    return ''
+  }
+
+  if (
+    trafficIntent !== 'arrival'
+    && trafficIntent !== 'departure'
+    && !airportMatches(route.origin, airport)
+    && !airportMatches(route.destination, airport)
+  ) {
+    return ''
+  }
+
+  return formatFlightRouteLabel(route)
+}

--- a/src/utils/flightRouteDisplay.test.js
+++ b/src/utils/flightRouteDisplay.test.js
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+
+import {
+  formatFlightRouteLabel,
+  formatLocalFlightRouteLabel,
+} from './flightRouteDisplay.js'
+
+{
+  const label = formatFlightRouteLabel({
+    origin: { iata: 'JFK', icao: 'KJFK' },
+    destination: { iata: 'LHR', icao: 'EGLL' },
+  })
+
+  assert.equal(label, 'JFK -> LHR')
+}
+
+{
+  const label = formatFlightRouteLabel({
+    origin: { icao: 'KBOS' },
+    destination: { icao: 'KSFO' },
+  })
+
+  assert.equal(label, 'KBOS -> KSFO')
+}
+
+{
+  assert.equal(formatFlightRouteLabel(null), '')
+  assert.equal(formatFlightRouteLabel({ origin: { iata: 'BOS' } }), '')
+}
+
+{
+  const route = {
+    origin: { iata: 'LAX', icao: 'KLAX' },
+    destination: { iata: 'BOS', icao: 'KBOS' },
+  }
+
+  assert.equal(
+    formatLocalFlightRouteLabel(route, { iata: 'BOS', icao: 'KBOS' }, 'arrival'),
+    'LAX -> BOS',
+  )
+  assert.equal(
+    formatLocalFlightRouteLabel(route, { iata: 'BOS', icao: 'KBOS' }, 'departure'),
+    '',
+  )
+}
+
+{
+  const route = {
+    origin: { iata: 'BOS', icao: 'KBOS' },
+    destination: { iata: 'ATL', icao: 'KATL' },
+  }
+
+  assert.equal(
+    formatLocalFlightRouteLabel(route, { iata: 'BOS', icao: 'KBOS' }, 'departure'),
+    'BOS -> ATL',
+  )
+  assert.equal(
+    formatLocalFlightRouteLabel(route, { iata: 'BOS', icao: 'KBOS' }, 'arrival'),
+    '',
+  )
+}
+
+{
+  const route = {
+    origin: { iata: 'PHX', icao: 'KPHX' },
+    destination: { iata: 'MIA', icao: 'KMIA' },
+  }
+
+  assert.equal(
+    formatLocalFlightRouteLabel(route, { iata: 'BOS', icao: 'KBOS' }, 'unknown'),
+    '',
+  )
+}

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
       "source": "/api/proxy/aircraft/positions/:lat/:lon/:dist",
       "destination": "https://api.adsb.lol/v2/lat/:lat/lon/:lon/dist/:dist"
     },
+    {
+      "source": "/api/proxy/flight-routes/callsign/:callsign",
+      "destination": "https://api.adsbdb.com/v0/callsign/:callsign"
+    },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,14 @@ export default defineConfig({
           '/v2/lat/$1/lon/$2/dist/$3',
         ),
       },
+      '/api/proxy/flight-routes/callsign': {
+        target: 'https://api.adsbdb.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(
+          /^\/api\/proxy\/flight-routes\/callsign\/([^/]+)$/,
+          '/v0/callsign/$1',
+        ),
+      },
     }
   }
 })


### PR DESCRIPTION
## Summary
- add ADSBdb callsign route lookup through the existing proxy pattern
- show route labels on aircraft only when the matched route is plausible for the selected airport and inferred traffic intent
- keep speed/altitude visible while only the callsign text fades to `SOURCE -> DESTINATION`
- default the map to approach zoom and hide airport-area ground counts until airport/detail zoom

## Validation
- pnpm build
- pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
