### PR TITLE
Add airport context overlays and ground filtering to AirportMap

### DIFF
--- a/src/components/map/AirportMap.vue
+++ b/src/components/map/AirportMap.vue
@@ -77,6 +77,7 @@ import {
 } from "../../utils/aircraftMotion";
 import {
     ZOOM_APPROACH,
+    isGroundLikeAircraft as isGroundLikeAircraftForDisplay,
     shouldShowAirportArea,
 } from "../../utils/airportMapDisplay.js";
 import { AIRCRAFT_COLORS, BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft";
@@ -240,15 +241,10 @@ const escapeHtml = (value) =>
 
 
 const isGroundLikeAircraft = (ac) => {
-    const speedKt = Number(ac?.velocity ?? 0);
-    const altitudeFt = Number(ac?.altitude ?? 0);
-    const distanceNm = Number(ac?.distanceNm ?? Number.POSITIVE_INFINITY);
-    const apiGrounded = Boolean(ac?.onGround);
-
-    if (apiGrounded) return true;
-    if (!Number.isFinite(distanceNm)) return false;
-
-    return distanceNm <= AIRPORT_AREA_RADIUS_NM && altitudeFt < 3000 && speedKt < 140;
+    return isGroundLikeAircraftForDisplay(ac, {
+        airportAreaRadiusNm: AIRPORT_AREA_RADIUS_NM,
+        slowAircraftThresholdKt: SLOW_AIRCRAFT_THRESHOLD_KT,
+    });
 };
 
 const formatTelemetryValue = (value) => {

--- a/src/components/map/AirportMap.vue
+++ b/src/components/map/AirportMap.vue
@@ -76,9 +76,11 @@ import {
     SLOW_AIRCRAFT_THRESHOLD_KT,
 } from "../../utils/aircraftMotion";
 import {
+    ZOOM_APPROACH,
     shouldShowAirportArea,
 } from "../../utils/airportMapDisplay.js";
 import { AIRCRAFT_COLORS, BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft";
+import { DEFAULT_AIRCRAFT_DIST_NM } from "../../services/aviationData.js";
 
 const props = defineProps({
     icao: { type: String, default: "" },
@@ -87,6 +89,7 @@ const props = defineProps({
     zoom: { type: Number, default: 13 },
     accent: { type: String, default: "#FF5A1F" },
     aircraft: { type: Array, default: () => [] },
+    airport: { type: Object, default: null },
 });
 
 const mapEl = ref(null);
@@ -95,6 +98,9 @@ const currentTheme = ref("dark");
 let map = null;
 let sizeObs = null;
 let airportAreaLayer = null;
+let queryRangeLayer = null;
+let airportInfoMarker = null;
+let airportGroundCountMarker = null;
 let baseTileLayer = null;
 let labelTileLayer = null;
 let themeObs = null;
@@ -199,6 +205,7 @@ const initMap = () => {
     updateTileLayers();
 
     updateAirportArea();
+    updateAirportContextOverlays();
 
     latStr.value = props.lat
         ? `${Math.abs(props.lat).toFixed(2)}°${props.lat >= 0 ? "N" : "S"}`
@@ -230,6 +237,19 @@ const escapeHtml = (value) =>
         .replaceAll(">", "&gt;")
         .replaceAll('"', "&quot;")
         .replaceAll("'", "&#39;");
+
+
+const isGroundLikeAircraft = (ac) => {
+    const speedKt = Number(ac?.velocity ?? 0);
+    const altitudeFt = Number(ac?.altitude ?? 0);
+    const distanceNm = Number(ac?.distanceNm ?? Number.POSITIVE_INFINITY);
+    const apiGrounded = Boolean(ac?.onGround);
+
+    if (apiGrounded) return true;
+    if (!Number.isFinite(distanceNm)) return false;
+
+    return distanceNm <= AIRPORT_AREA_RADIUS_NM && altitudeFt < 3000 && speedKt < 140;
+};
 
 const formatTelemetryValue = (value) => {
     if (value == null || value === "" || value === "ground") return null;
@@ -296,7 +316,13 @@ const updateAirportArea = () => {
     if (!map) return;
 
     airportAreaLayer?.removeFrom(map);
+    queryRangeLayer?.removeFrom(map);
+    airportInfoMarker?.removeFrom(map);
+    airportGroundCountMarker?.removeFrom(map);
     airportAreaLayer = null;
+    queryRangeLayer = null;
+    airportInfoMarker = null;
+    airportGroundCountMarker = null;
 
     if (!props.lat || !props.lon || !shouldShowAirportArea(props.zoom)) return;
 
@@ -309,15 +335,9 @@ const updateAirportArea = () => {
             ? "rgba(18,21,26,0.045)"
             : "rgba(255,255,255,0.02)";
 
-    const d = 0.032;
-    const bounds = [
-        [props.lat + d, props.lon - d],
-        [props.lat + d, props.lon + d],
-        [props.lat - d, props.lon + d],
-        [props.lat - d, props.lon - d],
-    ];
     airportAreaLayer = L.layerGroup([
-        L.polygon(bounds, {
+        L.circle([props.lat, props.lon], {
+            radius: AIRPORT_AREA_RADIUS_NM * NM_TO_METERS,
             color: borderColor,
             weight: 1,
             dashArray: "4 4",
@@ -327,6 +347,72 @@ const updateAirportArea = () => {
     ]).addTo(map);
 };
 
+
+const QUERY_RANGE_NM = DEFAULT_AIRCRAFT_DIST_NM;
+const AIRPORT_AREA_RADIUS_NM = 2.2;
+const NM_TO_METERS = 1852;
+
+const buildAirportOverlayDetails = () => {
+    const details = [];
+    const runways = props.airport?.runways;
+    if (Array.isArray(runways) && runways.length) details.push(`RWY ${runways.length}`);
+
+    const approachCount = Number(props.airport?.approachCount);
+    if (Number.isFinite(approachCount) && approachCount > 0) details.push(`APP ${approachCount}`);
+
+    return details;
+};
+
+const updateAirportContextOverlays = () => {
+    if (!map || !props.lat || !props.lon) return;
+
+    queryRangeLayer?.removeFrom(map);
+    airportInfoMarker?.removeFrom(map);
+    airportGroundCountMarker?.removeFrom(map);
+    queryRangeLayer = null;
+    airportInfoMarker = null;
+    airportGroundCountMarker = null;
+
+    const stroke = currentTheme.value === "light" ? "rgba(18,21,26,0.22)" : "rgba(255,255,255,0.28)";
+    const fill = currentTheme.value === "light" ? "rgba(18,21,26,0.06)" : "rgba(255,255,255,0.05)";
+
+    queryRangeLayer = L.circle([props.lat, props.lon], {
+        radius: QUERY_RANGE_NM * NM_TO_METERS,
+        color: stroke,
+        weight: 1,
+        dashArray: "6 6",
+        fillColor: fill,
+        fillOpacity: 1,
+    }).addTo(map);
+
+    const airportCode = escapeHtml((props.airport?.iata || props.icao || "").trim());
+    const detailLines = buildAirportOverlayDetails()
+        .map((line) => `<span>${escapeHtml(line)}</span>`)
+        .join("");
+
+    airportInfoMarker = L.marker([props.lat, props.lon], {
+        interactive: false,
+        icon: L.divIcon({
+            className: "",
+            html: `<div class="airport-overlay-label">${airportCode}${detailLines}</div>`,
+            iconSize: [120, 34],
+            iconAnchor: [0, -8],
+        }),
+    }).addTo(map);
+
+    if (Number(props.zoom) === ZOOM_APPROACH) {
+        const groundCount = props.aircraft.filter((item) => isGroundLikeAircraft(item)).length;
+        airportGroundCountMarker = L.marker([props.lat, props.lon], {
+            interactive: false,
+            icon: L.divIcon({
+                className: "",
+                html: `<div class="airport-ground-count">GROUND ${groundCount}</div>`,
+                iconSize: [92, 18],
+                iconAnchor: [46, 24],
+            }),
+        }).addTo(map);
+    }
+};
 const makeAcIcon = (
     color,
     label,
@@ -397,7 +483,12 @@ const updateAircraft = () => {
 
     const now = Date.now();
     const seen = new Set();
+    const onlyMovingAtApproach = Number(props.zoom) === ZOOM_APPROACH;
     props.aircraft.forEach((ac) => {
+        const speedKt = Number(ac.velocity ?? 0);
+        const isMoving = speedKt >= SLOW_AIRCRAFT_THRESHOLD_KT;
+        const isGroundLike = isGroundLikeAircraft(ac);
+        if (onlyMovingAtApproach && (isGroundLike || !isMoving)) return;
         if (!ac.lat || !ac.lon) return;
         seen.add(ac.icao24);
         const vel = ac.velocity ?? 0;
@@ -496,6 +587,7 @@ const updateAircraft = () => {
     }
 
     updateAirportArea();
+    updateAirportContextOverlays();
 };
 
 watch(() => props.aircraft, updateAircraft, { deep: true });
@@ -504,6 +596,7 @@ watch(
     () => {
         updateTileLayers();
         updateAirportArea();
+        updateAirportContextOverlays();
     },
 );
 
@@ -515,6 +608,7 @@ watch(
             latStr.value = `${Math.abs(lat).toFixed(2)}°${lat >= 0 ? "N" : "S"}`;
             lonStr.value = `${Math.abs(lon).toFixed(2)}°${lon >= 0 ? "E" : "W"}`;
             updateAirportArea();
+            updateAirportContextOverlays();
         }
     },
 );
@@ -524,6 +618,8 @@ watch(
         if (map) {
             map.setZoom(zoom);
             updateAirportArea();
+            updateAirportContextOverlays();
+            updateAircraft();
         }
     },
 );
@@ -547,7 +643,13 @@ onUnmounted(() => {
         unmountAircraftTelemetry(entry.marker);
     acMarkersMap.clear();
     airportAreaLayer?.removeFrom(map);
+    queryRangeLayer?.removeFrom(map);
+    airportInfoMarker?.removeFrom(map);
+    airportGroundCountMarker?.removeFrom(map);
     airportAreaLayer = null;
+    queryRangeLayer = null;
+    airportInfoMarker = null;
+    airportGroundCountMarker = null;
     themeObs?.disconnect();
     themeObs = null;
     baseTileLayer = null;
@@ -694,6 +796,38 @@ onUnmounted(() => {
 .aircraft-telemetry-separator {
     color: rgba(255, 90, 31, 0.72);
     font-size: 0.9em;
+}
+
+
+.airport-overlay-label {
+    color: var(--atc-text);
+    display: flex;
+    flex-direction: column;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 9px;
+    font-weight: 700;
+    gap: 1px;
+    letter-spacing: 0.6px;
+    text-shadow: 0 0 6px var(--map-label-glow);
+}
+
+.airport-overlay-label > span {
+    color: var(--atc-dim);
+    font-size: 8px;
+    font-weight: 600;
+}
+
+.airport-ground-count {
+    background: color-mix(in oklab, var(--atc-card) 78%, transparent);
+    border: 1px solid color-mix(in oklab, var(--atc-line-strong) 88%, transparent);
+    border-radius: 999px;
+    color: var(--atc-text);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.8px;
+    padding: 1px 6px;
+    text-shadow: 0 0 6px var(--map-label-glow);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/screens/AirportCaptionScreen.vue
+++ b/src/components/screens/AirportCaptionScreen.vue
@@ -18,6 +18,7 @@
                 :zoom="mapZoom"
                 accent="#FF5A1F"
                 :aircraft="aircraftWithRoutes"
+                :airport="airport"
             />
         </div>
 

--- a/src/utils/airportMapDisplay.js
+++ b/src/utils/airportMapDisplay.js
@@ -4,5 +4,25 @@ export const ZOOM_DETAIL = 14
 
 export const shouldShowAirportArea = (zoom) => Number(zoom) >= ZOOM_AIRPORT
 
+export const isGroundLikeAircraft = (
+  aircraft,
+  {
+    airportAreaRadiusNm,
+    slowAircraftThresholdKt,
+  } = {},
+) => {
+  if (aircraft?.onGround) return true
+
+  const distanceNm = Number(aircraft?.distanceNm)
+  const speedKt = Number(aircraft?.velocity ?? 0)
+
+  return (
+    Number.isFinite(distanceNm)
+    && distanceNm <= airportAreaRadiusNm
+    && Number.isFinite(speedKt)
+    && speedKt < slowAircraftThresholdKt
+  )
+}
+
 export const countGroundAircraft = (aircraft = []) =>
   aircraft.filter((item) => item?.onGround).length

--- a/src/utils/airportMapDisplay.test.js
+++ b/src/utils/airportMapDisplay.test.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 
-import { countGroundAircraft, shouldShowAirportArea } from './airportMapDisplay.js'
+import {
+  countGroundAircraft,
+  isGroundLikeAircraft,
+  shouldShowAirportArea,
+} from './airportMapDisplay.js'
 
 assert.equal(shouldShowAirportArea(10), false)
 assert.equal(shouldShowAirportArea(13), true)
@@ -14,4 +18,45 @@ assert.equal(
     {},
   ]),
   2,
+)
+
+const groundLikeOptions = {
+  airportAreaRadiusNm: 2.2,
+  slowAircraftThresholdKt: 30,
+}
+
+assert.equal(
+  isGroundLikeAircraft(
+    { distanceNm: 0.8, velocity: 0, altitude: 'ground' },
+    groundLikeOptions,
+  ),
+  true,
+)
+assert.equal(
+  isGroundLikeAircraft(
+    { distanceNm: 2.1, velocity: 29.9, altitude: 12000 },
+    groundLikeOptions,
+  ),
+  true,
+)
+assert.equal(
+  isGroundLikeAircraft(
+    { distanceNm: 2.3, velocity: 0 },
+    groundLikeOptions,
+  ),
+  false,
+)
+assert.equal(
+  isGroundLikeAircraft(
+    { distanceNm: 0.8, velocity: 30 },
+    groundLikeOptions,
+  ),
+  false,
+)
+assert.equal(
+  isGroundLikeAircraft(
+    { onGround: true, distanceNm: 8, velocity: 220 },
+    groundLikeOptions,
+  ),
+  true,
 )


### PR DESCRIPTION
### Motivation
- Provide richer airport context on the map (range ring, airport label, runway/approach info and ground count) and more accurate airport area rendering. 
- Hide irrelevant aircraft when zoomed to an approach view by filtering out ground-like and very slow aircraft to reduce clutter. 

### Description
- Added a new `airport` prop to `AirportMap` and passed it from `AirportCaptionScreen` so overlay details can be rendered from airport metadata. 
- Introduced `updateAirportContextOverlays`, `buildAirportOverlayDetails`, and `isGroundLikeAircraft` plus constants `QUERY_RANGE_NM`, `AIRPORT_AREA_RADIUS_NM` and `NM_TO_METERS` to draw the query range circle, an airport info label, and a ground-count badge at the map center. 
- Replaced the crude airport polygon with a proper circular airport area using `AIRPORT_AREA_RADIUS_NM` and switched to using `DEFAULT_AIRCRAFT_DIST_NM` and `ZOOM_APPROACH` imports for range/zoom behavior. 
- Filtered aircraft in `updateAircraft` so when zoom equals `ZOOM_APPROACH` ground-like or non-moving aircraft are not shown, and added cleanup for the new overlay layers/markers; also added CSS styles for the new overlay labels. 

### Testing
- Ran the project's automated unit test suite (`npm test`), and all tests passed. 
- Ran linting (`npm run lint`), and linting succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27f36b8308331ad0624b61d2d1635)