### PR TITLE
refactor: extract AirportCaptionScreen panels and scroll parallax (#76)

### DIFF
--- a/src/components/panels/TrafficPanel.vue
+++ b/src/components/panels/TrafficPanel.vue
@@ -1,0 +1,158 @@
+<script setup>
+import NumberFlow from "@number-flow/vue";
+import { AIRCRAFT_COLORS } from "../../constants/aircraft.js";
+
+defineProps({
+    aircraft: {
+        type: Array,
+        default: () => [],
+    },
+    trafficCounts: {
+        type: Object,
+        default: () => ({ ascending: 0, descending: 0, level: 0 }),
+    },
+});
+</script>
+
+<template>
+    <section class="glass-panel traffic-panel">
+        <div class="panel-heading">
+            <div>
+                <div class="panel-kicker">Airport traffic</div>
+                <h2>Nearby aircraft</h2>
+            </div>
+        </div>
+
+        <div class="traffic-counts">
+            <div>
+                <span>Total</span>
+                <strong style="color: var(--atc-text)"
+                    ><NumberFlow :value="aircraft.length"
+                /></strong>
+            </div>
+            <div>
+                <span>Ascending</span>
+                <strong :style="{ color: AIRCRAFT_COLORS.ascending }"
+                    ><NumberFlow :value="trafficCounts.ascending"
+                /></strong>
+            </div>
+            <div>
+                <span>Descending</span>
+                <strong :style="{ color: AIRCRAFT_COLORS.descending }"
+                    ><NumberFlow :value="trafficCounts.descending"
+                /></strong>
+            </div>
+            <div>
+                <span>Level</span>
+                <strong :style="{ color: 'var(--traffic-level-color)' }"
+                    ><NumberFlow :value="trafficCounts.level"
+                /></strong>
+            </div>
+        </div>
+    </section>
+</template>
+
+<style scoped>
+.glass-panel {
+    background: linear-gradient(
+        145deg,
+        var(--glass-card-top),
+        var(--glass-card-bottom)
+    );
+    border: 1px solid var(--glass-card-border);
+    border-radius: var(--atc-radius-panel);
+    box-shadow:
+        0 8px 24px rgba(0, 0, 0, 0.18),
+        0 24px 64px rgba(0, 0, 0, 0.22),
+        inset 0 1px 0 var(--glass-card-inset);
+    max-height: 250px;
+    min-width: 0;
+    overflow: hidden;
+    padding: 16px;
+    position: relative;
+    backdrop-filter: blur(6px) saturate(120%);
+    -webkit-backdrop-filter: blur(6px) saturate(120%);
+}
+
+.glass-panel::before {
+    background: linear-gradient(
+        120deg,
+        var(--glass-card-glint-strong) 0%,
+        var(--glass-card-glint-soft) 45%,
+        transparent 60%
+    );
+    content: "";
+    inset: 0;
+    pointer-events: none;
+    position: absolute;
+}
+
+.panel-heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+    position: relative;
+}
+
+.panel-heading h2 {
+    color: var(--atc-text);
+    font-size: 16px;
+    font-weight: 800;
+    line-height: 1.15;
+    margin: 4px 0 0;
+}
+
+.panel-kicker {
+    color: var(--atc-faint);
+    font-size: 10px;
+    letter-spacing: 1.6px;
+    text-transform: uppercase;
+}
+
+.traffic-counts {
+    display: grid;
+    gap: 12px 18px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: 18px;
+}
+
+.traffic-counts > div {
+    border-top: 1px solid var(--atc-line);
+    padding-top: 10px;
+}
+
+.traffic-counts span {
+    color: var(--atc-faint);
+    display: block;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+}
+
+.traffic-counts strong {
+    display: block;
+    font-size: 30px;
+    line-height: 1;
+    margin-top: 9px;
+}
+
+@media (max-width: 980px) {
+    .traffic-panel {
+        grid-column: 1;
+        min-height: 220px;
+    }
+
+    .glass-panel {
+        max-height: none;
+    }
+}
+
+@media (max-width: 620px) {
+    .glass-panel {
+        border-radius: var(--atc-radius-panel);
+        padding: 16px;
+    }
+}
+</style>

