### PR TITLE
Unify corner radius styling across core UI components

### DIFF
--- a/src/components/screens/AirportCaptionScreen.vue
+++ b/src/components/screens/AirportCaptionScreen.vue
@@ -684,7 +684,7 @@ const formatObsTime = (value) => {
         var(--glass-card-bottom)
     );
     border: 1px solid var(--glass-card-border);
-    border-radius: 24px;
+    border-radius: var(--atc-radius-panel);
     box-shadow:
         0 8px 24px rgba(0, 0, 0, 0.18),
         0 24px 64px rgba(0, 0, 0, 0.22),
@@ -737,7 +737,7 @@ const formatObsTime = (value) => {
 .panel-pill,
 .panel-link {
     border: 1px solid var(--atc-line-strong);
-    border-radius: 999px;
+    border-radius: var(--atc-radius-pill);
     color: var(--atc-dim);
     flex-shrink: 0;
     font-size: 10px;
@@ -823,7 +823,7 @@ const formatObsTime = (value) => {
     appearance: none;
     background: color-mix(in oklab, var(--atc-dim) 48%, transparent);
     border: 0;
-    border-radius: 999px;
+    border-radius: var(--atc-radius-pill);
     cursor: pointer;
     height: 7px;
     padding: 0;
@@ -1071,7 +1071,7 @@ const formatObsTime = (value) => {
     }
 
     .glass-panel {
-        border-radius: 24px;
+        border-radius: var(--atc-radius-panel);
         padding: 16px;
     }
 

--- a/src/components/screens/SearchScreen.vue
+++ b/src/components/screens/SearchScreen.vue
@@ -384,7 +384,7 @@ onUnmounted(() => {
     color-mix(in oklab, var(--atc-elev) 88%, transparent)
   );
   border: 1px solid color-mix(in oklab, var(--atc-line-strong) 82%, transparent);
-  border-radius: 26px;
+  border-radius: var(--atc-radius-panel);
   box-shadow:
     0 26px 90px color-mix(in oklab, var(--atc-bg) 62%, transparent),
     inset 0 1px 0 color-mix(in oklab, var(--atc-line-strong) 58%, transparent);
@@ -398,7 +398,7 @@ onUnmounted(() => {
 .search-row {
   background: color-mix(in oklab, var(--atc-card) 62%, transparent);
   border: 1px solid color-mix(in oklab, var(--atc-line-strong) 78%, transparent);
-  border-radius: 18px;
+  border-radius: var(--atc-radius-panel);
 }
 
 .search-row:hover {

--- a/src/components/ui/MapControlBar.vue
+++ b/src/components/ui/MapControlBar.vue
@@ -196,7 +196,7 @@ const toggleAudio = () => {
     backdrop-filter: blur(6px) saturate(120%);
     -webkit-backdrop-filter: blur(6px) saturate(120%);
     border: 1px solid var(--atc-line-strong);
-    border-radius: 20px;
+    border-radius: var(--atc-radius-panel);
     bottom: 18px;
     box-shadow:
         0 8px 24px rgba(0, 0, 0, 0.18),
@@ -234,7 +234,7 @@ const toggleAudio = () => {
     align-items: center;
     background: transparent;
     border: 1px solid transparent;
-    border-radius: 10px;
+    border-radius: var(--atc-radius-control);
     color: var(--atc-faint);
     cursor: pointer;
     display: flex;
@@ -268,7 +268,7 @@ const toggleAudio = () => {
 
 .ctrl-sep {
     background: var(--atc-line-strong);
-    border-radius: 1px;
+    border-radius: var(--atc-radius-control);
     height: 1px;
     margin: 2px 6px;
     width: calc(100% - 12px);

--- a/src/style.css
+++ b/src/style.css
@@ -61,7 +61,7 @@
 
   --radius-selector: 999px;
   --radius-field: 1rem;
-  --radius-box: 0.75rem;
+  --radius-box: 1rem;
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
   --border: 1px;
@@ -153,6 +153,10 @@
   --glass-card-border: rgba(0,0,0,0.12);
   --glass-card-inset: rgba(255,255,255,0.3);
   --traffic-level-color: #64748b;
+
+  --atc-radius-pill: 999px;
+  --atc-radius-panel: 20px;
+  --atc-radius-control: 12px;
 }
 
 :root[data-theme='dark'] {
@@ -176,6 +180,10 @@
   --glass-card-border: rgba(255,255,255,0.13);
   --glass-card-inset: rgba(255,255,255,0.14);
   --traffic-level-color: #94a3b8;
+
+  --atc-radius-pill: 999px;
+  --atc-radius-panel: 20px;
+  --atc-radius-control: 12px;
 }
 
 body {


### PR DESCRIPTION
### Motivation
- Create a consistent corner-radius language across the UI so components feel visually unified and polished.
- Replace scattered literal `border-radius` values with shared design tokens to make future radius changes simple and consistent.

### Description
- Added shared radius tokens in `src/style.css` for both light and dark roots: `--atc-radius-pill`, `--atc-radius-panel`, and `--atc-radius-control`, and aligned DaisyUI `--radius-box` to `1rem`.
- Replaced hard-coded radii with the new tokens in `src/components/ui/MapControlBar.vue` for the floating control container, control buttons, and separator.
- Replaced hard-coded radii with the new tokens in `src/components/screens/AirportCaptionScreen.vue` for panels, pills, and UI dots/buttons.
- Replaced hard-coded radii with the new tokens in `src/components/screens/SearchScreen.vue` for the search input and result rows.

### Testing
- Ran the production build with `pnpm build`, which completed successfully and produced the production bundles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25b91f46c8331b63f145b9587b8dc)