### PR TITLE
Add system-aware light and dark themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:airport-wiki": "node src/services/airportWiki.test.js",
     "test:flight-route-display": "node src/utils/flightRouteDisplay.test.js",
     "test:airport-map-display": "node src/utils/airportMapDisplay.test.js",
+    "test:theme": "node src/utils/theme.test.js",
     "test:metar": "node src/composables/useMetar.test.js",
     "test:aircraft-motion": "node src/utils/aircraftMotion.test.js",
     "test:aircraft-traffic-intent": "node src/utils/aircraftTrafficIntent.test.js",

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,9 @@
                 <component :is="Component" />
             </transition>
         </router-view>
+        <div class="fixed right-4 top-4 z-50">
+            <ThemeSwitcher />
+        </div>
         <Analytics />
     </div>
     <SpeedInsights />
@@ -13,4 +16,5 @@
 <script setup>
 import { SpeedInsights } from "@vercel/speed-insights/vue";
 import { Analytics } from "@vercel/analytics/vue";
+import ThemeSwitcher from "./components/ThemeSwitcher.vue";
 </script>

--- a/src/components/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher.vue
@@ -1,28 +1,35 @@
 <template>
-  <div class="dropdown dropdown-top dropdown-end w-full">
-    <div tabindex="0" role="button" class="btn btn-ghost btn-block justify-between normal-case h-10 min-h-0 px-2 hover:bg-base-200">
+  <div class="relative">
+    <button
+      type="button"
+      tabindex="0"
+      class="btn h-10 min-h-0 rounded-full border-atc-line bg-atc-card/90 px-3 font-sans normal-case text-atc-text shadow-[0_12px_34px_rgba(0,0,0,0.18)] backdrop-blur hover:border-atc-line-strong hover:bg-atc-elev"
+      aria-label="Theme"
+      :aria-expanded="menuOpen"
+      @click.stop="menuOpen = !menuOpen"
+    >
       <div class="flex items-center gap-3">
-        <Sun v-if="currentTheme === 'light'" class="w-4 h-4 opacity-70" />
-        <Moon v-else-if="currentTheme === 'dark'" class="w-4 h-4 opacity-70" />
-        <Monitor v-else class="w-4 h-4 opacity-70" />
-        <span class="text-xs capitalize">{{ currentTheme }}</span>
+        <Sun v-if="currentPreference === 'light'" class="h-4 w-4 opacity-70" />
+        <Moon v-else-if="currentPreference === 'dark'" class="h-4 w-4 opacity-70" />
+        <Monitor v-else class="h-4 w-4 opacity-70" />
+        <span class="hidden text-xs capitalize sm:inline">{{ currentPreference }}</span>
       </div>
-      <ChevronUp class="w-4 h-4 opacity-30" />
-    </div>
-    <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow-xl bg-base-200 rounded-xl w-full mb-2 border border-base-content/5">
-      <li>
-        <button @click="setTheme('light')" class="flex items-center gap-3 py-2 text-xs" :class="{ 'bg-primary/10 text-primary': currentTheme === 'light' }">
-          <Sun class="w-4 h-4" /> Light
-        </button>
-      </li>
-      <li>
-        <button @click="setTheme('dark')" class="flex items-center gap-3 py-2 text-xs" :class="{ 'bg-primary/10 text-primary': currentTheme === 'dark' }">
-          <Moon class="w-4 h-4" /> Dark
-        </button>
-      </li>
-      <li>
-        <button @click="setTheme('system')" class="flex items-center gap-3 py-2 text-xs" :class="{ 'bg-primary/10 text-primary': currentTheme === 'system' }">
-          <Monitor class="w-4 h-4" /> System
+      <ChevronDown class="h-4 w-4 opacity-35" />
+    </button>
+    <ul
+      v-if="menuOpen"
+      tabindex="0"
+      class="menu absolute right-0 z-50 mt-2 w-40 rounded-xl border border-atc-line bg-atc-card p-2 text-atc-text shadow-xl"
+    >
+      <li v-for="option in themeOptions" :key="option.id">
+        <button
+          type="button"
+          class="flex items-center gap-3 rounded-lg py-2 text-xs"
+          :class="{ 'bg-atc-orange-soft text-atc-orange': currentPreference === option.id }"
+          @click="setTheme(option.id)"
+        >
+          <component :is="option.icon" class="h-4 w-4" />
+          {{ option.label }}
         </button>
       </li>
     </ul>
