### PR TITLE
feat(MobileStatusBar): dynamic width with staggered fade/resize animation

### DIFF
--- a/src/components/panels/MobileStatusBar.vue
+++ b/src/components/panels/MobileStatusBar.vue
@@ -30,9 +30,15 @@
         >
             <div class="status-kicker">Traffic</div>
             <div class="status-main">
-                <span>↑ <NumberFlow :value="trafficCounts.ascending" /></span>
-                <span>↓ <NumberFlow :value="trafficCounts.descending" /></span>
-                <span>→ <NumberFlow :value="trafficCounts.level" /></span>
+                <span :style="{ color: AIRCRAFT_COLORS.ascending }"
+                    >↑ <NumberFlow :value="trafficCounts.ascending"
+                /></span>
+                <span :style="{ color: AIRCRAFT_COLORS.descending }"
+                    >↓ <NumberFlow :value="trafficCounts.descending"
+                /></span>
+                <span :style="{ color: AIRCRAFT_COLORS.level }"
+                    >→ <NumberFlow :value="trafficCounts.level"
+                /></span>
             </div>
         </div>
     </section>
@@ -41,6 +47,7 @@
 <script setup>
 import NumberFlow from "@number-flow/vue";
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
+import { AIRCRAFT_COLORS } from "../../constants/aircraft.js";
 
 const props = defineProps({
     metar: { type: Object, default: null },

--- a/src/components/panels/MobileStatusBar.vue
+++ b/src/components/panels/MobileStatusBar.vue
@@ -58,7 +58,7 @@ const barRef = ref(null);
 const metarSlot = ref(null);
 const trafficSlot = ref(null);
 
-const DURATIONS = { fadeOut: 160, resize: 260, fadeIn: 200 };
+const DURATIONS = { fadeOut: 160, resize: 260, fadeIn: 200, expandReveal: 170 };
 const INTERVAL_MS = 4200;
 
 const hasMetar = computed(() => Boolean(props.metar));
@@ -107,6 +107,8 @@ async function rotate() {
         nextView === "metar" ? metarSlot.value : trafficSlot.value;
     const barEl = barRef.value;
     const fromW = barEl ? barEl.getBoundingClientRect().width : 300;
+    const toW = measureBarWidth(barEl, incomingEl);
+    const isExpanding = toW > fromW;
 
     // 1. Fade out current content
     phase.value = "fade-out";
@@ -118,7 +120,30 @@ async function rotate() {
     await nextTick();
     activeView.value = nextView;
     await nextTick();
-    const toW = measureBarWidth(barEl, incomingEl);
+
+    if (isExpanding) {
+        // On expansion, start revealing late enough that the incoming text
+        // is not readable while the card is still too narrow for it.
+        void barEl?.offsetHeight; // force layout
+        phase.value = "resize";
+        lockWidth.value = toW;
+        await sleep(DURATIONS.expandReveal);
+        if (!mounted) return;
+
+        phase.value = "fade-in";
+        await sleep(
+            Math.max(
+                DURATIONS.resize - DURATIONS.expandReveal,
+                DURATIONS.fadeIn,
+            ),
+        );
+        if (!mounted) return;
+
+        lockWidth.value = null;
+        phase.value = "idle";
+        rotating = false;
+        return;
+    }
 
     // 3. Animate card width from -> to
     void barEl?.offsetHeight; // force layout

--- a/src/components/panels/MobileStatusBar.vue
+++ b/src/components/panels/MobileStatusBar.vue
@@ -1,33 +1,39 @@
 <template>
-    <section class="mobile-status-bar" role="status" aria-live="polite">
-        <transition name="status-fade" mode="out-in">
-            <div :key="activeView" class="status-content">
-                <template v-if="activeView === 'metar'">
-                    <div class="status-kicker">METAR</div>
-                    <div class="status-main">
-                        <span>{{ metar.flightCategory || 'Observed' }}</span>
-                        <span>·</span>
-                        <span>{{ metar.wind || 'Wind —' }}</span>
-                        <span>·</span>
-                        <span>{{ metar.vis || 'Vis —' }}</span>
-                    </div>
-                </template>
-                <template v-else>
-                    <div class="status-kicker">Traffic</div>
-                    <div class="status-main">
-                        <span>↑ <NumberFlow :value="trafficCounts.ascending" /></span>
-                        <span>↓ <NumberFlow :value="trafficCounts.descending" /></span>
-                        <span>→ <NumberFlow :value="trafficCounts.level" /></span>
-                    </div>
-                </template>
+    <section
+        class="mobile-status-bar"
+        role="status"
+        aria-live="polite"
+        :style="barStyle"
+    >
+        <!-- Both slots always mounted; one hidden, one visible per phase -->
+        <div ref="metarSlot" class="status-slot" :style="slotStyle('metar')">
+            <div class="status-kicker">METAR</div>
+            <div class="status-main">
+                <span>{{ metar.flightCategory || "Observed" }}</span>
+                <span>·</span>
+                <span>{{ metar.wind || "Wind —" }}</span>
+                <span>·</span>
+                <span>{{ metar.vis || "Vis —" }}</span>
             </div>
-        </transition>
+        </div>
+        <div
+            ref="trafficSlot"
+            class="status-slot"
+            :style="slotStyle('traffic')"
+        >
+            <div class="status-kicker">Traffic</div>
+            <div class="status-main">
+                <span>↑ <NumberFlow :value="trafficCounts.ascending" /></span>
+                <span>↓ <NumberFlow :value="trafficCounts.descending" /></span>
+                <span>→ <NumberFlow :value="trafficCounts.level" /></span>
+            </div>
+        </div>
     </section>
 </template>
 
 <script setup>
-import NumberFlow from '@number-flow/vue';
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import NumberFlow from "@number-flow/vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 
 const props = defineProps({
     metar: { type: Object, default: null },
@@ -37,23 +43,99 @@ const props = defineProps({
     },
 });
 
-const activeView = ref('metar');
-let rotationTimer = null;
+// ── Phase machine ────────────────────────────────────────
+// idle → fade-out → resize → fade-in → idle
+const phase = ref("idle");
+const activeView = ref("metar");
+const metarSlot = ref(null);
+const trafficSlot = ref(null);
+
+const DURATIONS = { fadeOut: 160, resize: 260, fadeIn: 200 };
+const INTERVAL_MS = 4200;
 
 const hasMetar = computed(() => Boolean(props.metar));
 
-onMounted(() => {
-    rotationTimer = window.setInterval(() => {
-        if (!hasMetar.value) {
-            activeView.value = 'traffic';
-            return;
-        }
-        activeView.value = activeView.value === 'metar' ? 'traffic' : 'metar';
-    }, 4200);
-});
+// Lock width to a px value during resize so CSS transition can animate it
+const lockWidth = ref(null);
+const barStyle = computed(() =>
+    lockWidth.value != null ? { width: `${lockWidth.value}px` } : {},
+);
 
+function slotStyle(view) {
+    const isActive = view === activeView.value;
+    if (phase.value === "idle" || phase.value === "resize") {
+        return {
+            opacity: isActive ? 1 : 0,
+            pointerEvents: isActive ? "auto" : "none",
+        };
+    }
+    // Both hidden during fade-out
+    if (phase.value === "fade-out") {
+        return { opacity: 0, pointerEvents: "none" };
+    }
+    // fade-in: new slot fades up
+    if (phase.value === "fade-in") {
+        return {
+            opacity: isActive ? 1 : 0,
+            pointerEvents: isActive ? "auto" : "none",
+        };
+    }
+    return {};
+}
+
+// ── Rotation ─────────────────────────────────────────────
+async function rotate() {
+    if (!hasMetar.value && activeView.value === "traffic") return;
+    if (!hasMetar.value) {
+        activeView.value = "traffic";
+        return;
+    }
+
+    const nextView = activeView.value === "metar" ? "traffic" : "metar";
+    const incomingEl =
+        nextView === "metar" ? metarSlot.value : trafficSlot.value;
+    const barEl = document.querySelector(".mobile-status-bar");
+    const fromW = barEl ? barEl.offsetWidth : 300;
+
+    // 1. Fade out current content
+    phase.value = "fade-out";
+    await sleep(DURATIONS.fadeOut);
+
+    // 2. Switch active view, briefly reveal incoming to measure its natural width
+    activeView.value = nextView;
+    await nextTick();
+    incomingEl.style.opacity = "1";
+    await nextTick();
+    const toW = incomingEl.offsetWidth;
+    incomingEl.style.opacity = "";
+
+    // 3. Animate card width from → to
+    lockWidth.value = fromW;
+    void barEl?.offsetHeight; // force layout
+    phase.value = "resize";
+    lockWidth.value = toW;
+    await sleep(DURATIONS.resize);
+
+    // 4. Fade in new content, release width lock
+    lockWidth.value = null;
+    phase.value = "fade-in";
+    await sleep(DURATIONS.fadeIn);
+
+    // Done
+    phase.value = "idle";
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Lifecycle ────────────────────────────────────────────
+let timer = null;
+onMounted(() => {
+    timer = window.setInterval(rotate, INTERVAL_MS);
+});
 onBeforeUnmount(() => {
-    if (rotationTimer) window.clearInterval(rotationTimer);
+    if (timer) window.clearInterval(timer);
 });
 </script>
 
@@ -74,25 +156,28 @@ onBeforeUnmount(() => {
         0 12px 34px rgba(0, 0, 0, 0.24),
         inset 0 1px 0 var(--glass-card-inset);
     display: none;
-    gap: 8px;
     left: 50%;
     min-height: 52px;
     padding: 10px 14px;
     position: fixed;
     transform: translateX(-50%);
-    width: min(92vw, 420px);
+    transition: width 0.26s cubic-bezier(0.4, 0, 0.2, 1);
+    width: fit-content;
+    max-width: min(92vw, 420px);
     z-index: 45;
+    overflow: hidden;
 }
 
-.status-content {
-    display: grid;
+.status-slot {
+    display: flex;
+    flex-direction: column;
     gap: 6px;
-    width: 100%;
+    white-space: nowrap;
 }
 
 .status-kicker {
     color: var(--atc-faint);
-    font-family: 'JetBrains Mono', monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 10px;
     letter-spacing: 1.1px;
     text-transform: uppercase;
@@ -101,26 +186,15 @@ onBeforeUnmount(() => {
 .status-main {
     color: var(--atc-text);
     display: flex;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 700;
     gap: 10px;
     line-height: 1.2;
 }
 
-.status-fade-enter-active,
-.status-fade-leave-active {
-    transition: opacity 0.32s ease;
-}
-
-.status-fade-enter-from,
-.status-fade-leave-to {
-    opacity: 0;
-}
-
 @media (max-width: 1080px) {
     .mobile-status-bar {
-        display: grid;
+        display: flex;
     }
 }
 </style>

--- a/src/components/panels/MobileStatusBar.vue
+++ b/src/components/panels/MobileStatusBar.vue
@@ -1,25 +1,32 @@
 <template>
     <section
+        ref="barRef"
         class="mobile-status-bar"
         role="status"
         aria-live="polite"
         :style="barStyle"
     >
         <!-- Both slots always mounted; one hidden, one visible per phase -->
-        <div ref="metarSlot" class="status-slot" :style="slotStyle('metar')">
+        <div
+            ref="metarSlot"
+            :class="slotClass('metar')"
+            :style="slotStyle('metar')"
+            :aria-hidden="activeView !== 'metar'"
+        >
             <div class="status-kicker">METAR</div>
             <div class="status-main">
-                <span>{{ metar.flightCategory || "Observed" }}</span>
+                <span>{{ metar?.flightCategory || "Observed" }}</span>
                 <span>·</span>
-                <span>{{ metar.wind || "Wind —" }}</span>
+                <span>{{ metar?.wind || "Wind —" }}</span>
                 <span>·</span>
-                <span>{{ metar.vis || "Vis —" }}</span>
+                <span>{{ metar?.vis || "Vis —" }}</span>
             </div>
         </div>
         <div
             ref="trafficSlot"
-            class="status-slot"
+            :class="slotClass('traffic')"
             :style="slotStyle('traffic')"
+            :aria-hidden="activeView !== 'traffic'"
         >
             <div class="status-kicker">Traffic</div>
             <div class="status-main">
@@ -47,6 +54,7 @@ const props = defineProps({
 // idle → fade-out → resize → fade-in → idle
 const phase = ref("idle");
 const activeView = ref("metar");
+const barRef = ref(null);
 const metarSlot = ref(null);
 const trafficSlot = ref(null);
 
@@ -63,78 +71,99 @@ const barStyle = computed(() =>
 
 function slotStyle(view) {
     const isActive = view === activeView.value;
-    if (phase.value === "idle" || phase.value === "resize") {
+    if (phase.value === "idle" || phase.value === "fade-in") {
         return {
             opacity: isActive ? 1 : 0,
             pointerEvents: isActive ? "auto" : "none",
         };
     }
-    // Both hidden during fade-out
-    if (phase.value === "fade-out") {
-        return { opacity: 0, pointerEvents: "none" };
-    }
-    // fade-in: new slot fades up
-    if (phase.value === "fade-in") {
-        return {
-            opacity: isActive ? 1 : 0,
-            pointerEvents: isActive ? "auto" : "none",
-        };
-    }
-    return {};
+
+    // Keep the active slot in flow during fade-out/resize for measuring, but
+    // hide all content until the final fade-in phase.
+    return { opacity: 0, pointerEvents: "none" };
+}
+
+function slotClass(view) {
+    return {
+        "status-slot": true,
+        "status-slot--layered": view !== activeView.value,
+    };
 }
 
 // ── Rotation ─────────────────────────────────────────────
+let rotating = false;
+let mounted = false;
 async function rotate() {
+    if (rotating) return;
     if (!hasMetar.value && activeView.value === "traffic") return;
     if (!hasMetar.value) {
         activeView.value = "traffic";
         return;
     }
 
+    rotating = true;
     const nextView = activeView.value === "metar" ? "traffic" : "metar";
     const incomingEl =
         nextView === "metar" ? metarSlot.value : trafficSlot.value;
-    const barEl = document.querySelector(".mobile-status-bar");
-    const fromW = barEl ? barEl.offsetWidth : 300;
+    const barEl = barRef.value;
+    const fromW = barEl ? barEl.getBoundingClientRect().width : 300;
 
     // 1. Fade out current content
     phase.value = "fade-out";
     await sleep(DURATIONS.fadeOut);
+    if (!mounted) return;
 
-    // 2. Switch active view, briefly reveal incoming to measure its natural width
+    // 2. Lock current width, then switch active slot while hidden.
+    lockWidth.value = fromW;
+    await nextTick();
     activeView.value = nextView;
     await nextTick();
-    incomingEl.style.opacity = "1";
-    await nextTick();
-    const toW = incomingEl.offsetWidth;
-    incomingEl.style.opacity = "";
+    const toW = measureBarWidth(barEl, incomingEl);
 
-    // 3. Animate card width from → to
-    lockWidth.value = fromW;
+    // 3. Animate card width from -> to
     void barEl?.offsetHeight; // force layout
     phase.value = "resize";
     lockWidth.value = toW;
     await sleep(DURATIONS.resize);
+    if (!mounted) return;
 
     // 4. Fade in new content, release width lock
-    lockWidth.value = null;
     phase.value = "fade-in";
     await sleep(DURATIONS.fadeIn);
+    if (!mounted) return;
 
     // Done
+    lockWidth.value = null;
     phase.value = "idle";
+    rotating = false;
 }
 
 function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function measureBarWidth(barEl, slotEl) {
+    if (!barEl || !slotEl) return 300;
+
+    const styles = window.getComputedStyle(barEl);
+    const chromeWidth = [
+        styles.paddingLeft,
+        styles.paddingRight,
+        styles.borderLeftWidth,
+        styles.borderRightWidth,
+    ].reduce((sum, value) => sum + (Number.parseFloat(value) || 0), 0);
+
+    return Math.ceil(slotEl.scrollWidth + chromeWidth);
+}
+
 // ── Lifecycle ────────────────────────────────────────────
 let timer = null;
 onMounted(() => {
+    mounted = true;
     timer = window.setInterval(rotate, INTERVAL_MS);
 });
 onBeforeUnmount(() => {
+    mounted = false;
     if (timer) window.clearInterval(timer);
 });
 </script>
@@ -155,6 +184,7 @@ onBeforeUnmount(() => {
     box-shadow:
         0 12px 34px rgba(0, 0, 0, 0.24),
         inset 0 1px 0 var(--glass-card-inset);
+    box-sizing: border-box;
     display: none;
     left: 50%;
     min-height: 52px;
@@ -172,7 +202,17 @@ onBeforeUnmount(() => {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    max-width: calc(min(92vw, 420px) - 30px);
+    min-width: 0;
+    transition: opacity 0.2s ease;
     white-space: nowrap;
+    width: max-content;
+}
+
+.status-slot--layered {
+    left: 14px;
+    position: absolute;
+    top: 10px;
 }
 
 .status-kicker {
@@ -190,6 +230,8 @@ onBeforeUnmount(() => {
     font-weight: 700;
     gap: 10px;
     line-height: 1.2;
+    min-width: 0;
+    overflow: hidden;
 }
 
 @media (max-width: 1080px) {


### PR DESCRIPTION
## Summary

Refactors the mobile bottom status bar to dynamically adapt its width to the current content, with a smooth staggered animation:

1. **fade-out** (160ms) — current content fades to transparent
2. **resize** (260ms) — card width transitions smoothly via CSS `transition: width` to match new content
3. **fade-in** (200ms) — new content fades in

### Changes

- Replaced Vue `<Transition mode="out-in">` (opacity-only, no width animation) with a JS-driven phase machine (`idle → fade-out → resize → fade-in → idle`)
- Card uses `width: fit-content` + `max-width` so it sizes to content, with height fixed at `min-height: 52px`
- Content text uses system font instead of JetBrains Mono for better readability at small sizes
- Both METAR and Traffic slots remain mounted throughout — visibility is driven by `opacity` + `pointerEvents` via computed styles