### PR TITLE
feat: area badge shows ICAO + count, approach zoom hides all in-circle aircraft

### DIFF
--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -8,12 +8,9 @@ import AreaMarker, { AIRPORT_AREA_RADIUS_NM } from "./AreaMarker.jsx";
 import AirportMarker from "./AirportMarker.jsx";
 import GroundStatsCounter from "./GroundStatsCounter.jsx";
 import AircraftPosition from "./AircraftPosition.jsx";
-import { SLOW_AIRCRAFT_THRESHOLD_KT } from "../../utils/aircraftMotion.js";
-import {
-  ZOOM_APPROACH,
-  isGroundLikeAircraft,
-} from "../../utils/airportMapDisplay.js";
+import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
 import { AIRCRAFT_COLORS } from "../../constants/aircraft.js";
+import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
 
 const trafficLegend = [
   { id: "departure", label: "DEP", color: AIRCRAFT_COLORS.departure },
@@ -91,22 +88,15 @@ export default function AirportMap({
     }
   }, [lat, lon, zoom]);
 
-  const onlyMovingAtApproach = Number(zoom) === ZOOM_APPROACH;
+  const atApproachZoom = Number(zoom) === ZOOM_APPROACH;
   const visibleAircraft = useMemo(() => {
-    if (!onlyMovingAtApproach) {
-      return aircraft.filter((ac) => ac.lat != null && ac.lon != null);
-    }
     return aircraft.filter((ac) => {
       if (ac.lat == null || ac.lon == null) return false;
-      const speedKt = Number(ac.velocity ?? 0);
-      const isMoving = speedKt >= SLOW_AIRCRAFT_THRESHOLD_KT;
-      const isGroundLike = isGroundLikeAircraft(ac, {
-        airportAreaRadiusNm: AIRPORT_AREA_RADIUS_NM,
-        slowAircraftThresholdKt: SLOW_AIRCRAFT_THRESHOLD_KT,
-      });
-      return !isGroundLike && isMoving;
+      if (!atApproachZoom) return true;
+      const distNm = getDistanceNm(lat, lon, ac.lat, ac.lon);
+      return distNm == null || distNm > AIRPORT_AREA_RADIUS_NM;
     });
-  }, [aircraft, onlyMovingAtApproach]);
+  }, [aircraft, atApproachZoom, lat, lon]);
 
   const latStr = lat
     ? `${Math.abs(lat).toFixed(2)}${lat >= 0 ? "N" : "S"}`
@@ -147,6 +137,7 @@ export default function AirportMap({
             lat={lat}
             lon={lon}
             zoom={zoom}
+            icao={icao}
             aircraft={aircraft}
           />
           {visibleAircraft.map((ac) => (

--- a/src/components/map/GroundStatsCounter.jsx
+++ b/src/components/map/GroundStatsCounter.jsx
@@ -5,14 +5,11 @@ import { createPortal } from "react-dom";
 import NumberFlow from "@number-flow/react";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext.js";
-import {
-  ZOOM_APPROACH,
-  isGroundLikeAircraft,
-} from "../../utils/airportMapDisplay.js";
-import { SLOW_AIRCRAFT_THRESHOLD_KT } from "../../utils/aircraftMotion.js";
+import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
 import { AIRPORT_AREA_RADIUS_NM } from "./AreaMarker.jsx";
+import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
 
-export default function GroundStatsCounter({ lat, lon, zoom, aircraft = [] }) {
+export default function GroundStatsCounter({ lat, lon, zoom, icao = "", aircraft = [] }) {
   const map = useMapInstance();
   const markerRef = useRef(null);
   const [container] = useState(() =>
@@ -21,15 +18,13 @@ export default function GroundStatsCounter({ lat, lon, zoom, aircraft = [] }) {
 
   const visible = Number(zoom) === ZOOM_APPROACH && lat && lon;
 
-  const groundCount = useMemo(() => {
+  const areaCount = useMemo(() => {
     if (!visible) return 0;
-    return aircraft.filter((item) =>
-      isGroundLikeAircraft(item, {
-        airportAreaRadiusNm: AIRPORT_AREA_RADIUS_NM,
-        slowAircraftThresholdKt: SLOW_AIRCRAFT_THRESHOLD_KT,
-      }),
-    ).length;
-  }, [aircraft, visible]);
+    return aircraft.filter((item) => {
+      const distNm = getDistanceNm(lat, lon, item.lat, item.lon);
+      return distNm != null && distNm <= AIRPORT_AREA_RADIUS_NM;
+    }).length;
+  }, [aircraft, visible, lat, lon]);
 
   useEffect(() => {
     if (!map || !map.getContainer || !visible || !container) {
@@ -42,8 +37,8 @@ export default function GroundStatsCounter({ lat, lon, zoom, aircraft = [] }) {
       icon: L.divIcon({
         className: "",
         html: container,
-        iconSize: [58, 18],
-        iconAnchor: [29, 24],
+        iconSize: [80, 18],
+        iconAnchor: [40, 24],
       }),
     }).addTo(map);
     markerRef.current = marker;
@@ -56,7 +51,7 @@ export default function GroundStatsCounter({ lat, lon, zoom, aircraft = [] }) {
   if (!container || !visible) return null;
   return createPortal(
     <div className="airport-ground-count">
-      GND <NumberFlow value={groundCount} />
+      {icao} <NumberFlow value={areaCount} />
     </div>,
     container,
   );

--- a/src/style.css
+++ b/src/style.css
@@ -1840,7 +1840,7 @@ body {
     justify-content: center;
     letter-spacing: 0.55px;
     line-height: 1;
-    min-width: 46px;
+    min-width: 60px;
     padding: 3px 5px;
     text-shadow: 0 0 6px var(--map-label-glow);
     white-space: nowrap;


### PR DESCRIPTION
## Summary

- Badge at airport center now shows `{ICAO} {count}` where count is all aircraft within the 2.2 NM small circle, regardless of movement/flight status
- At approach zoom, all aircraft inside the small circle are hidden (filter uses haversine distance via `getDistanceNm`, replacing the old `isGroundLikeAircraft` speed+area check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)