--- a/src/components/panels/WeatherPanel.vue
+++ b/src/components/panels/WeatherPanel.vue
@@ -1,0 +1,347 @@
+<script setup>
+import { ref, computed } from "vue";
+import NumberFlow from "@number-flow/vue";
+
+const props = defineProps({
+    metar: {
+        type: Object,
+        default: null,
+    },
+    metarRaw: {
+        type: String,
+        default: "",
+    },
+    metarLoading: {
+        type: Boolean,
+        default: false,
+    },
+    metarError: {
+        type: String,
+        default: null,
+    },
+});
+
+const activeWeatherView = ref("parsed");
+
+const weatherSummary = computed(() => {
+    if (!props.metar) return "Weather report pending";
+    const category = props.metar.flightCategory || "Observed";
+    const wind =
+        props.metar.wind && props.metar.wind !== "—"
+            ? props.metar.wind
+            : "wind unavailable";
+    return `${category} · ${wind}`;
+});
+
+const visInfo = computed(() => {
+    const raw = props.metar?.vis;
+    const match = raw?.match(/^(\d+(?:\.\d+)?)(\+)?\s*SM$/);
+    if (!match) return null;
+
+    return {
+        value: Number(match[1]),
+        plus: Boolean(match[2]),
+    };
+});
+
+const formatObsTime = (value) => {
+    if (!value) return "latest";
+    const date = new Date(
+        Number(value) < 10_000_000_000 ? Number(value) * 1000 : value,
+    );
+    if (Number.isNaN(date.getTime())) return "latest";
+    return date.toLocaleTimeString([], {
+        hour12: false,
+        hour: "2-digit",
+        minute: "2-digit",
+    });
+};
+</script>
+
+<template>
+    <section class="glass-panel weather-instrument-panel">
+        <div class="panel-heading">
+            <div>
+                <div class="panel-kicker">METAR / Weather</div>
+                <h2>
+                    {{
+                        activeWeatherView === "parsed"
+                            ? weatherSummary
+                            : "Observation string"
+                    }}
+                </h2>
+            </div>
+            <span class="panel-pill">{{
+                formatObsTime(metar?.obsTime)
+            }}</span>
+        </div>
+
+        <div class="weather-view-frame">
+            <dl
+                v-if="activeWeatherView === 'parsed'"
+                class="weather-readout"
+            >
+                <div>
+                    <dt>Wind</dt>
+                    <dd>{{ metar?.wind || "—" }}</dd>
+                </div>
+                <div>
+                    <dt>Visibility</dt>
+                    <dd>
+                        <template v-if="visInfo">
+                            <NumberFlow
+                                :value="visInfo.value"
+                                :suffix="
+                                    visInfo.plus ? '+ SM' : ' SM'
+                                "
+                            />
+                        </template>
+                        <template v-else>{{
+                            metar?.vis || "—"
+                        }}</template>
+                    </dd>
+                </div>
+                <div>
+                    <dt>Ceiling</dt>
+                    <dd>{{ metar?.ceiling || "—" }}</dd>
+                </div>
+                <div>
+                    <dt>Temp / Dew</dt>
+                    <dd>
+                        {{
+                            metar
+                                ? `${metar.temp} / ${metar.dew}`
+                                : "—"
+                        }}
+                    </dd>
+                </div>
+                <div>
+                    <dt>Altimeter</dt>
+                    <dd>{{ metar?.altim || "—" }}</dd>
+                </div>
+                <div>
+                    <dt>Weather</dt>
+                    <dd>
+                        {{ metar?.wxString || "None reported" }}
+                    </dd>
+                </div>
+            </dl>
+
+            <div v-else class="metar-code">
+                <span v-if="metarRaw">{{ metarRaw }}</span>
+                <span v-else-if="metarLoading">Loading METAR...</span>
+                <span v-else>No METAR available.</span>
+            </div>
+        </div>
+
+        <div v-if="metarError" class="panel-error">
+            {{ metarError }}
+        </div>
+
+        <div
+            class="weather-view-dots"
+            role="tablist"
+            aria-label="Weather card view"
+        >
+            <button
+                type="button"
+                role="tab"
+                aria-label="Parsed weather"
+                :aria-selected="activeWeatherView === 'parsed'"
+                :class="{ active: activeWeatherView === 'parsed' }"
+                @click="activeWeatherView = 'parsed'"
+            />
+            <button
+                type="button"
+                role="tab"
+                aria-label="Raw METAR"
+                :aria-selected="activeWeatherView === 'raw'"
+                :class="{ active: activeWeatherView === 'raw' }"
+                @click="activeWeatherView = 'raw'"
+            />
+        </div>
+    </section>
+</template>
+
+<style scoped>
+.glass-panel {
+    background: linear-gradient(
+        145deg,
+        var(--glass-card-top),
+        var(--glass-card-bottom)
+    );
+    border: 1px solid var(--glass-card-border);
+    border-radius: var(--atc-radius-panel);
+    box-shadow:
+        0 8px 24px rgba(0, 0, 0, 0.18),
+        0 24px 64px rgba(0, 0, 0, 0.22),
+        inset 0 1px 0 var(--glass-card-inset);
+    max-height: 250px;
+    min-width: 0;
+    overflow: hidden;
+    padding: 16px;
+    position: relative;
+    backdrop-filter: blur(6px) saturate(120%);
+    -webkit-backdrop-filter: blur(6px) saturate(120%);
+}
+
+.glass-panel::before {
+    background: linear-gradient(
+        120deg,
+        var(--glass-card-glint-strong) 0%,
+        var(--glass-card-glint-soft) 45%,
+        transparent 60%
+    );
+    content: "";
+    inset: 0;
+    pointer-events: none;
+    position: absolute;
+}
+
+.panel-heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+    position: relative;
+}
+
+.panel-heading h2 {
+    color: var(--atc-text);
+    font-size: 16px;
+    font-weight: 800;
+    line-height: 1.15;
+    margin: 4px 0 0;
+}
+
+.panel-kicker {
+    color: var(--atc-faint);
+    font-size: 10px;
+    letter-spacing: 1.6px;
+    text-transform: uppercase;
+}
+
+.panel-pill {
+    border: 1px solid var(--atc-line-strong);
+    border-radius: var(--atc-radius-pill);
+    color: var(--atc-dim);
+    flex-shrink: 0;
+    font-size: 10px;
+    letter-spacing: 1px;
+    padding: 5px 9px;
+    text-transform: uppercase;
+}
+
+.weather-instrument-panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 250px;
+}
+
+.weather-view-frame {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.metar-code {
+    color: var(--atc-text);
+    font-family: "JetBrains Mono", monospace;
+    font-size: clamp(14px, 1.1vw, 18px);
+    font-weight: 800;
+    line-height: 1.3;
+    margin-top: 14px;
+    max-height: 156px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+
+.panel-error {
+    color: var(--atc-red);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    letter-spacing: 0.8px;
+    margin-top: 10px;
+    text-transform: uppercase;
+}
+
+.weather-readout {
+    display: grid;
+    gap: 7px 18px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin: 14px 0 0;
+}
+
+.weather-readout div {
+    border-top: 1px solid var(--atc-line);
+    padding-top: 8px;
+}
+
+.weather-readout dt {
+    color: var(--atc-faint);
+    display: block;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+}
+
+.weather-readout dd {
+    color: var(--atc-text);
+    display: block;
+    font-size: 14px;
+    font-weight: 800;
+    line-height: 1.18;
+    margin: 6px 0 0;
+}
+
+.weather-view-dots {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    margin-top: 12px;
+    position: relative;
+}
+
+.weather-view-dots button {
+    appearance: none;
+    background: color-mix(in oklab, var(--atc-dim) 48%, transparent);
+    border: 0;
+    border-radius: var(--atc-radius-pill);
+    cursor: pointer;
+    height: 7px;
+    padding: 0;
+    transition:
+        background 0.16s ease,
+        transform 0.16s ease,
+        width 0.16s ease;
+    width: 7px;
+}
+
+.weather-view-dots button.active {
+    background: var(--atc-orange);
+    transform: scale(1.08);
+    width: 18px;
+}
+
+@media (max-width: 980px) {
+    .glass-panel {
+        max-height: none;
+    }
+
+    .weather-instrument-panel {
+        grid-column: 1;
+    }
+}
+
+@media (max-width: 620px) {
+    .glass-panel {
+        border-radius: var(--atc-radius-panel);
+        padding: 16px;
+    }
+
+    .weather-instrument-panel {
+        min-height: 292px;
+    }
+}
+</style>

--- a/src/components/panels/WikiPanel.vue
+++ b/src/components/panels/WikiPanel.vue
@@ -1,0 +1,168 @@
+<script setup>
+defineProps({
+    wikiSummary: {
+        type: Object,
+        default: null,
+    },
+    wikiLoading: {
+        type: Boolean,
+        default: false,
+    },
+    airportName: {
+        type: String,
+        default: "Airport",
+    },
+});
+</script>
+
+<template>
+    <section class="glass-panel wiki-panel">
+        <div class="panel-heading">
+            <div>
+                <div class="panel-kicker">Airport wiki</div>
+                <h2>{{ wikiSummary?.title || airportName }}</h2>
+            </div>
+            <a
+                v-if="wikiSummary?.url"
+                class="panel-link"
+                :href="wikiSummary.url"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Wikipedia
+            </a>
+        </div>
+
+        <p class="wiki-copy">
+            <span v-if="wikiSummary?.extract">{{
+                wikiSummary.extract
+            }}</span>
+            <span v-else-if="wikiLoading"
+                >Loading airport introduction...</span
+            >
+            <span v-else>
+                No Wikipedia summary was found for this airport. The
+                rest of the dashboard remains live.
+            </span>
+        </p>
+
+        <div class="wiki-source">Source: Wikipedia summary API</div>
+    </section>
+</template>
+
+<style scoped>
+.glass-panel {
+    background: linear-gradient(
+        145deg,
+        var(--glass-card-top),
+        var(--glass-card-bottom)
+    );
+    border: 1px solid var(--glass-card-border);
+    border-radius: var(--atc-radius-panel);
+    box-shadow:
+        0 8px 24px rgba(0, 0, 0, 0.18),
+        0 24px 64px rgba(0, 0, 0, 0.22),
+        inset 0 1px 0 var(--glass-card-inset);
+    max-height: 250px;
+    min-width: 0;
+    overflow: hidden;
+    padding: 16px;
+    position: relative;
+    backdrop-filter: blur(6px) saturate(120%);
+    -webkit-backdrop-filter: blur(6px) saturate(120%);
+}
+
+.glass-panel::before {
+    background: linear-gradient(
+        120deg,
+        var(--glass-card-glint-strong) 0%,
+        var(--glass-card-glint-soft) 45%,
+        transparent 60%
+    );
+    content: "";
+    inset: 0;
+    pointer-events: none;
+    position: absolute;
+}
+
+.panel-heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+    position: relative;
+}
+
+.panel-heading h2 {
+    color: var(--atc-text);
+    font-size: 16px;
+    font-weight: 800;
+    line-height: 1.15;
+    margin: 4px 0 0;
+}
+
+.panel-kicker {
+    color: var(--atc-faint);
+    font-size: 10px;
+    letter-spacing: 1.6px;
+    text-transform: uppercase;
+}
+
+.panel-link {
+    border: 1px solid var(--atc-line-strong);
+    border-radius: var(--atc-radius-pill);
+    color: var(--atc-dim);
+    flex-shrink: 0;
+    font-size: 10px;
+    letter-spacing: 1px;
+    padding: 5px 9px;
+    text-decoration: none;
+    text-transform: uppercase;
+}
+
+.wiki-copy {
+    color: color-mix(in oklab, var(--atc-text) 86%, transparent);
+    font-size: 14px;
+    line-height: 1.55;
+    margin: 14px 0 0;
+    max-height: 132px;
+    overflow: auto;
+    position: relative;
+}
+
+.wiki-source {
+    border-top: 1px solid var(--atc-line);
+    color: var(--atc-faint);
+    font-size: 10px;
+    letter-spacing: 1px;
+    margin-top: 20px;
+    padding-top: 12px;
+    text-transform: uppercase;
+}
+
+@media (max-width: 980px) {
+    .wiki-panel {
+        grid-column: 1;
+        min-height: 220px;
+    }
+
+    .glass-panel {
+        max-height: none;
+    }
+}
+
+@media (max-width: 620px) {
+    .wiki-panel {
+        grid-column: 1;
+    }
+
+    .glass-panel {
+        border-radius: var(--atc-radius-panel);
+        padding: 16px;
+    }
+
+    .wiki-copy {
+        max-height: 138px;
+    }
+}
+</style>

--- a/src/components/screens/AirportCaptionScreen.vue
+++ b/src/components/screens/AirportCaptionScreen.vue
@@ -3,11 +3,12 @@
         ref="screenRef"
         class="airport-screen relative min-h-screen bg-atc-bg font-sans text-atc-text"
         :style="{
-            '--mobile-map-dim': mobileMapDim,
-            '--mobile-breadcrumb-opacity': mobileBreadcrumbOpacity,
-            '--mobile-title-opacity': mobileTitleOpacity,
-            '--mobile-compact-title-opacity': mobileCompactTitleOpacity,
-            '--mobile-top-mask-opacity': mobileTopMaskOpacity,
+            '--mobile-map-dim': parallax.mapDim.value,
+            '--mobile-breadcrumb-opacity': parallax.breadcrumbOpacity.value,
+            '--mobile-title-opacity': parallax.titleOpacity.value,
+            '--mobile-compact-title-opacity':
+                parallax.compactTitleOpacity.value,
+            '--mobile-top-mask-opacity': parallax.topMaskOpacity.value,
         }"
     >
         <div class="airport-map-layer absolute inset-0 z-0">