@@ -30,32 +37,54 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
-import { Sun, Moon, Monitor, ChevronUp } from 'lucide-vue-next'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { ChevronDown, Monitor, Moon, Sun } from 'lucide-vue-next'
+import {
+  applyThemePreference,
+  getInitialThemePreference,
+  THEME_PREFERENCES,
+} from '../utils/theme.js'
 
-const currentTheme = ref('system')
+const themeOptions = [
+  { id: 'system', label: 'System', icon: Monitor },
+  { id: 'light', label: 'Light', icon: Sun },
+  { id: 'dark', label: 'Dark', icon: Moon },
+]
+
+const currentPreference = ref('system')
+const menuOpen = ref(false)
+let systemMedia = null
+let removeSystemListener = null
 
 const setTheme = (theme) => {
-  currentTheme.value = theme
-  localStorage.setItem('theme', theme)
-  
-  if (theme === 'system') {
-    const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-    document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light')
-  } else {
-    document.documentElement.setAttribute('data-theme', theme)
+  if (!THEME_PREFERENCES.includes(theme)) return
+  currentPreference.value = applyThemePreference(theme, { systemMedia }).preference
+  menuOpen.value = false
+}
+
+const syncSystemTheme = () => {
+  if (currentPreference.value === 'system') {
+    applyThemePreference('system', { systemMedia })
   }
 }
 
 onMounted(() => {
-  const savedTheme = localStorage.getItem('theme') || 'system'
-  setTheme(savedTheme)
-  
-  // Listen for system theme changes if set to system
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-    if (currentTheme.value === 'system') {
-      document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light')
-    }
-  })
+  systemMedia = window.matchMedia('(prefers-color-scheme: dark)')
+  currentPreference.value = getInitialThemePreference()
+  applyThemePreference(currentPreference.value, { systemMedia })
+
+  systemMedia.addEventListener?.('change', syncSystemTheme)
+  removeSystemListener = () => systemMedia?.removeEventListener?.('change', syncSystemTheme)
+
+  document.addEventListener('click', closeMenu)
 })
+
+onBeforeUnmount(() => {
+  removeSystemListener?.()
+  document.removeEventListener('click', closeMenu)
+})
+
+const closeMenu = () => {
+  menuOpen.value = false
+}
 </script>

--- a/src/components/screens/SearchScreen.vue
+++ b/src/components/screens/SearchScreen.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-atc-bg bg-[radial-gradient(circle_at_22%_12%,rgba(255,90,31,0.22),transparent_32%),radial-gradient(circle_at_78%_80%,rgba(255,255,255,0.045),transparent_34%),linear-gradient(135deg,rgba(255,90,31,0.08),transparent_38%)] text-atc-text">
+  <div class="min-h-screen bg-atc-bg bg-[image:var(--atc-page-glow)] text-atc-text">
     <main class="grid min-h-screen place-items-start px-5 py-6 sm:place-items-center sm:p-10 lg:p-14">
       <section class="w-full max-w-[860px]">
         <div class="mb-4 flex items-center gap-2.5 font-mono text-[11px] uppercase tracking-[1.4px] text-atc-dim">
@@ -9,8 +9,8 @@
         </div>
 
         <label
-          class="input flex h-auto w-full items-center gap-3 rounded-[26px] border-white/20 bg-[linear-gradient(145deg,rgba(38,40,46,0.9),rgba(17,18,22,0.84))] px-4 py-4 text-atc-text shadow-[0_26px_90px_rgba(0,0,0,0.38),inset_0_1px_0_rgba(255,255,255,0.08)] transition-[border-color,box-shadow] duration-150 sm:gap-3.5 sm:px-5 sm:py-5"
-          :class="{ 'border-atc-orange/70 shadow-[0_30px_100px_rgba(0,0,0,0.42),0_0_0_1px_rgba(255,90,31,0.18)_inset]': focused }"
+          class="input flex h-auto w-full items-center gap-3 rounded-[26px] border-[var(--atc-line-strong)] bg-[image:var(--atc-search-gradient)] px-4 py-4 text-atc-text shadow-[var(--atc-search-shadow)] transition-[border-color,box-shadow] duration-150 sm:gap-3.5 sm:px-5 sm:py-5"
+          :class="{ 'border-atc-orange/70 shadow-[var(--atc-search-focus-shadow)]': focused }"
         >
           <svg class="shrink-0 text-atc-orange" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="11" cy="11" r="8" />
