### PR TITLE
feat(map): add map-label and telemetry toggles to control bar

### DIFF
--- a/src/components/map/AirportMap.vue
+++ b/src/components/map/AirportMap.vue
@@ -94,6 +94,8 @@ const props = defineProps({
     accent: { type: String, default: "#FF5A1F" },
     aircraft: { type: Array, default: () => [] },
     airport: { type: Object, default: null },
+    showMapLabels: { type: Boolean, default: true },
+    showTelemetry: { type: Boolean, default: true },
 });
 
 const mapEl = ref(null);
@@ -155,11 +157,13 @@ const updateTileLayers = () => {
         subdomains: "abcd",
         maxZoom: 20,
     }).addTo(map);
-    labelTileLayer = L.tileLayer(variant.labels, {
-        subdomains: "abcd",
-        maxZoom: 20,
-        opacity: variant.labelOpacity,
-    }).addTo(map);
+    if (props.showMapLabels) {
+        labelTileLayer = L.tileLayer(variant.labels, {
+            subdomains: "abcd",
+            maxZoom: 20,
+            opacity: variant.labelOpacity,
+        }).addTo(map);
+    }
 };
 
 const trafficLegend = [
@@ -439,7 +443,7 @@ const makeAcIcon = (
     const safeRouteLabel = escapeHtml(routeLabel);
     const labelTop = showArrow && hasTelemetry ? "-4px" : "2px";
     const telemetryLine =
-        showArrow && hasTelemetry
+        showArrow && hasTelemetry && props.showTelemetry
             ? `<div class="aircraft-telemetry">
         <span data-aircraft-flow="speed"></span>
         <span class="aircraft-telemetry-separator">|</span>
@@ -600,6 +604,18 @@ const updateAircraft = () => {
 };
 
 watch(() => props.aircraft, updateAircraft, { deep: true });
+watch(
+    () => props.showMapLabels,
+    () => {
+        updateTileLayers();
+    },
+);
+watch(
+    () => props.showTelemetry,
+    () => {
+        updateAircraft();
+    },
+);
 watch(
     () => currentTheme.value,
     () => {

--- a/src/components/screens/AirportCaptionScreen.vue
+++ b/src/components/screens/AirportCaptionScreen.vue
@@ -19,6 +19,8 @@
                 accent="#FF5A1F"
                 :aircraft="aircraftWithRoutes"
                 :airport="airport"
+                :show-map-labels="showMapLabels"
+                :show-telemetry="showTelemetry"
             />
         </div>
 
@@ -32,7 +34,14 @@
             <span class="mobile-compact-name">{{ airportName }}</span>
         </div>
 
-        <MapControlBar :active-zoom="mapZoom" @zoom="mapZoom = $event" />
+        <MapControlBar
+            :active-zoom="mapZoom"
+            :show-map-labels="showMapLabels"
+            :show-telemetry="showTelemetry"
+            @zoom="mapZoom = $event"
+            @toggle-map-labels="showMapLabels = !showMapLabels"
+            @toggle-telemetry="showTelemetry = !showTelemetry"
+        />
 
         <div
             class="airport-content relative z-20 flex min-h-screen flex-col px-5 py-5 md:px-8 lg:px-10"
@@ -151,6 +160,8 @@ const props = defineProps({
 defineEmits(["back"]);
 
 const mapZoom = ref(ZOOM_APPROACH);
+const showMapLabels = ref(true);
+const showTelemetry = ref(true);
 const screenRef = ref(null);
 
 const parallax = useScrollParallax(screenRef);

--- a/src/components/ui/MapControlBar.vue
+++ b/src/components/ui/MapControlBar.vue
@@ -49,6 +49,26 @@
             </button>
 
             <button
+                class="ctrl-btn"
+                :class="{ active: showMapLabels }"
+                :aria-pressed="showMapLabels"
+                :title="showMapLabels ? 'Hide map labels' : 'Show map labels'"
+                @click="emit('toggle-map-labels')"
+            >
+                <Type />
+            </button>
+
+            <button
+                class="ctrl-btn"
+                :class="{ active: showTelemetry }"
+                :aria-pressed="showTelemetry"
+                :title="showTelemetry ? 'Hide speed/altitude' : 'Show speed/altitude'"
+                @click="emit('toggle-telemetry')"
+            >
+                <Gauge />
+            </button>
+
+            <button
                 class="ctrl-btn ctrl-more"
                 :class="{ active: drawerOpen }"
                 :aria-expanded="drawerOpen"
@@ -64,7 +84,7 @@
 
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { SlidersHorizontal } from "lucide-vue-next";
+import { Gauge, SlidersHorizontal, Type } from "lucide-vue-next";
 import {
     ZOOM_AIRPORT,
     ZOOM_APPROACH,
@@ -89,9 +109,11 @@ const VIDEO_ID = "JDQiaRYmTGk";
 
 const props = defineProps({
     activeZoom: { type: Number, default: ZOOM_AIRPORT },
+    showMapLabels: { type: Boolean, default: true },
+    showTelemetry: { type: Boolean, default: true },
 });
 
-const emit = defineEmits(["zoom"]);
+const emit = defineEmits(["zoom", "toggle-map-labels", "toggle-telemetry"]);
 
 const controlZone = ref(null);
 const playerEl = ref(null);


### PR DESCRIPTION
### Motivation
- Provide quick controls on the map toolbar to show/hide place-name labels and aircraft telemetry (speed/altitude) so users can declutter the map or surface telemetry on demand.

### Description
- Added two new control buttons to `MapControlBar` with `Type` and `Gauge` icons and new props/events `showMapLabels`/`showTelemetry` and `toggle-map-labels`/`toggle-telemetry` to drive visibility toggles.
- Wired local state into `AirportCaptionScreen` with `showMapLabels` and `showTelemetry` refs and passed them to `MapControlBar` and `AirportMap`, and bound toggle events to flip those refs.
- Updated `AirportMap` to accept `showMapLabels` and `showTelemetry` props, conditionally mount/unmount the label tile layer in `updateTileLayers`, conditionally render the aircraft telemetry line in `makeAcIcon`, and added watchers to refresh tiles/markers when toggles change.
- Minor UI/logic changes only; callsign/identifier labels remain visible while telemetry and map place-name tiles are toggled independently.

### Testing
- Ran `pnpm -s test:airport-map-display`, which completed successfully.
- Ran a production build with `pnpm -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39a7b91f88331aa15ee67f19463b2)