@@ -93,194 +94,41 @@
             </div>
 
             <main class="airport-dashboard">
-                <section class="glass-panel weather-instrument-panel">
-                    <div class="panel-heading">
-                        <div>
-                            <div class="panel-kicker">METAR / Weather</div>
-                            <h2>
-                                {{
-                                    activeWeatherView === "parsed"
-                                        ? weatherSummary
-                                        : "Observation string"
-                                }}
-                            </h2>
-                        </div>
-                        <span class="panel-pill">{{
-                            formatObsTime(metar?.obsTime)
-                        }}</span>
-                    </div>
+                <WeatherPanel
+                    :metar="metar"
+                    :metar-raw="metarRaw"
+                    :metar-loading="metarLoading"
+                    :metar-error="metarError"
+                />
 
-                    <div class="weather-view-frame">
-                        <dl
-                            v-if="activeWeatherView === 'parsed'"
-                            class="weather-readout"
-                        >
-                            <div>
-                                <dt>Wind</dt>
-                                <dd>{{ metar?.wind || "—" }}</dd>
-                            </div>
-                            <div>
-                                <dt>Visibility</dt>
-                                <dd>
-                                    <template v-if="visInfo">
-                                        <NumberFlow
-                                            :value="visInfo.value"
-                                            :suffix="
-                                                visInfo.plus ? '+ SM' : ' SM'
-                                            "
-                                        />
-                                    </template>
-                                    <template v-else>{{
-                                        metar?.vis || "—"
-                                    }}</template>
-                                </dd>
-                            </div>
-                            <div>
-                                <dt>Ceiling</dt>
-                                <dd>{{ metar?.ceiling || "—" }}</dd>
-                            </div>
-                            <div>
-                                <dt>Temp / Dew</dt>
-                                <dd>
-                                    {{
-                                        metar
-                                            ? `${metar.temp} / ${metar.dew}`
-                                            : "—"
-                                    }}
-                                </dd>
-                            </div>
-                            <div>
-                                <dt>Altimeter</dt>
-                                <dd>{{ metar?.altim || "—" }}</dd>
-                            </div>
-                            <div>
-                                <dt>Weather</dt>
-                                <dd>
-                                    {{ metar?.wxString || "None reported" }}
-                                </dd>
-                            </div>
-                        </dl>
+                <TrafficPanel
+                    :aircraft="aircraft"
+                    :traffic-counts="trafficCounts"
+                />
 
