### PR TITLE
Refine mobile layout and spacing; add compact header and hide background on small screens

### DIFF
--- a/src/components/screens/AboutClient.jsx
+++ b/src/components/screens/AboutClient.jsx
@@ -130,7 +130,25 @@ export default function AboutClient() {
     <div className="dither-page-shell flex h-screen text-atc-text">
       <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
         <div className="flex-none px-6 pt-7 pb-6">
-          <div className="flex items-center gap-3">
+          <div className="mb-4 hidden items-center justify-between border-b border-[var(--atc-line)] pb-2.5 max-[720px]:flex">
+            <Link
+              href="/"
+              className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text"
+            >
+              ← ADSBao
+            </Link>
+            <button
+              type="button"
+              className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+              title={themeTitle}
+              onClick={cycleTheme}
+            >
+              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>{themePreference}</span>
+            </button>
+          </div>
+
+          <div className="flex items-center gap-3 max-[720px]:hidden">
             <Logo size={28} className="text-atc-text" />
             <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
               About
@@ -236,7 +254,7 @@ export default function AboutClient() {
           </div>
         </div>
 
-        <div className="flex-none flex items-center justify-between border-t border-[var(--atc-line)] px-6 py-3">
+        <div className="flex-none items-center justify-between border-t border-[var(--atc-line)] px-6 py-3 max-[720px]:hidden sm:flex">
           <Link
             href="/"
             className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text"

--- a/src/components/screens/SearchScreen.jsx
+++ b/src/components/screens/SearchScreen.jsx
@@ -235,7 +235,27 @@ export default function SearchScreen({ onOpenAirport }) {
     <div className="dither-page-shell search-screen flex h-screen text-atc-text">
       <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
         <div className="flex-none px-6 pt-7 pb-6">
-          <div className="flex items-center gap-3">
+          <div className="mb-4 hidden items-center justify-between border-b border-[var(--atc-line)] pb-2.5 max-[720px]:flex">
+            <Link
+              href="/about"
+              title="About ADSBao"
+              className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+            >
+              <Info className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>About</span>
+            </Link>
+            <button
+              type="button"
+              className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+              title={themeTitle}
+              onClick={cycleTheme}
+            >
+              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>{themePreference}</span>
+            </button>
+          </div>
+
+          <div className="flex items-center gap-3 max-[720px]:hidden">
             <Logo size={28} className="text-atc-text" />
             <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
               Airport search
@@ -265,12 +285,11 @@ export default function SearchScreen({ onOpenAirport }) {
           <Search className="h-5 w-5 shrink-0 text-atc-orange" />
           <Input
             value={q}
-            autoFocus
             onChange={(event) => setQ(event.target.value)}
             className="flex-1 p-0 text-base font-semibold tracking-normal text-atc-text"
             placeholder="Search ICAO, IATA, city, or name"
           />
-          <kbd className="hidden shrink-0 items-center px-2 py-1 font-mono text-[10px] uppercase tracking-[1px] text-atc-dim sm:inline-flex">
+          <kbd className="hidden shrink-0 items-center px-2 py-1 font-mono text-[10px] uppercase tracking-[0.04em] text-atc-dim sm:inline-flex">
             {searchLoading ? "..." : "enter"}
           </kbd>
         </form>
@@ -290,18 +309,18 @@ export default function SearchScreen({ onOpenAirport }) {
           )}
         </div>
 
-        <div className="flex-none flex items-center justify-between border-t border-[var(--atc-line)] px-6 py-3">
+        <div className="flex-none items-center justify-between border-t border-[var(--atc-line)] px-6 py-3 max-[720px]:hidden sm:flex">
           <Link
             href="/about"
             title="About ADSBao"
-            className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+            className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
           >
             <Info className="h-3.5 w-3.5" aria-hidden="true" />
             <span>About</span>
           </Link>
           <button
             type="button"
-            className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+            className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
             title={themeTitle}
             onClick={cycleTheme}
           >

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -12,16 +12,16 @@ export default function AircraftTable({ aircraft = [], fill = true }) {
   return (
     <div className={`flex flex-col ${fill ? "h-full" : ""}`}>
       <div className="flex-none">
-        <div className="flex items-baseline justify-between px-6 pt-6 pb-3">
-          <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
+        <div className="flex items-baseline justify-between px-6 pt-4 pb-2.5">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint">
             Aircraft
           </div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-atc-dim">
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-atc-dim">
             <NumberFlow value={aircraft.length} suffix=" nearby" />
           </div>
         </div>
 
-        <div className="grid grid-cols-[minmax(0,1fr)_72px_92px] items-center gap-3 border-y border-[var(--atc-line)] px-6 py-2 font-mono text-[9px] uppercase tracking-[0.2em] text-atc-faint">
+        <div className="grid grid-cols-[minmax(0,1fr)_72px_92px] items-center gap-3 border-y border-[var(--atc-line)] px-6 py-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-atc-faint">
           <span>Callsign / Route</span>
           <span className="text-right">GS</span>
           <span className="text-right">ALT</span>
@@ -30,7 +30,7 @@ export default function AircraftTable({ aircraft = [], fill = true }) {
 
       <div className={fill ? "flex-1 overflow-y-auto" : "overflow-visible"}>
         {sorted.length === 0 ? (
-          <div className="px-6 py-10 text-center font-mono text-[11px] uppercase tracking-[0.2em] text-atc-faint">
+          <div className="px-6 py-8 text-center font-mono text-[11px] uppercase tracking-[0.12em] text-atc-faint">
             No aircraft in range
           </div>
         ) : (
@@ -57,9 +57,9 @@ function AircraftRow({ aircraft }) {
   const altValue = toNumber(aircraft.altitude);
 
   return (
-    <li className="grid grid-cols-[minmax(0,1fr)_72px_92px] items-center gap-3 px-6 py-3 transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)]">
+    <li className="grid grid-cols-[minmax(0,1fr)_72px_92px] items-center gap-3 px-6 py-2.5 transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)]">
       <div className="min-w-0">
-        <div className="font-mono text-[12.5px] font-semibold tracking-[0.04em] text-atc-text">
+        <div className="font-mono text-[12.5px] font-semibold tracking-[0.02em] text-atc-text">
           {callsign}
         </div>
         <div className="mt-0.5 truncate text-[11.5px] text-atc-dim">
@@ -90,7 +90,7 @@ function NumberWithUnit({ value, unit }) {
   return (
     <span className="inline-flex items-baseline justify-end gap-0.5 tabular-nums">
       <NumberFlow value={value} />
-      <sub className="relative top-[0.22em] text-[7px] font-semibold leading-none tracking-[0.08em] text-atc-dim">
+      <sub className="relative top-[0.22em] text-[7px] font-semibold leading-none tracking-[0.03em] text-atc-dim">
         {unit}
       </sub>
     </span>

--- a/src/components/sidebar/AirportSidebar.jsx
+++ b/src/components/sidebar/AirportSidebar.jsx
@@ -36,7 +36,7 @@ export default function AirportSidebar({
         <button
           type="button"
           onClick={onBack}
-          className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text"
+          className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text"
         >
           ← ADSBao
         </button>
@@ -44,14 +44,14 @@ export default function AirportSidebar({
           <button
             type="button"
             onClick={onClose}
-            className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text"
+            className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text"
           >
             Map →
           </button>
         ) : (
           <span
             key={updatedLabel}
-            className={`airport-feed-status airport-feed-status--${feedStatus} font-mono text-[10px] uppercase tracking-[0.18em] text-atc-dim`}
+            className={`airport-feed-status airport-feed-status--${feedStatus} font-mono text-[10px] uppercase tracking-[0.12em] text-atc-dim`}
           >
             {updatedLabel}
           </span>

--- a/src/components/sidebar/WeatherCarousel.jsx
+++ b/src/components/sidebar/WeatherCarousel.jsx
@@ -131,12 +131,12 @@ export default function WeatherCarousel({
   };
 
   return (
-    <section className="weather-carousel-section px-6 pt-5 pb-5">
+    <section className="weather-carousel-section px-6 pt-4 pb-4">
       <div className="weather-carousel-header flex items-baseline justify-between">
-        <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
+        <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint">
           Weather
         </div>
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-atc-dim">
+        <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-atc-dim">
           {activeSlide?.title || "—"}
         </div>
       </div>
@@ -144,7 +144,7 @@ export default function WeatherCarousel({
       <div
         ref={trackRef}
         onScroll={handleScroll}
-        className="weather-carousel-track mt-4 -mx-1 min-h-[180px]"
+        className="weather-carousel-track mt-3 -mx-1 min-h-[148px]"
       >
         {slides.map((slide, index) => (
           <article

--- a/src/style.css
+++ b/src/style.css
@@ -414,16 +414,13 @@ body {
 
 @media (max-width: 720px) {
     .dither-page-background {
-        inset: 0;
-        position: absolute;
-        z-index: 0;
+        display: none;
     }
 
     .dither-page-panel {
-        background: color-mix(in oklab, var(--atc-bg) 84%, transparent);
-        backdrop-filter: blur(10px);
-        box-shadow: 18px 0 40px rgba(0, 0, 0, 0.26);
-        width: min(88vw, 400px) !important;
+        background: var(--atc-bg);
+        box-shadow: none;
+        width: 100vw !important;
     }
 }
 


### PR DESCRIPTION
### Motivation

- Make the left panel layout friendlier on small screens by surfacing a compact top bar with the theme toggle and navigation links. 
- Tighten spacing and typographic tracking across sidebars and lists for a more consistent, denser UI. 
- Disable the heavy dither/canvas background on phones to reduce visual noise and improve performance. 

### Description

- Updated `AboutClient.jsx` and `SearchScreen.jsx` to add a compact top row for screens `max-width:720px` that exposes a back/about link and the theme toggle, while hiding the full header on small viewports. 
- Adjusted search input behavior and styling in `SearchScreen.jsx` by removing `autoFocus`, tightening `kbd` tracking, and changing header/link tracking values. 
- Tweaked `AircraftTable.jsx`, `AirportSidebar.jsx`, and `WeatherCarousel.jsx` to reduce paddings, lower section min-heights, and adjust multiple `tracking` values for tighter typography; also adjusted grid row paddings and hover spacing. 
- Modified `NumberWithUnit` sub-element tracking in `AircraftTable.jsx` for visual alignment. 
- Updated `style.css` under the `@media (max-width: 720px)` rule to hide the dither background (`display: none`), remove the blurred/translucent backdrop, and set the panel width to `100vw` with `box-shadow` removed. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e1f7c9748331af428fbbcaaf9084)