### PR TITLE
Add MobileStatusBar and simplify mobile AirportCaptionScreen (remove mobile swipe dashboard)

### DIFF
--- a/src/components/panels/MobileStatusBar.vue
+++ b/src/components/panels/MobileStatusBar.vue
@@ -1,0 +1,124 @@
+<template>
+    <section class="mobile-status-bar" role="status" aria-live="polite">
+        <transition name="status-fade" mode="out-in">
+            <div :key="activeView" class="status-content">
+                <template v-if="activeView === 'metar'">
+                    <div class="status-kicker">METAR</div>
+                    <div class="status-main">
+                        <span>{{ metar.flightCategory || 'Observed' }}</span>
+                        <span>·</span>
+                        <span>{{ metar.wind || 'Wind —' }}</span>
+                        <span>·</span>
+                        <span>{{ metar.vis || 'Vis —' }}</span>
+                    </div>
+                </template>
+                <template v-else>
+                    <div class="status-kicker">Traffic</div>
+                    <div class="status-main">
+                        <span>↑ <NumberFlow :value="trafficCounts.ascending" /></span>
+                        <span>↓ <NumberFlow :value="trafficCounts.descending" /></span>
+                        <span>→ <NumberFlow :value="trafficCounts.level" /></span>
+                    </div>
+                </template>
+            </div>
+        </transition>
+    </section>
+</template>
+
+<script setup>
+import NumberFlow from '@number-flow/vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+
+const props = defineProps({
+    metar: { type: Object, default: null },
+    trafficCounts: {
+        type: Object,
+        default: () => ({ ascending: 0, descending: 0, level: 0 }),
+    },
+});
+
+const activeView = ref('metar');
+let rotationTimer = null;
+
+const hasMetar = computed(() => Boolean(props.metar));
+
+onMounted(() => {
+    rotationTimer = window.setInterval(() => {
+        if (!hasMetar.value) {
+            activeView.value = 'traffic';
+            return;
+        }
+        activeView.value = activeView.value === 'metar' ? 'traffic' : 'metar';
+    }, 4200);
+});
+
+onBeforeUnmount(() => {
+    if (rotationTimer) window.clearInterval(rotationTimer);
+});
+</script>
+
+<style scoped>
+.mobile-status-bar {
+    align-items: center;
+    backdrop-filter: blur(10px) saturate(125%);
+    -webkit-backdrop-filter: blur(10px) saturate(125%);
+    background: linear-gradient(
+        145deg,
+        var(--glass-card-top),
+        var(--glass-card-bottom)
+    );
+    border: 1px solid var(--glass-card-border);
+    border-radius: 18px;
+    bottom: 14px;
+    box-shadow:
+        0 12px 34px rgba(0, 0, 0, 0.24),
+        inset 0 1px 0 var(--glass-card-inset);
+    display: none;
+    gap: 8px;
+    left: 50%;
+    min-height: 52px;
+    padding: 10px 14px;
+    position: fixed;
+    transform: translateX(-50%);
+    width: min(92vw, 420px);
+    z-index: 45;
+}
+
+.status-content {
+    width: 100%;
+}
+
+.status-kicker {
+    color: var(--atc-faint);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 1.1px;
+    text-transform: uppercase;
+}
+
+.status-main {
+    color: var(--atc-text);
+    display: flex;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    font-weight: 700;
+    gap: 10px;
+    line-height: 1.2;
+}
+
+.status-fade-enter-active,
+.status-fade-leave-active {
+    transition: opacity 0.32s ease;
+}
+
+.status-fade-enter-from,
+.status-fade-leave-to {
+    opacity: 0;
+}
+
+@media (max-width: 1080px) {
+    .mobile-status-bar {
+        display: grid;
+    }
+}
+</style>

--- a/src/components/screens/AirportCaptionScreen.vue
+++ b/src/components/screens/AirportCaptionScreen.vue
@@ -2,8 +2,6 @@
     <div
         ref="screenRef"
         class="airport-screen relative min-h-screen bg-atc-bg font-sans text-atc-text"
-        @touchstart.passive="onMobileTouchStart"
-        @touchend.passive="onMobileTouchEnd"
         :style="{
             '--mobile-breadcrumb-opacity': parallax.breadcrumbOpacity.value,
             '--mobile-title-opacity': parallax.titleOpacity.value,
@@ -96,7 +94,7 @@
 
             <main
                 class="airport-dashboard"
-                :class="`is-${dashboardMode}`"
+                
             >
                 <WeatherPanel
                     :metar="metar"
@@ -118,26 +116,20 @@
             </main>
         </div>
 
-        <button
-            class="dashboard-scroll-cue"
-            :class="{ 'is-visible': dashboardMode === 'hidden' }"
-            type="button"
-            aria-label="Scroll up to show airport cards"
-            @click="dashboardMode = 'peek'"
-        >
-            <ChevronUp aria-hidden="true" :size="24" :stroke-width="2.2" />
-        </button>
+
+        <MobileStatusBar :metar="metar" :traffic-counts="trafficCounts" />
+
     </div>
 </template>
 
 <script setup>
 import { computed, ref } from "vue";
