### PR TITLE
fix: recolor aircraft immediately when flight route lands

### DIFF
--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { flightRouteClient } from "../services/aviationData.js";
 
 const HIT_CACHE_MS = 6 * 60 * 60 * 1000;
@@ -27,13 +27,21 @@ const getFreshCacheEntry = (callsign, now = Date.now()) => {
 export function useFlightRoutes(aircraft) {
   const [version, setVersion] = useState(0);
   const [loadingCount, setLoadingCount] = useState(0);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    let disposed = false;
-    const bump = () => setVersion((value) => value + 1);
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const bump = () => {
+      if (mountedRef.current) setVersion((value) => value + 1);
+    };
     const lookup = async (callsign) => {
       inFlight.add(callsign);
-      setLoadingCount(inFlight.size);
+      if (mountedRef.current) setLoadingCount(inFlight.size);
       try {
         const route = await flightRouteClient.fetchFlightRoute(callsign);
         routeCache.set(callsign, { route, time: Date.now() });
@@ -42,10 +50,10 @@ export function useFlightRoutes(aircraft) {
         routeCache.set(callsign, { route: null, time: Date.now() });
       } finally {
         inFlight.delete(callsign);
-        if (!disposed) {
-          setLoadingCount(inFlight.size);
-          bump();
-        }
+        // Always bump so the color updates the moment the route lands,
+        // even if the aircraft list has refreshed since this fetch started.
+        bump();
+        if (mountedRef.current) setLoadingCount(inFlight.size);
       }
     };
 
@@ -69,10 +77,6 @@ export function useFlightRoutes(aircraft) {
       else requestAnimationFrame(() => lookup(callsign));
     });
     bump();
-
-    return () => {
-      disposed = true;
-    };
   }, [aircraft]);
 
   const routesByCallsign = useMemo(() => {

--- a/src/hooks/useMetar.js
+++ b/src/hooks/useMetar.js
@@ -69,7 +69,7 @@ export function useMetar(icao) {
 function formatWind(m) {
   if (!m.wdir && !m.wspd) return "-";
   const dir =
-    m.wdir === "VRB" ? "VRB" : `${String(m.wdir ?? 0).padStart(3, "0")}deg`;
+    m.wdir === "VRB" ? "VRB" : `${String(m.wdir ?? 0).padStart(3, "0")}°`;
   const spd = `${m.wspd ?? 0} kt`;
   return m.wgst ? `${dir} / ${spd} G${m.wgst}kt` : `${dir} / ${spd}`;
 }


### PR DESCRIPTION
## Summary

- Fixes aircraft staying stuck as UNKNOWN color for a full poll interval after their flight route was fetched
- Replaces the per-effect `disposed` flag with a component-level `mountedRef` — the old flag was reset to `true` on every poll cycle cleanup, silencing `bump()` for any route fetch that completed after the aircraft list refreshed
- Also fixes wind direction unit: `350deg` → `350°` in the METAR status bar

## Root cause

`useFlightRoutes` used `let disposed = false` scoped to each effect run. React cleans up the effect every time `aircraft` changes (every poll cycle), setting `disposed = true`. Any route fetch still in flight at that moment would complete, cache the route correctly, but skip `bump()` — so `routesByCallsign` never updated until the next automatic bump at the following poll. Aircraft stayed UNKNOWN for up to one full poll interval after their route arrived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)