### PR TITLE
feat(map): add airport range overlays and approach-only moving traffic rendering

### DIFF
--- a/src/components/map/AirportMap.vue
+++ b/src/components/map/AirportMap.vue
@@ -76,6 +76,7 @@ import {
     SLOW_AIRCRAFT_THRESHOLD_KT,
 } from "../../utils/aircraftMotion";
 import {
+    ZOOM_APPROACH,
     shouldShowAirportArea,
 } from "../../utils/airportMapDisplay.js";
 import { AIRCRAFT_COLORS, BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft";
@@ -87,6 +88,7 @@ const props = defineProps({
     zoom: { type: Number, default: 13 },
     accent: { type: String, default: "#FF5A1F" },
     aircraft: { type: Array, default: () => [] },
+    airport: { type: Object, default: null },
 });
 
 const mapEl = ref(null);
@@ -95,6 +97,9 @@ const currentTheme = ref("dark");
 let map = null;
 let sizeObs = null;
 let airportAreaLayer = null;
+let queryRangeLayer = null;
+let airportInfoMarker = null;
+let airportGroundCountMarker = null;
 let baseTileLayer = null;
 let labelTileLayer = null;
 let themeObs = null;
@@ -199,6 +204,7 @@ const initMap = () => {
     updateTileLayers();
 
     updateAirportArea();
+    updateAirportContextOverlays();
 
     latStr.value = props.lat
         ? `${Math.abs(props.lat).toFixed(2)}°${props.lat >= 0 ? "N" : "S"}`
@@ -296,7 +302,13 @@ const updateAirportArea = () => {
     if (!map) return;
 
     airportAreaLayer?.removeFrom(map);
+    queryRangeLayer?.removeFrom(map);
+    airportInfoMarker?.removeFrom(map);
+    airportGroundCountMarker?.removeFrom(map);
     airportAreaLayer = null;
+    queryRangeLayer = null;
+    airportInfoMarker = null;
+    airportGroundCountMarker = null;
 
     if (!props.lat || !props.lon || !shouldShowAirportArea(props.zoom)) return;
 
@@ -327,6 +339,65 @@ const updateAirportArea = () => {
     ]).addTo(map);
 };
 
+
+const QUERY_RANGE_NM = 20;
+const NM_TO_METERS = 1852;
+
+const formatAirportOverlayLine = () => {
+    const runways = props.airport?.runways;
+    if (Array.isArray(runways) && runways.length) return `RWY ${runways.length}`;
+    return "RWY N/A";
+};
+
+const updateAirportContextOverlays = () => {
+    if (!map || !props.lat || !props.lon) return;
+
+    queryRangeLayer?.removeFrom(map);
+    airportInfoMarker?.removeFrom(map);
+    airportGroundCountMarker?.removeFrom(map);
+    queryRangeLayer = null;
+    airportInfoMarker = null;
+    airportGroundCountMarker = null;
+
+    const stroke = currentTheme.value === "light" ? "rgba(18,21,26,0.22)" : "rgba(255,255,255,0.28)";
+    const fill = currentTheme.value === "light" ? "rgba(18,21,26,0.06)" : "rgba(255,255,255,0.05)";
+
+    queryRangeLayer = L.circle([props.lat, props.lon], {
+        radius: QUERY_RANGE_NM * NM_TO_METERS,
+        color: stroke,
+        weight: 1,
+        dashArray: "6 6",
+        fillColor: fill,
+        fillOpacity: 1,
+    }).addTo(map);
+
+    const airportCode = escapeHtml((props.airport?.iata || props.icao || "").trim());
+    const overlayLine = escapeHtml(formatAirportOverlayLine());
+    const procLine = "PROC APP N/A";
+
+    airportInfoMarker = L.marker([props.lat, props.lon], {
+        interactive: false,
+        icon: L.divIcon({
+            className: "",
+            html: `<div class="airport-overlay-label">${airportCode}<span>${overlayLine}</span><span>${procLine}</span></div>`,
+            iconSize: [120, 34],
+            iconAnchor: [0, -8],
+        }),
+    }).addTo(map);
+
+    if (Number(props.zoom) === ZOOM_APPROACH) {
+        const groundCount = props.aircraft.filter((item) => item?.onGround).length;
+        airportGroundCountMarker = L.marker([props.lat, props.lon], {
+            interactive: false,
+            icon: L.divIcon({
+                className: "",
+                html: `<div class="airport-ground-count">GROUND ${groundCount}</div>`,
+                iconSize: [92, 18],
+                iconAnchor: [46, 24],
+            }),
+        }).addTo(map);
+    }
+};
 const makeAcIcon = (
     color,
     label,
@@ -397,7 +468,9 @@ const updateAircraft = () => {
 
     const now = Date.now();
     const seen = new Set();
+    const onlyMovingAtApproach = Number(props.zoom) === ZOOM_APPROACH;
     props.aircraft.forEach((ac) => {
+        if (onlyMovingAtApproach && ac.onGround) return;
         if (!ac.lat || !ac.lon) return;
         seen.add(ac.icao24);
         const vel = ac.velocity ?? 0;
@@ -496,6 +569,7 @@ const updateAircraft = () => {
     }
 
     updateAirportArea();
+    updateAirportContextOverlays();
 };
 
 watch(() => props.aircraft, updateAircraft, { deep: true });
@@ -504,6 +578,7 @@ watch(
     () => {
         updateTileLayers();
         updateAirportArea();
+    updateAirportContextOverlays();
     },
 );
 
@@ -515,6 +590,9 @@ watch(
             latStr.value = `${Math.abs(lat).toFixed(2)}°${lat >= 0 ? "N" : "S"}`;
             lonStr.value = `${Math.abs(lon).toFixed(2)}°${lon >= 0 ? "E" : "W"}`;
             updateAirportArea();
+            updateAirportContextOverlays();
+            updateAirportContextOverlays();
+    updateAirportContextOverlays();
         }
     },
 );
@@ -524,6 +602,8 @@ watch(
         if (map) {
             map.setZoom(zoom);
             updateAirportArea();
+            updateAirportContextOverlays();
+    updateAirportContextOverlays();
         }
     },
 );
@@ -547,7 +627,13 @@ onUnmounted(() => {
         unmountAircraftTelemetry(entry.marker);
     acMarkersMap.clear();
     airportAreaLayer?.removeFrom(map);
+    queryRangeLayer?.removeFrom(map);
+    airportInfoMarker?.removeFrom(map);
+    airportGroundCountMarker?.removeFrom(map);
     airportAreaLayer = null;
+    queryRangeLayer = null;
+    airportInfoMarker = null;
+    airportGroundCountMarker = null;
     themeObs?.disconnect();
     themeObs = null;
     baseTileLayer = null;
@@ -694,6 +780,38 @@ onUnmounted(() => {
 .aircraft-telemetry-separator {
     color: rgba(255, 90, 31, 0.72);
     font-size: 0.9em;
+}
+
+
+.airport-overlay-label {
+    color: var(--atc-text);
+    display: flex;
+    flex-direction: column;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 9px;
+    font-weight: 700;
+    gap: 1px;
+    letter-spacing: 0.6px;
+    text-shadow: 0 0 6px var(--map-label-glow);
+}
+
+.airport-overlay-label > span {
+    color: var(--atc-dim);
+    font-size: 8px;
+    font-weight: 600;
+}
+
+.airport-ground-count {
+    background: color-mix(in oklab, var(--atc-card) 78%, transparent);
+    border: 1px solid color-mix(in oklab, var(--atc-line-strong) 88%, transparent);
+    border-radius: 999px;
+    color: var(--atc-text);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.8px;
+    padding: 1px 6px;
+    text-shadow: 0 0 6px var(--map-label-glow);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/screens/AirportCaptionScreen.vue
+++ b/src/components/screens/AirportCaptionScreen.vue
@@ -18,6 +18,7 @@
                 :zoom="mapZoom"
                 accent="#FF5A1F"
                 :aircraft="aircraftWithRoutes"
+                :airport="airport"
             />
         </div>
 


### PR DESCRIPTION
### Motivation
- Provide visual context for the current airport by drawing the query range and airport metadata on the map so users can see the 20nm search area and basic airport info. 
- Reduce clutter in the `Approaching` zoom by hiding static ground markers while still surfacing a concise ground-aircraft count.

### Description
- Added a 20nm semi-transparent query circle and airport info marker to `src/components/map/AirportMap.vue` using `QUERY_RANGE_NM` and projected meters conversion. 
- Passed the resolved `airport` object from `src/components/screens/AirportCaptionScreen.vue` into `AirportMap` so overlays can access runway/procedure metadata. 
- Implemented `updateAirportContextOverlays()` and new layer variables (`queryRangeLayer`, `airportInfoMarker`, `airportGroundCountMarker`) and wired them into map lifecycle and watchers to update on theme/coords/zoom changes. 
- When `zoom === ZOOM_APPROACH`, hide on-ground aircraft markers during marker creation and render a `GROUND X` badge at the airport center instead; added supporting CSS classes for overlay labels and ground-count badge. 

### Testing
- Ran `pnpm -s test:airport-map-display` and the test suite completed successfully. 
- Built the frontend with `pnpm -s build` and the production build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27f36b8308331ad0624b61d2d1635)