### PR TITLE
Resilience, component reorg, About page, and design tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 
 # Playwright operations
 .playwright-mcp
+*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ docs/superpowers
 *.log
 *.local
 dist-ssr
+
+# Playwright operations
+.playwright-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,29 @@ Frontend runs on `http://localhost:3000` by default.
 | `src/utils/airport.js` | Shared airport display helpers (`airportSubtitle`) |
 | `src/data/airportFallbacks.js` | Fallback airport metadata and coordinates |
 
+## Styling — Tailwind first
+
+This project uses **Tailwind CSS v4**. When adding or changing styles, reach for Tailwind utilities in JSX *before* writing custom CSS in `src/style.css`. Custom CSS is reserved for cases utilities can't express cleanly.
+
+Decision order when styling something:
+
+1. **Tailwind utility classes** in JSX (`flex`, `gap-2`, `text-[12px]`, `bg-atc-card`, etc.) — preferred default.
+2. **Tailwind arbitrary values** (`bg-[var(--tone-card-soft)]`, `rounded-[var(--atc-radius-panel)]`) when a one-off needs an existing CSS variable.
+3. **Custom CSS in `src/style.css`** only for things utilities can't do, e.g.:
+   - Multi-layer gradient backgrounds and `color-mix()` blends.
+   - `::before` / `::after` decorative pseudo-elements.
+   - Theme-aware overrides under `[data-theme="..."]` selectors.
+   - Animations (`@keyframes`) and `prefers-reduced-motion` blocks.
+   - Leaflet/marker DOM that we don't own and can't pass classes to.
+
+When you do write custom CSS, follow the existing DRY patterns:
+
+- **Use the existing tokens.** `:root` defines `--atc-*` (theme colors) and `--tone-*` (composed `color-mix` blends like `--tone-card-soft`, `--tone-border-firm`, `--tone-orange-warm`). Reuse them instead of re-typing `color-mix(in oklab, var(--atc-card) 62%, transparent)`. If you need a new tone variant, add a token in `:root` rather than inlining it at the use site.
+- **Merge selectors that share a declaration block** with comma-separated lists (e.g. `.search-row, .about-source { ... }`) — don't duplicate the rule.
+- **Tailwind v4 quirks**: `normal-case` no longer exists; use `capitalize` (or rewrite the source text) when you need to override an inherited `uppercase`. Theme tokens declared in `@theme inline` at the top of `style.css` become utility classes (e.g. `bg-atc-card`); add new theme colors there if you want utility access.
+
+Watch the dev server (`pnpm run dev`) for layout regressions after touching `style.css` — many panels share the same surface tokens, so a token edit ripples broadly by design.
+
 ## Build
 
 ```bash

--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -1,58 +1,236 @@
-import { Github, Info, X } from "lucide-react";
+import Link from "next/link";
+import { ArrowUpRight, Github } from "lucide-react";
+import { Badge } from "../../components/ui/badge.jsx";
+import BackgroundRays from "../../components/effects/BackgroundRays.jsx";
+import Logo from "../../components/brand/Logo.jsx";
+
+export const metadata = {
+  title: "About · ADSBao",
+};
+
+const buildMeta = [
+  { label: "Version", value: "0.8.0" },
+  { label: "Release", value: "Next.js Web" },
+  { label: "Stack", value: "React 19 · Next 16 · Leaflet" },
+  { label: "Scope", value: "Maps · Weather · Traffic" },
+];
+
+const dataSources = [
+  {
+    glyph: "METAR",
+    title: "Aviation Weather METAR",
+    description: "Live observations and decoded sky conditions for each airport.",
+    host: "aviationweather.gov",
+    href: "https://aviationweather.gov/data/api/",
+  },
+  {
+    glyph: "ADS-B",
+    title: "adsb.lol Aircraft Feed",
+    description: "Crowdsourced ADS-B positions used to render nearby traffic.",
+    host: "api.adsb.lol",
+    href: "https://api.adsb.lol/",
+  },
+  {
+    glyph: "ROUTE",
+    title: "adsbdb Flight Routes",
+    description: "Callsign-to-route lookup for origin and destination airports.",
+    host: "adsbdb.com",
+    href: "https://www.adsbdb.com/",
+  },
+  {
+    glyph: "WX",
+    title: "Open-Meteo Current Weather",
+    description: "Local temperature, wind, and conditions for the airport area.",
+    host: "open-meteo.com",
+    href: "https://open-meteo.com/",
+  },
+  {
+    glyph: "DIR",
+    title: "Airports API Directory",
+    description: "ICAO/IATA directory powering search and resolution.",
+    host: "airportsapi.com",
+    href: "https://airportsapi.com/",
+  },
+  {
+    glyph: "WIKI",
+    title: "Wikipedia Summary",
+    description: "First-paragraph summaries for airport context cards.",
+    host: "en.wikipedia.org",
+    href: "https://en.wikipedia.org/api/rest_v1/",
+  },
+  {
+    glyph: "MAP",
+    title: "OpenStreetMap · CartoDB",
+    description: "Light and dark base map tiles plus reference labels.",
+    host: "cartocdn.com",
+    href: "https://carto.com/attributions",
+  },
+];
 
 export default function AboutPage() {
   return (
-    <div className="flex min-h-screen flex-col bg-atc-bg text-atc-text">
-      <div className="mx-auto mt-20 w-full max-w-xl rounded-2xl border border-atc-line bg-atc-card p-8 shadow-sm">
-        <div className="mb-10 flex items-center gap-4">
-          <div className="rounded-2xl border border-atc-line-strong p-3 shadow-2xl">
-            <Info className="h-6 w-6" />
-          </div>
-          <h1 className="text-3xl uppercase">About</h1>
+    <div className="about-screen min-h-screen text-atc-text">
+      <BackgroundRays />
+      <main className="mx-auto flex min-h-screen w-full max-w-[920px] flex-col px-5 pb-16 pt-7 sm:px-10 sm:pt-10 lg:px-14">
+        <div className="flex items-center gap-2.5 font-mono text-[11px] uppercase tracking-[1.4px] text-atc-dim">
+          <Link
+            href="/"
+            className="flex items-center gap-2.5 text-atc-text transition-colors hover:text-atc-orange"
+          >
+            <Logo size={20} />
+            <span>ADSBao</span>
+          </Link>
+          <span className="text-atc-orange">/</span>
+          <span>About</span>
         </div>
 
-        <div className="space-y-8">
-          <div className="space-y-4">
-            <h2 className="text-xl uppercase">ADSBao</h2>
-            <p className="text-sm leading-relaxed text-atc-dim">
-              ADSBao is an airport explorer focused on airport lookup, weather
-              context, and nearby traffic visualization.
-            </p>
+        <header className="about-hero relative mt-8 overflow-hidden rounded-[var(--atc-radius-panel)] border border-atc-line bg-atc-card px-6 py-7 sm:mt-12 sm:px-8 sm:py-9">
+          <div className="flex flex-col gap-3 font-mono text-[10px] uppercase tracking-[1.6px] text-atc-faint sm:flex-row sm:items-center sm:gap-4">
+            <span className="inline-flex items-center gap-2 text-atc-orange">
+              <span className="h-1.5 w-1.5 rounded-full bg-atc-orange shadow-[0_0_8px_var(--atc-orange)]" />
+              RUNWAY 0.8.0
+            </span>
+            <span className="hidden text-atc-line-strong sm:inline">·</span>
+            <span>FLIGHT PROGRESS STRIP</span>
+            <span className="hidden text-atc-line-strong sm:inline">·</span>
+            <span>BUILT FOR THE WEB</span>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div className="rounded-2xl border border-atc-line p-4">
-              <span className="mb-1 block text-[10px] uppercase text-atc-faint">
-                Version
-              </span>
-              <span className="text-sm">0.8.0 - Next.js Web</span>
-            </div>
-            <div className="rounded-2xl border border-atc-line p-4">
-              <span className="mb-1 block text-[10px] uppercase text-atc-faint">
-                Focus
-              </span>
-              <span className="text-sm">Maps · Weather · Traffic</span>
-            </div>
-          </div>
+          <h1 className="about-title mt-4 leading-[0.85] tracking-[-0.02em]">
+            <span className="font-extrabold">ADSB</span>
+            <span className="font-display italic text-atc-orange">ao</span>
+          </h1>
 
-          <div className="flex flex-col gap-4 border-t border-atc-line pt-8">
-            <a
-              href="https://github.com/orriduck/ADSBao"
-              target="_blank"
-              rel="noreferrer"
-              className="group flex items-center justify-between rounded-2xl border border-atc-line p-4 transition-all hover:bg-atc-elev"
-            >
-              <div className="flex items-center gap-3">
-                <Github className="h-5 w-5 text-atc-dim transition-colors group-hover:text-atc-text" />
-                <span className="text-sm text-atc-dim transition-colors group-hover:text-atc-text">
-                  Source Code
+          <p className="mt-5 max-w-[560px] text-[14px] leading-relaxed text-atc-text/85 sm:text-[15px]">
+            An airport explorer that stitches together live ATC weather, nearby
+            ADS-B traffic, and reference cartography into one quiet console.
+            Built to feel like reading a flight progress strip — at a glance,
+            no clutter.
+          </p>
+
+          <div className="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-[var(--atc-radius-control)] border border-atc-line bg-atc-line text-left sm:grid-cols-4">
+            {buildMeta.map((item) => (
+              <div
+                key={item.label}
+                className="flex min-w-0 flex-col gap-0.5 bg-atc-card px-3 py-2.5"
+              >
+                <span className="font-mono text-[9px] uppercase tracking-[1.6px] text-atc-faint">
+                  {item.label}
+                </span>
+                <span className="truncate text-[12px] font-semibold text-atc-text">
+                  {item.value}
                 </span>
               </div>
-              <X className="h-4 w-4 rotate-45 text-atc-faint" />
-            </a>
+            ))}
           </div>
-        </div>
-      </div>
+        </header>
+
+        <section className="mt-12 sm:mt-16">
+          <div className="flex items-end justify-between gap-4 border-b border-atc-line pb-3">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[1.6px] text-atc-faint">
+                Frequencies
+              </div>
+              <h2 className="mt-1 font-display text-[26px] italic leading-[1] text-atc-text sm:text-[30px]">
+                Data sources
+              </h2>
+            </div>
+            <Badge variant="atcCode" className="hidden sm:inline-flex">
+              {dataSources.length} feeds
+            </Badge>
+          </div>
+
+          <ol className="mt-3 grid gap-2">
+            {dataSources.map((source, index) => (
+              <li key={source.glyph}>
+                <a
+                  href={source.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="about-source group grid w-full grid-cols-[72px_minmax(0,1fr)_auto] items-center gap-3 rounded-[var(--atc-radius-control)] border border-atc-line bg-atc-card px-3.5 py-3 transition-colors hover:border-atc-line-strong hover:bg-atc-elev sm:grid-cols-[92px_minmax(0,1fr)_auto] sm:px-4 sm:py-3.5"
+                >
+                  <span className="flex flex-col gap-0.5">
+                    <span className="font-mono text-[9px] uppercase tracking-[1.6px] text-atc-faint">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <span className="font-display text-[20px] italic leading-[0.9] text-atc-orange sm:text-[22px]">
+                      {source.glyph}
+                    </span>
+                  </span>
+                  <span className="min-w-0">
+                    <strong className="block truncate text-[13px] font-extrabold text-atc-text sm:text-[14px]">
+                      {source.title}
+                    </strong>
+                    <small className="mt-0.5 block truncate text-[12px] text-atc-dim">
+                      {source.description}
+                    </small>
+                  </span>
+                  <span className="hidden items-center gap-2.5 sm:flex">
+                    <span className="font-mono text-[10px] uppercase tracking-[1.4px] text-atc-dim transition-colors group-hover:text-atc-text">
+                      {source.host}
+                    </span>
+                    <ArrowUpRight
+                      className="h-4 w-4 text-atc-faint transition-colors group-hover:text-atc-orange"
+                      aria-hidden="true"
+                    />
+                  </span>
+                  <ArrowUpRight
+                    className="h-4 w-4 text-atc-faint transition-colors group-hover:text-atc-orange sm:hidden"
+                    aria-hidden="true"
+                  />
+                </a>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="mt-12 sm:mt-16">
+          <div className="flex items-end justify-between border-b border-atc-line pb-3">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[1.6px] text-atc-faint">
+                Source
+              </div>
+              <h2 className="mt-1 font-display text-[26px] italic leading-[1] text-atc-text sm:text-[30px]">
+                Repository
+              </h2>
+            </div>
+          </div>
+          <a
+            href="https://github.com/orriduck/ADSBao"
+            target="_blank"
+            rel="noreferrer"
+            className="about-source group mt-3 flex items-center justify-between gap-3 rounded-[var(--atc-radius-control)] border border-atc-line bg-atc-card px-3.5 py-3 transition-colors hover:border-atc-line-strong hover:bg-atc-elev sm:px-4 sm:py-4"
+          >
+            <div className="flex items-center gap-3">
+              <span className="grid h-9 w-9 place-items-center rounded-full border border-atc-line bg-atc-bg text-atc-text">
+                <Github className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
+              <div>
+                <strong className="block text-[13px] font-extrabold text-atc-text sm:text-[14px]">
+                  orriduck / ADSBao
+                </strong>
+                <small className="mt-0.5 block text-[12px] text-atc-dim">
+                  Public source, MIT-leaning. Issues and PRs welcome.
+                </small>
+              </div>
+            </div>
+            <span className="flex items-center gap-2.5">
+              <span className="hidden font-mono text-[10px] uppercase tracking-[1.4px] text-atc-dim transition-colors group-hover:text-atc-text sm:inline">
+                github.com
+              </span>
+              <ArrowUpRight
+                className="h-4 w-4 text-atc-faint transition-colors group-hover:text-atc-orange"
+                aria-hidden="true"
+              />
+            </span>
+          </a>
+        </section>
+
+        <footer className="mt-14 flex flex-col gap-2 border-t border-atc-line pt-5 font-mono text-[10px] uppercase tracking-[1.6px] text-atc-faint sm:flex-row sm:items-center sm:justify-between">
+          <span>END OF TRANSMISSION · ADSBao 0.8.0</span>
+          <span>Map tiles © OpenStreetMap · CartoDB</span>
+        </footer>
+      </main>
     </div>
   );
 }

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <rect width="32" height="32" rx="6" fill="#12151A"/>
+  <g transform="rotate(22 16 11)">
+    <path d="M16 4 L20 17 L16 14.5 L12 17 Z" fill="#FF5A1F"/>
+  </g>
+  <line x1="4.5" y1="20.5" x2="27.5" y2="20.5" stroke="#F5F5F7" stroke-width="1" stroke-dasharray="1 2.5" stroke-linecap="round" opacity="0.45"/>
+  <line x1="9" y1="26" x2="23" y2="26" stroke="#F5F5F7" stroke-width="1.4" stroke-linecap="round" opacity="0.7"/>
+  <circle cx="16" cy="26" r="1.6" fill="#FF5A1F"/>
+</svg>

--- a/src/components/brand/Logo.jsx
+++ b/src/components/brand/Logo.jsx
@@ -1,0 +1,54 @@
+const ACCENT = "#FF5A1F";
+
+export default function Logo({
+  size = 24,
+  className = "",
+  ariaLabel = "ADSBao",
+  ...rest
+}) {
+  return (
+    <svg
+      role="img"
+      aria-label={ariaLabel}
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...rest}
+    >
+      <g transform="rotate(22 16 11)">
+        <path
+          d="M16 4 L20 17 L16 14.5 L12 17 Z"
+          fill={ACCENT}
+        />
+      </g>
+
+      <line
+        x1="4.5"
+        y1="20.5"
+        x2="27.5"
+        y2="20.5"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeDasharray="1 2.5"
+        strokeLinecap="round"
+        opacity="0.45"
+      />
+
+      <line
+        x1="9"
+        y1="26"
+        x2="23"
+        y2="26"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        opacity="0.7"
+      />
+
+      <circle cx="16" cy="26" r="1.6" fill={ACCENT} />
+    </svg>
+  );
+}

--- a/src/components/effects/BackgroundRays.jsx
+++ b/src/components/effects/BackgroundRays.jsx
@@ -18,6 +18,7 @@ export default function BackgroundRays() {
         noiseAmount={0.06}
         distortion={0.04}
         saturation={0.9}
+        pulsating={true}
       />
     </div>
   );

--- a/src/components/effects/BackgroundRays.jsx
+++ b/src/components/effects/BackgroundRays.jsx
@@ -1,0 +1,24 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const LightRays = dynamic(() => import("./LightRays.jsx"), { ssr: false });
+
+export default function BackgroundRays() {
+  return (
+    <div className="background-rays" aria-hidden="true">
+      <LightRays
+        raysOrigin="top-center"
+        raysColor="#FF5A1F"
+        raysSpeed={0.9}
+        lightSpread={0.85}
+        rayLength={1.4}
+        followMouse
+        mouseInfluence={0.08}
+        noiseAmount={0.06}
+        distortion={0.04}
+        saturation={0.9}
+      />
+    </div>
+  );
+}

--- a/src/components/effects/LightRays.css
+++ b/src/components/effects/LightRays.css
@@ -1,0 +1,8 @@
+.light-rays-container {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  pointer-events: none;
+  z-index: 3;
+  overflow: hidden;
+}

--- a/src/components/effects/LightRays.jsx
+++ b/src/components/effects/LightRays.jsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useRef, useEffect, useState } from "react";
+import { Renderer, Program, Triangle, Mesh } from "ogl";
+import "./LightRays.css";
+
+const DEFAULT_COLOR = "#ffffff";
+
+const hexToRgb = (hex) => {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return m
+    ? [
+        parseInt(m[1], 16) / 255,
+        parseInt(m[2], 16) / 255,
+        parseInt(m[3], 16) / 255,
+      ]
+    : [1, 1, 1];
+};
+
+const getAnchorAndDir = (origin, w, h) => {
+  const outside = 0.2;
+  switch (origin) {
+    case "top-left":
+      return { anchor: [0, -outside * h], dir: [0, 1] };
+    case "top-right":
+      return { anchor: [w, -outside * h], dir: [0, 1] };
+    case "left":
+      return { anchor: [-outside * w, 0.5 * h], dir: [1, 0] };
+    case "right":
+      return { anchor: [(1 + outside) * w, 0.5 * h], dir: [-1, 0] };
+    case "bottom-left":
+      return { anchor: [0, (1 + outside) * h], dir: [0, -1] };
+    case "bottom-center":
+      return { anchor: [0.5 * w, (1 + outside) * h], dir: [0, -1] };
+    case "bottom-right":
+      return { anchor: [w, (1 + outside) * h], dir: [0, -1] };
+    default:
+      return { anchor: [0.5 * w, -outside * h], dir: [0, 1] };
+  }
+};
+
+const LightRays = ({
+  raysOrigin = "top-center",
+  raysColor = DEFAULT_COLOR,
+  raysSpeed = 1,
+  lightSpread = 1,
+  rayLength = 2,
+  pulsating = false,
+  fadeDistance = 1.0,
+  saturation = 1.0,
+  followMouse = true,
+  mouseInfluence = 0.1,
+  noiseAmount = 0.0,
+  distortion = 0.0,
+  className = "",
+}) => {
+  const containerRef = useRef(null);
+  const uniformsRef = useRef(null);
+  const rendererRef = useRef(null);
+  const mouseRef = useRef({ x: 0.5, y: 0.5 });
+  const smoothMouseRef = useRef({ x: 0.5, y: 0.5 });
+  const animationIdRef = useRef(null);
+  const meshRef = useRef(null);
+  const cleanupFunctionRef = useRef(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const observerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        setIsVisible(entry.isIntersecting);
+      },
+      { threshold: 0.1 },
+    );
+
+    observerRef.current.observe(containerRef.current);
+
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible || !containerRef.current) return;
+
+    if (cleanupFunctionRef.current) {
+      cleanupFunctionRef.current();
+      cleanupFunctionRef.current = null;
+    }
+
+    const initializeWebGL = async () => {
+      if (!containerRef.current) return;
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      if (!containerRef.current) return;
+
+      const renderer = new Renderer({
+        dpr: Math.min(window.devicePixelRatio, 2),
+        alpha: true,
+      });
+      rendererRef.current = renderer;
+
+      const gl = renderer.gl;
+      gl.canvas.style.width = "100%";
+      gl.canvas.style.height = "100%";
+
+      while (containerRef.current.firstChild) {
+        containerRef.current.removeChild(containerRef.current.firstChild);
+      }
+      containerRef.current.appendChild(gl.canvas);
+
+      const vert = `
+attribute vec2 position;
+varying vec2 vUv;
+void main() {
+  vUv = position * 0.5 + 0.5;
+  gl_Position = vec4(position, 0.0, 1.0);
+}`;
+
+      const frag = `precision highp float;
+
+uniform float iTime;
+uniform vec2  iResolution;
+
+uniform vec2  rayPos;
+uniform vec2  rayDir;
+uniform vec3  raysColor;
+uniform float raysSpeed;
+uniform float lightSpread;
+uniform float rayLength;
+uniform float pulsating;
+uniform float fadeDistance;
+uniform float saturation;
+uniform vec2  mousePos;
+uniform float mouseInfluence;
+uniform float noiseAmount;
+uniform float distortion;
+
+varying vec2 vUv;
+
+float noise(vec2 st) {
+  return fract(sin(dot(st.xy, vec2(12.9898,78.233))) * 43758.5453123);
+}
+
+float rayStrength(vec2 raySource, vec2 rayRefDirection, vec2 coord,
+                  float seedA, float seedB, float speed) {
+  vec2 sourceToCoord = coord - raySource;
+  vec2 dirNorm = normalize(sourceToCoord);
+  float cosAngle = dot(dirNorm, rayRefDirection);
+
+  float distortedAngle = cosAngle + distortion * sin(iTime * 2.0 + length(sourceToCoord) * 0.01) * 0.2;
+
+  float spreadFactor = pow(max(distortedAngle, 0.0), 1.0 / max(lightSpread, 0.001));
+
+  float distance = length(sourceToCoord);
+  float maxDistance = iResolution.x * rayLength;
+  float lengthFalloff = clamp((maxDistance - distance) / maxDistance, 0.0, 1.0);
+
+  float fadeFalloff = clamp((iResolution.x * fadeDistance - distance) / (iResolution.x * fadeDistance), 0.5, 1.0);
+  float pulse = pulsating > 0.5 ? (0.8 + 0.2 * sin(iTime * speed * 3.0)) : 1.0;
+
+  float baseStrength = clamp(
+    (0.45 + 0.15 * sin(distortedAngle * seedA + iTime * speed)) +
+    (0.3 + 0.2 * cos(-distortedAngle * seedB + iTime * speed)),
+    0.0, 1.0
+  );
+
+  return baseStrength * lengthFalloff * fadeFalloff * spreadFactor * pulse;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 coord = vec2(fragCoord.x, iResolution.y - fragCoord.y);
+
+  vec2 finalRayDir = rayDir;
+  if (mouseInfluence > 0.0) {
+    vec2 mouseScreenPos = mousePos * iResolution.xy;
+    vec2 mouseDirection = normalize(mouseScreenPos - rayPos);
+    finalRayDir = normalize(mix(rayDir, mouseDirection, mouseInfluence));
+  }
+
+  vec4 rays1 = vec4(1.0) *
+               rayStrength(rayPos, finalRayDir, coord, 36.2214, 21.11349,
+                           1.5 * raysSpeed);
+  vec4 rays2 = vec4(1.0) *
+               rayStrength(rayPos, finalRayDir, coord, 22.3991, 18.0234,
+                           1.1 * raysSpeed);
+
+  fragColor = rays1 * 0.5 + rays2 * 0.4;
+
+  if (noiseAmount > 0.0) {
+    float n = noise(coord * 0.01 + iTime * 0.1);
+    fragColor.rgb *= (1.0 - noiseAmount + noiseAmount * n);
+  }
+
+  float brightness = 1.0 - (coord.y / iResolution.y);
+  fragColor.x *= 0.1 + brightness * 0.8;
+  fragColor.y *= 0.3 + brightness * 0.6;
+  fragColor.z *= 0.5 + brightness * 0.5;
+
+  if (saturation != 1.0) {
+    float gray = dot(fragColor.rgb, vec3(0.299, 0.587, 0.114));
+    fragColor.rgb = mix(vec3(gray), fragColor.rgb, saturation);
+  }
+
+  fragColor.rgb *= raysColor;
+}
+
+void main() {
+  vec4 color;
+  mainImage(color, gl_FragCoord.xy);
+  gl_FragColor  = color;
+}`;
+
+      const uniforms = {
+        iTime: { value: 0 },
+        iResolution: { value: [1, 1] },
+
+        rayPos: { value: [0, 0] },
+        rayDir: { value: [0, 1] },
+
+        raysColor: { value: hexToRgb(raysColor) },
+        raysSpeed: { value: raysSpeed },
+        lightSpread: { value: lightSpread },
+        rayLength: { value: rayLength },
+        pulsating: { value: pulsating ? 1.0 : 0.0 },
+        fadeDistance: { value: fadeDistance },
+        saturation: { value: saturation },
+        mousePos: { value: [0.5, 0.5] },
+        mouseInfluence: { value: mouseInfluence },
+        noiseAmount: { value: noiseAmount },
+        distortion: { value: distortion },
+      };
+      uniformsRef.current = uniforms;
+
+      const geometry = new Triangle(gl);
+      const program = new Program(gl, {
+        vertex: vert,
+        fragment: frag,
+        uniforms,
+      });
+      const mesh = new Mesh(gl, { geometry, program });
+      meshRef.current = mesh;
+
+      const updatePlacement = () => {
+        if (!containerRef.current || !renderer) return;
+
+        renderer.dpr = Math.min(window.devicePixelRatio, 2);
+
+        const { clientWidth: wCSS, clientHeight: hCSS } = containerRef.current;
+        renderer.setSize(wCSS, hCSS);
+
+        const dpr = renderer.dpr;
+        const w = wCSS * dpr;
+        const h = hCSS * dpr;
+
+        uniforms.iResolution.value = [w, h];
+
+        const { anchor, dir } = getAnchorAndDir(raysOrigin, w, h);
+        uniforms.rayPos.value = anchor;
+        uniforms.rayDir.value = dir;
+      };
+
+      const loop = (t) => {
+        if (!rendererRef.current || !uniformsRef.current || !meshRef.current) {
+          return;
+        }
+
+        uniforms.iTime.value = t * 0.001;
+
+        if (followMouse && mouseInfluence > 0.0) {
+          const smoothing = 0.92;
+
+          smoothMouseRef.current.x =
+            smoothMouseRef.current.x * smoothing +
+            mouseRef.current.x * (1 - smoothing);
+          smoothMouseRef.current.y =
+            smoothMouseRef.current.y * smoothing +
+            mouseRef.current.y * (1 - smoothing);
+
+          uniforms.mousePos.value = [
+            smoothMouseRef.current.x,
+            smoothMouseRef.current.y,
+          ];
+        }
+
+        try {
+          renderer.render({ scene: mesh });
+          animationIdRef.current = requestAnimationFrame(loop);
+        } catch (error) {
+          console.warn("WebGL rendering error:", error);
+          return;
+        }
+      };
+
+      window.addEventListener("resize", updatePlacement);
+      updatePlacement();
+      animationIdRef.current = requestAnimationFrame(loop);
+
+      cleanupFunctionRef.current = () => {
+        if (animationIdRef.current) {
+          cancelAnimationFrame(animationIdRef.current);
+          animationIdRef.current = null;
+        }
+
+        window.removeEventListener("resize", updatePlacement);
+
+        if (renderer) {
+          try {
+            const canvas = renderer.gl.canvas;
+            const loseContextExt = renderer.gl.getExtension("WEBGL_lose_context");
+            if (loseContextExt) {
+              loseContextExt.loseContext();
+            }
+
+            if (canvas && canvas.parentNode) {
+              canvas.parentNode.removeChild(canvas);
+            }
+          } catch (error) {
+            console.warn("Error during WebGL cleanup:", error);
+          }
+        }
+
+        rendererRef.current = null;
+        uniformsRef.current = null;
+        meshRef.current = null;
+      };
+    };
+
+    initializeWebGL();
+
+    return () => {
+      if (cleanupFunctionRef.current) {
+        cleanupFunctionRef.current();
+        cleanupFunctionRef.current = null;
+      }
+    };
+  }, [
+    isVisible,
+    raysOrigin,
+    raysColor,
+    raysSpeed,
+    lightSpread,
+    rayLength,
+    pulsating,
+    fadeDistance,
+    saturation,
+    followMouse,
+    mouseInfluence,
+    noiseAmount,
+    distortion,
+  ]);
+
+  useEffect(() => {
+    if (!uniformsRef.current || !containerRef.current || !rendererRef.current)
+      return;
+
+    const u = uniformsRef.current;
+    const renderer = rendererRef.current;
+
+    u.raysColor.value = hexToRgb(raysColor);
+    u.raysSpeed.value = raysSpeed;
+    u.lightSpread.value = lightSpread;
+    u.rayLength.value = rayLength;
+    u.pulsating.value = pulsating ? 1.0 : 0.0;
+    u.fadeDistance.value = fadeDistance;
+    u.saturation.value = saturation;
+    u.mouseInfluence.value = mouseInfluence;
+    u.noiseAmount.value = noiseAmount;
+    u.distortion.value = distortion;
+
+    const { clientWidth: wCSS, clientHeight: hCSS } = containerRef.current;
+    const dpr = renderer.dpr;
+    const { anchor, dir } = getAnchorAndDir(
+      raysOrigin,
+      wCSS * dpr,
+      hCSS * dpr,
+    );
+    u.rayPos.value = anchor;
+    u.rayDir.value = dir;
+  }, [
+    raysColor,
+    raysSpeed,
+    lightSpread,
+    raysOrigin,
+    rayLength,
+    pulsating,
+    fadeDistance,
+    saturation,
+    mouseInfluence,
+    noiseAmount,
+    distortion,
+  ]);
+
+  useEffect(() => {
+    const handleMouseMove = (e) => {
+      if (!containerRef.current || !rendererRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = (e.clientX - rect.left) / rect.width;
+      const y = (e.clientY - rect.top) / rect.height;
+      mouseRef.current = { x, y };
+    };
+
+    if (followMouse) {
+      window.addEventListener("mousemove", handleMouseMove);
+      return () => window.removeEventListener("mousemove", handleMouseMove);
+    }
+  }, [followMouse]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`light-rays-container ${className}`.trim()}
+    />
+  );
+};
+
+export default LightRays;

--- a/src/components/map/AircraftPosition.jsx
+++ b/src/components/map/AircraftPosition.jsx
@@ -15,11 +15,9 @@ import {
   BARO_RATE_THRESHOLD_FPM,
 } from "../../constants/aircraft.js";
 
-const getAircraftColor = (ac, showArrow, theme) => {
+const getAircraftColor = (ac, showArrow) => {
   if (ac.onGround) return AIRCRAFT_COLORS.ground;
-  if (!showArrow || ac.baroRate == null) {
-    return theme === "light" ? "#475569" : AIRCRAFT_COLORS.level;
-  }
+  if (!showArrow || ac.baroRate == null) return AIRCRAFT_COLORS.level;
   if (ac.baroRate >= BARO_RATE_THRESHOLD_FPM) return AIRCRAFT_COLORS.ascending;
   if (ac.baroRate < -BARO_RATE_THRESHOLD_FPM) return AIRCRAFT_COLORS.descending;
   return AIRCRAFT_COLORS.level;
@@ -90,7 +88,7 @@ export default function AircraftPosition({
 
   const speedKt = Number(aircraft.velocity ?? 0);
   const showArrow = speedKt >= SLOW_AIRCRAFT_THRESHOLD_KT;
-  const color = getAircraftColor(aircraft, showArrow, theme);
+  const color = getAircraftColor(aircraft, showArrow);
   const rot = Math.round(aircraft.track || 0);
   const label = (aircraft.callsign || aircraft.icao24 || "").trim();
   const routeLabel = (aircraft.flightRouteLabel || "").trim();

--- a/src/components/map/AircraftPosition.jsx
+++ b/src/components/map/AircraftPosition.jsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import NumberFlow from "@number-flow/react";
+import L from "leaflet";
+import { useMapInstance } from "./MapContext.js";
+import {
+  beginAircraftMotionState,
+  calculateAircraftVisualPosition,
+  SLOW_AIRCRAFT_THRESHOLD_KT,
+} from "../../utils/aircraftMotion.js";
+import {
+  AIRCRAFT_COLORS,
+  BARO_RATE_THRESHOLD_FPM,
+} from "../../constants/aircraft.js";
+
+const getAircraftColor = (ac, showArrow, theme) => {
+  if (ac.onGround) return AIRCRAFT_COLORS.ground;
+  if (!showArrow || ac.baroRate == null) {
+    return theme === "light" ? "#475569" : AIRCRAFT_COLORS.level;
+  }
+  if (ac.baroRate >= BARO_RATE_THRESHOLD_FPM) return AIRCRAFT_COLORS.ascending;
+  if (ac.baroRate < -BARO_RATE_THRESHOLD_FPM) return AIRCRAFT_COLORS.descending;
+  return AIRCRAFT_COLORS.level;
+};
+
+const isFiniteNumber = (value) => Number.isFinite(Number(value));
+
+export default function AircraftPosition({
+  aircraft,
+  theme = "dark",
+  showTelemetry = true,
+}) {
+  const map = useMapInstance();
+  const motionRef = useRef(null);
+  const markerRef = useRef(null);
+  const [container] = useState(() => {
+    if (typeof document === "undefined") return null;
+    const el = document.createElement("div");
+    el.style.cssText = "position:relative;display:flex;align-items:center";
+    return el;
+  });
+
+  useEffect(() => {
+    if (!map || !container) return undefined;
+    const now = Date.now();
+    motionRef.current = beginAircraftMotionState(aircraft, now);
+    const visualPos = calculateAircraftVisualPosition(motionRef.current, now);
+
+    const marker = L.marker([visualPos.lat, visualPos.lon], {
+      icon: L.divIcon({
+        className: "",
+        html: container,
+        iconSize: [18, 18],
+        iconAnchor: [9, 9],
+      }),
+    }).addTo(map);
+    markerRef.current = marker;
+
+    let rafId = requestAnimationFrame(function tick() {
+      const motion = motionRef.current;
+      if (motion) {
+        const pos = calculateAircraftVisualPosition(motion);
+        marker.setLatLng([pos.lat, pos.lon]);
+      }
+      rafId = requestAnimationFrame(tick);
+    });
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      marker.remove();
+      markerRef.current = null;
+    };
+    // We intentionally only re-run on map/container change. Aircraft data
+    // updates are handled in a separate effect that mutates motionRef.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, container]);
+
+  useEffect(() => {
+    if (!markerRef.current) return;
+    const cur = markerRef.current.getLatLng();
+    motionRef.current = beginAircraftMotionState(aircraft, Date.now(), {
+      lat: cur.lat,
+      lon: cur.lng,
+    });
+  }, [aircraft]);
+
+  if (!container) return null;
+
+  const speedKt = Number(aircraft.velocity ?? 0);
+  const showArrow = speedKt >= SLOW_AIRCRAFT_THRESHOLD_KT;
+  const color = getAircraftColor(aircraft, showArrow, theme);
+  const rot = Math.round(aircraft.track || 0);
+  const label = (aircraft.callsign || aircraft.icao24 || "").trim();
+  const routeLabel = (aircraft.flightRouteLabel || "").trim();
+  const hasTelemetry =
+    !aircraft.onGround &&
+    showArrow &&
+    isFiniteNumber(aircraft.velocity) &&
+    isFiniteNumber(aircraft.altitude);
+  const renderTelemetry = hasTelemetry && showTelemetry;
+
+  return createPortal(
+    <>
+      <Pointer color={color} rot={rot} showArrow={showArrow} />
+      <Label
+        color={color}
+        label={label}
+        routeLabel={routeLabel}
+        showArrow={showArrow}
+        renderTelemetry={renderTelemetry}
+        velocity={aircraft.velocity}
+        altitude={aircraft.altitude}
+      />
+    </>,
+    container,
+  );
+}
+
+function Pointer({ color, rot, showArrow }) {
+  if (showArrow) {
+    return (
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        style={{
+          transform: `rotate(${rot}deg)`,
+          filter: `drop-shadow(0 0 4px ${color})`,
+        }}
+      >
+        <path d="M12 2L16 20L12 17L8 20Z" fill={color} />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      width="7"
+      height="7"
+      viewBox="0 0 7 7"
+      style={{
+        filter: `drop-shadow(0 0 3px ${color})`,
+        margin: "5.5px",
+      }}
+    >
+      <circle cx="3.5" cy="3.5" r="3.5" fill={color} />
+    </svg>
+  );
+}
+
+function Label({
+  color,
+  label,
+  routeLabel,
+  showArrow,
+  renderTelemetry,
+  velocity,
+  altitude,
+}) {
+  const labelTop = showArrow && renderTelemetry ? "-4px" : "2px";
+  const left = showArrow ? 22 : 18;
+  const labelClass = routeLabel
+    ? "aircraft-label aircraft-label--route-cycle"
+    : "aircraft-label";
+
+  return (
+    <div
+      className={labelClass}
+      style={{ left: `${left}px`, top: labelTop, color }}
+    >
+      {routeLabel ? (
+        <div className="aircraft-title-cycle">
+          <div className="aircraft-label-title aircraft-callsign-state">
+            {label}
+          </div>
+          <div className="aircraft-route-label">{routeLabel}</div>
+        </div>
+      ) : (
+        <div className="aircraft-label-title">{label}</div>
+      )}
+      {renderTelemetry && (
+        <Telemetry velocity={velocity} altitude={altitude} />
+      )}
+    </div>
+  );
+}
+
+function Telemetry({ velocity, altitude }) {
+  return (
+    <div className="aircraft-telemetry">
+      <span>
+        <NumberFlow value={Math.round(Number(velocity) || 0)} />
+        kt
+      </span>
+      <span className="aircraft-telemetry-separator">|</span>
+      <span>
+        <NumberFlow value={Math.round(Number(altitude) || 0)} />
+        ft
+      </span>
+    </div>
+  );
+}

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -1,39 +1,19 @@
 "use client";
 
-/* eslint-disable react-hooks/exhaustive-deps */
-
 import { useEffect, useMemo, useRef, useState } from "react";
 import L from "leaflet";
-import {
-  beginAircraftMotionState,
-  calculateAircraftVisualPosition,
-  SLOW_AIRCRAFT_THRESHOLD_KT,
-} from "../../utils/aircraftMotion.js";
+import { MapContext } from "./MapContext.js";
+import MapTileLayers from "./MapTileLayers.jsx";
+import AreaMarker, { AIRPORT_AREA_RADIUS_NM } from "./AreaMarker.jsx";
+import AirportMarker from "./AirportMarker.jsx";
+import GroundStatsCounter from "./GroundStatsCounter.jsx";
+import AircraftPosition from "./AircraftPosition.jsx";
+import { SLOW_AIRCRAFT_THRESHOLD_KT } from "../../utils/aircraftMotion.js";
 import {
   ZOOM_APPROACH,
-  isGroundLikeAircraft as isGroundLikeAircraftForDisplay,
-  shouldShowAirportArea,
+  isGroundLikeAircraft,
 } from "../../utils/airportMapDisplay.js";
-import {
-  AIRCRAFT_COLORS,
-  BARO_RATE_THRESHOLD_FPM,
-} from "../../constants/aircraft.js";
-import { DEFAULT_WIDE_RANGE_NM } from "../../services/aviationData.js";
-
-const TILE_VARIANTS = {
-  light: {
-    base: "https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}@2x.png",
-    labels:
-      "https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}@2x.png",
-    labelOpacity: 0.66,
-  },
-  dark: {
-    base: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}@2x.png",
-    labels:
-      "https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}@2x.png",
-    labelOpacity: 0.55,
-  },
-};
+import { AIRCRAFT_COLORS } from "../../constants/aircraft.js";
 
 const trafficLegend = [
   { id: "ascending", label: "ASC", color: AIRCRAFT_COLORS.ascending },
@@ -41,9 +21,11 @@ const trafficLegend = [
   { id: "descending", label: "DESC", color: AIRCRAFT_COLORS.descending },
 ];
 
-const QUERY_RANGE_NM = DEFAULT_WIDE_RANGE_NM;
-const AIRPORT_AREA_RADIUS_NM = 2.2;
-const NM_TO_METERS = 1852;
+const resolveCurrentTheme = () =>
+  typeof document !== "undefined" &&
+  document.documentElement.getAttribute("data-theme") === "light"
+    ? "light"
+    : "dark";
 
 export default function AirportMap({
   icao = "",
@@ -59,346 +41,8 @@ export default function AirportMap({
   const mapEl = useRef(null);
   const mapRef = useRef(null);
   const sizeObs = useRef(null);
-  const baseTileLayer = useRef(null);
-  const labelTileLayer = useRef(null);
-  const airportAreaLayer = useRef(null);
-  const queryRangeLayer = useRef(null);
-  const airportInfoMarker = useRef(null);
-  const airportGroundCountMarker = useRef(null);
-  const acMarkersMap = useRef(new Map());
-  const rafId = useRef(null);
-  const [mapReady, setMapReady] = useState(false);
+  const [mapInstance, setMapInstance] = useState(null);
   const [currentTheme, setCurrentTheme] = useState(() => resolveCurrentTheme());
-
-  const latStr = lat
-    ? `${Math.abs(lat).toFixed(2)}${lat >= 0 ? "N" : "S"}`
-    : "";
-  const lonStr = lon
-    ? `${Math.abs(lon).toFixed(2)}${lon >= 0 ? "E" : "W"}`
-    : "";
-  const mapBackground = currentTheme === "light" ? "#d6dde8" : "#0e0e12";
-  const mapLabelShadowColor =
-    currentTheme === "light" ? "rgba(248,250,252,0.95)" : "#0a0a0b";
-  const mapAttributionColor =
-    currentTheme === "light" ? "rgba(18,21,26,0.45)" : "rgba(245,245,247,0.28)";
-
-  const latestProps = useRef({
-    lat,
-    lon,
-    zoom,
-    airport,
-    aircraft,
-    showMapLabels,
-    showTelemetry,
-    currentTheme,
-    icao,
-  });
-  latestProps.current = {
-    lat,
-    lon,
-    zoom,
-    airport,
-    aircraft,
-    showMapLabels,
-    showTelemetry,
-    currentTheme,
-    icao,
-  };
-
-  const helpers = useMemo(() => {
-    const removeAirportContext = () => {
-      airportAreaLayer.current?.removeFrom(mapRef.current);
-      queryRangeLayer.current?.removeFrom(mapRef.current);
-      airportInfoMarker.current?.removeFrom(mapRef.current);
-      airportGroundCountMarker.current?.removeFrom(mapRef.current);
-      airportAreaLayer.current = null;
-      queryRangeLayer.current = null;
-      airportInfoMarker.current = null;
-      airportGroundCountMarker.current = null;
-    };
-
-    const updateTileLayers = () => {
-      const map = mapRef.current;
-      if (!map) return;
-      baseTileLayer.current?.removeFrom(map);
-      labelTileLayer.current?.removeFrom(map);
-      const props = latestProps.current;
-      const variant = TILE_VARIANTS[props.currentTheme] || TILE_VARIANTS.dark;
-      baseTileLayer.current = L.tileLayer(variant.base, {
-        subdomains: "abcd",
-        maxZoom: 20,
-      }).addTo(map);
-      if (props.showMapLabels) {
-        labelTileLayer.current = L.tileLayer(variant.labels, {
-          subdomains: "abcd",
-          maxZoom: 20,
-          opacity: variant.labelOpacity,
-        }).addTo(map);
-      }
-    };
-
-    const isGroundLikeAircraft = (ac) =>
-      isGroundLikeAircraftForDisplay(ac, {
-        airportAreaRadiusNm: AIRPORT_AREA_RADIUS_NM,
-        slowAircraftThresholdKt: SLOW_AIRCRAFT_THRESHOLD_KT,
-      });
-
-    const buildAirportOverlayDetails = () => {
-      const { airport: nextAirport } = latestProps.current;
-      const details = [];
-      const runways = nextAirport?.runways;
-      if (Array.isArray(runways) && runways.length)
-        details.push(`RWY ${runways.length}`);
-      const approachCount = Number(nextAirport?.approachCount);
-      if (Number.isFinite(approachCount) && approachCount > 0) {
-        details.push(`APP ${approachCount}`);
-      }
-      return details;
-    };
-
-    const updateAirportContextOverlays = () => {
-      const map = mapRef.current;
-      const props = latestProps.current;
-      if (!map || !props.lat || !props.lon) return;
-
-      airportAreaLayer.current?.removeFrom(map);
-      queryRangeLayer.current?.removeFrom(map);
-      airportInfoMarker.current?.removeFrom(map);
-      airportGroundCountMarker.current?.removeFrom(map);
-
-      const stroke =
-        props.currentTheme === "light"
-          ? "rgba(18,21,26,0.22)"
-          : "rgba(255,255,255,0.28)";
-      const fill =
-        props.currentTheme === "light"
-          ? "rgba(18,21,26,0.06)"
-          : "rgba(255,255,255,0.05)";
-
-      if (shouldShowAirportArea(props.zoom)) {
-        airportAreaLayer.current = L.layerGroup([
-          L.circle([props.lat, props.lon], {
-            radius: AIRPORT_AREA_RADIUS_NM * NM_TO_METERS,
-            color: stroke,
-            weight: 1,
-            dashArray: "4 4",
-            fillColor: fill,
-            fillOpacity: 1,
-          }),
-        ]).addTo(map);
-      }
-
-      queryRangeLayer.current = L.circle([props.lat, props.lon], {
-        radius: QUERY_RANGE_NM * NM_TO_METERS,
-        color: stroke,
-        weight: 1,
-        dashArray: "6 6",
-        fillColor: fill,
-        fillOpacity: 1,
-      }).addTo(map);
-
-      const airportCode = escapeHtml(
-        (props.airport?.iata || props.icao || "").trim(),
-      );
-      const detailLines = buildAirportOverlayDetails()
-        .map((line) => `<span>${escapeHtml(line)}</span>`)
-        .join("");
-      airportInfoMarker.current = L.marker([props.lat, props.lon], {
-        interactive: false,
-        icon: L.divIcon({
-          className: "",
-          html: `<div class="airport-overlay-label">${airportCode}${detailLines}</div>`,
-          iconSize: [120, 34],
-          iconAnchor: [0, -8],
-        }),
-      }).addTo(map);
-
-      if (Number(props.zoom) === ZOOM_APPROACH) {
-        const groundCount = props.aircraft.filter((item) =>
-          isGroundLikeAircraft(item),
-        ).length;
-        airportGroundCountMarker.current = L.marker([props.lat, props.lon], {
-          interactive: false,
-          icon: L.divIcon({
-            className: "",
-            html: `<div class="airport-ground-count">GND ${groundCount}</div>`,
-            iconSize: [58, 18],
-            iconAnchor: [29, 24],
-          }),
-        }).addTo(map);
-      }
-    };
-
-    const makeAcIcon = (
-      color,
-      label,
-      rot = 0,
-      showArrow = true,
-      hasTelemetry = false,
-      routeLabel = "",
-    ) => {
-      const symbol = showArrow
-        ? `<svg width="18" height="18" viewBox="0 0 24 24" style="transform:rotate(${rot}deg);filter:drop-shadow(0 0 4px ${color})"><path d="M12 2L16 20L12 17L8 20Z" fill="${color}"/></svg>`
-        : `<svg width="7" height="7" viewBox="0 0 7 7" style="filter:drop-shadow(0 0 3px ${color});margin:5.5px"><circle cx="3.5" cy="3.5" r="3.5" fill="${color}"/></svg>`;
-      const safeLabel = escapeHtml(label);
-      const safeRouteLabel = escapeHtml(routeLabel);
-      const labelTop = showArrow && hasTelemetry ? "-4px" : "2px";
-      const props = latestProps.current;
-      const telemetryLine =
-        showArrow && hasTelemetry && props.showTelemetry
-          ? `<div class="aircraft-telemetry"><span>${formatTelemetryValue(props.currentAircraft?.velocity)}kt</span><span class="aircraft-telemetry-separator">|</span><span>${formatTelemetryValue(props.currentAircraft?.altitude)}ft</span></div>`
-          : "";
-      const routeLine = safeRouteLabel
-        ? `<div class="aircraft-route-label">${safeRouteLabel}</div>`
-        : "";
-      const labelClass = safeRouteLabel
-        ? "aircraft-label aircraft-label--route-cycle"
-        : "aircraft-label";
-      const titleLine = safeRouteLabel
-        ? `<div class="aircraft-title-cycle"><div class="aircraft-label-title aircraft-callsign-state">${safeLabel}</div>${routeLine}</div>`
-        : `<div class="aircraft-label-title">${safeLabel}</div>`;
-
-      return L.divIcon({
-        className: "",
-        html: `<div style="position:relative;display:flex;align-items:center">${symbol}<div class="${labelClass}" style="left:${showArrow ? 22 : 18}px;top:${labelTop};color:${color}">${titleLine}${telemetryLine}</div></div>`,
-        iconSize: [18, 18],
-        iconAnchor: [9, 9],
-      });
-    };
-
-    const getAircraftColor = (ac, showArrow) => {
-      const props = latestProps.current;
-      if (ac.onGround) return AIRCRAFT_COLORS.ground;
-      if (!showArrow || ac.baroRate == null) {
-        return props.currentTheme === "light"
-          ? "#475569"
-          : AIRCRAFT_COLORS.level;
-      }
-      if (ac.baroRate >= BARO_RATE_THRESHOLD_FPM)
-        return AIRCRAFT_COLORS.ascending;
-      if (ac.baroRate < -BARO_RATE_THRESHOLD_FPM)
-        return AIRCRAFT_COLORS.descending;
-      return AIRCRAFT_COLORS.level;
-    };
-
-    const updateAircraft = () => {
-      const map = mapRef.current;
-      const props = latestProps.current;
-      if (!map) return;
-      const now = Date.now();
-      const seen = new Set();
-      const onlyMovingAtApproach = Number(props.zoom) === ZOOM_APPROACH;
-      for (const ac of props.aircraft) {
-        const speedKt = Number(ac.velocity ?? 0);
-        const isMoving = speedKt >= SLOW_AIRCRAFT_THRESHOLD_KT;
-        const isGroundLike = isGroundLikeAircraft(ac);
-        if (onlyMovingAtApproach && (isGroundLike || !isMoving)) continue;
-        if (!ac.lat || !ac.lon) continue;
-        seen.add(ac.icao24);
-        const vel = ac.velocity ?? 0;
-        const showArrow = vel >= SLOW_AIRCRAFT_THRESHOLD_KT;
-        const isAnimated = !ac.onGround && showArrow;
-        const color = getAircraftColor(ac, showArrow);
-        const label = (ac.callsign || ac.icao24 || "").trim();
-        const routeLabel = (ac.flightRouteLabel || "").trim();
-        const rot = Math.round(ac.track || 0);
-        const hasTelemetry =
-          !ac.onGround &&
-          showArrow &&
-          formatTelemetryValue(ac.velocity) != null &&
-          formatTelemetryValue(ac.altitude) != null;
-
-        latestProps.current.currentAircraft = ac;
-        if (acMarkersMap.current.has(ac.icao24)) {
-          const entry = acMarkersMap.current.get(ac.icao24);
-          const currentLatLng = entry.marker.getLatLng();
-          const motionState = beginAircraftMotionState(ac, now, {
-            lat: currentLatLng.lat,
-            lon: currentLatLng.lng,
-          });
-          Object.assign(entry, motionState, {
-            velocity: vel,
-            track: ac.track ?? 0,
-            isAnimated,
-          });
-          if (
-            color !== entry.color ||
-            label !== entry.label ||
-            rot !== entry.rot ||
-            showArrow !== entry.showArrow ||
-            hasTelemetry !== entry.hasTelemetry ||
-            routeLabel !== entry.routeLabel ||
-            props.showTelemetry !== entry.showTelemetry
-          ) {
-            entry.marker.setIcon(
-              makeAcIcon(
-                color,
-                label,
-                rot,
-                showArrow,
-                hasTelemetry,
-                routeLabel,
-              ),
-            );
-            Object.assign(entry, {
-              color,
-              label,
-              rot,
-              showArrow,
-              hasTelemetry,
-              routeLabel,
-              showTelemetry: props.showTelemetry,
-            });
-          }
-        } else {
-          const motionState = beginAircraftMotionState(ac, now);
-          const visualPosition = calculateAircraftVisualPosition(
-            motionState,
-            now,
-          );
-          const marker = L.marker([visualPosition.lat, visualPosition.lon], {
-            icon: makeAcIcon(
-              color,
-              label,
-              rot,
-              showArrow,
-              hasTelemetry,
-              routeLabel,
-            ),
-          }).addTo(map);
-          acMarkersMap.current.set(ac.icao24, {
-            marker,
-            color,
-            label,
-            rot,
-            showArrow,
-            hasTelemetry,
-            routeLabel,
-            showTelemetry: props.showTelemetry,
-            ...motionState,
-            velocity: vel,
-            track: ac.track ?? 0,
-            isAnimated,
-          });
-        }
-      }
-
-      for (const [id, entry] of acMarkersMap.current) {
-        if (!seen.has(id)) {
-          entry.marker.remove();
-          acMarkersMap.current.delete(id);
-        }
-      }
-      updateAirportContextOverlays();
-    };
-
-    return {
-      removeAirportContext,
-      updateTileLayers,
-      updateAirportContextOverlays,
-      updateAircraft,
-    };
-  }, []);
 
   useEffect(() => {
     setCurrentTheme(resolveCurrentTheme());
@@ -424,21 +68,7 @@ export default function AirportMap({
       dragging: false,
     });
     mapRef.current = map;
-    helpers.updateTileLayers();
-    helpers.updateAirportContextOverlays();
-    setMapReady(true);
-    helpers.updateAircraft();
-
-    const animateLoop = () => {
-      if (!mapRef.current) return;
-      const now = Date.now();
-      for (const [, entry] of acMarkersMap.current) {
-        const position = calculateAircraftVisualPosition(entry, now);
-        entry.marker.setLatLng([position.lat, position.lon]);
-      }
-      rafId.current = requestAnimationFrame(animateLoop);
-    };
-    rafId.current = requestAnimationFrame(animateLoop);
+    setMapInstance(map);
 
     sizeObs.current = new ResizeObserver(() => {
       requestAnimationFrame(() => mapRef.current?.invalidateSize());
@@ -446,30 +76,49 @@ export default function AirportMap({
     sizeObs.current.observe(mapEl.current);
 
     return () => {
-      if (rafId.current != null) cancelAnimationFrame(rafId.current);
       sizeObs.current?.disconnect();
-      for (const [, entry] of acMarkersMap.current) entry.marker.remove();
-      acMarkersMap.current.clear();
-      helpers.removeAirportContext();
-      baseTileLayer.current = null;
-      labelTileLayer.current = null;
+      sizeObs.current = null;
       map.remove();
       mapRef.current = null;
+      setMapInstance(null);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    helpers.updateTileLayers();
-    helpers.updateAirportContextOverlays();
-  }, [showMapLabels, currentTheme]);
 
   useEffect(() => {
     if (mapRef.current && lat && lon) {
       mapRef.current.setView([lat, lon], zoom);
-      helpers.updateAirportContextOverlays();
-      helpers.updateAircraft();
     }
-  }, [lat, lon, zoom, aircraft, showTelemetry]);
+  }, [lat, lon, zoom]);
+
+  const onlyMovingAtApproach = Number(zoom) === ZOOM_APPROACH;
+  const visibleAircraft = useMemo(() => {
+    if (!onlyMovingAtApproach) {
+      return aircraft.filter((ac) => ac.lat != null && ac.lon != null);
+    }
+    return aircraft.filter((ac) => {
+      if (ac.lat == null || ac.lon == null) return false;
+      const speedKt = Number(ac.velocity ?? 0);
+      const isMoving = speedKt >= SLOW_AIRCRAFT_THRESHOLD_KT;
+      const isGroundLike = isGroundLikeAircraft(ac, {
+        airportAreaRadiusNm: AIRPORT_AREA_RADIUS_NM,
+        slowAircraftThresholdKt: SLOW_AIRCRAFT_THRESHOLD_KT,
+      });
+      return !isGroundLike && isMoving;
+    });
+  }, [aircraft, onlyMovingAtApproach]);
+
+  const latStr = lat
+    ? `${Math.abs(lat).toFixed(2)}${lat >= 0 ? "N" : "S"}`
+    : "";
+  const lonStr = lon
+    ? `${Math.abs(lon).toFixed(2)}${lon >= 0 ? "E" : "W"}`
+    : "";
+  const mapBackground = currentTheme === "light" ? "#d6dde8" : "#0e0e12";
+  const mapLabelShadowColor =
+    currentTheme === "light" ? "rgba(248,250,252,0.95)" : "#0a0a0b";
+  const mapAttributionColor =
+    currentTheme === "light" ? "rgba(18,21,26,0.45)" : "rgba(245,245,247,0.28)";
 
   return (
     <div className="relative h-full w-full">
@@ -479,7 +128,39 @@ export default function AirportMap({
         style={{ background: mapBackground }}
       />
 
-      {mapReady && (
+      {mapInstance && (
+        <MapContext.Provider value={mapInstance}>
+          <MapTileLayers theme={currentTheme} showLabels={showMapLabels} />
+          <AreaMarker
+            lat={lat}
+            lon={lon}
+            zoom={zoom}
+            theme={currentTheme}
+          />
+          <AirportMarker
+            lat={lat}
+            lon={lon}
+            icao={icao}
+            airport={airport}
+          />
+          <GroundStatsCounter
+            lat={lat}
+            lon={lon}
+            zoom={zoom}
+            aircraft={aircraft}
+          />
+          {visibleAircraft.map((ac) => (
+            <AircraftPosition
+              key={ac.icao24}
+              aircraft={ac}
+              theme={currentTheme}
+              showTelemetry={showTelemetry}
+            />
+          ))}
+        </MapContext.Provider>
+      )}
+
+      {mapInstance && (
         <>
           <div
             className="pointer-events-none absolute left-3.5 top-3 font-mono text-[10px] font-semibold tracking-[2px]"
@@ -516,32 +197,13 @@ export default function AirportMap({
         </>
       )}
 
-      {!mapReady ? (
+      {!mapInstance && (
         <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-atc-card">
           <div className="font-mono text-[11px] tracking-widest text-atc-faint">
             LOADING MAP...
           </div>
         </div>
-      ) : null}
+      )}
     </div>
   );
 }
-
-const resolveCurrentTheme = () =>
-  document.documentElement.getAttribute("data-theme") === "light"
-    ? "light"
-    : "dark";
-
-const escapeHtml = (value) =>
-  String(value)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-
-const formatTelemetryValue = (value) => {
-  if (value == null || value === "" || value === "ground") return null;
-  const number = Number(value);
-  return Number.isFinite(number) ? Math.round(number) : null;
-};

--- a/src/components/map/AirportMarker.jsx
+++ b/src/components/map/AirportMarker.jsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import L from "leaflet";
+import { useMapInstance } from "./MapContext.js";
+
+export default function AirportMarker({ lat, lon, icao = "", airport = null }) {
+  const map = useMapInstance();
+  const markerRef = useRef(null);
+  const [container] = useState(() =>
+    typeof document !== "undefined" ? document.createElement("div") : null,
+  );
+
+  useEffect(() => {
+    if (!map || !lat || !lon || !container) return undefined;
+    const marker = L.marker([lat, lon], {
+      interactive: false,
+      icon: L.divIcon({
+        className: "",
+        html: container,
+        iconSize: [120, 34],
+        iconAnchor: [0, -8],
+      }),
+    }).addTo(map);
+    markerRef.current = marker;
+    return () => {
+      marker.remove();
+      markerRef.current = null;
+    };
+  }, [map, lat, lon, container]);
+
+  if (!container) return null;
+
+  const code = (airport?.iata || icao || "").trim();
+  const details = [];
+  const runways = airport?.runways;
+  if (Array.isArray(runways) && runways.length) {
+    details.push(`RWY ${runways.length}`);
+  }
+  const approachCount = Number(airport?.approachCount);
+  if (Number.isFinite(approachCount) && approachCount > 0) {
+    details.push(`APP ${approachCount}`);
+  }
+
+  return createPortal(
+    <div className="airport-overlay-label">
+      {code}
+      {details.map((line) => (
+        <span key={line}>{line}</span>
+      ))}
+    </div>,
+    container,
+  );
+}

--- a/src/components/map/AreaMarker.jsx
+++ b/src/components/map/AreaMarker.jsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import { useMapInstance } from "./MapContext.js";
+import { shouldShowAirportArea } from "../../utils/airportMapDisplay.js";
+import { DEFAULT_WIDE_RANGE_NM } from "../../services/aviationData.js";
+
+export const AIRPORT_AREA_RADIUS_NM = 2.2;
+const NM_TO_METERS = 1852;
+
+export default function AreaMarker({ lat, lon, zoom, theme = "dark" }) {
+  const map = useMapInstance();
+  const closeRef = useRef(null);
+  const wideRef = useRef(null);
+
+  useEffect(() => {
+    if (!map || !lat || !lon) return undefined;
+
+    const stroke =
+      theme === "light" ? "rgba(18,21,26,0.22)" : "rgba(255,255,255,0.28)";
+    const fill =
+      theme === "light" ? "rgba(18,21,26,0.06)" : "rgba(255,255,255,0.05)";
+
+    closeRef.current?.removeFrom(map);
+    closeRef.current = null;
+    if (shouldShowAirportArea(zoom)) {
+      closeRef.current = L.circle([lat, lon], {
+        radius: AIRPORT_AREA_RADIUS_NM * NM_TO_METERS,
+        color: stroke,
+        weight: 1,
+        dashArray: "4 4",
+        fillColor: fill,
+        fillOpacity: 1,
+      }).addTo(map);
+    }
+
+    wideRef.current?.removeFrom(map);
+    wideRef.current = L.circle([lat, lon], {
+      radius: DEFAULT_WIDE_RANGE_NM * NM_TO_METERS,
+      color: stroke,
+      weight: 1,
+      dashArray: "6 6",
+      fillColor: fill,
+      fillOpacity: 1,
+    }).addTo(map);
+
+    return () => {
+      closeRef.current?.removeFrom(map);
+      wideRef.current?.removeFrom(map);
+      closeRef.current = null;
+      wideRef.current = null;
+    };
+  }, [map, lat, lon, zoom, theme]);
+
+  return null;
+}

--- a/src/components/map/GroundStatsCounter.jsx
+++ b/src/components/map/GroundStatsCounter.jsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import NumberFlow from "@number-flow/react";
+import L from "leaflet";
+import { useMapInstance } from "./MapContext.js";
+import {
+  ZOOM_APPROACH,
+  isGroundLikeAircraft,
+} from "../../utils/airportMapDisplay.js";
+import { SLOW_AIRCRAFT_THRESHOLD_KT } from "../../utils/aircraftMotion.js";
+import { AIRPORT_AREA_RADIUS_NM } from "./AreaMarker.jsx";
+
+export default function GroundStatsCounter({ lat, lon, zoom, aircraft = [] }) {
+  const map = useMapInstance();
+  const markerRef = useRef(null);
+  const [container] = useState(() =>
+    typeof document !== "undefined" ? document.createElement("div") : null,
+  );
+
+  const visible = Number(zoom) === ZOOM_APPROACH && lat && lon;
+
+  const groundCount = useMemo(() => {
+    if (!visible) return 0;
+    return aircraft.filter((item) =>
+      isGroundLikeAircraft(item, {
+        airportAreaRadiusNm: AIRPORT_AREA_RADIUS_NM,
+        slowAircraftThresholdKt: SLOW_AIRCRAFT_THRESHOLD_KT,
+      }),
+    ).length;
+  }, [aircraft, visible]);
+
+  useEffect(() => {
+    if (!map || !visible || !container) {
+      markerRef.current?.remove();
+      markerRef.current = null;
+      return undefined;
+    }
+    const marker = L.marker([lat, lon], {
+      interactive: false,
+      icon: L.divIcon({
+        className: "",
+        html: container,
+        iconSize: [58, 18],
+        iconAnchor: [29, 24],
+      }),
+    }).addTo(map);
+    markerRef.current = marker;
+    return () => {
+      marker.remove();
+      markerRef.current = null;
+    };
+  }, [map, visible, lat, lon, container]);
+
+  if (!container || !visible) return null;
+  return createPortal(
+    <div className="airport-ground-count">
+      GND <NumberFlow value={groundCount} />
+    </div>,
+    container,
+  );
+}

--- a/src/components/map/MapContext.js
+++ b/src/components/map/MapContext.js
@@ -1,0 +1,7 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export const MapContext = createContext(null);
+
+export const useMapInstance = () => useContext(MapContext);

--- a/src/components/map/MapTileLayers.jsx
+++ b/src/components/map/MapTileLayers.jsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import { useMapInstance } from "./MapContext.js";
+
+const TILE_VARIANTS = {
+  light: {
+    base: "https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}@2x.png",
+    labels:
+      "https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}@2x.png",
+    labelOpacity: 0.66,
+  },
+  dark: {
+    base: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}@2x.png",
+    labels:
+      "https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}@2x.png",
+    labelOpacity: 0.55,
+  },
+};
+
+export default function MapTileLayers({ theme = "dark", showLabels = true }) {
+  const map = useMapInstance();
+  const baseRef = useRef(null);
+  const labelRef = useRef(null);
+
+  useEffect(() => {
+    if (!map) return undefined;
+    const variant = TILE_VARIANTS[theme] || TILE_VARIANTS.dark;
+
+    baseRef.current?.removeFrom(map);
+    baseRef.current = L.tileLayer(variant.base, {
+      subdomains: "abcd",
+      maxZoom: 20,
+    }).addTo(map);
+
+    labelRef.current?.removeFrom(map);
+    if (showLabels) {
+      labelRef.current = L.tileLayer(variant.labels, {
+        subdomains: "abcd",
+        maxZoom: 20,
+        opacity: variant.labelOpacity,
+      }).addTo(map);
+    }
+
+    return () => {
+      baseRef.current?.removeFrom(map);
+      labelRef.current?.removeFrom(map);
+      baseRef.current = null;
+      labelRef.current = null;
+    };
+  }, [map, theme, showLabels]);
+
+  return null;
+}

--- a/src/components/panels/WeatherPanel.jsx
+++ b/src/components/panels/WeatherPanel.jsx
@@ -30,70 +30,78 @@ export default function WeatherPanel({
   } = useLocalWeather(airportLat, airportLon);
 
   const slides = useMemo(
-    () => [
-      {
-        id: "metar",
-        label: "METAR",
-        title: "METAR report",
-        eyebrow: "METAR / Weather",
-        content: (
-          <MetarSlide
-            metarRaw={metarRaw}
-            metarLoading={metarLoading}
-            metarError={metarError}
-          />
-        ),
-      },
-      {
-        id: "rules",
-        label: "Rules",
-        title: "Flight rules",
-        eyebrow: "Operational context",
-        content: <FlightRulesSlide metar={metar} />,
-      },
-      {
-        id: "ceiling",
-        label: "Ceiling",
-        title: "Ceiling / visibility",
-        eyebrow: "Cloud deck",
-        content: <CeilingSlide metar={metar} />,
-      },
-      {
-        id: "wind",
-        label: "Wind",
-        title: "Wind speed",
-        eyebrow: "Surface flow",
-        content: <WindSlide metar={metar} localWeather={localWeather} />,
-      },
-      {
-        id: "temp",
-        label: "Temp",
-        title: "Temp / dew",
-        eyebrow: "Thermal spread",
-        content: <TemperatureSlide metar={metar} localWeather={localWeather} />,
-      },
-      {
-        id: "pressure",
-        label: "Pressure",
-        title: "Pressure",
-        eyebrow: "Altimeter",
-        content: <PressureSlide metar={metar} localWeather={localWeather} />,
-      },
-      {
-        id: "local",
-        label: "Local",
-        title: "Local weather",
-        eyebrow: "Open-Meteo",
-        content: (
-          <LocalWeatherSlide
-            airportCode={airportCode}
-            localWeather={localWeather}
-            localWeatherError={localWeatherError}
-            localWeatherLoading={localWeatherLoading}
-          />
-        ),
-      },
-    ],
+    () => {
+      const ceilingFt = getCeilingFeet(metar);
+      const hasVisibility = metar?.rawVisib != null && Number.isFinite(Number(metar.rawVisib));
+      const shouldShowCeiling = ceilingFt != null || hasVisibility;
+
+      return [
+        {
+          id: "metar",
+          label: "METAR",
+          title: "METAR report",
+          eyebrow: "METAR / Weather",
+          content: (
+            <MetarSlide
+              metarRaw={metarRaw}
+              metarLoading={metarLoading}
+              metarError={metarError}
+            />
+          ),
+        },
+        {
+          id: "rules",
+          label: "Rules",
+          title: "Flight rules",
+          eyebrow: "Operational context",
+          content: <FlightRulesSlide metar={metar} />,
+        },
+        shouldShowCeiling
+          ? {
+              id: "ceiling",
+              label: "Ceiling",
+              title: "Ceiling / visibility",
+              eyebrow: "Cloud deck",
+              content: <CeilingSlide metar={metar} />,
+            }
+          : null,
+        {
+          id: "wind",
+          label: "Wind",
+          title: "Wind speed",
+          eyebrow: "Surface flow",
+          content: <WindSlide metar={metar} localWeather={localWeather} />,
+        },
+        {
+          id: "temp",
+          label: "Temp",
+          title: "Temp / dew",
+          eyebrow: "Thermal spread",
+          content: <TemperatureSlide metar={metar} localWeather={localWeather} />,
+        },
+        {
+          id: "pressure",
+          label: "Pressure",
+          title: "Pressure",
+          eyebrow: "Altimeter",
+          content: <PressureSlide metar={metar} localWeather={localWeather} />,
+        },
+        {
+          id: "local",
+          label: "Local",
+          title: "Local weather",
+          eyebrow: "Open-Meteo",
+          content: (
+            <LocalWeatherSlide
+              airportCode={airportCode}
+              localWeather={localWeather}
+              localWeatherError={localWeatherError}
+              localWeatherLoading={localWeatherLoading}
+            />
+          ),
+        },
+      ].filter(Boolean);
+    },
     [
       airportCode,
       localWeather,
@@ -170,6 +178,14 @@ export default function WeatherPanel({
       </div>
     </section>
   );
+}
+
+function getCeilingFeet(metar) {
+  const layer = metar?.rawClouds?.find((item) =>
+    ["BKN", "OVC", "VV"].includes(item.cover),
+  );
+  const number = Number(layer?.base);
+  return Number.isFinite(number) ? number : null;
 }
 
 function formatObsTime(value) {

--- a/src/components/panels/WeatherPanel.jsx
+++ b/src/components/panels/WeatherPanel.jsx
@@ -3,6 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import { useLocalWeather } from "../../hooks/useLocalWeather.js";
 import {
+  CeilingSlide,
   FlightRulesSlide,
   LocalWeatherSlide,
   MetarSlide,
@@ -49,6 +50,13 @@ export default function WeatherPanel({
         title: "Flight rules",
         eyebrow: "Operational context",
         content: <FlightRulesSlide metar={metar} />,
+      },
+      {
+        id: "ceiling",
+        label: "Ceiling",
+        title: "Ceiling / visibility",
+        eyebrow: "Cloud deck",
+        content: <CeilingSlide metar={metar} />,
       },
       {
         id: "wind",

--- a/src/components/screens/AirportCaptionScreen.jsx
+++ b/src/components/screens/AirportCaptionScreen.jsx
@@ -229,6 +229,22 @@ const normalizeCallsign = (callsign) =>
 function AircraftDataLoadingOverlay({ active }) {
   const [visible, setVisible] = useState(active);
   const [exiting, setExiting] = useState(false);
+  const [isLightTheme, setIsLightTheme] = useState(false);
+
+  useEffect(() => {
+    const syncTheme = () => {
+      setIsLightTheme(document.documentElement.getAttribute("data-theme") !== "dark");
+    };
+    syncTheme();
+
+    const observer = new MutationObserver(syncTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     let fadeTimer;
@@ -267,10 +283,10 @@ function AircraftDataLoadingOverlay({ active }) {
     >
       <div className="adsb-loading-orb-shell" aria-hidden="true">
         <Orb
-          backgroundColor="#0a0a0b"
+          backgroundColor={isLightTheme ? "#f8fafc" : "#0a0a0b"}
           color1="#ff5a1f"
-          color2="#ffb15f"
-          color3="#5f160b"
+          color2={isLightTheme ? "#ffd29a" : "#ffb15f"}
+          color3={isLightTheme ? "#fff4ea" : "#5f160b"}
           forceHoverState={false}
           hoverIntensity={0}
           hue={0}

--- a/src/components/screens/SearchScreen.jsx
+++ b/src/components/screens/SearchScreen.jsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Monitor, Moon, Search, Sun } from "lucide-react";
+import Link from "next/link";
+import { Info, Monitor, Moon, Search, Sun } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { HOME_AIRPORT_COUNTRY } from "../../config/homeAirportDirectory.js";
 import { airportDirectoryClient } from "../../services/airportDirectory.js";
@@ -17,6 +18,8 @@ import {
 import { Badge } from "../ui/badge.jsx";
 import { Button } from "../ui/button.jsx";
 import { Input } from "../ui/input.jsx";
+import BackgroundRays from "../effects/BackgroundRays.jsx";
+import Logo from "../brand/Logo.jsx";
 
 const featuredAirports = [
   {
@@ -224,25 +227,40 @@ export default function SearchScreen({ onOpenAirport }) {
 
   return (
     <div className="search-screen min-h-screen text-atc-text">
+      <BackgroundRays />
       <main className="grid min-h-screen place-items-start px-5 py-6 sm:place-items-center sm:p-10 lg:p-14">
         <section className="w-full max-w-[860px]">
           <div className="mb-4 flex items-center justify-between gap-2.5 font-mono text-[11px] uppercase tracking-[1.4px] text-atc-dim">
             <div className="flex items-center gap-2.5">
+              <Logo size={20} className="text-atc-text" />
               <span className="text-atc-text">ADSBao</span>
               <span className="text-atc-orange">/</span>
               <span>Airport search</span>
             </div>
-            <Button
-              type="button"
-              variant="atcChip"
-              size="sm"
-              className="theme-chip gap-1.5 text-[12px] tracking-[0.2px]"
-              title={themeTitle}
-              onClick={cycleTheme}
-            >
-              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-              <span>{themePreference}</span>
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                asChild
+                variant="atcChip"
+                size="sm"
+                className="theme-chip gap-1.5 text-[12px] capitalize tracking-[0.2px]"
+              >
+                <Link href="/about" title="About ADSBao">
+                  <Info className="h-3.5 w-3.5" aria-hidden="true" />
+                  <span>About</span>
+                </Link>
+              </Button>
+              <Button
+                type="button"
+                variant="atcChip"
+                size="sm"
+                className="theme-chip gap-1.5 text-[12px] capitalize tracking-[0.2px]"
+                title={themeTitle}
+                onClick={cycleTheme}
+              >
+                <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                <span>{themePreference}</span>
+              </Button>
+            </div>
           </div>
 
           <form
@@ -260,7 +278,7 @@ export default function SearchScreen({ onOpenAirport }) {
               onChange={(event) => setQ(event.target.value)}
               onFocus={() => setFocused(true)}
               onBlur={() => setFocused(false)}
-              className="flex-1 p-0 text-2xl font-extrabold tracking-normal text-atc-text sm:text-3xl"
+              className="flex-1 p-0 text-lg font-extrabold tracking-normal text-atc-text sm:text-xl"
               placeholder="Search by ICAO, IATA, city, or airport name"
             />
             <kbd className="search-kbd hidden shrink-0 items-center rounded-[var(--atc-radius-control)] px-2 py-1 font-mono text-[10px] uppercase tracking-[1px] text-atc-dim sm:inline-flex">

--- a/src/components/ui/Orb.jsx
+++ b/src/components/ui/Orb.jsx
@@ -158,7 +158,16 @@ export default function Orb({
       lightCol = mix(backgroundColor, lightCol, v0);
       lightCol = clamp(lightCol, 0.0, 1.0);
 
-      vec3 finalCol = mix(darkCol, lightCol, bgLuminance);
+      float mask = v2 * v3;
+      vec3 maskColor = mix(vec3(0.0), backgroundColor, bgLuminance);
+      vec3 innerColor = mix(darkCol, lightCol, bgLuminance);
+      vec3 blendedColor = mix(maskColor, innerColor, v3 * v3);
+      float dimFactor = 1.0 - bgLuminance;
+      // In light mode: gate v0 by v3 so interior pixels (v3=0) contribute nothing,
+      // preventing the ring glow from filling the transparent interior as a grey disc.
+      // In dark mode (dimFactor=1): effectiveV0 = v0, original behavior preserved.
+      float effectiveV0 = mix(v0 * v3, v0, dimFactor);
+      vec3 finalCol = mix(maskColor * mask * dimFactor, blendedColor, effectiveV0);
 
       return extractAlpha(finalCol);
     }

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -88,26 +88,6 @@ export function MetarSlide({ metarRaw, metarLoading, metarError }) {
 export function FlightRulesSlide({ metar }) {
   const code = metar?.flightCategory || "VFR";
   const rules = FLIGHT_RULES[code] || FLIGHT_RULES.VFR;
-  const visibility = toNumber(metar?.rawVisib);
-  const ceilingFt = getCeilingFeet(metar);
-  const detailMeters = [
-    ceilingFt == null
-      ? null
-      : {
-          icon: <Cloud size={16} />,
-          label: "Ceiling",
-          marker: Math.min(1, ceilingFt / 3000),
-          value: `${ceilingFt.toLocaleString()} ft`,
-        },
-    visibility == null
-      ? null
-      : {
-          icon: <Eye size={16} />,
-          label: "Visibility",
-          marker: Math.min(1, visibility / 5),
-          value: `${visibility >= 10 ? "10+" : visibility} SM`,
-        },
-  ].filter(Boolean);
 
   return (
     <div className="weather-slide-stack">
@@ -125,21 +105,43 @@ export function FlightRulesSlide({ metar }) {
             />
           ))}
         </div>
-        {detailMeters.length ? (
-          <div className={`weather-two-up weather-two-up--${detailMeters.length}`}>
-            {detailMeters.map((item) => (
-              <ThresholdMeter
-                key={item.label}
-                icon={item.icon}
-                label={item.label}
-                marker={item.marker}
-                value={item.value}
-              />
-            ))}
-          </div>
-        ) : null}
       </div>
       <WeatherDescription>{rules.context}</WeatherDescription>
+    </div>
+  );
+}
+
+export function CeilingSlide({ metar }) {
+  const visibility = toNumber(metar?.rawVisib);
+  const ceilingFt = getCeilingFeet(metar);
+  const ceilingLabel = metar?.ceiling || (ceilingFt == null ? "CLR" : `${ceilingFt.toLocaleString()} ft`);
+  const ceilingPct = ceilingFt == null ? 1 : clamp(ceilingFt / 10000, 0.06, 1);
+  const visibilityPct = visibility == null ? 0 : clamp(visibility / 10, 0.06, 1);
+
+  return (
+    <div className="weather-slide-stack">
+      <div className="weather-slide-readout">
+        <div className="ceiling-instrument">
+          <div className="cloud-deck" aria-hidden="true">
+            <Cloud size={18} />
+            <i style={{ "--ceiling-pct": `${ceilingPct * 100}%` }} />
+          </div>
+          <div className="ceiling-readouts">
+            <MetricLine
+              icon={<Cloud size={16} />}
+              label="Ceiling"
+              value={ceilingLabel}
+            />
+            <ThresholdMeter
+              icon={<Eye size={16} />}
+              label="Visibility"
+              marker={visibilityPct}
+              value={visibility == null ? "-" : `${visibility >= 10 ? "10+" : visibility} SM`}
+            />
+          </div>
+        </div>
+      </div>
+      <WeatherDescription>{describeCeiling(ceilingFt, visibility)}</WeatherDescription>
     </div>
   );
 }
@@ -212,31 +214,20 @@ export function TemperatureSlide({ metar, localWeather }) {
 export function PressureSlide({ metar, localWeather }) {
   const altim = metar?.rawAltim;
   const pressure = localWeather?.pressureMslHpa;
-  const hpa = pressure ?? (altim != null ? altim * 33.8639 : null);
-  const pressurePct = hpa == null ? 0.5 : clamp((hpa - 980) / 60, 0.03, 0.97);
 
   return (
     <div className="weather-slide-stack">
       <div className="weather-slide-readout">
-        <div className="pressure-instrument">
-          <div
-            className="pressure-dial"
-            style={{ "--pressure-pct": `${pressurePct}` }}
-            aria-hidden="true"
-          >
-            <Gauge size={18} />
-          </div>
-          <div className="pressure-strip">
-            <MetricLine
-              icon={<Gauge size={16} />}
-              label="Altimeter"
-              value={metar?.altim || "-"}
-            />
-            <MetricLine
-              label="MSL pressure"
-              value={pressure == null ? "-" : `${Math.round(pressure)} hPa`}
-            />
-          </div>
+        <div className="pressure-strip">
+          <MetricLine
+            icon={<Gauge size={16} />}
+            label="Altimeter"
+            value={metar?.altim || "-"}
+          />
+          <MetricLine
+            label="MSL pressure"
+            value={pressure == null ? "-" : `${Math.round(pressure)} hPa`}
+          />
         </div>
       </div>
       <WeatherDescription>{describePressure(altim, pressure)}</WeatherDescription>
@@ -254,7 +245,7 @@ export function LocalWeatherSlide({
     ? WEATHER_CODES[localWeather.weatherCode] || "Current conditions"
     : "Local weather pending";
   const humidity = localWeather?.humidity;
-  const cloudCover = localWeather?.cloudCover;
+  const feelsLike = localWeather?.apparentTemperatureC;
 
   return (
     <div className="weather-visual-layout">
@@ -278,17 +269,11 @@ export function LocalWeatherSlide({
               ? `Open-Meteo unavailable: ${localWeatherError}`
               : condition}
           </p>
-          <div className="local-weather-meter-grid">
-            <CompactMeter
-              label="Humidity"
-              value={humidity == null ? "-" : `${Math.round(humidity)}%`}
-              marker={humidity == null ? 0 : humidity / 100}
-            />
-            <CompactMeter
-              label="Cloud"
-              value={cloudCover == null ? "-" : `${Math.round(cloudCover)}%`}
-              marker={cloudCover == null ? 0 : cloudCover / 100}
-            />
+          <div className="local-weather-meta">
+            <span>Humidity {humidity == null ? "-" : `${Math.round(humidity)}%`}</span>
+            <span>
+              Feels {feelsLike == null ? "-" : `${round1(feelsLike)}°C`}
+            </span>
           </div>
         </div>
       </div>
@@ -370,6 +355,19 @@ function describePressure(altim, pressure) {
   return "Pressure is near standard range, so altimeter setting is important but not a major performance driver.";
 }
 
+function describeCeiling(ceilingFt, visibility) {
+  if (ceilingFt == null && visibility == null) {
+    return "No limiting ceiling or visibility value is available in the current METAR.";
+  }
+  if (ceilingFt != null && ceilingFt < 1000) {
+    return "Low ceiling can push arrivals toward instrument procedures and reduce visual runway flexibility.";
+  }
+  if (visibility != null && visibility < 3) {
+    return "Reduced visibility can increase spacing and make surface movement more dependent on tower guidance.";
+  }
+  return "Ceiling and visibility are comfortably above the usual VFR thresholds for airport operations.";
+}
+
 function MetricLine({ label, value, icon = null }) {
   return (
     <div className="weather-metric-line">
@@ -392,18 +390,6 @@ function ThresholdMeter({ label, value, marker, icon }) {
       <strong>{value}</strong>
       <div className="threshold-track">
         <i style={{ left: `${marker * 100}%` }} />
-      </div>
-    </div>
-  );
-}
-
-function CompactMeter({ label, value, marker }) {
-  return (
-    <div className="compact-meter">
-      <span>{label}</span>
-      <strong>{value}</strong>
-      <div className="threshold-track">
-        <i style={{ left: `${clamp(marker, 0, 1) * 100}%` }} />
       </div>
     </div>
   );

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -61,10 +61,24 @@ const WEATHER_CODES = {
 };
 
 export function MetarSlide({ metarRaw, metarLoading, metarError }) {
+  const tokens = getMetarTokens(metarRaw);
+
   return (
     <div className="weather-slide-stack">
-      <div className="metar-code weather-metar-code">
-        {metarRaw || (metarLoading ? "Loading METAR..." : "No METAR available.")}
+      <div className="metar-instrument">
+        <div className="metar-token-strip" aria-hidden={!tokens.length}>
+          {tokens.length
+            ? tokens.map((item) => (
+                <span key={item.label}>
+                  <small>{item.label}</small>
+                  <strong>{item.value}</strong>
+                </span>
+              ))
+            : null}
+        </div>
+        <div className="metar-code weather-metar-code">
+          {metarRaw || (metarLoading ? "Loading METAR..." : "No METAR available.")}
+        </div>
       </div>
       {metarError ? <div className="panel-error">{metarError}</div> : null}
     </div>
@@ -101,6 +115,15 @@ export function FlightRulesSlide({ metar }) {
         <div className="flight-rule-banner">
           <span style={{ background: rules.color }}>{code}</span>
           <strong style={{ color: rules.color }}>{rules.label}</strong>
+        </div>
+        <div className="flight-rule-rail" aria-hidden="true">
+          {["VFR", "MVFR", "IFR", "LIFR"].map((item) => (
+            <i
+              key={item}
+              className={item === code ? "active" : ""}
+              style={{ "--rule-color": FLIGHT_RULES[item].color }}
+            />
+          ))}
         </div>
         {detailMeters.length ? (
           <div className={`weather-two-up weather-two-up--${detailMeters.length}`}>
@@ -144,10 +167,26 @@ export function TemperatureSlide({ metar, localWeather }) {
   const temp = toNumber(metar?.rawTemp) ?? localWeather?.temperatureC;
   const dew = toNumber(metar?.rawDewp) ?? null;
   const spread = temp != null && dew != null ? Math.max(0, temp - dew) : null;
+  const tempPct = temp == null ? 0.5 : clamp((temp + 20) / 60, 0.04, 0.96);
+  const dewPct = dew == null ? null : clamp((dew + 20) / 60, 0.04, 0.96);
 
   return (
     <div className="weather-slide-stack">
       <div className="weather-slide-readout">
+        <div
+          className="thermal-band"
+          style={{
+            "--temp-pct": `${tempPct * 100}%`,
+            "--dew-pct": `${(dewPct ?? tempPct) * 100}%`,
+          }}
+          aria-hidden="true"
+        >
+          <span>cold</span>
+          <i>
+            <b />
+          </i>
+          <span>hot</span>
+        </div>
         <div className="temperature-strip">
           <MetricLine
             label="Temperature"
@@ -173,20 +212,31 @@ export function TemperatureSlide({ metar, localWeather }) {
 export function PressureSlide({ metar, localWeather }) {
   const altim = metar?.rawAltim;
   const pressure = localWeather?.pressureMslHpa;
+  const hpa = pressure ?? (altim != null ? altim * 33.8639 : null);
+  const pressurePct = hpa == null ? 0.5 : clamp((hpa - 980) / 60, 0.03, 0.97);
 
   return (
     <div className="weather-slide-stack">
       <div className="weather-slide-readout">
-        <div className="pressure-strip">
-          <MetricLine
-            icon={<Gauge size={16} />}
-            label="Altimeter"
-            value={metar?.altim || "-"}
-          />
-          <MetricLine
-            label="MSL pressure"
-            value={pressure == null ? "-" : `${Math.round(pressure)} hPa`}
-          />
+        <div className="pressure-instrument">
+          <div
+            className="pressure-dial"
+            style={{ "--pressure-pct": `${pressurePct}` }}
+            aria-hidden="true"
+          >
+            <Gauge size={18} />
+          </div>
+          <div className="pressure-strip">
+            <MetricLine
+              icon={<Gauge size={16} />}
+              label="Altimeter"
+              value={metar?.altim || "-"}
+            />
+            <MetricLine
+              label="MSL pressure"
+              value={pressure == null ? "-" : `${Math.round(pressure)} hPa`}
+            />
+          </div>
         </div>
       </div>
       <WeatherDescription>{describePressure(altim, pressure)}</WeatherDescription>
@@ -203,6 +253,8 @@ export function LocalWeatherSlide({
   const condition = localWeather
     ? WEATHER_CODES[localWeather.weatherCode] || "Current conditions"
     : "Local weather pending";
+  const humidity = localWeather?.humidity;
+  const cloudCover = localWeather?.cloudCover;
 
   return (
     <div className="weather-visual-layout">
@@ -222,10 +274,22 @@ export function LocalWeatherSlide({
             }
           />
           <p className="weather-context-copy">
-          {localWeatherError
-            ? `Open-Meteo unavailable: ${localWeatherError}`
-            : condition}
+            {localWeatherError
+              ? `Open-Meteo unavailable: ${localWeatherError}`
+              : condition}
           </p>
+          <div className="local-weather-meter-grid">
+            <CompactMeter
+              label="Humidity"
+              value={humidity == null ? "-" : `${Math.round(humidity)}%`}
+              marker={humidity == null ? 0 : humidity / 100}
+            />
+            <CompactMeter
+              label="Cloud"
+              value={cloudCover == null ? "-" : `${Math.round(cloudCover)}%`}
+              marker={cloudCover == null ? 0 : cloudCover / 100}
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -236,10 +300,17 @@ function WindVector({ speed, gust, direction }) {
   return (
     <div className="wind-vector-card">
       <div
-        className="wind-vector-arrow"
-        style={{ transform: `rotate(${direction ?? 0}deg)` }}
+        className="wind-compass"
+        style={{ "--wind-bearing": `${direction ?? 0}deg` }}
+        aria-label={direction == null ? "Variable wind" : `Wind from ${Math.round(direction)} degrees`}
       >
-        <Navigation size={21} fill="currentColor" />
+        <span>N</span>
+        <span>E</span>
+        <span>S</span>
+        <span>W</span>
+        <i>
+          <Navigation size={20} fill="currentColor" />
+        </i>
       </div>
       <div>
         <span>Direction</span>
@@ -326,6 +397,39 @@ function ThresholdMeter({ label, value, marker, icon }) {
   );
 }
 
+function CompactMeter({ label, value, marker }) {
+  return (
+    <div className="compact-meter">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <div className="threshold-track">
+        <i style={{ left: `${clamp(marker, 0, 1) * 100}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function getMetarTokens(raw) {
+  const parts = String(raw || "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (!parts.length) return [];
+  const reportPrefix = /^(METAR|SPECI)$/i.test(parts[0]);
+  const station = reportPrefix ? parts[1] : parts[0];
+  const issued = reportPrefix ? parts[2] : parts[1];
+
+  const wind = parts.find((item) => /^(VRB|\d{3})\d{2,3}(G\d{2,3})?KT$/.test(item));
+  const visibility = parts.find((item) => /^(\d{1,2}|\d{1,2}SM|P\d{1,2}SM|\d\/\dSM)$/.test(item));
+
+  return [
+    { label: "Station", value: station || "-" },
+    { label: "Issued", value: issued || "-" },
+    { label: "Wind", value: wind || "-" },
+    { label: "Vis", value: visibility || "-" },
+  ];
+}
+
 function getCeilingFeet(metar) {
   const layer = metar?.rawClouds?.find((item) =>
     ["BKN", "OVC", "VV"].includes(item.cover),
@@ -339,3 +443,5 @@ const toNumber = (value) => {
 };
 
 const round1 = (value) => Number(value).toFixed(1);
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -115,30 +115,21 @@ export function CeilingSlide({ metar }) {
   const visibility = toNumber(metar?.rawVisib);
   const ceilingFt = getCeilingFeet(metar);
   const ceilingLabel = metar?.ceiling || (ceilingFt == null ? "CLR" : `${ceilingFt.toLocaleString()} ft`);
-  const ceilingPct = ceilingFt == null ? 1 : clamp(ceilingFt / 10000, 0.06, 1);
-  const visibilityPct = visibility == null ? 0 : clamp(visibility / 10, 0.06, 1);
 
   return (
     <div className="weather-slide-stack">
       <div className="weather-slide-readout">
-        <div className="ceiling-instrument">
-          <div className="cloud-deck" aria-hidden="true">
-            <Cloud size={18} />
-            <i style={{ "--ceiling-pct": `${ceilingPct * 100}%` }} />
-          </div>
-          <div className="ceiling-readouts">
-            <MetricLine
-              icon={<Cloud size={16} />}
-              label="Ceiling"
-              value={ceilingLabel}
-            />
-            <ThresholdMeter
-              icon={<Eye size={16} />}
-              label="Visibility"
-              marker={visibilityPct}
-              value={visibility == null ? "-" : `${visibility >= 10 ? "10+" : visibility} SM`}
-            />
-          </div>
+        <div className="ceiling-readouts">
+          <MetricLine
+            icon={<Cloud size={15} />}
+            label="Ceiling"
+            value={ceilingLabel}
+          />
+          <MetricLine
+            icon={<Eye size={15} />}
+            label="Visibility"
+            value={visibility == null ? "-" : `${visibility >= 10 ? "10+" : visibility} SM`}
+          />
         </div>
       </div>
       <WeatherDescription>{describeCeiling(ceilingFt, visibility)}</WeatherDescription>
@@ -376,21 +367,6 @@ function MetricLine({ label, value, icon = null }) {
         {label}
       </span>
       <strong>{value}</strong>
-    </div>
-  );
-}
-
-function ThresholdMeter({ label, value, marker, icon }) {
-  return (
-    <div className="threshold-meter">
-      <span>
-        {icon}
-        {label}
-      </span>
-      <strong>{value}</strong>
-      <div className="threshold-track">
-        <i style={{ left: `${marker * 100}%` }} />
-      </div>
     </div>
   );
 }

--- a/src/constants/aircraft.js
+++ b/src/constants/aircraft.js
@@ -1,8 +1,8 @@
 export const AIRCRAFT_COLORS = {
-  ascending: 'var(--aircraft-ascending)',
-  descending: 'var(--aircraft-descending)',
-  level: 'var(--aircraft-level)',
-  ground: 'var(--aircraft-ground)',
-}
+  ascending: "var(--aircraft-ascending)",
+  descending: "var(--aircraft-descending)",
+  level: "var(--aircraft-level)",
+  ground: "var(--aircraft-ground)",
+};
 
-export const BARO_RATE_THRESHOLD_FPM = 100
+export const BARO_RATE_THRESHOLD_FPM = 50;

--- a/src/constants/aircraft.js
+++ b/src/constants/aircraft.js
@@ -1,8 +1,8 @@
 export const AIRCRAFT_COLORS = {
-  ascending: '#fb923c',
-  descending: '#2dd4bf',
-  level: '#94a3b8',
-  ground: '#34d399',
+  ascending: 'var(--aircraft-ascending)',
+  descending: 'var(--aircraft-descending)',
+  level: 'var(--aircraft-level)',
+  ground: 'var(--aircraft-ground)',
 }
 
 export const BARO_RATE_THRESHOLD_FPM = 100

--- a/src/hooks/useAircraftPositions.js
+++ b/src/hooks/useAircraftPositions.js
@@ -21,6 +21,7 @@ export function useAircraftPositions(icao, lat, lon) {
   const timerRef = useRef(null);
   const wasActiveRef = useRef(false);
   const hiddenSinceRef = useRef(0);
+  const consecutiveFailuresRef = useRef(0);
 
   useEffect(() => {
     let disposed = false;
@@ -78,10 +79,14 @@ export function useAircraftPositions(icao, lat, lon) {
         setAircraft(
           trackerRef.current.update([...seen.values()], { lat, lon }, receiveTime),
         );
+        consecutiveFailuresRef.current = 0;
         setLastUpdated(new Date());
         setInitialLoading(false);
       } catch (e) {
-        console.warn("ADS-B fetch failed:", e.message);
+        consecutiveFailuresRef.current++;
+        const isTimeout = e.name === "TimeoutError" || /timed out|signal timed out/i.test(e.message);
+        const kind = isTimeout ? "timeout" : e.message || "unknown";
+        console.warn(`[${icao}] ADS-B fetch failed (${kind}, consecutive: ${consecutiveFailuresRef.current})`);
       } finally {
         if (!disposed) setLoading(false);
       }
@@ -90,6 +95,7 @@ export function useAircraftPositions(icao, lat, lon) {
     const start = () => {
       stop();
       trackerRef.current.clear();
+      consecutiveFailuresRef.current = 0;
       setInitialLoading(true);
       setLastUpdated(null);
       poll();

--- a/src/services/aviationData.js
+++ b/src/services/aviationData.js
@@ -189,7 +189,7 @@ export const createAircraftPositionClient = ({
         auditedFetch,
         `${baseUrl}/${encodedLat}/${encodedLon}/${encodedDist}`,
         {
-          timeoutMs: 14_000,
+          timeoutMs: DEFAULT_AIRCRAFT_POLL_MS,
         },
       );
     },

--- a/src/style.css
+++ b/src/style.css
@@ -121,6 +121,11 @@
     --glass-card-inset: rgba(255, 255, 255, 0.3);
     --traffic-level-color: #64748b;
 
+    --aircraft-ascending: #ea580c;
+    --aircraft-descending: #16a34a;
+    --aircraft-level: #475569;
+    --aircraft-ground: #15803d;
+
     --atc-radius-pill: 999px;
     --atc-radius-panel: 20px;
     --atc-radius-control: 12px;
@@ -166,6 +171,11 @@
     --glass-card-border: rgba(255, 255, 255, 0.13);
     --glass-card-inset: rgba(255, 255, 255, 0.14);
     --traffic-level-color: #94a3b8;
+
+    --aircraft-ascending: #fb923c;
+    --aircraft-descending: #2dd4bf;
+    --aircraft-level: #94a3b8;
+    --aircraft-ground: #34d399;
 
     --atc-radius-pill: 999px;
     --atc-radius-panel: 20px;
@@ -319,6 +329,116 @@ body {
         color-mix(in oklab, var(--atc-orange) 16%, transparent),
         color-mix(in oklab, var(--atc-card) 72%, transparent)
     );
+}
+
+.about-screen {
+    background:
+        radial-gradient(
+            circle at 22% 12%,
+            color-mix(in oklab, var(--atc-orange) 22%, transparent),
+            transparent 32%
+        ),
+        radial-gradient(
+            circle at 78% 80%,
+            color-mix(in oklab, var(--atc-line) 50%, transparent),
+            transparent 34%
+        ),
+        linear-gradient(
+            135deg,
+            color-mix(in oklab, var(--atc-orange) 8%, transparent),
+            transparent 38%
+        ),
+        var(--atc-bg);
+}
+
+.background-rays {
+    inset: 0;
+    pointer-events: none;
+    position: fixed;
+    z-index: 0;
+}
+
+.background-rays .light-rays-container {
+    mix-blend-mode: screen;
+    opacity: 0.55;
+}
+
+[data-theme="light"] .background-rays .light-rays-container {
+    mix-blend-mode: multiply;
+    opacity: 0.35;
+}
+
+.search-screen,
+.about-screen {
+    isolation: isolate;
+    position: relative;
+}
+
+.search-screen > main,
+.about-screen > main {
+    position: relative;
+    z-index: 1;
+}
+
+.about-chip {
+    background: color-mix(in oklab, var(--atc-card) 72%, transparent);
+    border-color: color-mix(in oklab, var(--atc-line-strong) 82%, transparent);
+    font-family: var(--font-sans);
+}
+
+.about-hero {
+    background:
+        radial-gradient(
+            circle at 100% 0%,
+            color-mix(in oklab, var(--atc-orange) 18%, transparent),
+            transparent 42%
+        ),
+        linear-gradient(
+            145deg,
+            color-mix(in oklab, var(--atc-card) 92%, transparent),
+            color-mix(in oklab, var(--atc-elev) 92%, transparent)
+        );
+    border: 1px solid
+        color-mix(in oklab, var(--atc-line-strong) 78%, transparent);
+    box-shadow:
+        0 30px 90px color-mix(in oklab, var(--atc-bg) 62%, transparent),
+        inset 0 1px 0
+            color-mix(in oklab, var(--atc-line-strong) 50%, transparent);
+}
+
+.about-hero::before {
+    background: linear-gradient(
+        90deg,
+        transparent,
+        color-mix(in oklab, var(--atc-orange) 78%, transparent),
+        transparent
+    );
+    content: "";
+    height: 1px;
+    inset: 0 0 auto 0;
+    position: absolute;
+    pointer-events: none;
+}
+
+.about-title {
+    font-family: var(--font-sans);
+    font-size: clamp(44px, 8vw, 88px);
+    font-weight: 900;
+    letter-spacing: -0.04em;
+}
+
+.about-title .font-display {
+    font-weight: 400;
+    letter-spacing: -0.02em;
+}
+
+.about-source {
+    background: color-mix(in oklab, var(--atc-card) 62%, transparent);
+    border-color: color-mix(in oklab, var(--atc-line-strong) 70%, transparent);
+}
+
+.about-source:hover {
+    background: color-mix(in oklab, var(--atc-card) 80%, transparent);
 }
 
 .airport-screen {

--- a/src/style.css
+++ b/src/style.css
@@ -356,21 +356,18 @@ body {
 }
 
 :root[data-theme="light"] .adsb-loading-overlay {
-    background:
-        radial-gradient(
-            circle at 50% 44%,
-            rgba(255, 255, 255, 0.64),
-            rgba(255, 247, 242, 0.28) 24%,
-            transparent 42%
-        ),
-        radial-gradient(
-            circle at 52% 50%,
-            rgba(255, 255, 255, 0.6),
-            rgba(248, 250, 252, 0.34) 58%,
-            rgba(248, 250, 252, 0.54) 100%
-        );
-    -webkit-backdrop-filter: brightness(1.08) saturate(0.98);
-    backdrop-filter: brightness(1.08) saturate(0.98);
+    background: radial-gradient(
+        circle at 52% 50%,
+        rgba(255, 255, 255, 0.38),
+        rgba(248, 250, 252, 0.46) 58%,
+        rgba(248, 250, 252, 0.54) 100%
+    );
+    -webkit-backdrop-filter: brightness(1.4) saturate(0.5);
+    backdrop-filter: brightness(1.4) saturate(0.5);
+}
+
+:root[data-theme="light"] .adsb-loading-orb-shell {
+    filter: drop-shadow(0 0 28px rgba(255, 90, 31, 0.28));
 }
 
 .adsb-loading-overlay.is-exiting {
@@ -816,7 +813,8 @@ body {
 .weather-carousel-slide {
     flex: 0 0 100%;
     min-width: 0;
-    padding-top: 8px;
+    padding-block: 8px 0;
+    padding-inline: 10px;
     scroll-snap-align: start;
     scroll-snap-stop: always;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -126,6 +126,35 @@
     --aircraft-level: #475569;
     --aircraft-ground: #15803d;
 
+    /* Tone tokens — composed from theme colors via color-mix.
+       Defined once in :root because their inputs are themeable;
+       both light and dark inherit the same expressions. */
+    --tone-card-soft: color-mix(in oklab, var(--atc-card) 62%, transparent);
+    --tone-card-mid: color-mix(in oklab, var(--atc-card) 72%, transparent);
+    --tone-card-warm: color-mix(in oklab, var(--atc-card) 76%, transparent);
+    --tone-card-strong: color-mix(in oklab, var(--atc-card) 84%, transparent);
+    --tone-card-bright: color-mix(in oklab, var(--atc-card) 92%, transparent);
+    --tone-elev-strong: color-mix(in oklab, var(--atc-elev) 88%, transparent);
+    --tone-elev-bright: color-mix(in oklab, var(--atc-elev) 92%, transparent);
+    --tone-orange-wash: color-mix(in oklab, var(--atc-orange) 8%, transparent);
+    --tone-orange-warm: color-mix(in oklab, var(--atc-orange) 16%, transparent);
+    --tone-orange-strong: color-mix(in oklab, var(--atc-orange) 22%, transparent);
+    --tone-orange-edge: color-mix(in oklab, var(--atc-orange) 78%, transparent);
+    --tone-bg-soft: color-mix(in oklab, var(--atc-bg) 62%, transparent);
+    --tone-line-soft: color-mix(in oklab, var(--atc-line) 50%, transparent);
+    --tone-border-soft: color-mix(in oklab, var(--atc-line-strong) 58%, transparent);
+    --tone-border-mid: color-mix(in oklab, var(--atc-line-strong) 70%, transparent);
+    --tone-border-strong: color-mix(
+        in oklab,
+        var(--atc-line-strong) 78%,
+        transparent
+    );
+    --tone-border-firm: color-mix(
+        in oklab,
+        var(--atc-line-strong) 82%,
+        transparent
+    );
+
     --atc-radius-pill: 999px;
     --atc-radius-panel: 20px;
     --atc-radius-control: 12px;
@@ -259,46 +288,73 @@ body {
     transform: translateY(-6px);
 }
 
-.search-screen {
+/* Shared screen background — search + about share the same atmosphere */
+.search-screen,
+.about-screen {
     background:
         radial-gradient(
             circle at 22% 12%,
-            color-mix(in oklab, var(--atc-orange) 22%, transparent),
+            var(--tone-orange-strong),
             transparent 32%
         ),
         radial-gradient(
             circle at 78% 80%,
-            color-mix(in oklab, var(--atc-line) 50%, transparent),
+            var(--tone-line-soft),
             transparent 34%
         ),
-        linear-gradient(
-            135deg,
-            color-mix(in oklab, var(--atc-orange) 8%, transparent),
-            transparent 38%
-        ),
+        linear-gradient(135deg, var(--tone-orange-wash), transparent 38%),
         var(--atc-bg);
+    isolation: isolate;
+    position: relative;
 }
 
-.theme-chip {
-    background: color-mix(in oklab, var(--atc-card) 72%, transparent);
-    border: 1px solid
-        color-mix(in oklab, var(--atc-line-strong) 82%, transparent);
+.search-screen > main,
+.about-screen > main {
+    position: relative;
+    z-index: 1;
+}
+
+/* Pill chips — theme toggle + about link share one surface */
+.theme-chip,
+.about-chip {
+    background: var(--tone-card-mid);
+    border: 1px solid var(--tone-border-firm);
     font-family: var(--font-sans);
+}
+
+/* Selectable rows — featured search rows + about data-source rows */
+.search-row,
+.about-source {
+    background: var(--tone-card-soft);
+    border: 1px solid var(--tone-border-strong);
+    border-radius: var(--atc-radius-panel);
+}
+
+.search-row:hover,
+.about-source:hover {
+    background: var(--tone-card-warm);
+}
+
+.search-row--featured:first-child,
+.search-row--featured {
+    background: linear-gradient(
+        100deg,
+        var(--tone-orange-warm),
+        var(--tone-card-mid)
+    );
 }
 
 .search-input {
     background: linear-gradient(
         145deg,
-        color-mix(in oklab, var(--atc-card) 84%, transparent),
-        color-mix(in oklab, var(--atc-elev) 88%, transparent)
+        var(--tone-card-strong),
+        var(--tone-elev-strong)
     );
-    border: 1px solid
-        color-mix(in oklab, var(--atc-line-strong) 82%, transparent);
+    border: 1px solid var(--tone-border-firm);
     border-radius: var(--atc-radius-panel);
     box-shadow:
-        0 26px 90px color-mix(in oklab, var(--atc-bg) 62%, transparent),
-        inset 0 1px 0
-            color-mix(in oklab, var(--atc-line-strong) 58%, transparent);
+        0 26px 90px var(--tone-bg-soft),
+        inset 0 1px 0 var(--tone-border-soft);
 }
 
 .search-input:focus-within {
@@ -309,46 +365,6 @@ body {
 .search-kbd {
     background: transparent;
     border: 1px solid var(--atc-line-strong);
-}
-
-.search-row {
-    background: color-mix(in oklab, var(--atc-card) 62%, transparent);
-    border: 1px solid
-        color-mix(in oklab, var(--atc-line-strong) 78%, transparent);
-    border-radius: var(--atc-radius-panel);
-}
-
-.search-row:hover {
-    background: color-mix(in oklab, var(--atc-card) 76%, transparent);
-}
-
-.search-row--featured:first-child,
-.search-row--featured {
-    background: linear-gradient(
-        100deg,
-        color-mix(in oklab, var(--atc-orange) 16%, transparent),
-        color-mix(in oklab, var(--atc-card) 72%, transparent)
-    );
-}
-
-.about-screen {
-    background:
-        radial-gradient(
-            circle at 22% 12%,
-            color-mix(in oklab, var(--atc-orange) 22%, transparent),
-            transparent 32%
-        ),
-        radial-gradient(
-            circle at 78% 80%,
-            color-mix(in oklab, var(--atc-line) 50%, transparent),
-            transparent 34%
-        ),
-        linear-gradient(
-            135deg,
-            color-mix(in oklab, var(--atc-orange) 8%, transparent),
-            transparent 38%
-        ),
-        var(--atc-bg);
 }
 
 .background-rays {
@@ -368,24 +384,6 @@ body {
     opacity: 0.35;
 }
 
-.search-screen,
-.about-screen {
-    isolation: isolate;
-    position: relative;
-}
-
-.search-screen > main,
-.about-screen > main {
-    position: relative;
-    z-index: 1;
-}
-
-.about-chip {
-    background: color-mix(in oklab, var(--atc-card) 72%, transparent);
-    border-color: color-mix(in oklab, var(--atc-line-strong) 82%, transparent);
-    font-family: var(--font-sans);
-}
-
 .about-hero {
     background:
         radial-gradient(
@@ -395,13 +393,12 @@ body {
         ),
         linear-gradient(
             145deg,
-            color-mix(in oklab, var(--atc-card) 92%, transparent),
-            color-mix(in oklab, var(--atc-elev) 92%, transparent)
+            var(--tone-card-bright),
+            var(--tone-elev-bright)
         );
-    border: 1px solid
-        color-mix(in oklab, var(--atc-line-strong) 78%, transparent);
+    border: 1px solid var(--tone-border-strong);
     box-shadow:
-        0 30px 90px color-mix(in oklab, var(--atc-bg) 62%, transparent),
+        0 30px 90px var(--tone-bg-soft),
         inset 0 1px 0
             color-mix(in oklab, var(--atc-line-strong) 50%, transparent);
 }
@@ -410,7 +407,7 @@ body {
     background: linear-gradient(
         90deg,
         transparent,
-        color-mix(in oklab, var(--atc-orange) 78%, transparent),
+        var(--tone-orange-edge),
         transparent
     );
     content: "";
@@ -430,15 +427,6 @@ body {
 .about-title .font-display {
     font-weight: 400;
     letter-spacing: -0.02em;
-}
-
-.about-source {
-    background: color-mix(in oklab, var(--atc-card) 62%, transparent);
-    border-color: color-mix(in oklab, var(--atc-line-strong) 70%, transparent);
-}
-
-.about-source:hover {
-    background: color-mix(in oklab, var(--atc-card) 80%, transparent);
 }
 
 .airport-screen {

--- a/src/style.css
+++ b/src/style.css
@@ -876,8 +876,7 @@ body {
     padding: 7px 8px;
 }
 
-.metar-token-strip small,
-.compact-meter span {
+.metar-token-strip small {
     color: var(--atc-faint);
     font-family: "JetBrains Mono", monospace;
     font-size: 8px;
@@ -1000,15 +999,10 @@ body {
     opacity: 1;
 }
 
-.weather-two-up,
 .temperature-strip {
     display: grid;
     gap: 12px;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.weather-two-up--1 {
-    grid-template-columns: minmax(0, 1fr);
 }
 
 .temperature-strip {
@@ -1018,20 +1012,6 @@ body {
 .threshold-meter {
     display: grid;
     gap: 6px;
-}
-
-.compact-meter {
-    display: grid;
-    gap: 5px;
-    min-width: 0;
-}
-
-.compact-meter strong {
-    color: var(--atc-text);
-    font-family: "JetBrains Mono", monospace;
-    font-size: 12px;
-    font-weight: 800;
-    line-height: 1;
 }
 
 .threshold-track {
@@ -1077,6 +1057,49 @@ body {
     width: 48px;
 }
 
+.ceiling-instrument {
+    align-items: stretch;
+    display: grid;
+    gap: 14px;
+    grid-template-columns: 74px minmax(0, 1fr);
+}
+
+.cloud-deck {
+    align-items: center;
+    background:
+        linear-gradient(
+            180deg,
+            color-mix(in oklab, var(--atc-text) 9%, transparent),
+            transparent var(--ceiling-pct)
+        ),
+        color-mix(in oklab, var(--atc-card) 34%, transparent);
+    border: 1px solid var(--atc-line);
+    border-radius: 16px;
+    color: var(--atc-dim);
+    display: flex;
+    justify-content: center;
+    min-width: 0;
+    overflow: hidden;
+    position: relative;
+}
+
+.cloud-deck i {
+    background: var(--atc-orange);
+    border-radius: var(--atc-radius-pill);
+    bottom: var(--ceiling-pct);
+    height: 2px;
+    left: 10px;
+    opacity: 0.75;
+    position: absolute;
+    right: 10px;
+}
+
+.ceiling-readouts {
+    display: grid;
+    gap: 12px;
+    min-width: 0;
+}
+
 .wind-vector-card {
     align-items: stretch;
     border-top: 1px solid var(--atc-line);
@@ -1086,7 +1109,7 @@ body {
     padding-top: 4px;
 }
 
-.wind-vector-card > div:not(.wind-vector-arrow) {
+.wind-vector-card > div:not(.wind-compass) {
     display: grid;
     gap: 5px;
     min-width: 0;
@@ -1141,19 +1164,27 @@ body {
 }
 
 .wind-compass span:nth-child(1) {
+    left: 50%;
     top: 4px;
+    transform: translateX(-50%);
 }
 
 .wind-compass span:nth-child(2) {
     right: 5px;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .wind-compass span:nth-child(3) {
     bottom: 4px;
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 .wind-compass span:nth-child(4) {
     left: 5px;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .wind-compass i {
@@ -1172,37 +1203,6 @@ body {
     display: grid;
     gap: 12px;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.pressure-instrument {
-    align-items: stretch;
-    display: grid;
-    gap: 14px;
-    grid-template-columns: 72px minmax(0, 1fr);
-}
-
-.pressure-dial {
-    align-items: center;
-    aspect-ratio: 1;
-    background:
-        conic-gradient(
-            from -132deg,
-            color-mix(in oklab, var(--atc-orange) 74%, transparent)
-                calc(var(--pressure-pct) * 264deg),
-            color-mix(in oklab, var(--atc-line) 90%, transparent) 0 264deg,
-            transparent 0
-        ),
-        radial-gradient(
-            circle,
-            color-mix(in oklab, var(--atc-card) 80%, transparent) 0 55%,
-            transparent 56%
-        );
-    border: 1px solid var(--atc-line);
-    border-radius: 999px;
-    color: var(--atc-orange);
-    display: flex;
-    justify-content: center;
-    min-width: 0;
 }
 
 .thermal-band {
@@ -1267,11 +1267,21 @@ body {
     justify-content: start;
 }
 
-.local-weather-meter-grid {
-    display: grid;
-    gap: 10px;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+.local-weather-meta {
+    border-top: 1px solid var(--atc-line);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
     margin-top: 12px;
+    padding-top: 10px;
+}
+
+.local-weather-meta span {
+    color: var(--atc-dim);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
 }
 
 .temperature-strip .weather-metric-line {

--- a/src/style.css
+++ b/src/style.css
@@ -355,6 +355,24 @@ body {
     z-index: 15;
 }
 
+:root[data-theme="light"] .adsb-loading-overlay {
+    background:
+        radial-gradient(
+            circle at 50% 44%,
+            rgba(255, 255, 255, 0.64),
+            rgba(255, 247, 242, 0.28) 24%,
+            transparent 42%
+        ),
+        radial-gradient(
+            circle at 52% 50%,
+            rgba(255, 255, 255, 0.6),
+            rgba(248, 250, 252, 0.34) 58%,
+            rgba(248, 250, 252, 0.54) 100%
+        );
+    -webkit-backdrop-filter: brightness(1.08) saturate(0.98);
+    backdrop-filter: brightness(1.08) saturate(0.98);
+}
+
 .adsb-loading-overlay.is-exiting {
     animation: adsb-loading-fade-out 1.1s ease forwards;
     -webkit-backdrop-filter: brightness(1) saturate(1);
@@ -919,8 +937,7 @@ body {
     padding-top: 8px;
 }
 
-.weather-metric-line span,
-.threshold-meter span {
+.weather-metric-line span {
     align-items: center;
     color: var(--atc-faint);
     display: inline-flex;
@@ -932,7 +949,6 @@ body {
 }
 
 .weather-metric-line strong,
-.threshold-meter strong,
 .wind-vector-card strong {
     color: var(--atc-text);
     font-size: 1.1875rem;
@@ -1009,33 +1025,6 @@ body {
     grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.threshold-meter {
-    display: grid;
-    gap: 6px;
-}
-
-.threshold-track {
-    background: linear-gradient(
-        90deg,
-        rgba(255, 90, 31, 0.22),
-        rgba(255, 90, 31, 0.74)
-    );
-    border-radius: var(--atc-radius-pill);
-    height: 6px;
-    position: relative;
-}
-
-.threshold-track i {
-    background: var(--atc-bg);
-    border: 2px solid var(--atc-orange);
-    border-radius: 50%;
-    height: 13px;
-    position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    width: 13px;
-}
-
 .local-weather-glyph {
     align-items: center;
     background:
@@ -1057,46 +1046,10 @@ body {
     width: 48px;
 }
 
-.ceiling-instrument {
-    align-items: stretch;
-    display: grid;
-    gap: 14px;
-    grid-template-columns: 74px minmax(0, 1fr);
-}
-
-.cloud-deck {
-    align-items: center;
-    background:
-        linear-gradient(
-            180deg,
-            color-mix(in oklab, var(--atc-text) 9%, transparent),
-            transparent var(--ceiling-pct)
-        ),
-        color-mix(in oklab, var(--atc-card) 34%, transparent);
-    border: 1px solid var(--atc-line);
-    border-radius: 16px;
-    color: var(--atc-dim);
-    display: flex;
-    justify-content: center;
-    min-width: 0;
-    overflow: hidden;
-    position: relative;
-}
-
-.cloud-deck i {
-    background: var(--atc-orange);
-    border-radius: var(--atc-radius-pill);
-    bottom: var(--ceiling-pct);
-    height: 2px;
-    left: 10px;
-    opacity: 0.75;
-    position: absolute;
-    right: 10px;
-}
-
 .ceiling-readouts {
     display: grid;
-    gap: 12px;
+    gap: 16px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     min-width: 0;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -845,6 +845,58 @@ body {
     max-height: 134px;
 }
 
+.metar-instrument {
+    display: grid;
+    gap: 10px;
+}
+
+.metar-token-strip {
+    display: grid;
+    gap: 7px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.metar-token-strip:empty {
+    display: none;
+}
+
+.metar-token-strip span {
+    background:
+        linear-gradient(
+            180deg,
+            color-mix(in oklab, var(--atc-text) 6%, transparent),
+            transparent
+        ),
+        color-mix(in oklab, var(--atc-card) 28%, transparent);
+    border: 1px solid var(--atc-line);
+    border-radius: 11px;
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+    padding: 7px 8px;
+}
+
+.metar-token-strip small,
+.compact-meter span {
+    color: var(--atc-faint);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 8px;
+    letter-spacing: 1px;
+    line-height: 1;
+    text-transform: uppercase;
+}
+
+.metar-token-strip strong {
+    color: var(--atc-text);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    font-weight: 900;
+    line-height: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .panel-error {
     color: var(--atc-red);
     font-family: "JetBrains Mono", monospace;
@@ -924,6 +976,30 @@ body {
     line-height: 1.05;
 }
 
+.flight-rule-rail {
+    background: color-mix(in oklab, var(--atc-card) 34%, transparent);
+    border: 1px solid var(--atc-line);
+    border-radius: var(--atc-radius-pill);
+    display: grid;
+    gap: 4px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    margin: -3px 0 12px;
+    padding: 4px;
+}
+
+.flight-rule-rail i {
+    background: color-mix(in oklab, var(--rule-color) 22%, transparent);
+    border-radius: var(--atc-radius-pill);
+    height: 7px;
+    opacity: 0.55;
+}
+
+.flight-rule-rail i.active {
+    background: var(--rule-color);
+    box-shadow: 0 0 14px color-mix(in oklab, var(--rule-color) 44%, transparent);
+    opacity: 1;
+}
+
 .weather-two-up,
 .temperature-strip {
     display: grid;
@@ -942,6 +1018,20 @@ body {
 .threshold-meter {
     display: grid;
     gap: 6px;
+}
+
+.compact-meter {
+    display: grid;
+    gap: 5px;
+    min-width: 0;
+}
+
+.compact-meter strong {
+    color: var(--atc-text);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
 }
 
 .threshold-track {
@@ -991,9 +1081,9 @@ body {
     align-items: stretch;
     border-top: 1px solid var(--atc-line);
     display: grid;
-    gap: 10px;
-    grid-template-columns: 34px repeat(3, minmax(0, 1fr));
-    padding-top: 9px;
+    gap: 12px;
+    grid-template-columns: 62px repeat(3, minmax(0, 1fr));
+    padding-top: 4px;
 }
 
 .wind-vector-card > div:not(.wind-vector-arrow) {
@@ -1017,16 +1107,59 @@ body {
     white-space: nowrap;
 }
 
-.wind-vector-arrow {
+.wind-compass {
     align-items: center;
     aspect-ratio: 1;
-    background: color-mix(in oklab, var(--atc-orange) 12%, transparent);
+    background:
+        radial-gradient(
+            circle,
+            color-mix(in oklab, var(--atc-orange) 15%, transparent) 0 23%,
+            transparent 24% 100%
+        ),
+        repeating-conic-gradient(
+            from -1deg,
+            color-mix(in oklab, var(--atc-line-strong) 64%, transparent) 0 2deg,
+            transparent 2deg 45deg
+        ),
+        color-mix(in oklab, var(--atc-card) 34%, transparent);
     border: 1px solid
         color-mix(in oklab, var(--atc-orange) 35%, var(--atc-line));
     border-radius: 999px;
     color: var(--atc-orange);
     display: flex;
     justify-content: center;
+    min-width: 0;
+    position: relative;
+    transform-origin: center;
+}
+
+.wind-compass span {
+    color: var(--atc-faint);
+    font-size: 7px;
+    letter-spacing: 0;
+    position: absolute;
+}
+
+.wind-compass span:nth-child(1) {
+    top: 4px;
+}
+
+.wind-compass span:nth-child(2) {
+    right: 5px;
+}
+
+.wind-compass span:nth-child(3) {
+    bottom: 4px;
+}
+
+.wind-compass span:nth-child(4) {
+    left: 5px;
+}
+
+.wind-compass i {
+    display: flex;
+    filter: drop-shadow(0 0 8px color-mix(in oklab, var(--atc-orange) 50%, transparent));
+    transform: rotate(var(--wind-bearing));
     transform-origin: center;
 }
 
@@ -1039,6 +1172,83 @@ body {
     display: grid;
     gap: 12px;
     grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.pressure-instrument {
+    align-items: stretch;
+    display: grid;
+    gap: 14px;
+    grid-template-columns: 72px minmax(0, 1fr);
+}
+
+.pressure-dial {
+    align-items: center;
+    aspect-ratio: 1;
+    background:
+        conic-gradient(
+            from -132deg,
+            color-mix(in oklab, var(--atc-orange) 74%, transparent)
+                calc(var(--pressure-pct) * 264deg),
+            color-mix(in oklab, var(--atc-line) 90%, transparent) 0 264deg,
+            transparent 0
+        ),
+        radial-gradient(
+            circle,
+            color-mix(in oklab, var(--atc-card) 80%, transparent) 0 55%,
+            transparent 56%
+        );
+    border: 1px solid var(--atc-line);
+    border-radius: 999px;
+    color: var(--atc-orange);
+    display: flex;
+    justify-content: center;
+    min-width: 0;
+}
+
+.thermal-band {
+    align-items: center;
+    display: grid;
+    gap: 8px;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    margin: 0 0 12px;
+}
+
+.thermal-band span {
+    color: var(--atc-faint);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 8px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.thermal-band i {
+    background: linear-gradient(90deg, #60a5fa, var(--atc-orange));
+    border-radius: var(--atc-radius-pill);
+    height: 7px;
+    position: relative;
+}
+
+.thermal-band i::before,
+.thermal-band i b {
+    border-radius: 50%;
+    content: "";
+    height: 13px;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 13px;
+}
+
+.thermal-band i::before {
+    background: var(--atc-orange);
+    border: 2px solid color-mix(in oklab, var(--atc-bg) 80%, white);
+    left: var(--temp-pct);
+}
+
+.thermal-band i b {
+    background: color-mix(in oklab, var(--atc-mint) 82%, white);
+    border: 2px solid color-mix(in oklab, var(--atc-bg) 80%, white);
+    left: var(--dew-pct);
 }
 
 .local-weather-row {
@@ -1055,6 +1265,13 @@ body {
 
 .local-weather-row .weather-slide-stack {
     justify-content: start;
+}
+
+.local-weather-meter-grid {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: 12px;
 }
 
 .temperature-strip .weather-metric-line {

--- a/src/utils/aircraftMotion.js
+++ b/src/utils/aircraftMotion.js
@@ -6,7 +6,9 @@ const METERS_PER_DEGREE_LAT = 111_320
 export const VISUAL_DELAY_MS = 750
 export const CORRECTION_DURATION_MS = 750
 export const SLOW_AIRCRAFT_THRESHOLD_KT = 30
+export const CRUISE_SPEED_THRESHOLD_KT = 100
 export const FAST_EXTRAPOLATION_LIMIT_MS = 4_000
+export const CRUISE_EXTRAPOLATION_LIMIT_MS = 30_000
 export const SLOW_FULL_SPEED_WINDOW_MS = 500
 export const SLOW_EXTRAPOLATION_SCALE = 0.25
 
@@ -27,9 +29,9 @@ export const parseAdsbPositionTime = (aircraft, responseNow, receiveTime = Date.
 
 export const getAircraftExtrapolationLimitMs = (aircraft) => {
   const velocity = Math.max(0, toFiniteNumber(aircraft?.velocity) ?? 0)
-  return aircraft?.onGround || velocity < SLOW_AIRCRAFT_THRESHOLD_KT
-    ? FAST_EXTRAPOLATION_LIMIT_MS
-    : FAST_EXTRAPOLATION_LIMIT_MS
+  if (aircraft?.onGround || velocity < SLOW_AIRCRAFT_THRESHOLD_KT) return FAST_EXTRAPOLATION_LIMIT_MS
+  if (velocity >= CRUISE_SPEED_THRESHOLD_KT) return CRUISE_EXTRAPOLATION_LIMIT_MS
+  return FAST_EXTRAPOLATION_LIMIT_MS
 }
 
 const getEffectiveElapsedMs = (aircraft, elapsedMs) => {


### PR DESCRIPTION
## Summary

This branch grew well beyond its original "operation context tabs" scope. Bundles together:

- **adsb.lol resilience**: 14s timeout reduced to `DEFAULT_AIRCRAFT_POLL_MS` (3s), cruising aircraft (≥100 kt) extrapolation extended to 30s in `aircraftMotion.js` so positions keep moving smoothly through 502s/timeouts, categorized + counted failure logging in `useAircraftPositions.js`.
- **AirportMap component reorg**: split the 567-line imperative Leaflet wrapper into `MapContext`, `MapTileLayers`, `AreaMarker`, `AirportMarker`, `GroundStatsCounter`, `AircraftPosition` (with internal `Pointer` + `Label` + `Telemetry` sub-components). Each marker owns a persistent DOM container that React portals into, so `<NumberFlow>` digits stay mounted across polls and animate smoothly instead of flashing.
- **About page redesign**: flight-progress-strip aesthetic — italic display-serif wordmark, mono "Frequencies" data-source list with `METAR` / `ADS-B` / `ROUTE` / `WX` / `DIR` / `WIKI` / `MAP` glyphs, build-meta strip, repository block, and an `END OF TRANSMISSION` footer. Linked from the home-page header chip.
- **`<LightRays>` shared background**: WebGL ray sweep (ogl) wrapped in `BackgroundRays.jsx`, used as a fixed-position layer behind both home and about screens. Theme-aware blend modes.
- **Logo**: new `src/components/brand/Logo.jsx` (radar-contact mark — aircraft pointer above runway baseline + airport tick) plus `src/app/icon.svg` favicon. Surfaced in both top bars.
- **Theme-aware aircraft colors**: `AIRCRAFT_COLORS` now points at `var(--aircraft-*)` CSS variables. Light theme gets darker orange (#ea580c) and true green (#16a34a) for ascending/descending so they read on the bright background.
- **CSS DRY pass**: extracted `--tone-*` tokens (`tone-card-soft/mid/warm/strong/bright`, `tone-border-soft/mid/strong/firm`, `tone-orange-wash/warm/strong/edge`, `tone-bg-soft`, `tone-line-soft`) for the recurring `color-mix(in oklab, ...)` blends, and merged duplicate selectors (`.search-screen + .about-screen`, `.theme-chip + .about-chip`, `.search-row + .about-source`).
- **CLAUDE.md**: added "Styling — Tailwind first" section codifying the decision order (utilities → arbitrary values → custom CSS) and the v4 `normal-case`-removal quirk we hit.

## Test plan

- [x] `pnpm build` succeeds
- [x] Existing test suite per `CLAUDE.md` Tests command
- [x] Visit `/` — search screen renders, light rays animate behind, theme/about chips align, logo + wordmark in header
- [x] Visit `/about` — hero wordmark, frequencies list, repository block, ADSBao link returns to home
- [x] Visit `/KBOS` (or any ICAO) — aircraft markers render with smooth `<NumberFlow>` telemetry, dead-reckoning continues during simulated adsb.lol outages
- [x] Toggle theme to light — aircraft colors switch to darker variants, light rays blend mode flips to multiply

🤖 Generated with [Claude Code](https://claude.com/claude-code)