### PR TITLE
Add Google site verification meta tag to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="google-site-verification" content="2x8Gzq0W4yEL_2m5MKCy9WSd0RPeYxzvrM_HmgSIU6I" />
   <title>ADSBao</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
### Motivation
- Enable Google Search Console site ownership verification by including the required verification meta tag in the app HTML head.

### Description
- Inserted `<meta name="google-site-verification" content="2x8Gzq0W4yEL_2m5MKCy9WSd0RPeYxzvrM_HmgSIU6I" />` into `index.html` inside the `<head>` element.

### Testing
- No automated tests were run because this is a static HTML metadata change with no runtime behavior impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f354916ff48331a96201438570b57a)