### PR TITLE
feat: add weather carousel card

### DIFF
--- a/src/app/api/proxy/local-weather/[lat]/[lon]/route.js
+++ b/src/app/api/proxy/local-weather/[lat]/[lon]/route.js
@@ -1,0 +1,57 @@
+const CURRENT_VARIABLES = [
+  "temperature_2m",
+  "relative_humidity_2m",
+  "apparent_temperature",
+  "is_day",
+  "precipitation",
+  "rain",
+  "showers",
+  "snowfall",
+  "weather_code",
+  "cloud_cover",
+  "pressure_msl",
+  "surface_pressure",
+  "wind_speed_10m",
+  "wind_direction_10m",
+  "wind_gusts_10m",
+].join(",");
+
+export async function GET(_request, { params }) {
+  const { lat, lon } = await params;
+  const latitude = Number(lat);
+  const longitude = Number(lon);
+
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return Response.json({ error: "Invalid coordinates" }, { status: 400 });
+  }
+
+  const url = new URL("https://api.open-meteo.com/v1/forecast");
+  url.searchParams.set("latitude", String(latitude));
+  url.searchParams.set("longitude", String(longitude));
+  url.searchParams.set("current", CURRENT_VARIABLES);
+  url.searchParams.set("temperature_unit", "celsius");
+  url.searchParams.set("wind_speed_unit", "kn");
+  url.searchParams.set("precipitation_unit", "inch");
+  url.searchParams.set("timezone", "auto");
+  url.searchParams.set("forecast_days", "1");
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "ADSBao/0.8 (https://github.com/orriduck/ADSBao)",
+    },
+    next: {
+      revalidate: 300,
+    },
+  });
+
+  const body = await response.text();
+
+  return new Response(body, {
+    status: response.status,
+    headers: {
+      "content-type":
+        response.headers.get("content-type") || "application/json; charset=utf-8",
+    },
+  });
+}

