### PR TITLE
Replace airport loading bar with Sonner toast.promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
     "next": "^16.0.10",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",
-    "tailwindcss": "^4.2.4",
     "eslint": "^9.39.2",
-    "eslint-config-next": "^16.0.10"
+    "eslint-config-next": "^16.0.10",
+    "tailwindcss": "^4.2.4"
   },
   "license": "GPL-3.0-or-later"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -1903,6 +1906,12 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2715,7 +2724,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
       '@vue/shared': 3.5.26
       entities: 7.0.0
       estree-walker: 2.0.2
@@ -2730,7 +2739,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
       '@vue/compiler-core': 3.5.26
       '@vue/compiler-dom': 3.5.26
       '@vue/compiler-ssr': 3.5.26
@@ -4068,6 +4077,11 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -74,12 +74,10 @@ export default function RootLayout({ children }) {
         <ThemeBootScript />
         <div className="min-h-screen bg-atc-bg text-atc-text">{children}</div>
         <Toaster
+          theme="system"
           position="top-center"
           toastOptions={{
             style: {
-              background: "var(--atc-card)",
-              color: "var(--atc-text)",
-              border: "1px solid var(--atc-line-strong)",
               fontFamily: "'Inter', system-ui, sans-serif",
               fontSize: "14px",
             },

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -73,7 +73,18 @@ export default function RootLayout({ children }) {
       <body>
         <ThemeBootScript />
         <div className="min-h-screen bg-atc-bg text-atc-text">{children}</div>
-        <Toaster position="top-center" />
+        <Toaster
+          position="top-center"
+          toastOptions={{
+            style: {
+              background: "var(--atc-card)",
+              color: "var(--atc-text)",
+              border: "1px solid var(--atc-line-strong)",
+              fontFamily: "'Inter', system-ui, sans-serif",
+              fontSize: "14px",
+            },
+          }}
+        />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -2,6 +2,7 @@
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import Script from "next/script";
+import { Toaster } from "sonner";
 import "leaflet/dist/leaflet.css";
 import {
   SITE_DESCRIPTION,
@@ -59,7 +60,11 @@ export default function RootLayout({ children }) {
     <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
         <link
           href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
           rel="stylesheet"
@@ -68,6 +73,7 @@ export default function RootLayout({ children }) {
       <body>
         <ThemeBootScript />
         <div className="min-h-screen bg-atc-bg text-atc-text">{children}</div>
+        <Toaster position="top-center" />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -14,18 +14,23 @@ import {
   isGroundLikeAircraft as isGroundLikeAircraftForDisplay,
   shouldShowAirportArea,
 } from "../../utils/airportMapDisplay.js";
-import { AIRCRAFT_COLORS, BARO_RATE_THRESHOLD_FPM } from "../../constants/aircraft.js";
+import {
+  AIRCRAFT_COLORS,
+  BARO_RATE_THRESHOLD_FPM,
+} from "../../constants/aircraft.js";
 import { DEFAULT_WIDE_RANGE_NM } from "../../services/aviationData.js";
 
 const TILE_VARIANTS = {
   light: {
     base: "https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}@2x.png",
-    labels: "https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}@2x.png",
+    labels:
+      "https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}@2x.png",
     labelOpacity: 0.66,
   },
   dark: {
     base: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}@2x.png",
-    labels: "https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}@2x.png",
+    labels:
+      "https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}@2x.png",
     labelOpacity: 0.55,
   },
 };
@@ -63,17 +68,19 @@ export default function AirportMap({
   const acMarkersMap = useRef(new Map());
   const rafId = useRef(null);
   const [mapReady, setMapReady] = useState(false);
-  const [currentTheme, setCurrentTheme] = useState("dark");
+  const [currentTheme, setCurrentTheme] = useState(() => resolveCurrentTheme());
 
-  const latStr = lat ? `${Math.abs(lat).toFixed(2)}${lat >= 0 ? "N" : "S"}` : "";
-  const lonStr = lon ? `${Math.abs(lon).toFixed(2)}${lon >= 0 ? "E" : "W"}` : "";
+  const latStr = lat
+    ? `${Math.abs(lat).toFixed(2)}${lat >= 0 ? "N" : "S"}`
+    : "";
+  const lonStr = lon
+    ? `${Math.abs(lon).toFixed(2)}${lon >= 0 ? "E" : "W"}`
+    : "";
   const mapBackground = currentTheme === "light" ? "#d6dde8" : "#0e0e12";
   const mapLabelShadowColor =
     currentTheme === "light" ? "rgba(248,250,252,0.95)" : "#0a0a0b";
   const mapAttributionColor =
-    currentTheme === "light"
-      ? "rgba(18,21,26,0.45)"
-      : "rgba(245,245,247,0.28)";
+    currentTheme === "light" ? "rgba(18,21,26,0.45)" : "rgba(245,245,247,0.28)";
 
   const latestProps = useRef({
     lat,
@@ -140,7 +147,8 @@ export default function AirportMap({
       const { airport: nextAirport } = latestProps.current;
       const details = [];
       const runways = nextAirport?.runways;
-      if (Array.isArray(runways) && runways.length) details.push(`RWY ${runways.length}`);
+      if (Array.isArray(runways) && runways.length)
+        details.push(`RWY ${runways.length}`);
       const approachCount = Number(nextAirport?.approachCount);
       if (Number.isFinite(approachCount) && approachCount > 0) {
         details.push(`APP ${approachCount}`);
@@ -189,7 +197,9 @@ export default function AirportMap({
         fillOpacity: 1,
       }).addTo(map);
 
-      const airportCode = escapeHtml((props.airport?.iata || props.icao || "").trim());
+      const airportCode = escapeHtml(
+        (props.airport?.iata || props.icao || "").trim(),
+      );
       const detailLines = buildAirportOverlayDetails()
         .map((line) => `<span>${escapeHtml(line)}</span>`)
         .join("");
@@ -204,7 +214,9 @@ export default function AirportMap({
       }).addTo(map);
 
       if (Number(props.zoom) === ZOOM_APPROACH) {
-        const groundCount = props.aircraft.filter((item) => isGroundLikeAircraft(item)).length;
+        const groundCount = props.aircraft.filter((item) =>
+          isGroundLikeAircraft(item),
+        ).length;
         airportGroundCountMarker.current = L.marker([props.lat, props.lon], {
           interactive: false,
           icon: L.divIcon({
@@ -217,7 +229,14 @@ export default function AirportMap({
       }
     };
 
-    const makeAcIcon = (color, label, rot = 0, showArrow = true, hasTelemetry = false, routeLabel = "") => {
+    const makeAcIcon = (
+      color,
+      label,
+      rot = 0,
+      showArrow = true,
+      hasTelemetry = false,
+      routeLabel = "",
+    ) => {
       const symbol = showArrow
         ? `<svg width="18" height="18" viewBox="0 0 24 24" style="transform:rotate(${rot}deg);filter:drop-shadow(0 0 4px ${color})"><path d="M12 2L16 20L12 17L8 20Z" fill="${color}"/></svg>`
         : `<svg width="7" height="7" viewBox="0 0 7 7" style="filter:drop-shadow(0 0 3px ${color});margin:5.5px"><circle cx="3.5" cy="3.5" r="3.5" fill="${color}"/></svg>`;
@@ -229,8 +248,12 @@ export default function AirportMap({
         showArrow && hasTelemetry && props.showTelemetry
           ? `<div class="aircraft-telemetry"><span>${formatTelemetryValue(props.currentAircraft?.velocity)}kt</span><span class="aircraft-telemetry-separator">|</span><span>${formatTelemetryValue(props.currentAircraft?.altitude)}ft</span></div>`
           : "";
-      const routeLine = safeRouteLabel ? `<div class="aircraft-route-label">${safeRouteLabel}</div>` : "";
-      const labelClass = safeRouteLabel ? "aircraft-label aircraft-label--route-cycle" : "aircraft-label";
+      const routeLine = safeRouteLabel
+        ? `<div class="aircraft-route-label">${safeRouteLabel}</div>`
+        : "";
+      const labelClass = safeRouteLabel
+        ? "aircraft-label aircraft-label--route-cycle"
+        : "aircraft-label";
       const titleLine = safeRouteLabel
         ? `<div class="aircraft-title-cycle"><div class="aircraft-label-title aircraft-callsign-state">${safeLabel}</div>${routeLine}</div>`
         : `<div class="aircraft-label-title">${safeLabel}</div>`;
@@ -247,10 +270,14 @@ export default function AirportMap({
       const props = latestProps.current;
       if (ac.onGround) return AIRCRAFT_COLORS.ground;
       if (!showArrow || ac.baroRate == null) {
-        return props.currentTheme === "light" ? "#475569" : AIRCRAFT_COLORS.level;
+        return props.currentTheme === "light"
+          ? "#475569"
+          : AIRCRAFT_COLORS.level;
       }
-      if (ac.baroRate >= BARO_RATE_THRESHOLD_FPM) return AIRCRAFT_COLORS.ascending;
-      if (ac.baroRate < -BARO_RATE_THRESHOLD_FPM) return AIRCRAFT_COLORS.descending;
+      if (ac.baroRate >= BARO_RATE_THRESHOLD_FPM)
+        return AIRCRAFT_COLORS.ascending;
+      if (ac.baroRate < -BARO_RATE_THRESHOLD_FPM)
+        return AIRCRAFT_COLORS.descending;
       return AIRCRAFT_COLORS.level;
     };
 
@@ -303,7 +330,16 @@ export default function AirportMap({
             routeLabel !== entry.routeLabel ||
             props.showTelemetry !== entry.showTelemetry
           ) {
-            entry.marker.setIcon(makeAcIcon(color, label, rot, showArrow, hasTelemetry, routeLabel));
+            entry.marker.setIcon(
+              makeAcIcon(
+                color,
+                label,
+                rot,
+                showArrow,
+                hasTelemetry,
+                routeLabel,
+              ),
+            );
             Object.assign(entry, {
               color,
               label,
@@ -316,9 +352,19 @@ export default function AirportMap({
           }
         } else {
           const motionState = beginAircraftMotionState(ac, now);
-          const visualPosition = calculateAircraftVisualPosition(motionState, now);
+          const visualPosition = calculateAircraftVisualPosition(
+            motionState,
+            now,
+          );
           const marker = L.marker([visualPosition.lat, visualPosition.lon], {
-            icon: makeAcIcon(color, label, rot, showArrow, hasTelemetry, routeLabel),
+            icon: makeAcIcon(
+              color,
+              label,
+              rot,
+              showArrow,
+              hasTelemetry,
+              routeLabel,
+            ),
           }).addTo(map);
           acMarkersMap.current.set(ac.icao24, {
             marker,
@@ -433,32 +479,42 @@ export default function AirportMap({
         style={{ background: mapBackground }}
       />
 
-      <div
-        className="pointer-events-none absolute left-3.5 top-3 font-mono text-[10px] font-semibold tracking-[2px]"
-        style={{ color: accent, textShadow: `0 0 6px ${mapLabelShadowColor}` }}
-      >
-        * {icao} / {latStr} {lonStr}
-      </div>
-      <div
-        className="pointer-events-none absolute bottom-3 right-3 whitespace-nowrap font-sans text-[9px]"
-        style={{ color: mapAttributionColor, textShadow: `0 0 6px ${mapLabelShadowColor}` }}
-      >
-        OpenStreetMap / CartoDB
-      </div>
-      <div className="map-traffic-legend pointer-events-none absolute right-3 top-[168px] flex max-w-[calc(100%-24px)] flex-wrap gap-2 rounded px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.8px]">
-        {trafficLegend.map((item) => (
-          <span key={item.id} className="inline-flex items-center gap-1.5">
-            <span
-              className="h-1.5 w-1.5 rounded-full"
-              style={{
-                background: item.color,
-                boxShadow: `0 0 6px ${item.color}`,
-              }}
-            />
-            {item.label}
-          </span>
-        ))}
-      </div>
+      {mapReady && (
+        <>
+          <div
+            className="pointer-events-none absolute left-3.5 top-3 font-mono text-[10px] font-semibold tracking-[2px]"
+            style={{
+              color: accent,
+              textShadow: `0 0 6px ${mapLabelShadowColor}`,
+            }}
+          >
+            * {icao} / {latStr} {lonStr}
+          </div>
+          <div
+            className="pointer-events-none absolute bottom-3 right-3 whitespace-nowrap font-sans text-[9px]"
+            style={{
+              color: mapAttributionColor,
+              textShadow: `0 0 6px ${mapLabelShadowColor}`,
+            }}
+          >
+            OpenStreetMap / CartoDB
+          </div>
+          <div className="map-traffic-legend pointer-events-none absolute right-3 top-[168px] flex max-w-[calc(100%-24px)] flex-wrap gap-2 rounded px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.8px]">
+            {trafficLegend.map((item) => (
+              <span key={item.id} className="inline-flex items-center gap-1.5">
+                <span
+                  className="h-1.5 w-1.5 rounded-full"
+                  style={{
+                    background: item.color,
+                    boxShadow: `0 0 6px ${item.color}`,
+                  }}
+                />
+                {item.label}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
 
       {!mapReady ? (
         <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-atc-card">
@@ -472,7 +528,9 @@ export default function AirportMap({
 }
 
 const resolveCurrentTheme = () =>
-  document.documentElement.getAttribute("data-theme") === "light" ? "light" : "dark";
+  document.documentElement.getAttribute("data-theme") === "light"
+    ? "light"
+    : "dark";
 
 const escapeHtml = (value) =>
   String(value)

--- a/src/components/screens/AirportCaptionScreen.jsx
+++ b/src/components/screens/AirportCaptionScreen.jsx
@@ -30,8 +30,6 @@ const AirportMap = dynamic(() => import("../map/AirportMap"), {
 export default function AirportCaptionScreen({
   icao = "",
   airport = null,
-  loading = false,
-  error = null,
   onBack,
 }) {
   const [mapZoom, setMapZoom] = useState(ZOOM_APPROACH);
@@ -42,13 +40,19 @@ export default function AirportCaptionScreen({
 
   const normalizedIcao = String(airport?.icao || icao || "").toUpperCase();
   const airportFallback = AIRPORT_FALLBACKS[normalizedIcao] || null;
-  const airportCodeLabel = airport?.iata || airportFallback?.iata || normalizedIcao;
-  const airportName = airport?.name || airportFallback?.name || normalizedIcao || "Airport";
+  const airportCodeLabel =
+    airport?.iata || airportFallback?.iata || normalizedIcao;
+  const airportName =
+    airport?.name || airportFallback?.name || normalizedIcao || "Airport";
   const airportLat = COORDS[normalizedIcao]?.[0] || airport?.lat || 0;
   const airportLon = COORDS[normalizedIcao]?.[1] || airport?.lon || 0;
 
-  const { raw: metarRaw, parsed: metar, loading: metarLoading, error: metarError } =
-    useMetar(normalizedIcao);
+  const {
+    raw: metarRaw,
+    parsed: metar,
+    loading: metarLoading,
+    error: metarError,
+  } = useMetar(normalizedIcao);
   const { aircraft, lastUpdated } = useAircraftPositions(
     normalizedIcao,
     airportLat,
@@ -86,7 +90,8 @@ export default function AirportCaptionScreen({
     }),
     [airportName, normalizedIcao, airportCodeLabel],
   );
-  const { summary: wikiSummary, loading: wikiLoading } = useAirportWiki(wikiAirport);
+  const { summary: wikiSummary, loading: wikiLoading } =
+    useAirportWiki(wikiAirport);
 
   const coordinatesLabel = useMemo(() => {
     if (!airportLat || !airportLon) return "Coordinates pending";
@@ -183,24 +188,9 @@ export default function AirportCaptionScreen({
           </div>
         </header>
 
-        {loading || error ? (
-          <div
-            className={`glass-panel mt-4 border px-4 py-3 ${
-              error
-                ? "border-atc-red/40 bg-[#251011]/75"
-                : "border-atc-line-strong/70 bg-atc-card/60"
-            }`}
-          >
-            <div className={`panel-kicker ${error ? "text-atc-red" : "text-atc-faint"}`}>
-              {error ? "Airport lookup error" : "Refreshing airport data"}
-            </div>
-            <div className="mt-1 text-[13px] font-semibold text-atc-text">
-              {error || "Loading airport context..."}
-            </div>
-          </div>
-        ) : null}
-
-        <div className="dashboard-updated">Updated {fmtUpdated(lastUpdated)}</div>
+        <div className="dashboard-updated">
+          Updated {fmtUpdated(lastUpdated)}
+        </div>
 
         <main className="airport-dashboard">
           <WeatherPanel
@@ -224,7 +214,10 @@ export default function AirportCaptionScreen({
 }
 
 const normalizeCallsign = (callsign) =>
-  String(callsign || "").trim().toUpperCase().replace(/\s+/g, "");
+  String(callsign || "")
+    .trim()
+    .toUpperCase()
+    .replace(/\s+/g, "");
 
 const fmtUpdated = (date) => {
   if (!date) return "-";

--- a/src/components/screens/HomeClient.jsx
+++ b/src/components/screens/HomeClient.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import AirportCaptionScreen from "./AirportCaptionScreen";
 import SearchScreen from "./SearchScreen";
 import { airportDirectoryClient } from "../../services/airportDirectory.js";
@@ -10,23 +11,21 @@ export default function HomeClient({ initialIcao = "" }) {
   const router = useRouter();
   const [airport, setAirport] = useState(null);
   const [currentIcao, setCurrentIcao] = useState(initialIcao);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
 
   const loadAirport = async (icao) => {
     if (!icao || icao.length < 3) return;
-    setLoading(true);
-    setError(null);
     try {
-      const resolvedAirport = await airportDirectoryClient.resolveAirport(icao);
+      const request = airportDirectoryClient.resolveAirport(icao);
+      const resolvedAirport = await toast.promise(request, {
+        loading: "Loading airport context...",
+        success: false,
+        error: (err) => err?.message || "Airport not found or unavailable",
+      });
       setAirport(resolvedAirport);
       setCurrentIcao(String(resolvedAirport?.icao || icao).toUpperCase());
     } catch (err) {
       console.error("Failed to load airport", err);
       setAirport(null);
-      setError(err?.message || "Failed to load airport");
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -46,21 +45,18 @@ export default function HomeClient({ initialIcao = "" }) {
 
   const handleBack = () => {
     setAirport(null);
-    setError(null);
     setCurrentIcao("");
     router.push("/");
   };
 
   if (!currentIcao) {
-    return <SearchScreen loading={loading} error={error} onOpenAirport={handleOpenAirport} />;
+    return <SearchScreen onOpenAirport={handleOpenAirport} />;
   }
 
   return (
     <AirportCaptionScreen
       icao={currentIcao}
       airport={airport}
-      loading={loading}
-      error={error}
       onBack={handleBack}
     />
   );

--- a/src/components/screens/HomeClient.jsx
+++ b/src/components/screens/HomeClient.jsx
@@ -17,6 +17,7 @@ export default function HomeClient({ initialIcao = "" }) {
     try {
       const request = airportDirectoryClient.resolveAirport(icao);
       const resolvedAirport = await toast.promise(request, {
+        id: "airport-resolve",
         loading: "Loading airport context...",
         success: false,
         error: (err) => err?.message || "Airport not found or unavailable",

--- a/src/components/screens/HomeClient.jsx
+++ b/src/components/screens/HomeClient.jsx
@@ -14,18 +14,23 @@ export default function HomeClient({ initialIcao = "" }) {
 
   const loadAirport = async (icao) => {
     if (!icao || icao.length < 3) return;
-    const toastId = toast.loading("Loading airport context...", {
-      id: "airport-resolve",
-    });
+    let toastId = null;
+    const delayTimer = setTimeout(() => {
+      toastId = toast.loading("Loading airport context...", {
+        id: "airport-resolve",
+      });
+    }, 500);
     try {
       const resolvedAirport = await airportDirectoryClient.resolveAirport(icao);
-      toast.dismiss(toastId);
+      clearTimeout(delayTimer);
+      if (toastId) toast.dismiss(toastId);
       setAirport(resolvedAirport);
       setCurrentIcao(String(resolvedAirport?.icao || icao).toUpperCase());
     } catch (err) {
+      clearTimeout(delayTimer);
       console.error("Failed to load airport", err);
       toast.error(err?.message || "Airport not found or unavailable", {
-        id: toastId,
+        id: toastId ?? "airport-resolve",
       });
       setAirport(null);
     }

--- a/src/components/screens/HomeClient.jsx
+++ b/src/components/screens/HomeClient.jsx
@@ -14,18 +14,19 @@ export default function HomeClient({ initialIcao = "" }) {
 
   const loadAirport = async (icao) => {
     if (!icao || icao.length < 3) return;
+    const toastId = toast.loading("Loading airport context...", {
+      id: "airport-resolve",
+    });
     try {
-      const request = airportDirectoryClient.resolveAirport(icao);
-      const resolvedAirport = await toast.promise(request, {
-        id: "airport-resolve",
-        loading: "Loading airport context...",
-        success: false,
-        error: (err) => err?.message || "Airport not found or unavailable",
-      });
+      const resolvedAirport = await airportDirectoryClient.resolveAirport(icao);
+      toast.dismiss(toastId);
       setAirport(resolvedAirport);
       setCurrentIcao(String(resolvedAirport?.icao || icao).toUpperCase());
     } catch (err) {
       console.error("Failed to load airport", err);
+      toast.error(err?.message || "Airport not found or unavailable", {
+        id: toastId,
+      });
       setAirport(null);
     }
   };


### PR DESCRIPTION
## Summary
Replaces the full-width loading/error glass panel in `AirportCaptionScreen` with lightweight Sonner toast feedback, and fixes map overlay flashing.

## Changes

### 1. Integrate Sonner globally
- Install `sonner` (v2.0.7)
- Add `<Toaster theme="system" />` to `src/app/layout.js`

### 2. Update airport resolve logic (`HomeClient.jsx`)
- Removed `loading`/`error` state management
- Show loading toast after 500ms delay (instant cached resolves stay silent)
- Dismiss toast silently on success, show error toast on failure
- Use `id: "airport-resolve"` so rapid navigation reuses the same toast

### 3. Remove blocking UI (`AirportCaptionScreen.jsx`)
- Removed `loading`/`error` props
- Removed full-width glass panel block entirely

### 4. Fix map overlay flash (`AirportMap.jsx`)
- Wrap ICAO label, traffic legend, and attribution in `{mapReady && ...}`
- Initialize `currentTheme` from DOM on mount instead of hardcoding dark

### 5. Keep other fetches silent
- Aircraft positions, flight routes, METAR, and wiki fetches remain toast-free

## UX Change
**Before:** Full-width loading/error bar blocks page; map overlays flash before map is ready  
**After:** Small toast (only for slow fetches), map renders cleanly with no overlay flash