@@ -25,13 +25,13 @@
             class="min-w-0 flex-1 border-0 bg-transparent p-0 text-2xl font-extrabold tracking-normal text-atc-text outline-none placeholder:text-atc-dim sm:text-3xl"
             placeholder="Search by ICAO, IATA, city, or airport name"
           />
-          <kbd class="kbd hidden shrink-0 border-white/10 bg-transparent font-mono text-[10px] uppercase tracking-[1px] text-atc-dim sm:inline-flex">
+          <kbd class="kbd hidden shrink-0 border-[var(--atc-soft-border)] bg-transparent font-mono text-[10px] uppercase tracking-[1px] text-atc-dim sm:inline-flex">
             {{ searchLoading ? '...' : 'enter' }}
           </kbd>
         </label>
 
         <div v-if="q.trim()" class="mt-5">
-          <div class="flex items-center justify-between border-b border-white/10 pb-2.5 font-mono text-[10px] uppercase tracking-[1.5px] text-atc-dim">
+          <div class="flex items-center justify-between border-b border-atc-line pb-2.5 font-mono text-[10px] uppercase tracking-[1.5px] text-atc-dim">
             <span>Search results</span>
             <span>{{ resultCountLabel }}</span>
           </div>
@@ -43,7 +43,7 @@
             <button
               v-for="airport in searchRows"
               :key="airport.icao || airport.code || airport.name"
-              class="btn grid h-auto min-h-0 w-full grid-cols-[62px_minmax(0,1fr)] items-center justify-start gap-4 rounded-[18px] border-white/15 bg-white/[0.06] px-4 py-3.5 text-left font-sans normal-case text-atc-text hover:-translate-y-px hover:border-atc-orange/40 hover:bg-white/[0.09] sm:grid-cols-[86px_minmax(0,1fr)_auto]"
+              class="btn grid h-auto min-h-0 w-full grid-cols-[62px_minmax(0,1fr)] items-center justify-start gap-4 rounded-[18px] border-[var(--atc-muted-border)] !bg-[var(--atc-row-bg)] px-4 py-3.5 text-left font-sans normal-case !text-atc-text hover:-translate-y-px hover:border-atc-orange/40 hover:!bg-[var(--atc-row-hover-bg)] sm:grid-cols-[86px_minmax(0,1fr)_auto]"
               @click="openAirport(airport)"
             >
               <span class="font-display text-[32px] italic leading-[0.8] text-atc-orange sm:text-[38px]">{{ airport.iata || airport.icao || airport.code }}</span>
@@ -57,7 +57,7 @@
         </div>
 
         <div v-else class="mt-5">
-          <div class="flex items-center justify-between border-b border-white/10 pb-2.5 font-mono text-[10px] uppercase tracking-[1.5px] text-atc-dim">
+          <div class="flex items-center justify-between border-b border-atc-line pb-2.5 font-mono text-[10px] uppercase tracking-[1.5px] text-atc-dim">
             <span>Featured airports</span>
             <span>{{ featuredAirports.length }}</span>
           </div>
@@ -66,7 +66,7 @@
             <button
               v-for="airport in featuredAirports"
               :key="airport.icao"
-              class="btn grid h-auto min-h-0 w-full grid-cols-[62px_minmax(0,1fr)] items-center justify-start gap-4 rounded-[18px] border-white/15 bg-white/[0.06] px-4 py-3.5 text-left font-sans normal-case text-atc-text first:bg-[linear-gradient(100deg,rgba(255,90,31,0.16),rgba(255,255,255,0.065))] hover:-translate-y-px hover:border-atc-orange/40 hover:bg-white/[0.09] sm:grid-cols-[86px_minmax(0,1fr)_auto]"
+              class="btn grid h-auto min-h-0 w-full grid-cols-[62px_minmax(0,1fr)] items-center justify-start gap-4 rounded-[18px] border-[var(--atc-muted-border)] !bg-[var(--atc-row-bg)] px-4 py-3.5 text-left font-sans normal-case !text-atc-text first:!bg-[image:var(--atc-row-featured-bg)] hover:-translate-y-px hover:border-atc-orange/40 hover:!bg-[var(--atc-row-hover-bg)] sm:grid-cols-[86px_minmax(0,1fr)_auto]"
               @click="openAirport(airport)"
             >
               <span class="font-display text-[32px] italic leading-[0.8] text-atc-orange sm:text-[38px]">{{ airport.iata }}</span>

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,9 @@ import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
 import router from './router'