--- a/src/components/panels/WeatherPanel.jsx
+++ b/src/components/panels/WeatherPanel.jsx
@@ -3,7 +3,6 @@
 import { useMemo, useRef, useState } from "react";
 import { useLocalWeather } from "../../hooks/useLocalWeather.js";
 import {
-  CloudLayerSlide,
   FlightRulesSlide,
   LocalWeatherSlide,
   MetarSlide,
@@ -57,13 +56,6 @@ export default function WeatherPanel({
         title: "Wind speed",
         eyebrow: "Surface flow",
         content: <WindSlide metar={metar} localWeather={localWeather} />,
-      },
-      {
-        id: "clouds",
-        label: "Clouds",
-        title: "Cloud layers",
-        eyebrow: "Ceiling / cover",
-        content: <CloudLayerSlide metar={metar} localWeather={localWeather} />,
       },
       {
         id: "temp",

--- a/src/components/panels/WeatherPanel.jsx
+++ b/src/components/panels/WeatherPanel.jsx
@@ -1,103 +1,174 @@
 "use client";
 
-import NumberFlow from "@number-flow/react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { useLocalWeather } from "../../hooks/useLocalWeather.js";
+import {
+  CloudLayerSlide,
+  FlightRulesSlide,
+  LocalWeatherSlide,
+  MetarSlide,
+  PressureSlide,
+  TemperatureSlide,
+  WindSlide,
+} from "../weather/WeatherSlides";
 
 export default function WeatherPanel({
   metar,
   metarRaw = "",
   metarLoading = false,
   metarError = null,
+  airportLat = 0,
+  airportLon = 0,
+  airportCode = "",
 }) {
-  const [activeWeatherView, setActiveWeatherView] = useState("parsed");
-  const weatherSummary = useMemo(() => {
-    if (!metar) return "Weather report pending";
-    const category = metar.flightCategory || "Observed";
-    const wind = metar.wind && metar.wind !== "-" ? metar.wind : "wind unavailable";
-    return `${category} · ${wind}`;
-  }, [metar]);
-  const visInfo = useMemo(() => {
-    const match = metar?.vis?.match(/^(\d+(?:\.\d+)?)(\+)?\s*SM$/);
-    if (!match) return null;
-    return { value: Number(match[1]), plus: Boolean(match[2]) };
-  }, [metar]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const trackRef = useRef(null);
+  const {
+    weather: localWeather,
+    loading: localWeatherLoading,
+    error: localWeatherError,
+  } = useLocalWeather(airportLat, airportLon);
+
+  const slides = useMemo(
+    () => [
+      {
+        id: "metar",
+        label: "METAR",
+        title: "METAR report",
+        eyebrow: "METAR / Weather",
+        content: (
+          <MetarSlide
+            metarRaw={metarRaw}
+            metarLoading={metarLoading}
+            metarError={metarError}
+          />
+        ),
+      },
+      {
+        id: "rules",
+        label: "Rules",
+        title: "Flight rules",
+        eyebrow: "Operational context",
+        content: <FlightRulesSlide metar={metar} />,
+      },
+      {
+        id: "wind",
+        label: "Wind",
+        title: "Wind speed",
+        eyebrow: "Surface flow",
+        content: <WindSlide metar={metar} localWeather={localWeather} />,
+      },
+      {
+        id: "clouds",
+        label: "Clouds",
+        title: "Cloud layers",
+        eyebrow: "Ceiling / cover",
+        content: <CloudLayerSlide metar={metar} localWeather={localWeather} />,
+      },
+      {
+        id: "temp",
+        label: "Temp",
+        title: "Temp / dew",
+        eyebrow: "Thermal spread",
+        content: <TemperatureSlide metar={metar} localWeather={localWeather} />,
+      },
+      {
+        id: "pressure",
+        label: "Pressure",
+        title: "Pressure",
+        eyebrow: "Altimeter",
+        content: <PressureSlide metar={metar} localWeather={localWeather} />,
+      },
+      {
+        id: "local",
+        label: "Local",
+        title: "Local weather",
+        eyebrow: "Open-Meteo",
+        content: (
+          <LocalWeatherSlide
+            airportCode={airportCode}
+            localWeather={localWeather}
+            localWeatherError={localWeatherError}
+            localWeatherLoading={localWeatherLoading}
+          />
+        ),
+      },
+    ],
+    [
+      airportCode,
+      localWeather,
+      localWeatherError,
+      localWeatherLoading,
+      metar,
+      metarError,
+      metarLoading,
+      metarRaw,
+    ],
+  );
+
+  const activeSlide = slides[activeIndex] || slides[0];
+
+  const scrollToSlide = (index) => {
+    const track = trackRef.current;
+    if (!track) return;
+    track.scrollTo({
+      left: track.clientWidth * index,
+      behavior: "smooth",
+    });
+    setActiveIndex(index);
+  };
+
+  const handleScroll = () => {
+    const track = trackRef.current;
+    if (!track) return;
+    const nextIndex = Math.round(track.scrollLeft / Math.max(1, track.clientWidth));
+    setActiveIndex(Math.min(Math.max(nextIndex, 0), slides.length - 1));
+  };
 
   return (
-    <section className="glass-panel weather-instrument-panel">
-      <div className="panel-heading">
+    <section className="glass-panel weather-instrument-panel weather-carousel-panel">
+      <div className="panel-heading weather-carousel-heading">
         <div>
-          <div className="panel-kicker">METAR / Weather</div>
-          <h2>
-            {activeWeatherView === "parsed"
-              ? weatherSummary
-              : "Observation string"}
-          </h2>
+          <div className="panel-kicker">{activeSlide.eyebrow}</div>
+          <h2>{activeSlide.title}</h2>
         </div>
         <span className="panel-pill">{formatObsTime(metar?.obsTime)}</span>
       </div>
 
-      <div className="weather-view-frame">
-        {activeWeatherView === "parsed" ? (
-          <dl className="weather-readout">
-            <Readout label="Wind" value={metar?.wind || "-"} />
-            <div>
-              <dt>Visibility</dt>
-              <dd>
-                {visInfo ? (
-                  <NumberFlow
-                    value={visInfo.value}
-                    suffix={visInfo.plus ? "+ SM" : " SM"}
-                  />
-                ) : (
-                  metar?.vis || "-"
-                )}
-              </dd>
-            </div>
-            <Readout label="Ceiling" value={metar?.ceiling || "-"} />
-            <Readout
-              label="Temp / Dew"
-              value={metar ? `${metar.temp} / ${metar.dew}` : "-"}
-            />
-            <Readout label="Altimeter" value={metar?.altim || "-"} />
-            <Readout label="Weather" value={metar?.wxString || "None reported"} />
-          </dl>
-        ) : (
-          <div className="metar-code">
-            {metarRaw || (metarLoading ? "Loading METAR..." : "No METAR available.")}
-          </div>
-        )}
+      <div
+        ref={trackRef}
+        className="weather-carousel-track"
+        onScroll={handleScroll}
+      >
+        {slides.map((slide, index) => (
+          <article
+            key={slide.id}
+            aria-hidden={activeIndex !== index}
+            className="weather-carousel-slide"
+          >
+            {slide.content}
+          </article>
+        ))}
       </div>
 
-      {metarError ? <div className="panel-error">{metarError}</div> : null}
-
-      <div className="weather-view-dots" role="tablist" aria-label="Weather card view">
-        <button
-          type="button"
-          role="tab"
-          aria-label="Parsed weather"
-          aria-selected={activeWeatherView === "parsed"}
-          className={activeWeatherView === "parsed" ? "active" : ""}
-          onClick={() => setActiveWeatherView("parsed")}
-        />
-        <button
-          type="button"
-          role="tab"
-          aria-label="Raw METAR"
-          aria-selected={activeWeatherView === "raw"}
-          className={activeWeatherView === "raw" ? "active" : ""}
-          onClick={() => setActiveWeatherView("raw")}
-        />
+      <div
+        className="weather-view-dots weather-carousel-dots"
+        role="tablist"
+        aria-label="Weather card view"
+      >
+        {slides.map((slide, index) => (
+          <button
+            key={slide.id}
+            type="button"
+            role="tab"
+            aria-label={slide.label}
+            aria-selected={activeIndex === index}
+            className={activeIndex === index ? "active" : ""}
+            onClick={() => scrollToSlide(index)}
+          />
+        ))}
       </div>
     </section>
-  );
-}
-
-function Readout({ label, value }) {
-  return (
-    <div>
-      <dt>{label}</dt>
-      <dd>{value}</dd>
-    </div>
   );
 }
 

--- a/src/components/screens/AirportCaptionScreen.jsx
+++ b/src/components/screens/AirportCaptionScreen.jsx
@@ -198,6 +198,9 @@ export default function AirportCaptionScreen({
 
         <main className="airport-dashboard">
           <WeatherPanel
+            airportCode={airportCodeLabel}
+            airportLat={airportLat}
+            airportLon={airportLon}
             metar={metar}
             metarRaw={metarRaw}
             metarLoading={metarLoading}

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -206,11 +206,11 @@ export function LocalWeatherSlide({
 
   return (
     <div className="weather-visual-layout">
-      <div className="weather-slide-stack">
-        <div className="weather-slide-readout local-weather-readout">
-          <div className="local-weather-glyph">
-            {localWeather?.isDay ? <Sun size={42} /> : <Moon size={42} />}
-          </div>
+      <div className="local-weather-row">
+        <div className="local-weather-glyph">
+          {localWeather?.isDay ? <Sun size={42} /> : <Moon size={42} />}
+        </div>
+        <div className="weather-slide-stack">
           <MetricLine
             label={`${airportCode || "Airport"} local`}
             value={
@@ -221,12 +221,12 @@ export function LocalWeatherSlide({
                 : `${round1(localWeather.temperatureC)}°C`
             }
           />
-        </div>
-        <WeatherDescription>
+          <p className="weather-context-copy">
           {localWeatherError
             ? `Open-Meteo unavailable: ${localWeatherError}`
             : condition}
-        </WeatherDescription>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -97,24 +97,26 @@ export function FlightRulesSlide({ metar }) {
 
   return (
     <div className="weather-slide-stack">
-      <div className="flight-rule-banner">
-        <span style={{ background: rules.color }}>{code}</span>
-        <strong style={{ color: rules.color }}>{rules.label}</strong>
-      </div>
-      <p className="weather-context-copy">{rules.context}</p>
-      {detailMeters.length ? (
-        <div className={`weather-two-up weather-two-up--${detailMeters.length}`}>
-          {detailMeters.map((item) => (
-            <ThresholdMeter
-              key={item.label}
-              icon={item.icon}
-              label={item.label}
-              marker={item.marker}
-              value={item.value}
-            />
-          ))}
+      <div className="weather-slide-readout">
+        <div className="flight-rule-banner">
+          <span style={{ background: rules.color }}>{code}</span>
+          <strong style={{ color: rules.color }}>{rules.label}</strong>
         </div>
-      ) : null}
+        {detailMeters.length ? (
+          <div className={`weather-two-up weather-two-up--${detailMeters.length}`}>
+            {detailMeters.map((item) => (
+              <ThresholdMeter
+                key={item.label}
+                icon={item.icon}
+                label={item.label}
+                marker={item.marker}
+                value={item.value}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <WeatherDescription>{rules.context}</WeatherDescription>
     </div>
   );
 }
@@ -126,12 +128,14 @@ export function WindSlide({ metar, localWeather }) {
 
   return (
     <div className="weather-slide-stack">
-      <WindVector speed={speed} gust={gust} direction={direction} />
-      <p className="weather-context-copy">
+      <div className="weather-slide-readout">
+        <WindVector speed={speed} gust={gust} direction={direction} />
+      </div>
+      <WeatherDescription>
         {direction == null
           ? "Variable wind makes runway planning less predictable. Tower may switch flows or issue runway-specific guidance."
           : describeWind(speed, gust)}
-      </p>
+      </WeatherDescription>
     </div>
   );
 }
@@ -143,25 +147,25 @@ export function TemperatureSlide({ metar, localWeather }) {
 
   return (
     <div className="weather-slide-stack">
-      <div className="temperature-strip">
-        <MetricLine
-          label="Temperature"
-          value={temp == null ? "-" : `${round1(temp)}°C`}
-          icon={<Thermometer size={16} />}
-        />
-        <MetricLine
-          label="Dew point"
-          value={dew == null ? "-" : `${round1(dew)}°C`}
-          icon={<Droplets size={16} />}
-        />
-        <MetricLine
-          label="Spread"
-          value={spread == null ? "-" : `${round1(spread)}°C`}
-        />
+      <div className="weather-slide-readout">
+        <div className="temperature-strip">
+          <MetricLine
+            label="Temperature"
+            value={temp == null ? "-" : `${round1(temp)}°C`}
+            icon={<Thermometer size={16} />}
+          />
+          <MetricLine
+            label="Dew point"
+            value={dew == null ? "-" : `${round1(dew)}°C`}
+            icon={<Droplets size={16} />}
+          />
+          <MetricLine
+            label="Spread"
+            value={spread == null ? "-" : `${round1(spread)}°C`}
+          />
+        </div>
       </div>
-      <p className="weather-context-copy">
-        {describeTemperature(temp, spread)}
-      </p>
+      <WeatherDescription>{describeTemperature(temp, spread)}</WeatherDescription>
     </div>
   );
 }
@@ -172,18 +176,20 @@ export function PressureSlide({ metar, localWeather }) {
 
   return (
     <div className="weather-slide-stack">
-      <div className="pressure-strip">
-        <MetricLine
-          icon={<Gauge size={16} />}
-          label="Altimeter"
-          value={metar?.altim || "-"}
-        />
-        <MetricLine
-          label="MSL pressure"
-          value={pressure == null ? "-" : `${Math.round(pressure)} hPa`}
-        />
+      <div className="weather-slide-readout">
+        <div className="pressure-strip">
+          <MetricLine
+            icon={<Gauge size={16} />}
+            label="Altimeter"
+            value={metar?.altim || "-"}
+          />
+          <MetricLine
+            label="MSL pressure"
+            value={pressure == null ? "-" : `${Math.round(pressure)} hPa`}
+          />
+        </div>
       </div>
-      <p className="weather-context-copy">{describePressure(altim, pressure)}</p>
+      <WeatherDescription>{describePressure(altim, pressure)}</WeatherDescription>
     </div>
   );
 }
@@ -200,25 +206,27 @@ export function LocalWeatherSlide({
 
   return (
     <div className="weather-visual-layout">
-      <div className="local-weather-glyph">
-        {localWeather?.isDay ? <Sun size={58} /> : <Moon size={58} />}
-      </div>
       <div className="weather-slide-stack">
-        <MetricLine
-          label={`${airportCode || "Airport"} local`}
-          value={
-            localWeather?.temperatureC == null
-              ? localWeatherLoading
-                ? "Loading..."
-                : "-"
-              : `${round1(localWeather.temperatureC)}°C`
-          }
-        />
-        <p className="weather-context-copy">
+        <div className="weather-slide-readout local-weather-readout">
+          <div className="local-weather-glyph">
+            {localWeather?.isDay ? <Sun size={42} /> : <Moon size={42} />}
+          </div>
+          <MetricLine
+            label={`${airportCode || "Airport"} local`}
+            value={
+              localWeather?.temperatureC == null
+                ? localWeatherLoading
+                  ? "Loading..."
+                  : "-"
+                : `${round1(localWeather.temperatureC)}°C`
+            }
+          />
+        </div>
+        <WeatherDescription>
           {localWeatherError
             ? `Open-Meteo unavailable: ${localWeatherError}`
             : condition}
-        </p>
+        </WeatherDescription>
       </div>
     </div>
   );
@@ -247,6 +255,10 @@ function WindVector({ speed, gust, direction }) {
       </div>
     </div>
   );
+}
+
+function WeatherDescription({ children }) {
+  return <p className="weather-context-copy weather-slide-description">{children}</p>;
 }
 
 function describeWind(speed, gust) {

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -74,7 +74,7 @@ export function MetarSlide({ metarRaw, metarLoading, metarError }) {
 export function FlightRulesSlide({ metar }) {
   const code = metar?.flightCategory || "VFR";
   const rules = FLIGHT_RULES[code] || FLIGHT_RULES.VFR;
-  const visibility = metar?.rawVisib ?? null;
+  const visibility = toNumber(metar?.rawVisib);
   const ceilingFt = getCeilingFeet(metar);
   const detailMeters = [
     ceilingFt == null
@@ -318,7 +318,7 @@ function getCeilingFeet(metar) {
   const layer = metar?.rawClouds?.find((item) =>
     ["BKN", "OVC", "VV"].includes(item.cover),
   );
-  return layer?.base != null ? Number(layer.base) : null;
+  return toNumber(layer?.base);
 }
 
 const toNumber = (value) => {

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -127,14 +127,10 @@ export function WindSlide({ metar, localWeather }) {
   return (
     <div className="weather-slide-stack">
       <WindVector speed={speed} gust={gust} direction={direction} />
-      <SegmentBars value={speed} max={40} />
-      {gust != null ? <SegmentBars value={gust} max={50} tone="orange" /> : null}
       <p className="weather-context-copy">
         {direction == null
-          ? "Variable wind reported near the field. Watch tower instructions for runway-specific flow."
-          : `Wind from ${Math.round(direction)}° at ${Math.round(
-              speed,
-            )} kt${gust == null ? "" : ` with gusts to ${Math.round(gust)} kt`}.`}
+          ? "Variable wind makes runway planning less predictable. Tower may switch flows or issue runway-specific guidance."
+          : describeWind(speed, gust)}
       </p>
     </div>
   );
@@ -164,9 +160,7 @@ export function TemperatureSlide({ metar, localWeather }) {
         />
       </div>
       <p className="weather-context-copy">
-        {spread != null && spread < 3
-          ? "Small temperature-dewpoint spread can support fog, haze, or low cloud development."
-          : "Temperature and dewpoint are separated enough that fog risk is lower near the field."}
+        {describeTemperature(temp, spread)}
       </p>
     </div>
   );
@@ -177,26 +171,19 @@ export function PressureSlide({ metar, localWeather }) {
   const pressure = localWeather?.pressureMslHpa;
 
   return (
-    <div className="weather-visual-layout">
-      <div className="pressure-dial">
-        <Gauge size={42} />
-        <strong>{altim == null ? "-" : `${round2(altim)} inHg`}</strong>
-      </div>
-      <div className="weather-slide-stack">
-        <MetricLine label="Altimeter" value={metar?.altim || "-"} />
+    <div className="weather-slide-stack">
+      <div className="pressure-strip">
         <MetricLine
-          label="Sea-level pressure"
+          icon={<Gauge size={16} />}
+          label="Altimeter"
+          value={metar?.altim || "-"}
+        />
+        <MetricLine
+          label="MSL pressure"
           value={pressure == null ? "-" : `${Math.round(pressure)} hPa`}
         />
-        <MetricLine
-          label="Surface pressure"
-          value={
-            localWeather?.surfacePressureHpa == null
-              ? "-"
-              : `${Math.round(localWeather.surfacePressureHpa)} hPa`
-          }
-        />
       </div>
+      <p className="weather-context-copy">{describePressure(altim, pressure)}</p>
     </div>
   );
 }
@@ -262,6 +249,44 @@ function WindVector({ speed, gust, direction }) {
   );
 }
 
+function describeWind(speed, gust) {
+  const effective = Math.max(speed ?? 0, gust ?? 0);
+  if (effective >= 30) {
+    return "Strong winds or gusts can reduce arrival rates, increase go-around risk, and force stricter runway selection.";
+  }
+  if (effective >= 15) {
+    return "Moderate wind is workable, but crosswind components and gust spread can affect spacing and runway configuration.";
+  }
+  return "Light wind usually gives the airport more runway flexibility and keeps arrival and departure flow stable.";
+}
+
+function describeTemperature(temp, spread) {
+  if (spread != null && spread < 3) {
+    return "A small temperature-dewpoint spread can support fog, haze, or low cloud development near the field.";
+  }
+  if (temp != null && temp >= 32) {
+    return "Hot air reduces aircraft performance, which can lengthen takeoff rolls and affect climb margins.";
+  }
+  if (temp != null && temp <= 0) {
+    return "Cold conditions can improve density altitude, but icing, braking action, and deicing become operational concerns.";
+  }
+  return "Temperature and dewpoint are separated enough that fog risk is lower near the field.";
+}
+
+function describePressure(altim, pressure) {
+  const hpa = pressure ?? (altim != null ? altim * 33.8639 : null);
+  if (hpa == null) {
+    return "Pressure data helps crews set altimeters and judge density-altitude effects around the airport.";
+  }
+  if (hpa < 1000) {
+    return "Lower pressure increases density altitude and can come with unsettled weather, reducing performance margins.";
+  }
+  if (hpa > 1020) {
+    return "Higher pressure generally improves aircraft performance and often accompanies more stable weather.";
+  }
+  return "Pressure is near standard range, so altimeter setting is important but not a major performance driver.";
+}
+
 function MetricLine({ label, value, icon = null }) {
   return (
     <div className="weather-metric-line">
@@ -289,17 +314,6 @@ function ThresholdMeter({ label, value, marker, icon }) {
   );
 }
 
-function SegmentBars({ value, max, tone = "cyan" }) {
-  const active = Math.round((Math.min(Math.max(value, 0), max) / max) * 18);
-  return (
-    <div className={`segment-bars segment-bars--${tone}`} aria-hidden="true">
-      {Array.from({ length: 18 }).map((_, index) => (
-        <span key={index} className={index < active ? "active" : ""} />
-      ))}
-    </div>
-  );
-}
-
 function getCeilingFeet(metar) {
   const layer = metar?.rawClouds?.find((item) =>
     ["BKN", "OVC", "VV"].includes(item.cover),
@@ -313,4 +327,3 @@ const toNumber = (value) => {
 };
 
 const round1 = (value) => Number(value).toFixed(1);
-const round2 = (value) => Number(value).toFixed(2);

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -1,9 +1,7 @@
 "use client";
 
-import NumberFlow from "@number-flow/react";
 import {
   Cloud,
-  CloudSun,
   Droplets,
   Eye,
   Gauge,
@@ -11,7 +9,6 @@ import {
   Moon,
   Sun,
   Thermometer,
-  Wind,
 } from "lucide-react";
 
 const FLIGHT_RULES = {
@@ -79,6 +76,24 @@ export function FlightRulesSlide({ metar }) {
   const rules = FLIGHT_RULES[code] || FLIGHT_RULES.VFR;
   const visibility = metar?.rawVisib ?? null;
   const ceilingFt = getCeilingFeet(metar);
+  const detailMeters = [
+    ceilingFt == null
+      ? null
+      : {
+          icon: <Cloud size={16} />,
+          label: "Ceiling",
+          marker: Math.min(1, ceilingFt / 3000),
+          value: `${ceilingFt.toLocaleString()} ft`,
+        },
+    visibility == null
+      ? null
+      : {
+          icon: <Eye size={16} />,
+          label: "Visibility",
+          marker: Math.min(1, visibility / 5),
+          value: `${visibility >= 10 ? "10+" : visibility} SM`,
+        },
+  ].filter(Boolean);
 
   return (
     <div className="weather-slide-stack">
@@ -87,20 +102,19 @@ export function FlightRulesSlide({ metar }) {
         <strong style={{ color: rules.color }}>{rules.label}</strong>
       </div>
       <p className="weather-context-copy">{rules.context}</p>
-      <div className="weather-two-up">
-        <ThresholdMeter
-          icon={<Cloud size={16} />}
-          label="Ceiling"
-          marker={ceilingFt == null ? 1 : Math.min(1, ceilingFt / 3000)}
-          value={ceilingFt == null ? "None" : `${ceilingFt.toLocaleString()} ft`}
-        />
-        <ThresholdMeter
-          icon={<Eye size={16} />}
-          label="Visibility"
-          marker={visibility == null ? 1 : Math.min(1, visibility / 5)}
-          value={visibility == null ? "-" : `${visibility >= 10 ? "10+" : visibility} SM`}
-        />
-      </div>
+      {detailMeters.length ? (
+        <div className={`weather-two-up weather-two-up--${detailMeters.length}`}>
+          {detailMeters.map((item) => (
+            <ThresholdMeter
+              key={item.label}
+              icon={item.icon}
+              label={item.label}
+              marker={item.marker}
+              value={item.value}
+            />
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -111,60 +125,17 @@ export function WindSlide({ metar, localWeather }) {
   const direction = metar?.rawWvrb ? null : toNumber(metar?.rawWdir) ?? localWeather?.windDirection;
 
   return (
-    <div className="weather-visual-layout">
-      <div className="wind-rose" aria-label="Wind direction visualization">
-        <div
-          className="wind-rose-arrow"
-          style={{ transform: `rotate(${direction ?? 0}deg)` }}
-        >
-          <Navigation size={28} fill="currentColor" />
-        </div>
-        <span>{direction == null ? "VRB" : `${Math.round(direction)}deg`}</span>
-      </div>
-      <div className="weather-slide-stack">
-        <MetricLine
-          label="Wind"
-          value={`${Math.round(speed)} kt`}
-          icon={<Wind size={16} />}
-        />
-        <SegmentBars value={speed} max={40} />
-        <MetricLine
-          label="Gusts"
-          value={gust == null ? "None" : `${Math.round(gust)} kt`}
-          icon={<Wind size={16} />}
-        />
-        <SegmentBars value={gust ?? 0} max={50} tone="orange" />
-      </div>
-    </div>
-  );
-}
-
-export function CloudLayerSlide({ metar, localWeather }) {
-  const layers = metar?.rawClouds || [];
-  const cloudCover = localWeather?.cloudCover;
-
-  return (
     <div className="weather-slide-stack">
-      <MetricLine
-        label="Ceiling"
-        value={metar?.ceiling || "-"}
-        icon={<Cloud size={16} />}
-      />
-      <div className="cloud-cover-orbit">
-        <CloudSun size={42} />
-        <NumberFlow value={Math.round(cloudCover ?? 0)} suffix="%" />
-      </div>
-      <div className="cloud-layer-list">
-        {layers.length ? (
-          layers.slice(0, 3).map((layer, index) => (
-            <span key={`${layer.cover}-${layer.base}-${index}`}>
-              {layer.cover} {layer.base ? `${Number(layer.base).toLocaleString()} ft` : ""}
-            </span>
-          ))
-        ) : (
-          <span>CLR / no reported cloud layers</span>
-        )}
-      </div>
+      <WindVector speed={speed} gust={gust} direction={direction} />
+      <SegmentBars value={speed} max={40} />
+      {gust != null ? <SegmentBars value={gust} max={50} tone="orange" /> : null}
+      <p className="weather-context-copy">
+        {direction == null
+          ? "Variable wind reported near the field. Watch tower instructions for runway-specific flow."
+          : `Wind from ${Math.round(direction)}° at ${Math.round(
+              speed,
+            )} kt${gust == null ? "" : ` with gusts to ${Math.round(gust)} kt`}.`}
+      </p>
     </div>
   );
 }
@@ -176,22 +147,21 @@ export function TemperatureSlide({ metar, localWeather }) {
 
   return (
     <div className="weather-slide-stack">
-      <div className="temperature-readout">
+      <div className="temperature-strip">
         <MetricLine
           label="Temperature"
-          value={temp == null ? "-" : `${round1(temp)}deg C`}
+          value={temp == null ? "-" : `${round1(temp)}°C`}
           icon={<Thermometer size={16} />}
         />
         <MetricLine
           label="Dew point"
-          value={dew == null ? "-" : `${round1(dew)}deg C`}
+          value={dew == null ? "-" : `${round1(dew)}°C`}
           icon={<Droplets size={16} />}
         />
-      </div>
-      <div className="dew-spread-meter">
-        <span>Spread</span>
-        <strong>{spread == null ? "-" : `${round1(spread)}deg C`}</strong>
-        <SegmentBars value={spread ?? 0} max={18} />
+        <MetricLine
+          label="Spread"
+          value={spread == null ? "-" : `${round1(spread)}°C`}
+        />
       </div>
       <p className="weather-context-copy">
         {spread != null && spread < 3
@@ -254,24 +224,39 @@ export function LocalWeatherSlide({
               ? localWeatherLoading
                 ? "Loading..."
                 : "-"
-              : `${round1(localWeather.temperatureC)}deg C`
+              : `${round1(localWeather.temperatureC)}°C`
           }
         />
         <p className="weather-context-copy">
           {localWeatherError
             ? `Open-Meteo unavailable: ${localWeatherError}`
-            : `${condition}. Feels like ${
-                localWeather?.apparentTemperatureC == null
-                  ? "-"
-                  : `${round1(localWeather.apparentTemperatureC)}deg C`
-              }, humidity ${localWeather?.humidity ?? "-"}%.`}
+            : condition}
         </p>
-        <div className="local-weather-grid">
-          <span>Cloud {localWeather?.cloudCover ?? "-"}%</span>
-          <span>Wind {Math.round(localWeather?.windSpeedKt ?? 0)} kt</span>
-          <span>Rain {round2(localWeather?.rainIn ?? 0)} in</span>
-          <span>{localWeather?.source || "Open-Meteo"}</span>
-        </div>
+      </div>
+    </div>
+  );
+}
+
+function WindVector({ speed, gust, direction }) {
+  return (
+    <div className="wind-vector-card">
+      <div
+        className="wind-vector-arrow"
+        style={{ transform: `rotate(${direction ?? 0}deg)` }}
+      >
+        <Navigation size={21} fill="currentColor" />
+      </div>
+      <div>
+        <span>Direction</span>
+        <strong>{direction == null ? "VRB" : `${Math.round(direction)}°`}</strong>
+      </div>
+      <div>
+        <span>Wind</span>
+        <strong>{Math.round(speed)} kt</strong>
+      </div>
+      <div>
+        <span>Gust</span>
+        <strong>{gust == null ? "None" : `${Math.round(gust)} kt`}</strong>
       </div>
     </div>
   );

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -1,0 +1,331 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
+import {
+  Cloud,
+  CloudSun,
+  Droplets,
+  Eye,
+  Gauge,
+  Navigation,
+  Moon,
+  Sun,
+  Thermometer,
+  Wind,
+} from "lucide-react";
+
+const FLIGHT_RULES = {
+  VFR: {
+    label: "Visual Flight Rules",
+    color: "#19c37d",
+    context:
+      "Skies and visibility support normal visual operations. Weather is unlikely to constrain airport capacity.",
+  },
+  MVFR: {
+    label: "Marginal Visual Flight Rules",
+    color: "#2f8cff",
+    context:
+      "Visibility or ceiling is reduced. Arrivals and departures usually continue, but pilots watch weather margins closely.",
+  },
+  IFR: {
+    label: "Instrument Flight Rules",
+    color: "#ff453a",
+    context:
+      "Low clouds or limited visibility require instrument procedures. Arrival spacing can increase and delays become more likely.",
+  },
+  LIFR: {
+    label: "Low IFR",
+    color: "#e12aa2",
+    context:
+      "Very low ceiling or visibility limits airport flow. Only aircraft and runways equipped for low-visibility operations can land reliably.",
+  },
+};
+
+const WEATHER_CODES = {
+  0: "Clear",
+  1: "Mainly clear",
+  2: "Partly cloudy",
+  3: "Overcast",
+  45: "Fog",
+  48: "Rime fog",
+  51: "Light drizzle",
+  53: "Drizzle",
+  55: "Dense drizzle",
+  61: "Light rain",
+  63: "Rain",
+  65: "Heavy rain",
+  71: "Light snow",
+  73: "Snow",
+  75: "Heavy snow",
+  80: "Rain showers",
+  81: "Rain showers",
+  82: "Heavy showers",
+  95: "Thunderstorm",
+};
+
+export function MetarSlide({ metarRaw, metarLoading, metarError }) {
+  return (
+    <div className="weather-slide-stack">
+      <div className="metar-code weather-metar-code">
+        {metarRaw || (metarLoading ? "Loading METAR..." : "No METAR available.")}
+      </div>
+      {metarError ? <div className="panel-error">{metarError}</div> : null}
+    </div>
+  );
+}
+
+export function FlightRulesSlide({ metar }) {
+  const code = metar?.flightCategory || "VFR";
+  const rules = FLIGHT_RULES[code] || FLIGHT_RULES.VFR;
+  const visibility = metar?.rawVisib ?? null;
+  const ceilingFt = getCeilingFeet(metar);
+
+  return (
+    <div className="weather-slide-stack">
+      <div className="flight-rule-banner">
+        <span style={{ background: rules.color }}>{code}</span>
+        <strong style={{ color: rules.color }}>{rules.label}</strong>
+      </div>
+      <p className="weather-context-copy">{rules.context}</p>
+      <div className="weather-two-up">
+        <ThresholdMeter
+          icon={<Cloud size={16} />}
+          label="Ceiling"
+          marker={ceilingFt == null ? 1 : Math.min(1, ceilingFt / 3000)}
+          value={ceilingFt == null ? "None" : `${ceilingFt.toLocaleString()} ft`}
+        />
+        <ThresholdMeter
+          icon={<Eye size={16} />}
+          label="Visibility"
+          marker={visibility == null ? 1 : Math.min(1, visibility / 5)}
+          value={visibility == null ? "-" : `${visibility >= 10 ? "10+" : visibility} SM`}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function WindSlide({ metar, localWeather }) {
+  const speed = toNumber(metar?.rawWspd) ?? localWeather?.windSpeedKt ?? 0;
+  const gust = toNumber(metar?.rawWgst) ?? localWeather?.windGustKt ?? null;
+  const direction = metar?.rawWvrb ? null : toNumber(metar?.rawWdir) ?? localWeather?.windDirection;
+
+  return (
+    <div className="weather-visual-layout">
+      <div className="wind-rose" aria-label="Wind direction visualization">
+        <div
+          className="wind-rose-arrow"
+          style={{ transform: `rotate(${direction ?? 0}deg)` }}
+        >
+          <Navigation size={28} fill="currentColor" />
+        </div>
+        <span>{direction == null ? "VRB" : `${Math.round(direction)}deg`}</span>
+      </div>
+      <div className="weather-slide-stack">
+        <MetricLine
+          label="Wind"
+          value={`${Math.round(speed)} kt`}
+          icon={<Wind size={16} />}
+        />
+        <SegmentBars value={speed} max={40} />
+        <MetricLine
+          label="Gusts"
+          value={gust == null ? "None" : `${Math.round(gust)} kt`}
+          icon={<Wind size={16} />}
+        />
+        <SegmentBars value={gust ?? 0} max={50} tone="orange" />
+      </div>
+    </div>
+  );
+}
+
+export function CloudLayerSlide({ metar, localWeather }) {
+  const layers = metar?.rawClouds || [];
+  const cloudCover = localWeather?.cloudCover;
+
+  return (
+    <div className="weather-slide-stack">
+      <MetricLine
+        label="Ceiling"
+        value={metar?.ceiling || "-"}
+        icon={<Cloud size={16} />}
+      />
+      <div className="cloud-cover-orbit">
+        <CloudSun size={42} />
+        <NumberFlow value={Math.round(cloudCover ?? 0)} suffix="%" />
+      </div>
+      <div className="cloud-layer-list">
+        {layers.length ? (
+          layers.slice(0, 3).map((layer, index) => (
+            <span key={`${layer.cover}-${layer.base}-${index}`}>
+              {layer.cover} {layer.base ? `${Number(layer.base).toLocaleString()} ft` : ""}
+            </span>
+          ))
+        ) : (
+          <span>CLR / no reported cloud layers</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TemperatureSlide({ metar, localWeather }) {
+  const temp = toNumber(metar?.rawTemp) ?? localWeather?.temperatureC;
+  const dew = toNumber(metar?.rawDewp) ?? null;
+  const spread = temp != null && dew != null ? Math.max(0, temp - dew) : null;
+
+  return (
+    <div className="weather-slide-stack">
+      <div className="temperature-readout">
+        <MetricLine
+          label="Temperature"
+          value={temp == null ? "-" : `${round1(temp)}deg C`}
+          icon={<Thermometer size={16} />}
+        />
+        <MetricLine
+          label="Dew point"
+          value={dew == null ? "-" : `${round1(dew)}deg C`}
+          icon={<Droplets size={16} />}
+        />
+      </div>
+      <div className="dew-spread-meter">
+        <span>Spread</span>
+        <strong>{spread == null ? "-" : `${round1(spread)}deg C`}</strong>
+        <SegmentBars value={spread ?? 0} max={18} />
+      </div>
+      <p className="weather-context-copy">
+        {spread != null && spread < 3
+          ? "Small temperature-dewpoint spread can support fog, haze, or low cloud development."
+          : "Temperature and dewpoint are separated enough that fog risk is lower near the field."}
+      </p>
+    </div>
+  );
+}
+
+export function PressureSlide({ metar, localWeather }) {
+  const altim = metar?.rawAltim;
+  const pressure = localWeather?.pressureMslHpa;
+
+  return (
+    <div className="weather-visual-layout">
+      <div className="pressure-dial">
+        <Gauge size={42} />
+        <strong>{altim == null ? "-" : `${round2(altim)} inHg`}</strong>
+      </div>
+      <div className="weather-slide-stack">
+        <MetricLine label="Altimeter" value={metar?.altim || "-"} />
+        <MetricLine
+          label="Sea-level pressure"
+          value={pressure == null ? "-" : `${Math.round(pressure)} hPa`}
+        />
+        <MetricLine
+          label="Surface pressure"
+          value={
+            localWeather?.surfacePressureHpa == null
+              ? "-"
+              : `${Math.round(localWeather.surfacePressureHpa)} hPa`
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+export function LocalWeatherSlide({
+  airportCode,
+  localWeather,
+  localWeatherError,
+  localWeatherLoading,
+}) {
+  const condition = localWeather
+    ? WEATHER_CODES[localWeather.weatherCode] || "Current conditions"
+    : "Local weather pending";
+
+  return (
+    <div className="weather-visual-layout">
+      <div className="local-weather-glyph">
+        {localWeather?.isDay ? <Sun size={58} /> : <Moon size={58} />}
+      </div>
+      <div className="weather-slide-stack">
+        <MetricLine
+          label={`${airportCode || "Airport"} local`}
+          value={
+            localWeather?.temperatureC == null
+              ? localWeatherLoading
+                ? "Loading..."
+                : "-"
+              : `${round1(localWeather.temperatureC)}deg C`
+          }
+        />
+        <p className="weather-context-copy">
+          {localWeatherError
+            ? `Open-Meteo unavailable: ${localWeatherError}`
+            : `${condition}. Feels like ${
+                localWeather?.apparentTemperatureC == null
+                  ? "-"
+                  : `${round1(localWeather.apparentTemperatureC)}deg C`
+              }, humidity ${localWeather?.humidity ?? "-"}%.`}
+        </p>
+        <div className="local-weather-grid">
+          <span>Cloud {localWeather?.cloudCover ?? "-"}%</span>
+          <span>Wind {Math.round(localWeather?.windSpeedKt ?? 0)} kt</span>
+          <span>Rain {round2(localWeather?.rainIn ?? 0)} in</span>
+          <span>{localWeather?.source || "Open-Meteo"}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetricLine({ label, value, icon = null }) {
+  return (
+    <div className="weather-metric-line">
+      <span>
+        {icon}
+        {label}
+      </span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function ThresholdMeter({ label, value, marker, icon }) {
+  return (
+    <div className="threshold-meter">
+      <span>
+        {icon}
+        {label}
+      </span>
+      <strong>{value}</strong>
+      <div className="threshold-track">
+        <i style={{ left: `${marker * 100}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function SegmentBars({ value, max, tone = "cyan" }) {
+  const active = Math.round((Math.min(Math.max(value, 0), max) / max) * 18);
+  return (
+    <div className={`segment-bars segment-bars--${tone}`} aria-hidden="true">
+      {Array.from({ length: 18 }).map((_, index) => (
+        <span key={index} className={index < active ? "active" : ""} />
+      ))}
+    </div>
+  );
+}
+
+function getCeilingFeet(metar) {
+  const layer = metar?.rawClouds?.find((item) =>
+    ["BKN", "OVC", "VV"].includes(item.cover),
+  );
+  return layer?.base != null ? Number(layer.base) : null;
+}
+
+const toNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+const round1 = (value) => Number(value).toFixed(1);
+const round2 = (value) => Number(value).toFixed(2);

--- a/src/config/vercelRouting.test.js
+++ b/src/config/vercelRouting.test.js
@@ -23,3 +23,4 @@ assert.deepEqual(config.rewrites?.slice(0, 3), [
 assert.equal(existsSync(new URL('../../api/proxy/metar/[icao].js', import.meta.url)), false)
 assert.equal(existsSync(new URL('../../api/proxy/aircraft/positions/[...params].js', import.meta.url)), false)
 assert.equal(existsSync(new URL('../app/api/proxy/flight-routes/callsign/[callsign]/route.js', import.meta.url)), true)
+assert.equal(existsSync(new URL('../app/api/proxy/local-weather/[lat]/[lon]/route.js', import.meta.url)), true)

--- a/src/hooks/useLocalWeather.js
+++ b/src/hooks/useLocalWeather.js
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { localWeatherClient } from "../services/aviationData.js";
+
+export function useLocalWeather(lat, lon) {
+  const [weather, setWeather] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchWeather = async () => {
+      if (!lat || !lon) {
+        setWeather(null);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const payload = await localWeatherClient.fetchCurrentWeather({ lat, lon });
+        if (cancelled) return;
+        setWeather(normalizeLocalWeather(payload));
+      } catch (e) {
+        if (!cancelled) {
+          console.warn("Local weather fetch failed:", e.message);
+          setError(e.message);
+          setWeather(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchWeather();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [lat, lon]);
+
+  return { weather, loading, error };
+}
+
+function normalizeLocalWeather(payload) {
+  const current = payload?.current;
+  if (!current) return null;
+
+  return {
+    time: current.time || "",
+    temperatureC: toFinite(current.temperature_2m),
+    apparentTemperatureC: toFinite(current.apparent_temperature),
+    humidity: toFinite(current.relative_humidity_2m),
+    isDay: current.is_day === 1,
+    precipitationIn: toFinite(current.precipitation),
+    rainIn: toFinite(current.rain),
+    showersIn: toFinite(current.showers),
+    snowfallIn: toFinite(current.snowfall),
+    weatherCode: toFinite(current.weather_code),
+    cloudCover: toFinite(current.cloud_cover),
+    pressureMslHpa: toFinite(current.pressure_msl),
+    surfacePressureHpa: toFinite(current.surface_pressure),
+    windSpeedKt: toFinite(current.wind_speed_10m),
+    windDirection: toFinite(current.wind_direction_10m),
+    windGustKt: toFinite(current.wind_gusts_10m),
+    timezone: payload.timezone || "",
+    source: "Open-Meteo",
+  };
+}
+
+const toFinite = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};

--- a/src/hooks/useMetar.js
+++ b/src/hooks/useMetar.js
@@ -29,8 +29,8 @@ export function useMetar(icao) {
         setParsed({
           wind: formatWind(m),
           vis: m.visib ? `${m.visib} SM` : "-",
-          temp: m.temp != null ? `${m.temp}deg C` : "-",
-          dew: m.dewp != null ? `${m.dewp}deg C` : "-",
+          temp: m.temp != null ? `${m.temp}°C` : "-",
+          dew: m.dewp != null ? `${m.dewp}°C` : "-",
           altim: m.altim ? `${m.altim} inHg` : "-",
           ceiling: formatCeiling(m),
           wxString: m.wxString || "",

--- a/src/hooks/useMetar.js
+++ b/src/hooks/useMetar.js
@@ -42,6 +42,7 @@ export function useMetar(icao) {
           rawAltim: m.altim != null ? Number(m.altim) : null,
           rawWspd: m.wspd ?? null,
           rawWgst: m.wgst ?? null,
+          rawClouds: Array.isArray(m.clouds) ? m.clouds : [],
           rawWdir:
             m.wdir === "VRB" ? null : m.wdir != null ? Number(m.wdir) : null,
           rawWvrb: m.wdir === "VRB",

--- a/src/services/aviationData.js
+++ b/src/services/aviationData.js
@@ -70,6 +70,7 @@ export const DEFAULT_CLOSE_RANGE_NM = 3;
 const DEFAULT_METAR_BASE = "/api/proxy/metar";
 const DEFAULT_AIRCRAFT_POSITIONS_BASE = "/api/proxy/aircraft/positions";
 const DEFAULT_FLIGHT_ROUTE_BASE = "/api/proxy/flight-routes/callsign";
+const DEFAULT_LOCAL_WEATHER_BASE = "/api/proxy/local-weather";
 
 const createTimeoutSignal = (timeoutMs) =>
   typeof AbortSignal !== "undefined" && AbortSignal.timeout
@@ -114,6 +115,43 @@ export const createMetarClient = ({
       return fetchJson(
         auditedFetch,
         `${baseUrl}/${encodeURIComponent(normalized)}`,
+        {
+          timeoutMs: 10_000,
+        },
+      );
+    },
+  };
+};
+
+export const createLocalWeatherClient = ({
+  fetchImpl = globalThis.fetch?.bind(globalThis),
+  baseUrl = env.NEXT_PUBLIC_LOCAL_WEATHER_BASE || DEFAULT_LOCAL_WEATHER_BASE,
+} = {}) => {
+  if (!fetchImpl) throw new Error("Local weather client requires fetch support");
+
+  const auditedFetch = withAuditLogging(fetchImpl, {
+    service: "Open-Meteo/CurrentWeather",
+    getParams(url) {
+      const p = url.split("/");
+      return {
+        lat: p[p.length - 2],
+        lon: p[p.length - 1],
+      };
+    },
+  });
+
+  return {
+    fetchCurrentWeather({ lat, lon }) {
+      const numericLat = Number(lat);
+      const numericLon = Number(lon);
+      if (!Number.isFinite(numericLat) || !Number.isFinite(numericLon)) {
+        return null;
+      }
+      return fetchJson(
+        auditedFetch,
+        `${baseUrl}/${encodeURIComponent(String(numericLat))}/${encodeURIComponent(
+          String(numericLon),
+        )}`,
         {
           timeoutMs: 10_000,
         },
@@ -292,3 +330,4 @@ export const createFlightRouteClient = ({
 export const metarClient = createMetarClient();
 export const aircraftPositionClient = createAircraftPositionClient();
 export const flightRouteClient = createFlightRouteClient();
+export const localWeatherClient = createLocalWeatherClient();

--- a/src/services/aviationData.test.js
+++ b/src/services/aviationData.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   createAircraftPositionClient,
   createFlightRouteClient,
+  createLocalWeatherClient,
   createMetarClient,
   createRateLimiter,
   DEFAULT_AIRCRAFT_POLL_MS,
@@ -151,6 +152,31 @@ try {
   assert.equal(calls.length, 1);
   assert.equal(calls[0], "/api/proxy/aircraft/positions/42.3656/-71.0096/15");
   assert.equal(payload.ac[0].hex, "a1b2c3");
+}
+
+{
+  const calls = [];
+  const client = createLocalWeatherClient({
+    fetchImpl: async (url) => {
+      calls.push(url);
+      return createJsonResponse({
+        current: {
+          temperature_2m: 16.4,
+          weather_code: 0,
+          wind_speed_10m: 12,
+        },
+      });
+    },
+  });
+
+  const payload = await client.fetchCurrentWeather({
+    lat: 42.3656,
+    lon: -71.0096,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0], "/api/proxy/local-weather/42.3656/-71.0096");
+  assert.equal(payload.current.temperature_2m, 16.4);
 }
 
 {

--- a/src/style.css
+++ b/src/style.css
@@ -888,11 +888,12 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.local-weather-readout {
+.local-weather-row {
   align-items: center;
   display: grid;
   gap: 14px;
   grid-template-columns: 48px minmax(0, 1fr);
+  min-height: 142px;
 }
 
 .temperature-strip .weather-metric-line {

--- a/src/style.css
+++ b/src/style.css
@@ -786,7 +786,7 @@ body {
 }
 
 .threshold-track {
-  background: linear-gradient(90deg, #e12aa2 0 24%, #ff453a 24% 48%, #2f8cff 48% 74%, #19c37d 74% 100%);
+  background: linear-gradient(90deg, rgba(255, 90, 31, 0.22), rgba(255, 90, 31, 0.74));
   border-radius: var(--atc-radius-pill);
   height: 6px;
   position: relative;
@@ -794,7 +794,7 @@ body {
 
 .threshold-track i {
   background: var(--atc-bg);
-  border: 2px solid #19c37d;
+  border: 2px solid var(--atc-orange);
   border-radius: 50%;
   height: 13px;
   position: absolute;
@@ -803,7 +803,6 @@ body {
   width: 13px;
 }
 
-.pressure-dial,
 .local-weather-glyph {
   align-items: center;
   aspect-ratio: 1;
@@ -818,15 +817,6 @@ body {
   justify-content: center;
   min-width: 0;
   position: relative;
-}
-
-.pressure-dial::before {
-  background: repeating-conic-gradient(from 0deg, color-mix(in oklab, var(--atc-text) 32%, transparent) 0 3deg, transparent 3deg 10deg);
-  border-radius: inherit;
-  content: "";
-  inset: 12px;
-  opacity: 0.45;
-  position: absolute;
 }
 
 .wind-vector-card {
@@ -875,53 +865,15 @@ body {
   transform-origin: center;
 }
 
-.pressure-dial strong {
-  color: var(--atc-text);
-  font-family: "JetBrains Mono", monospace;
-  font-size: 11px;
-  font-weight: 800;
-  position: relative;
-  z-index: 1;
-}
-
-.segment-bars {
-  display: grid;
-  gap: 4px;
-  grid-template-columns: repeat(18, 1fr);
-  height: 20px;
-}
-
-.segment-bars span {
-  align-self: end;
-  background: color-mix(in oklab, var(--atc-faint) 28%, transparent);
-  border-radius: 999px;
-  height: 11px;
-}
-
-.segment-bars span.active {
-  background: #38bdf8;
-  box-shadow: 0 0 10px rgba(56, 189, 248, 0.22);
-}
-
-.segment-bars--orange span.active {
-  background: var(--atc-orange);
-  box-shadow: 0 0 10px rgba(255, 90, 31, 0.24);
-}
-
-.pressure-dial strong {
-  font-size: 14px;
-  text-align: center;
-}
-
-.pressure-dial svg {
-  color: var(--atc-orange);
-  position: relative;
-  z-index: 1;
-}
-
 .local-weather-glyph {
   color: #ffd24a;
   text-shadow: 0 0 24px rgba(255, 210, 74, 0.25);
+}
+
+.pressure-strip {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .temperature-strip .weather-metric-line {

--- a/src/style.css
+++ b/src/style.css
@@ -889,11 +889,19 @@ body {
 }
 
 .local-weather-row {
-  align-items: center;
+  align-items: start;
   display: grid;
   gap: 14px;
   grid-template-columns: 48px minmax(0, 1fr);
   min-height: 142px;
+}
+
+.local-weather-row .local-weather-glyph {
+  margin-top: 2px;
+}
+
+.local-weather-row .weather-slide-stack {
+  justify-content: start;
 }
 
 .temperature-strip .weather-metric-line {

--- a/src/style.css
+++ b/src/style.css
@@ -665,15 +665,25 @@ body {
 .weather-slide-stack {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 0;
+  height: 100%;
+  justify-content: space-between;
   min-height: 0;
+}
+
+.weather-slide-readout {
+  min-height: 74px;
+}
+
+.weather-slide-description {
+  border-top: 1px solid var(--atc-line);
+  margin-top: 11px;
+  padding-top: 10px;
 }
 
 .weather-visual-layout {
   align-items: center;
-  display: grid;
-  gap: 18px;
-  grid-template-columns: minmax(104px, 0.42fr) minmax(0, 1fr);
+  display: block;
   min-height: 142px;
 }
 
@@ -748,6 +758,7 @@ body {
   align-items: center;
   display: flex;
   gap: 10px;
+  margin-bottom: 12px;
 }
 
 .flight-rule-banner span {
@@ -805,7 +816,6 @@ body {
 
 .local-weather-glyph {
   align-items: center;
-  aspect-ratio: 1;
   background:
     radial-gradient(circle at 50% 50%, color-mix(in oklab, var(--atc-orange) 14%, transparent), transparent 58%),
     color-mix(in oklab, var(--atc-card) 36%, transparent);
@@ -815,8 +825,10 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  height: 48px;
   min-width: 0;
   position: relative;
+  width: 48px;
 }
 
 .wind-vector-card {
@@ -874,6 +886,13 @@ body {
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.local-weather-readout {
+  align-items: center;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 48px minmax(0, 1fr);
 }
 
 .temperature-strip .weather-metric-line {

--- a/src/style.css
+++ b/src/style.css
@@ -766,10 +766,18 @@ body {
 }
 
 .weather-two-up,
-.temperature-readout {
+.temperature-strip {
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.weather-two-up--1 {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.temperature-strip {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .threshold-meter {
@@ -795,9 +803,7 @@ body {
   width: 13px;
 }
 
-.wind-rose,
 .pressure-dial,
-.cloud-cover-orbit,
 .local-weather-glyph {
   align-items: center;
   aspect-ratio: 1;
@@ -814,7 +820,6 @@ body {
   position: relative;
 }
 
-.wind-rose::before,
 .pressure-dial::before {
   background: repeating-conic-gradient(from 0deg, color-mix(in oklab, var(--atc-text) 32%, transparent) 0 3deg, transparent 3deg 10deg);
   border-radius: inherit;
@@ -824,18 +829,53 @@ body {
   position: absolute;
 }
 
-.wind-rose-arrow {
-  color: var(--atc-orange);
+.wind-vector-card {
+  align-items: stretch;
+  border-top: 1px solid var(--atc-line);
   display: grid;
-  place-items: center;
-  position: relative;
-  transform-origin: center;
-  z-index: 1;
+  gap: 10px;
+  grid-template-columns: 34px repeat(3, minmax(0, 1fr));
+  padding-top: 9px;
 }
 
-.wind-rose span,
-.pressure-dial strong,
-.cloud-cover-orbit span {
+.wind-vector-card > div:not(.wind-vector-arrow) {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.wind-vector-card span {
+  color: var(--atc-faint);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9px;
+  letter-spacing: 1px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.wind-vector-card strong {
+  color: var(--atc-text);
+  font-size: 15px;
+  font-weight: 850;
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wind-vector-arrow {
+  align-items: center;
+  aspect-ratio: 1;
+  background: color-mix(in oklab, var(--atc-orange) 12%, transparent);
+  border: 1px solid color-mix(in oklab, var(--atc-orange) 35%, var(--atc-line));
+  border-radius: 999px;
+  color: var(--atc-orange);
+  display: flex;
+  justify-content: center;
+  transform-origin: center;
+}
+
+.pressure-dial strong {
   color: var(--atc-text);
   font-family: "JetBrains Mono", monospace;
   font-size: 11px;
@@ -868,58 +908,6 @@ body {
   box-shadow: 0 0 10px rgba(255, 90, 31, 0.24);
 }
 
-.cloud-cover-orbit {
-  flex-direction: row;
-  gap: 8px;
-  margin-inline: auto;
-  width: min(128px, 42%);
-}
-
-.cloud-cover-orbit svg {
-  color: var(--atc-orange);
-}
-
-.cloud-cover-orbit span {
-  font-size: 20px;
-}
-
-.cloud-layer-list,
-.local-weather-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-}
-
-.cloud-layer-list span,
-.local-weather-grid span {
-  border: 1px solid var(--atc-line);
-  border-radius: var(--atc-radius-pill);
-  color: var(--atc-dim);
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10px;
-  letter-spacing: 0.5px;
-  padding: 5px 8px;
-  text-transform: uppercase;
-}
-
-.dew-spread-meter {
-  display: grid;
-  gap: 7px;
-}
-
-.dew-spread-meter span {
-  color: var(--atc-faint);
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10px;
-  letter-spacing: 1.1px;
-  text-transform: uppercase;
-}
-
-.dew-spread-meter strong {
-  font-size: 18px;
-  line-height: 1;
-}
-
 .pressure-dial strong {
   font-size: 14px;
   text-align: center;
@@ -934,6 +922,17 @@ body {
 .local-weather-glyph {
   color: #ffd24a;
   text-shadow: 0 0 24px rgba(255, 210, 74, 0.25);
+}
+
+.temperature-strip .weather-metric-line {
+  min-width: 0;
+}
+
+.temperature-strip .weather-metric-line strong {
+  font-size: 18px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .weather-readout div {

--- a/src/style.css
+++ b/src/style.css
@@ -622,9 +622,59 @@ body {
   min-height: 250px;
 }
 
-.weather-view-frame {
+.weather-carousel-panel {
+  padding-bottom: 13px;
+}
+
+.weather-carousel-heading {
+  min-height: 48px;
+}
+
+.weather-carousel-heading h2 {
+  max-width: 360px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.weather-carousel-track {
+  display: flex;
   flex: 1 1 auto;
+  gap: 0;
   min-height: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  touch-action: pan-x;
+}
+
+.weather-carousel-track::-webkit-scrollbar {
+  display: none;
+}
+
+.weather-carousel-slide {
+  flex: 0 0 100%;
+  min-width: 0;
+  padding-top: 8px;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}
+
+.weather-slide-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+}
+
+.weather-visual-layout {
+  align-items: center;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(104px, 0.42fr) minmax(0, 1fr);
+  min-height: 142px;
 }
 
 .metar-code {
@@ -637,6 +687,11 @@ body {
   max-height: 156px;
   overflow: auto;
   white-space: pre-wrap;
+}
+
+.weather-metar-code {
+  margin-top: 2px;
+  max-height: 134px;
 }
 
 .panel-error {
@@ -653,6 +708,232 @@ body {
   gap: 7px 18px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   margin: 14px 0 0;
+}
+
+.weather-metric-line {
+  border-top: 1px solid var(--atc-line);
+  display: grid;
+  gap: 6px;
+  padding-top: 8px;
+}
+
+.weather-metric-line span,
+.threshold-meter span {
+  align-items: center;
+  color: var(--atc-faint);
+  display: inline-flex;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  gap: 6px;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+}
+
+.weather-metric-line strong,
+.threshold-meter strong {
+  color: var(--atc-text);
+  font-size: 19px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.weather-context-copy {
+  color: color-mix(in oklab, var(--atc-text) 70%, transparent);
+  font-size: 12px;
+  line-height: 1.38;
+  margin: 0;
+}
+
+.flight-rule-banner {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+}
+
+.flight-rule-banner span {
+  border-radius: 10px;
+  color: white;
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1;
+  padding: 7px 10px;
+}
+
+.flight-rule-banner strong {
+  font-size: 19px;
+  font-weight: 900;
+  line-height: 1.05;
+}
+
+.weather-two-up,
+.temperature-readout {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.threshold-meter {
+  display: grid;
+  gap: 6px;
+}
+
+.threshold-track {
+  background: linear-gradient(90deg, #e12aa2 0 24%, #ff453a 24% 48%, #2f8cff 48% 74%, #19c37d 74% 100%);
+  border-radius: var(--atc-radius-pill);
+  height: 6px;
+  position: relative;
+}
+
+.threshold-track i {
+  background: var(--atc-bg);
+  border: 2px solid #19c37d;
+  border-radius: 50%;
+  height: 13px;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 13px;
+}
+
+.wind-rose,
+.pressure-dial,
+.cloud-cover-orbit,
+.local-weather-glyph {
+  align-items: center;
+  aspect-ratio: 1;
+  background:
+    radial-gradient(circle at 50% 50%, color-mix(in oklab, var(--atc-orange) 14%, transparent), transparent 58%),
+    color-mix(in oklab, var(--atc-card) 36%, transparent);
+  border: 1px solid var(--atc-line);
+  border-radius: 999px;
+  color: var(--atc-text);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  position: relative;
+}
+
+.wind-rose::before,
+.pressure-dial::before {
+  background: repeating-conic-gradient(from 0deg, color-mix(in oklab, var(--atc-text) 32%, transparent) 0 3deg, transparent 3deg 10deg);
+  border-radius: inherit;
+  content: "";
+  inset: 12px;
+  opacity: 0.45;
+  position: absolute;
+}
+
+.wind-rose-arrow {
+  color: var(--atc-orange);
+  display: grid;
+  place-items: center;
+  position: relative;
+  transform-origin: center;
+  z-index: 1;
+}
+
+.wind-rose span,
+.pressure-dial strong,
+.cloud-cover-orbit span {
+  color: var(--atc-text);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  font-weight: 800;
+  position: relative;
+  z-index: 1;
+}
+
+.segment-bars {
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(18, 1fr);
+  height: 20px;
+}
+
+.segment-bars span {
+  align-self: end;
+  background: color-mix(in oklab, var(--atc-faint) 28%, transparent);
+  border-radius: 999px;
+  height: 11px;
+}
+
+.segment-bars span.active {
+  background: #38bdf8;
+  box-shadow: 0 0 10px rgba(56, 189, 248, 0.22);
+}
+
+.segment-bars--orange span.active {
+  background: var(--atc-orange);
+  box-shadow: 0 0 10px rgba(255, 90, 31, 0.24);
+}
+
+.cloud-cover-orbit {
+  flex-direction: row;
+  gap: 8px;
+  margin-inline: auto;
+  width: min(128px, 42%);
+}
+
+.cloud-cover-orbit svg {
+  color: var(--atc-orange);
+}
+
+.cloud-cover-orbit span {
+  font-size: 20px;
+}
+
+.cloud-layer-list,
+.local-weather-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.cloud-layer-list span,
+.local-weather-grid span {
+  border: 1px solid var(--atc-line);
+  border-radius: var(--atc-radius-pill);
+  color: var(--atc-dim);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  padding: 5px 8px;
+  text-transform: uppercase;
+}
+
+.dew-spread-meter {
+  display: grid;
+  gap: 7px;
+}
+
+.dew-spread-meter span {
+  color: var(--atc-faint);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+}
+
+.dew-spread-meter strong {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.pressure-dial strong {
+  font-size: 14px;
+  text-align: center;
+}
+
+.pressure-dial svg {
+  color: var(--atc-orange);
+  position: relative;
+  z-index: 1;
+}
+
+.local-weather-glyph {
+  color: #ffd24a;
+  text-shadow: 0 0 24px rgba(255, 210, 74, 0.25);
 }
 
 .weather-readout div {
@@ -686,6 +967,10 @@ body {
   justify-content: center;
   margin-top: 12px;
   position: relative;
+}
+
+.weather-carousel-dots {
+  margin-top: 9px;
 }
 
 .weather-view-dots button {


### PR DESCRIPTION
## Summary
- replace the airport weather panel with a swipeable carousel covering METAR, flight rules, wind, cloud layers, temperature/dewpoint, pressure, and local weather
- add compact aviation-focused visualizations for flight rules, wind, cloud cover, dewpoint spread, pressure, and Open-Meteo local conditions
- add a same-origin Open-Meteo current weather proxy plus client hook for free no-key local weather data

## Verification
- pnpm lint
- pnpm build
- pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent

## Source note
- Open-Meteo docs describe the forecast endpoint, current variables, and no-key public access for non-commercial use.