-                        <div v-else class="metar-code">
-                            <span v-if="metarRaw">{{ metarRaw }}</span>
-                            <span v-else-if="metarLoading"
-                                >Loading METAR...</span
-                            >
-                            <span v-else>No METAR available.</span>
-                        </div>
-                    </div>
-
-                    <div v-if="metarError" class="panel-error">
-                        {{ metarError }}
-                    </div>
-
-                    <div
-                        class="weather-view-dots"
-                        role="tablist"
-                        aria-label="Weather card view"
-                    >
-                        <button
-                            type="button"
-                            role="tab"
-                            aria-label="Parsed weather"
-                            :aria-selected="activeWeatherView === 'parsed'"
-                            :class="{ active: activeWeatherView === 'parsed' }"
-                            @click="activeWeatherView = 'parsed'"
-                        />
-                        <button
-                            type="button"
-                            role="tab"
-                            aria-label="Raw METAR"
-                            :aria-selected="activeWeatherView === 'raw'"
-                            :class="{ active: activeWeatherView === 'raw' }"
-                            @click="activeWeatherView = 'raw'"
-                        />
-                    </div>
-                </section>
-
-                <section class="glass-panel traffic-panel">
-                    <div class="panel-heading">
-                        <div>
-                            <div class="panel-kicker">Airport traffic</div>
-                            <h2>Nearby aircraft</h2>
-                        </div>
-                    </div>
-
-                    <div class="traffic-counts">
-                        <div>
-                            <span>Total</span>
-                            <strong style="color: var(--atc-text)"
-                                ><NumberFlow :value="aircraft.length"
-                            /></strong>
-                        </div>
-                        <div>
-                            <span>Ascending</span>
-                            <strong :style="{ color: AIRCRAFT_COLORS.ascending }"
-                                ><NumberFlow :value="trafficCounts.ascending"
-                            /></strong>
-                        </div>
-                        <div>
-                            <span>Descending</span>
-                            <strong :style="{ color: AIRCRAFT_COLORS.descending }"
-                                ><NumberFlow :value="trafficCounts.descending"
-                            /></strong>
-                        </div>
-                        <div>
-                            <span>Level</span>
-                            <strong :style="{ color: 'var(--traffic-level-color)' }"
-                                ><NumberFlow :value="trafficCounts.level"
-                            /></strong>
-                        </div>
-                    </div>
-                </section>
-
-                <section class="glass-panel wiki-panel">
-                    <div class="panel-heading">
-                        <div>
-                            <div class="panel-kicker">Airport wiki</div>
-                            <h2>{{ wikiSummary?.title || airportName }}</h2>
-                        </div>
-                        <a
-                            v-if="wikiSummary?.url"
-                            class="panel-link"
-                            :href="wikiSummary.url"
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            Wikipedia
-                        </a>
-                    </div>
-
-                    <p class="wiki-copy">
-                        <span v-if="wikiSummary?.extract">{{
-                            wikiSummary.extract
-                        }}</span>
-                        <span v-else-if="wikiLoading"
-                            >Loading airport introduction...</span
-                        >
-                        <span v-else>
-                            No Wikipedia summary was found for this airport. The
-                            rest of the dashboard remains live.
-                        </span>
-                    </p>
-
-                    <div class="wiki-source">Source: Wikipedia summary API</div>
-                </section>
+                <WikiPanel
+                    :wiki-summary="wikiSummary"
+                    :wiki-loading="wikiLoading"
+                    :airport-name="airportName"
+                />
             </main>
         </div>
     </div>
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import NumberFlow from "@number-flow/vue";
+import { computed, ref } from "vue";
 import MapControlBar from "../ui/MapControlBar.vue";
 import AirportMap from "../map/AirportMap.vue";