-import { ChevronUp } from "lucide-vue-next";
 import MapControlBar from "../ui/MapControlBar.vue";
 import AirportMap from "../map/AirportMap.vue";
 import WeatherPanel from "../panels/WeatherPanel.vue";
 import TrafficPanel from "../panels/TrafficPanel.vue";
 import WikiPanel from "../panels/WikiPanel.vue";
+import MobileStatusBar from "../panels/MobileStatusBar.vue";
 import { useAircraftPositions } from "../../composables/useAircraftPositions.js";
 import { useAirportWiki } from "../../composables/useAirportWiki.js";
 import { useFlightRoutes } from "../../composables/useFlightRoutes.js";
@@ -160,33 +152,9 @@ defineEmits(["back"]);
 
 const mapZoom = ref(ZOOM_APPROACH);
 const screenRef = ref(null);
-const dashboardMode = ref("peek");
-const touchStartY = ref(null);
 
 const parallax = useScrollParallax(screenRef);
 
-const onMobileTouchStart = (event) => {
-    touchStartY.value = event.changedTouches?.[0]?.clientY ?? null;
-};
-
-const onMobileTouchEnd = (event) => {
-    if (touchStartY.value == null) return;
-    const endY = event.changedTouches?.[0]?.clientY;
-    if (endY == null) return;
-
-    const deltaY = endY - touchStartY.value;
-    touchStartY.value = null;
-    if (Math.abs(deltaY) < 44) return;
-
-    if (deltaY < 0) {
-        if (dashboardMode.value === "hidden") dashboardMode.value = "peek";
-        else dashboardMode.value = "expanded";
-        return;
-    }
-
-    if (dashboardMode.value === "expanded") dashboardMode.value = "peek";
-    else dashboardMode.value = "hidden";
-};
 
 const airportFallback = computed(
     () => AIRPORT_FALLBACKS[props.icao?.toUpperCase()] || null,
@@ -855,35 +823,7 @@ const fmtUpdated = (date) => {
     }
 
     .airport-dashboard {
-        bottom: 18px;
-        display: grid;
-        gap: 14px;
-        grid-template-columns: minmax(0, 1fr);
-        left: 50%;
-        margin-inline: 0;
-        overflow-x: hidden;
-        overflow-y: hidden;
-        padding: 0 2px 16px;
-        position: fixed;
-        transform: translateX(-50%) translateY(44%);
-        transition:
-            max-height 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-            transform 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-            width 0.22s cubic-bezier(0.22, 1, 0.36, 1);
-        width: min(82vw, 560px);
-        z-index: 35;
-    }
-
-    .airport-dashboard.is-expanded {
-        max-height: calc(100dvh - 132px);
-        overflow-y: auto;
-        transform: translateX(-50%) translateY(0);
-        width: min(92vw, 620px);
-    }
-
-    .airport-dashboard.is-hidden {
-        pointer-events: none;
-        transform: translateX(-50%) translateY(calc(100% + 34px));
+        display: none !important;
     }
 
     .glass-panel {
@@ -909,23 +849,7 @@ const fmtUpdated = (date) => {
         min-height: 220px;
     }
 
-    .dashboard-scroll-cue {
-        display: flex;
-        opacity: 0;
-        transform: translate(-50%, 10px);
-    }
-
-    .dashboard-scroll-cue.is-visible {
-        opacity: 1;
-        pointer-events: auto;
-        transform: translate(-50%, 0);
-    }
-}
-
-@media (max-width: 720px) {
-    .airport-dashboard {
-        width: min(84vw, 460px);
-    }
+    
 }
 
 @media (max-width: 620px) {
@@ -940,13 +864,6 @@ const fmtUpdated = (date) => {
 
     .dashboard-updated {
         display: none;
-    }
-
-    .airport-dashboard {
-        bottom: 14px;
-        margin-top: 0;
-        padding-bottom: 18px;
-        width: min(92vw, 430px);
     }
 
     .wiki-panel {


### PR DESCRIPTION
### Motivation
- Provide a compact, always-visible mobile status UI that surfaces METAR and traffic counts without the previous swipe/expand dashboard complexity.
- Reduce mobile interaction surface by removing the swipe-to-toggle dashboard behavior which conflicted with the map interactions on small screens.

### Description
- Add new `MobileStatusBar.vue` component that toggles between METAR and traffic views, animates transitions, and rotates every 4200ms, using `NumberFlow` for animated counters.
- Replace the previous mobile dashboard/scroll-cue with the new `<MobileStatusBar :metar="metar" :traffic-counts="trafficCounts" />` in `AirportCaptionScreen.vue` and import the component.
- Remove mobile touch handlers (`onMobileTouchStart`, `onMobileTouchEnd`), `dashboardMode` state, and the `dashboard-scroll-cue` button from `AirportCaptionScreen.vue` along with the `ChevronUp` import.
- Hide the mobile dashboard in CSS for small viewports by setting `.airport-dashboard` to `display: none !important;` and remove related expanded/hidden styles.

### Testing
- Ran unit tests with `npm run test:unit` and component tests, and they completed successfully.
- Ran linting with `npm run lint` and the codebase passed without errors.
- Performed a development build with `npm run build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cb6678c08331ac184f15d9919922)