### PR TITLE
feat: dual-range ADS-B poll (20nm wide + 3nm close) with icao24 dedup

### DIFF
--- a/src/components/map/AirportMap.vue
+++ b/src/components/map/AirportMap.vue
@@ -80,8 +80,11 @@ import {
     isGroundLikeAircraft as isGroundLikeAircraftForDisplay,
     shouldShowAirportArea,
 } from "../../utils/airportMapDisplay.js";
-import { AIRCRAFT_COLORS, BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft";
-import { DEFAULT_AIRCRAFT_DIST_NM } from "../../services/aviationData.js";
+import {
+    AIRCRAFT_COLORS,
+    BARO_RATE_THRESHOLD_FPM,
+} from "../../constants/aircraft";
+import { DEFAULT_WIDE_RANGE_NM } from "../../services/aviationData.js";
 
 const props = defineProps({
     icao: { type: String, default: "" },
@@ -126,14 +129,12 @@ const mapAttributionColor = computed(() =>
 const TILE_VARIANTS = {
     light: {
         base: "https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}@2x.png",
-        labels:
-            "https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}@2x.png",
+        labels: "https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}@2x.png",
         labelOpacity: 0.66,
     },
     dark: {
         base: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}@2x.png",
-        labels:
-            "https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}@2x.png",
+        labels: "https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}@2x.png",
         labelOpacity: 0.55,
     },
 };
@@ -239,7 +240,6 @@ const escapeHtml = (value) =>
         .replaceAll('"', "&quot;")
         .replaceAll("'", "&#39;");
 
-
 const isGroundLikeAircraft = (ac) => {
     return isGroundLikeAircraftForDisplay(ac, {
         airportAreaRadiusNm: AIRPORT_AREA_RADIUS_NM,
@@ -343,18 +343,19 @@ const updateAirportArea = () => {
     ]).addTo(map);
 };
 
-
-const QUERY_RANGE_NM = DEFAULT_AIRCRAFT_DIST_NM;
+const QUERY_RANGE_NM = DEFAULT_WIDE_RANGE_NM;
 const AIRPORT_AREA_RADIUS_NM = 2.2;
 const NM_TO_METERS = 1852;
 
 const buildAirportOverlayDetails = () => {
     const details = [];
     const runways = props.airport?.runways;
-    if (Array.isArray(runways) && runways.length) details.push(`RWY ${runways.length}`);
+    if (Array.isArray(runways) && runways.length)
+        details.push(`RWY ${runways.length}`);
 
     const approachCount = Number(props.airport?.approachCount);
-    if (Number.isFinite(approachCount) && approachCount > 0) details.push(`APP ${approachCount}`);
+    if (Number.isFinite(approachCount) && approachCount > 0)
+        details.push(`APP ${approachCount}`);
 
     return details;
 };
@@ -369,8 +370,14 @@ const updateAirportContextOverlays = () => {
     airportInfoMarker = null;
     airportGroundCountMarker = null;
 
-    const stroke = currentTheme.value === "light" ? "rgba(18,21,26,0.22)" : "rgba(255,255,255,0.28)";
-    const fill = currentTheme.value === "light" ? "rgba(18,21,26,0.06)" : "rgba(255,255,255,0.05)";
+    const stroke =
+        currentTheme.value === "light"
+            ? "rgba(18,21,26,0.22)"
+            : "rgba(255,255,255,0.28)";
+    const fill =
+        currentTheme.value === "light"
+            ? "rgba(18,21,26,0.06)"
+            : "rgba(255,255,255,0.05)";
 
     queryRangeLayer = L.circle([props.lat, props.lon], {
         radius: QUERY_RANGE_NM * NM_TO_METERS,
@@ -381,7 +388,9 @@ const updateAirportContextOverlays = () => {
         fillOpacity: 1,
     }).addTo(map);
 
-    const airportCode = escapeHtml((props.airport?.iata || props.icao || "").trim());
+    const airportCode = escapeHtml(
+        (props.airport?.iata || props.icao || "").trim(),
+    );
     const detailLines = buildAirportOverlayDetails()
         .map((line) => `<span>${escapeHtml(line)}</span>`)
         .join("");
@@ -397,7 +406,9 @@ const updateAirportContextOverlays = () => {
     }).addTo(map);
 
     if (Number(props.zoom) === ZOOM_APPROACH) {
-        const groundCount = props.aircraft.filter((item) => isGroundLikeAircraft(item)).length;
+        const groundCount = props.aircraft.filter((item) =>
+            isGroundLikeAircraft(item),
+        ).length;
         airportGroundCountMarker = L.marker([props.lat, props.lon], {
             interactive: false,
             icon: L.divIcon({
@@ -465,7 +476,9 @@ const makeAcIcon = (
 const getAircraftColor = (ac, showArrow) => {
     if (ac.onGround) return AIRCRAFT_COLORS.ground;
     if (!showArrow || ac.baroRate == null) {
-        return currentTheme.value === "light" ? "#475569" : AIRCRAFT_COLORS.level;
+        return currentTheme.value === "light"
+            ? "#475569"
+            : AIRCRAFT_COLORS.level;
     }
     if (ac.baroRate >= BARO_RATE_THRESHOLD_FPM)
         return AIRCRAFT_COLORS.ascending;
@@ -679,7 +692,8 @@ onUnmounted(() => {
 .map-traffic-legend {
     backdrop-filter: blur(10px);
     background: color-mix(in oklab, var(--atc-card) 72%, transparent);
-    border: 1px solid color-mix(in oklab, var(--atc-line-strong) 90%, transparent);
+    border: 1px solid
+        color-mix(in oklab, var(--atc-line-strong) 90%, transparent);
     color: var(--atc-dim);
     text-shadow: 0 0 6px var(--map-label-glow);
 }
@@ -794,7 +808,6 @@ onUnmounted(() => {
     font-size: 0.9em;
 }
 
-
 .airport-overlay-label {
     color: var(--atc-text);
     display: flex;
@@ -815,7 +828,8 @@ onUnmounted(() => {
 
 .airport-ground-count {
     background: color-mix(in oklab, var(--atc-card) 78%, transparent);
-    border: 1px solid color-mix(in oklab, var(--atc-line-strong) 88%, transparent);
+    border: 1px solid
+        color-mix(in oklab, var(--atc-line-strong) 88%, transparent);
     border-radius: 999px;
     color: var(--atc-text);
     font-family: "JetBrains Mono", monospace;

--- a/src/composables/useAircraftPositions.js
+++ b/src/composables/useAircraftPositions.js
@@ -1,7 +1,8 @@
 import { onUnmounted, ref, watch } from "vue";
 import {
   aircraftPositionClient,
-  DEFAULT_AIRCRAFT_DIST_NM,
+  DEFAULT_CLOSE_RANGE_NM,
+  DEFAULT_WIDE_RANGE_NM,
   DEFAULT_AIRCRAFT_POLL_MS,
 } from "../services/aviationData.js";
 import { parseAdsbPositionTime } from "../utils/aircraftMotion.js";
@@ -23,29 +24,51 @@ export function useAircraftPositions(icaoRef, latRef, lonRef) {
 
     loading.value = true;
     try {
-      const json = await aircraftPositionClient.fetchNearbyAircraft({
-        lat,
-        lon,
-        distNm: DEFAULT_AIRCRAFT_DIST_NM,
-      });
+      // Fetch two ranges in parallel:
+      //   Wide  (20 nm) — everything in the area
+      //   Close ( 3 nm) — airport immediate vicinity, catches ground/taxi aircraft
+      const [wideJson, closeJson] = await Promise.all([
+        aircraftPositionClient.fetchNearbyAircraft({
+          lat,
+          lon,
+          distNm: DEFAULT_WIDE_RANGE_NM,
+        }),
+        aircraftPositionClient.fetchNearbyAircraft({
+          lat,
+          lon,
+          distNm: DEFAULT_CLOSE_RANGE_NM,
+        }),
+      ]);
       const receiveTime = Date.now();
 
-      // adsb.lol response: { ac: [{ hex, flight, lat, lon, alt_baro, gs, track, gnd, ... }] }
-      const snapshots = (json.ac || [])
-        .filter((a) => a.lat != null && a.lon != null)
-        .map((a) => ({
-          icao24: a.hex || "",
-          callsign: (a.flight || a.r || "").trim(),
-          lat: a.lat,
-          lon: a.lon,
-          altitude: a.alt_baro ?? a.alt_geom ?? null,
-          baroRate: a.baro_rate ?? null,
-          onGround: a.gnd ?? false,
-          velocity: a.gs ?? null,
-          track: a.track ?? 0,
-          positionTime: parseAdsbPositionTime(a, json.now, receiveTime),
-          receiveTime,
-        }));
+      const parseAircraft = (a) => ({
+        icao24: a.hex || "",
+        callsign: (a.flight || a.r || "").trim(),
+        lat: a.lat,
+        lon: a.lon,
+        altitude: a.alt_baro ?? a.alt_geom ?? null,
+        baroRate: a.baro_rate ?? null,
+        onGround: a.gnd ?? false,
+        velocity: a.gs ?? null,
+        track: a.track ?? 0,
+        positionTime: parseAdsbPositionTime(a, wideJson.now, receiveTime),
+        receiveTime,
+      });
+
+      // Merge by icao24 — prefer the close-range snapshot when both exist
+      const seen = new Map();
+      const addSnapshots = (list) => {
+        for (const a of list || []) {
+          if (a.lat == null || a.lon == null) continue;
+          const key = a.hex || "";
+          if (key) seen.set(key, parseAircraft(a));
+        }
+      };
+      // Add close-range first so they take priority on key collision
+      addSnapshots(closeJson.ac);
+      addSnapshots(wideJson.ac);
+
+      const snapshots = [...seen.values()];
       aircraft.value = intentTracker.update(
         snapshots,
         { lat, lon },

--- a/src/services/aviationData.js
+++ b/src/services/aviationData.js
@@ -64,7 +64,8 @@ export const createRateLimiter = ({ maxTokens = 3, refillMs = 1000 } = {}) => {
 };
 
 export const DEFAULT_AIRCRAFT_POLL_MS = 3_000;
-export const DEFAULT_AIRCRAFT_DIST_NM = 20;
+export const DEFAULT_WIDE_RANGE_NM = 20;
+export const DEFAULT_CLOSE_RANGE_NM = 3;
 
 const DEFAULT_METAR_BASE = "/api/proxy/metar";
 const DEFAULT_AIRCRAFT_POSITIONS_BASE = "/api/proxy/aircraft/positions";
@@ -141,7 +142,7 @@ export const createAircraftPositionClient = ({
   });
 
   return {
-    fetchNearbyAircraft({ lat, lon, distNm = DEFAULT_AIRCRAFT_DIST_NM }) {
+    fetchNearbyAircraft({ lat, lon, distNm = DEFAULT_WIDE_RANGE_NM }) {
       const encodedLat = encodeURIComponent(String(lat));
       const encodedLon = encodeURIComponent(String(lon));
       const encodedDist = encodeURIComponent(String(distNm));


### PR DESCRIPTION
## Summary

Split ADS-B position polling into two parallel fetches and merge by `icao24`:

- **Wide range (20 nm)** — catches everything in the area, including high-altitude and distant traffic
- **Close range (3 nm)** — focuses on airport immediate vicinity, picks up ground/taxi movements that `adsb.lol` might miss in the wide query

Results are merged by `icao24` hex code, with close-range snapshots taking priority when the same aircraft appears in both responses.

### Changes

| File | What |
|------|------|
| `src/services/aviationData.js` | Rename `DEFAULT_AIRCRAFT_DIST_NM` → `DEFAULT_WIDE_RANGE_NM`, add `DEFAULT_CLOSE_RANGE_NM = 3` |
| `src/composables/useAircraftPositions.js` | Poll both ranges via `Promise.all`, merge by `icao24` with close-range priority |
| `src/components/map/AirportMap.vue` | Use `DEFAULT_WIDE_RANGE_NM` for visual query-range circle |

### No behavioral changes

- Existing `requestAnimationFrame` staggered lookups from #83 are unaffected
- `AirportMap` still draws the 20nm dashed circle as before
- Tests pass — default `distNm` parameter unchanged at 20nm