+import { initializeTheme } from './utils/theme.js'
 
+initializeTheme()
 const app = createApp(App)
 
 app.use(router)

--- a/src/style.css
+++ b/src/style.css
@@ -7,7 +7,7 @@
   logs: false;
 }
 @plugin "daisyui/theme" {
-  name: "adsbao";
+  name: "adsbao-dark";
   default: true;
   prefersdark: true;
   color-scheme: dark;
@@ -42,21 +42,55 @@
   --depth: 0;
   --noise: 0;
 }
+@plugin "daisyui/theme" {
+  name: "adsbao-light";
+  color-scheme: light;
+
+  --color-base-100: #f7f2ea;
+  --color-base-200: #fffaf3;
+  --color-base-300: #e9dfd2;
+  --color-base-content: #191614;
+  --color-primary: #FF5A1F;
+  --color-primary-content: #191614;
+  --color-secondary: #047857;
+  --color-secondary-content: #fffaf3;
+  --color-accent: #047857;
+  --color-accent-content: #fffaf3;
+  --color-neutral: #eee4d8;
+  --color-neutral-content: #191614;
+  --color-info: #2563eb;
+  --color-info-content: #fffaf3;
+  --color-success: #047857;
+  --color-success-content: #fffaf3;
+  --color-warning: #b45309;
+  --color-warning-content: #fffaf3;
+  --color-error: #dc2626;
+  --color-error-content: #fffaf3;
+
+  --radius-selector: 999px;
+  --radius-field: 1rem;
+  --radius-box: 0.75rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 0;
+  --noise: 0;
+}
 
 @theme {
-  --color-atc-bg: #0a0a0b;
-  --color-atc-card: #151518;
-  --color-atc-elev: #1d1d22;
-  --color-atc-high: #27272e;
-  --color-atc-orange: #FF5A1F;
-  --color-atc-orange-soft: rgba(255,90,31,0.12);
-  --color-atc-mint: #34d399;
-  --color-atc-red: #ff3b30;
-  --color-atc-text: #f5f5f7;
-  --color-atc-dim: rgba(245,245,247,0.62);
-  --color-atc-faint: rgba(245,245,247,0.38);
-  --color-atc-line: rgba(255,255,255,0.08);
-  --color-atc-line-strong: rgba(255,255,255,0.16);
+  --color-atc-bg: var(--atc-bg);
+  --color-atc-card: var(--atc-card);
+  --color-atc-elev: var(--atc-elev);
+  --color-atc-high: var(--atc-high);
+  --color-atc-orange: var(--atc-orange);
+  --color-atc-orange-soft: var(--atc-orange-soft);
+  --color-atc-mint: var(--atc-mint);
+  --color-atc-red: var(--atc-red);
+  --color-atc-text: var(--atc-text);
+  --color-atc-dim: var(--atc-dim);
+  --color-atc-faint: var(--atc-faint);
+  --color-atc-line: var(--atc-line);
+  --color-atc-line-strong: var(--atc-line-strong);
 
   --font-sans: "Inter", system-ui, sans-serif;
   --font-display: "Instrument Serif", "Playfair Display", Georgia, serif;
@@ -120,6 +154,44 @@
   --atc-faint:       rgba(245,245,247,0.38);
   --atc-line:        rgba(255,255,255,0.08);
   --atc-line-strong: rgba(255,255,255,0.16);
+  --atc-page-glow: radial-gradient(circle at 22% 12%, rgba(255,90,31,0.22), transparent 32%),
+    radial-gradient(circle at 78% 80%, rgba(255,255,255,0.045), transparent 34%),
+    linear-gradient(135deg, rgba(255,90,31,0.08), transparent 38%);
+  --atc-search-gradient: linear-gradient(145deg, rgba(38,40,46,0.9), rgba(17,18,22,0.84));
+  --atc-search-shadow: 0 26px 90px rgba(0,0,0,0.38), inset 0 1px 0 rgba(255,255,255,0.08);
+  --atc-search-focus-shadow: 0 30px 100px rgba(0,0,0,0.42), 0 0 0 1px rgba(255,90,31,0.18) inset;
+  --atc-muted-border: rgba(255,255,255,0.13);
+  --atc-soft-border: rgba(255,255,255,0.1);
+  --atc-row-bg: rgba(255,255,255,0.06);
+  --atc-row-hover-bg: rgba(255,255,255,0.09);
+  --atc-row-featured-bg: linear-gradient(100deg, rgba(255,90,31,0.16), rgba(255,255,255,0.065));
+}
+
+[data-theme="adsbao-light"] {
+  --atc-bg:          #f7f2ea;
+  --atc-card:        #fffaf3;
+  --atc-elev:        #eee4d8;
+  --atc-high:        #e3d5c4;
+  --atc-orange:      #e84f17;
+  --atc-orange-soft: rgba(232,79,23,0.13);
+  --atc-mint:        #047857;
+  --atc-red:         #dc2626;
+  --atc-text:        #191614;
+  --atc-dim:         rgba(25,22,20,0.68);
+  --atc-faint:       rgba(25,22,20,0.45);
+  --atc-line:        rgba(75,55,35,0.14);
+  --atc-line-strong: rgba(75,55,35,0.26);
+  --atc-page-glow: radial-gradient(circle at 20% 12%, rgba(255,90,31,0.2), transparent 34%),
+    radial-gradient(circle at 84% 78%, rgba(25,22,20,0.075), transparent 34%),
+    linear-gradient(135deg, rgba(255,90,31,0.1), transparent 42%);
+  --atc-search-gradient: linear-gradient(145deg, rgba(255,250,243,0.94), rgba(240,230,216,0.88));
+  --atc-search-shadow: 0 24px 80px rgba(91,66,38,0.18), inset 0 1px 0 rgba(255,255,255,0.75);
+  --atc-search-focus-shadow: 0 28px 84px rgba(91,66,38,0.2), 0 0 0 1px rgba(232,79,23,0.18) inset;
+  --atc-muted-border: rgba(75,55,35,0.18);
+  --atc-soft-border: rgba(75,55,35,0.12);
+  --atc-row-bg: rgba(255,250,243,0.7);
+  --atc-row-hover-bg: rgba(255,250,243,0.92);
+  --atc-row-featured-bg: linear-gradient(100deg, rgba(255,90,31,0.16), rgba(255,250,243,0.82));
 }
 
 body {

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,70 @@
+export const THEME_STORAGE_KEY = 'adsbao-theme'
+export const THEME_PREFERENCES = ['system', 'light', 'dark']
+export const THEME_BY_SCHEME = {
+  light: 'adsbao-light',
+  dark: 'adsbao-dark',
+}
+
+export const isThemePreference = (value) => THEME_PREFERENCES.includes(value)
+
+export const getInitialThemePreference = (storage = globalThis.localStorage) => {
+  try {
+    const saved = storage?.getItem?.(THEME_STORAGE_KEY)
+    return isThemePreference(saved) ? saved : 'system'
+  } catch {
+    return 'system'
+  }
+}
+
+export const getSystemScheme = (
+  systemMedia = globalThis.matchMedia?.('(prefers-color-scheme: dark)'),
+) => (systemMedia?.matches ? 'dark' : 'light')
+
+export const resolveThemePreference = (preference, systemMedia) => {
+  const normalizedPreference = isThemePreference(preference) ? preference : 'system'
+  const scheme = normalizedPreference === 'system'
+    ? getSystemScheme(systemMedia)
+    : normalizedPreference
+
+  return {
+    preference: normalizedPreference,
+    scheme,
+    resolvedTheme: THEME_BY_SCHEME[scheme],
+  }
+}
+
+export const applyThemePreference = (
+  preference,
+  {
+    root = globalThis.document?.documentElement,
+    storage = globalThis.localStorage,
+    systemMedia = globalThis.matchMedia?.('(prefers-color-scheme: dark)'),
+  } = {},
+) => {
+  const resolved = resolveThemePreference(preference, systemMedia)
+
+  root?.setAttribute?.('data-theme', resolved.resolvedTheme)
+  root?.setAttribute?.('data-theme-preference', resolved.preference)
+  if (root?.style) root.style.colorScheme = resolved.scheme
+
+  try {
+    storage?.setItem?.(THEME_STORAGE_KEY, resolved.preference)
+  } catch {
+    // Storage can be unavailable in private or restricted browser contexts.
+  }
+
+  return {
+    preference: resolved.preference,
+    resolvedTheme: resolved.resolvedTheme,
+  }
+}
+
+export const initializeTheme = ({
+  root = globalThis.document?.documentElement,
+  storage = globalThis.localStorage,
+  systemMedia = globalThis.matchMedia?.('(prefers-color-scheme: dark)'),
+} = {}) => applyThemePreference(getInitialThemePreference(storage), {
+  root,
+  storage,
+  systemMedia,
+})

--- a/src/utils/theme.test.js
+++ b/src/utils/theme.test.js
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+
+import {
+  THEME_STORAGE_KEY,
+  applyThemePreference,
+  getInitialThemePreference,
+  isThemePreference,
+} from './theme.js'
+
+const createRoot = () => {
+  const attributes = new Map()
+  const style = {}
+  return {
+    style,
+    setAttribute(name, value) {
+      attributes.set(name, value)
+    },
+    getAttribute(name) {
+      return attributes.get(name)
+    },
+  }
+}
+
+const createStorage = (initialValue) => {
+  const values = new Map()
+  if (initialValue !== undefined) values.set(THEME_STORAGE_KEY, initialValue)
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null
+    },
+    setItem(key, value) {
+      values.set(key, value)
+    },
+  }
+}
+
+const createMedia = (matches) => ({ matches })
+
+assert.equal(isThemePreference('system'), true)
+assert.equal(isThemePreference('light'), true)
+assert.equal(isThemePreference('dark'), true)
+assert.equal(isThemePreference('sepia'), false)
+
+assert.equal(getInitialThemePreference(createStorage('light')), 'light')
+assert.equal(getInitialThemePreference(createStorage('dark')), 'dark')
+assert.equal(getInitialThemePreference(createStorage('system')), 'system')
+assert.equal(getInitialThemePreference(createStorage('sepia')), 'system')
+assert.equal(getInitialThemePreference(null), 'system')
+
+{
+  const root = createRoot()
+  const storage = createStorage()
+  const result = applyThemePreference('system', {
+    root,
+    storage,
+    systemMedia: createMedia(false),
+  })
+
+  assert.deepEqual(result, { preference: 'system', resolvedTheme: 'adsbao-light' })
+  assert.equal(root.getAttribute('data-theme'), 'adsbao-light')
+  assert.equal(root.getAttribute('data-theme-preference'), 'system')
+  assert.equal(root.style.colorScheme, 'light')
+  assert.equal(storage.getItem(THEME_STORAGE_KEY), 'system')
+}
+
+{
+  const root = createRoot()
+  const result = applyThemePreference('system', {
+    root,
+    storage: createStorage(),
+    systemMedia: createMedia(true),
+  })
+
+  assert.deepEqual(result, { preference: 'system', resolvedTheme: 'adsbao-dark' })
+  assert.equal(root.getAttribute('data-theme'), 'adsbao-dark')
+  assert.equal(root.style.colorScheme, 'dark')
+}
+
+{
+  const root = createRoot()
+  const result = applyThemePreference('light', {
+    root,
+    storage: createStorage(),
+    systemMedia: createMedia(true),
+  })
+
+  assert.deepEqual(result, { preference: 'light', resolvedTheme: 'adsbao-light' })
+  assert.equal(root.getAttribute('data-theme'), 'adsbao-light')
+  assert.equal(root.style.colorScheme, 'light')
+}
+
+{
+  const root = createRoot()
+  const result = applyThemePreference('dark', {
+    root,
+    storage: createStorage(),
+    systemMedia: createMedia(false),
+  })
+
+  assert.deepEqual(result, { preference: 'dark', resolvedTheme: 'adsbao-dark' })
+  assert.equal(root.getAttribute('data-theme'), 'adsbao-dark')
+  assert.equal(root.style.colorScheme, 'dark')
+}


### PR DESCRIPTION
## Summary
- Add explicit ADSBao light and dark daisyUI themes while keeping ADSBao color tokens available through Tailwind and CSS variables
- Add a global theme switcher with System, Light, and Dark options; System is the default and resolves from prefers-color-scheme
- Centralize theme persistence/resolution in src/utils/theme.js with unit coverage
- Update the search screen's custom visuals to use theme variables so it adapts across themes

## Verification
- pnpm build
- pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:theme && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
- Playwright smoke checks for system/light/dark theme switching on desktop at http://localhost:5174/
- Playwright mobile light/system layout smoke check at http://localhost:5174/