+import WeatherPanel from "../panels/WeatherPanel.vue";
+import TrafficPanel from "../panels/TrafficPanel.vue";
+import WikiPanel from "../panels/WikiPanel.vue";
 import { useAircraftPositions } from "../../composables/useAircraftPositions.js";
 import { useAirportWiki } from "../../composables/useAirportWiki.js";
 import { useFlightRoutes } from "../../composables/useFlightRoutes.js";
 import { useMetar } from "../../composables/useMetar.js";
-import { AIRCRAFT_COLORS, BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft.js";
+import { useScrollParallax } from "../../composables/useScrollParallax.js";
+import { BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft.js";
 import { SLOW_AIRCRAFT_THRESHOLD_KT } from "../../utils/aircraftMotion.js";
 import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
 import { formatLocalFlightRouteLabel } from "../../utils/flightRouteDisplay.js";
@@ -296,58 +144,9 @@ const props = defineProps({
 defineEmits(["back"]);
 
 const mapZoom = ref(ZOOM_APPROACH);
-const activeWeatherView = ref("parsed");
-const mobileMapDim = ref(0);
-const mobileBreadcrumbOpacity = ref(1);
-const mobileTitleOpacity = ref(1);
-const mobileCompactTitleOpacity = ref(0);
-const mobileTopMaskOpacity = ref(0);
 const screenRef = ref(null);
 
-const syncMobileMapDim = () => {
-    const el = screenRef.value;
-    if (!el) return;
-
-    const progress = Math.min(
-        el.scrollTop / Math.max(window.innerHeight * 0.32, 1),
-        1,
-    );
-    const titleProgress = Math.min(
-        el.scrollTop / Math.max(window.innerHeight * 0.14, 1),
-        1,
-    );
-    const compactProgress = Math.max(
-        0,
-        Math.min((titleProgress - 0.08) / 0.34, 1),
-    );
-    mobileMapDim.value = Number((progress * 0.78).toFixed(3));
-    mobileBreadcrumbOpacity.value = Number(
-        Math.max(1 - compactProgress, 0).toFixed(3),
-    );
-    mobileTitleOpacity.value = Number(
-        Math.max(1 - titleProgress, 0).toFixed(3),
-    );
-    mobileCompactTitleOpacity.value = Number(compactProgress.toFixed(3));
-    mobileTopMaskOpacity.value = Number(
-        Math.min(0.22 + progress * 0.78, 1).toFixed(3),
-    );
-};
-
-onMounted(() => {
-    const el = screenRef.value;
-    if (!el) return;
-
-    syncMobileMapDim();
-    el.addEventListener("scroll", syncMobileMapDim, { passive: true });
-    window.addEventListener("resize", syncMobileMapDim);
-});
-
-onBeforeUnmount(() => {
-    const el = screenRef.value;
-    el?.removeEventListener("scroll", syncMobileMapDim);
-    window.removeEventListener("resize", syncMobileMapDim);
-});
-
+const parallax = useScrollParallax(screenRef);
 
 const airportFallback = computed(
     () => AIRPORT_FALLBACKS[props.icao?.toUpperCase()] || null,
@@ -390,7 +189,10 @@ const { aircraft, lastUpdated } = useAircraftPositions(icaoRef, latRef, lonRef);
 const { routesByCallsign } = useFlightRoutes(aircraft);
 
 const normalizeCallsign = (callsign) =>
-    String(callsign || "").trim().toUpperCase().replace(/\s+/g, "");
+    String(callsign || "")
+        .trim()
+        .toUpperCase()
+        .replace(/\s+/g, "");
 
 const aircraftWithRoutes = computed(() =>
     aircraft.value.map((item) => {
@@ -430,7 +232,8 @@ const coordinatesLabel = computed(() => {
 const trafficCounts = computed(() =>
     aircraft.value.reduce(
         (counts, item) => {
-            const showArrow = (item.velocity ?? 0) >= SLOW_AIRCRAFT_THRESHOLD_KT;
+            const showArrow =
+                (item.velocity ?? 0) >= SLOW_AIRCRAFT_THRESHOLD_KT;
             if (!item.onGround && showArrow && item.baroRate != null) {
                 if (item.baroRate > BARO_RATE_THRESHOLD_FPM) {
                     counts.ascending += 1;
@@ -448,27 +251,6 @@ const trafficCounts = computed(() =>
     ),
 );
 
-const weatherSummary = computed(() => {
-    if (!metar.value) return "Weather report pending";
-    const category = metar.value.flightCategory || "Observed";
-    const wind =
-        metar.value.wind && metar.value.wind !== "—"
-            ? metar.value.wind
-            : "wind unavailable";
-    return `${category} · ${wind}`;
-});
-
-const visInfo = computed(() => {
-    const raw = metar.value?.vis;
-    const match = raw?.match(/^(\d+(?:\.\d+)?)(\+)?\s*SM$/);
-    if (!match) return null;
-
-    return {
-        value: Number(match[1]),
-        plus: Boolean(match[2]),
-    };
-});
-
 const fmtUpdated = (date) => {
     if (!date) return "—";
     return date.toLocaleTimeString([], {
@@ -476,19 +258,6 @@ const fmtUpdated = (date) => {
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit",
-    });
-};
-
-const formatObsTime = (value) => {
-    if (!value) return "latest";
-    const date = new Date(
-        Number(value) < 10_000_000_000 ? Number(value) * 1000 : value,
-    );
-    if (Number.isNaN(date.getTime())) return "latest";
-    return date.toLocaleTimeString([], {
-        hour12: false,
-        hour: "2-digit",
-        minute: "2-digit",
     });
 };
 </script>
@@ -980,7 +749,8 @@ const formatObsTime = (value) => {
         max-width: min(300px, calc(100vw - 72px));
         position: relative;
         text-align: center;
-        text-shadow: 0 2px 18px color-mix(in oklab, var(--atc-bg) 95%, transparent);
+        text-shadow: 0 2px 18px
+            color-mix(in oklab, var(--atc-bg) 95%, transparent);
         z-index: 1;
     }
 

--- a/src/composables/useScrollParallax.js
+++ b/src/composables/useScrollParallax.js
@@ -1,0 +1,71 @@
+import { onBeforeUnmount, onMounted, ref } from "vue";
+
+/**
+ * Reactive scroll-driven parallax values for the airport caption screen.
+ *
+ * Watches scroll position on a given container element and updates
+ * CSS custom property refs used by the mobile header animations.
+ */
+export function useScrollParallax(screenRef) {
+  const mapDim = ref(0);
+  const breadcrumbOpacity = ref(1);
+  const titleOpacity = ref(1);
+  const compactTitleOpacity = ref(0);
+  const topMaskOpacity = ref(0);
+
+  let rafId = null;
+
+  const update = () => {
+    if (rafId != null) return;
+    rafId = requestAnimationFrame(() => {
+      rafId = null;
+      const el = screenRef.value;
+      if (!el) return;
+
+      const progress = Math.min(
+        el.scrollTop / Math.max(window.innerHeight * 0.32, 1),
+        1,
+      );
+      const titleProgress = Math.min(
+        el.scrollTop / Math.max(window.innerHeight * 0.14, 1),
+        1,
+      );
+      const compactProgress = Math.max(
+        0,
+        Math.min((titleProgress - 0.08) / 0.34, 1),
+      );
+
+      mapDim.value = Math.round(progress * 0.78 * 1000) / 1000;
+      breadcrumbOpacity.value =
+        Math.round(Math.max(1 - compactProgress, 0) * 1000) / 1000;
+      titleOpacity.value =
+        Math.round(Math.max(1 - titleProgress, 0) * 1000) / 1000;
+      compactTitleOpacity.value = Math.round(compactProgress * 1000) / 1000;
+      topMaskOpacity.value =
+        Math.round(Math.min(0.22 + progress * 0.78, 1) * 1000) / 1000;
+    });
+  };
+
+  onMounted(() => {
+    const el = screenRef.value;
+    if (!el) return;
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+  });
+
+  onBeforeUnmount(() => {
+    const el = screenRef.value;
+    el?.removeEventListener("scroll", update);
+    window.removeEventListener("resize", update);
+    if (rafId != null) cancelAnimationFrame(rafId);
+  });
+
+  return {
+    mapDim,
+    breadcrumbOpacity,
+    titleOpacity,
+    compactTitleOpacity,
+    topMaskOpacity,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #76 — Refactors the 1100-line `AirportCaptionScreen.vue` into smaller, focused components and composables.

## Changes

### New components (`src/components/panels/`)

| File | Responsibility |
|------|---------------|
| `WeatherPanel.vue` | METAR display with parsed/raw tab toggle, NumberFlow visibility animation, observation time pill |
| `TrafficPanel.vue` | Aircraft count dashboard — Total, Ascending, Descending, Level with color-coded NumberFlow values |
| `WikiPanel.vue` | Wikipedia summary card with loading/empty states and attribution |

### New composable

| File | Responsibility |
|------|---------------|
| `src/composables/useScrollParallax.js` | Scroll-driven CSS custom property animations with `requestAnimationFrame` throttle |

### Modified

- `src/components/screens/AirportCaptionScreen.vue` — **-268 lines** (template + script), now wires composable output to panel component props

## Why

- Each panel is now ~100-150 lines with a single responsibility
- Panels can be tested and styled independently
- `useScrollParallax` now has rAF throttling (also addresses #75)
- Easier to add new dashboard cards without touching 1100-line file

## Verification

- ✅ `pnpm build` succeeds (production build)
- ✅ All 10 test suites pass
- ✅ Template structure, CSS custom properties, and responsive breakpoints preserved