### PR TITLE
统一移动端顶部导航样式与机场详情页布局

### DIFF
--- a/src/components/navigation/MobileTopNav.jsx
+++ b/src/components/navigation/MobileTopNav.jsx
@@ -1,0 +1,8 @@
+export default function MobileTopNav({ left, right }) {
+  return (
+    <div className="mobile-top-nav hidden items-center justify-between max-[720px]:flex">
+      <div className="min-w-0">{left}</div>
+      <div className="min-w-0">{right}</div>
+    </div>
+  );
+}

--- a/src/components/screens/AboutClient.jsx
+++ b/src/components/screens/AboutClient.jsx
@@ -130,16 +130,16 @@ export default function AboutClient() {
     <div className="dither-page-shell flex h-screen text-atc-text">
       <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
         <div className="flex-none px-6 pt-7 pb-6">
-          <div className="mb-4 hidden items-center justify-between border-b border-[var(--atc-line)] pb-2.5 max-[720px]:flex">
+          <div className="mobile-top-nav mb-4 hidden items-center justify-between max-[720px]:flex">
             <Link
               href="/"
-              className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text"
+              className="mobile-top-nav-link"
             >
               ← ADSBao
             </Link>
             <button
               type="button"
-              className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+              className="mobile-top-nav-link flex items-center gap-1.5"
               title={themeTitle}
               onClick={cycleTheme}
             >

--- a/src/components/screens/AboutClient.jsx
+++ b/src/components/screens/AboutClient.jsx
@@ -129,25 +129,25 @@ export default function AboutClient() {
   return (
     <div className="dither-page-shell flex h-screen text-atc-text">
       <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
-        <div className="flex-none px-6 pt-7 pb-6">
-          <div className="mobile-top-nav mb-4 hidden items-center justify-between max-[720px]:flex">
-            <Link
-              href="/"
-              className="mobile-top-nav-link"
-            >
-              ← ADSBao
-            </Link>
-            <button
-              type="button"
-              className="mobile-top-nav-link flex items-center gap-1.5"
-              title={themeTitle}
-              onClick={cycleTheme}
-            >
-              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-              <span>{themePreference}</span>
-            </button>
-          </div>
+        <div className="mobile-top-nav hidden items-center justify-between max-[720px]:flex">
+          <Link
+            href="/"
+            className="mobile-top-nav-link"
+          >
+            ← ADSBao
+          </Link>
+          <button
+            type="button"
+            className="mobile-top-nav-link flex items-center gap-1.5"
+            title={themeTitle}
+            onClick={cycleTheme}
+          >
+            <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{themePreference}</span>
+          </button>
+        </div>
 
+        <div className="flex-none px-6 pt-7 pb-6">
           <div className="flex items-center gap-3 max-[720px]:hidden">
             <Logo size={28} className="text-atc-text" />
             <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">

--- a/src/components/screens/AboutClient.jsx
+++ b/src/components/screens/AboutClient.jsx
@@ -15,6 +15,7 @@ import {
 } from "../../utils/theme.js";
 import DitherBackground from "../effects/DitherBackground.jsx";
 import Logo from "../brand/Logo.jsx";
+import MobileTopNav from "../navigation/MobileTopNav.jsx";
 
 const buildMeta = [
   { label: "Version", value: "0.8.0" },
@@ -129,23 +130,27 @@ export default function AboutClient() {
   return (
     <div className="dither-page-shell flex h-screen text-atc-text">
       <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
-        <div className="mobile-top-nav hidden items-center justify-between max-[720px]:flex">
-          <Link
-            href="/"
-            className="mobile-top-nav-link"
-          >
-            ← ADSBao
-          </Link>
-          <button
-            type="button"
-            className="mobile-top-nav-link flex items-center gap-1.5"
-            title={themeTitle}
-            onClick={cycleTheme}
-          >
-            <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>{themePreference}</span>
-          </button>
-        </div>
+        <MobileTopNav
+          left={
+            <Link
+              href="/"
+              className="mobile-top-nav-link"
+            >
+              ← ADSBao
+            </Link>
+          }
+          right={
+            <button
+              type="button"
+              className="mobile-top-nav-link flex items-center gap-1.5"
+              title={themeTitle}
+              onClick={cycleTheme}
+            >
+              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>{themePreference}</span>
+            </button>
+          }
+        />
 
         <div className="flex-none px-6 pt-7 pb-6">
           <div className="flex items-center gap-3 max-[720px]:hidden">

--- a/src/components/screens/SearchScreen.jsx
+++ b/src/components/screens/SearchScreen.jsx
@@ -234,27 +234,27 @@ export default function SearchScreen({ onOpenAirport }) {
   return (
     <div className="dither-page-shell search-screen flex h-screen text-atc-text">
       <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
-        <div className="flex-none px-6 pt-7 pb-6">
-          <div className="mobile-top-nav mb-4 hidden items-center justify-between max-[720px]:flex">
-            <Link
-              href="/about"
-              title="About ADSBao"
-              className="mobile-top-nav-link flex items-center gap-1.5"
-            >
-              <Info className="h-3.5 w-3.5" aria-hidden="true" />
-              <span>About</span>
-            </Link>
-            <button
-              type="button"
-              className="mobile-top-nav-link flex items-center gap-1.5"
-              title={themeTitle}
-              onClick={cycleTheme}
-            >
-              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-              <span>{themePreference}</span>
-            </button>
-          </div>
+        <div className="mobile-top-nav hidden items-center justify-between max-[720px]:flex">
+          <Link
+            href="/about"
+            title="About ADSBao"
+            className="mobile-top-nav-link flex items-center gap-1.5"
+          >
+            <Info className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>About</span>
+          </Link>
+          <button
+            type="button"
+            className="mobile-top-nav-link flex items-center gap-1.5"
+            title={themeTitle}
+            onClick={cycleTheme}
+          >
+            <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{themePreference}</span>
+          </button>
+        </div>
 
+        <div className="flex-none px-6 pt-7 pb-6">
           <div className="flex items-center gap-3 max-[720px]:hidden">
             <Logo size={28} className="text-atc-text" />
             <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">

--- a/src/components/screens/SearchScreen.jsx
+++ b/src/components/screens/SearchScreen.jsx
@@ -19,6 +19,7 @@ import {
 import { Input } from "../ui/input.jsx";
 import DitherBackground from "../effects/DitherBackground.jsx";
 import Logo from "../brand/Logo.jsx";
+import MobileTopNav from "../navigation/MobileTopNav.jsx";
 
 const featuredAirports = [
   {
@@ -234,25 +235,29 @@ export default function SearchScreen({ onOpenAirport }) {
   return (
     <div className="dither-page-shell search-screen flex h-screen text-atc-text">
       <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
-        <div className="mobile-top-nav hidden items-center justify-between max-[720px]:flex">
-          <Link
-            href="/about"
-            title="About ADSBao"
-            className="mobile-top-nav-link flex items-center gap-1.5"
-          >
-            <Info className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>About</span>
-          </Link>
-          <button
-            type="button"
-            className="mobile-top-nav-link flex items-center gap-1.5"
-            title={themeTitle}
-            onClick={cycleTheme}
-          >
-            <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>{themePreference}</span>
-          </button>
-        </div>
+        <MobileTopNav
+          left={
+            <Link
+              href="/about"
+              title="About ADSBao"
+              className="mobile-top-nav-link flex items-center gap-1.5"
+            >
+              <Info className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>About</span>
+            </Link>
+          }
+          right={
+            <button
+              type="button"
+              className="mobile-top-nav-link flex items-center gap-1.5"
+              title={themeTitle}
+              onClick={cycleTheme}
+            >
+              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>{themePreference}</span>
+            </button>
+          }
+        />
 
         <div className="flex-none px-6 pt-7 pb-6">
           <div className="flex items-center gap-3 max-[720px]:hidden">

--- a/src/components/screens/SearchScreen.jsx
+++ b/src/components/screens/SearchScreen.jsx
@@ -235,18 +235,18 @@ export default function SearchScreen({ onOpenAirport }) {
     <div className="dither-page-shell search-screen flex h-screen text-atc-text">
       <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
         <div className="flex-none px-6 pt-7 pb-6">
-          <div className="mb-4 hidden items-center justify-between border-b border-[var(--atc-line)] pb-2.5 max-[720px]:flex">
+          <div className="mobile-top-nav mb-4 hidden items-center justify-between max-[720px]:flex">
             <Link
               href="/about"
               title="About ADSBao"
-              className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+              className="mobile-top-nav-link flex items-center gap-1.5"
             >
               <Info className="h-3.5 w-3.5" aria-hidden="true" />
               <span>About</span>
             </Link>
             <button
               type="button"
-              className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+              className="mobile-top-nav-link flex items-center gap-1.5"
               title={themeTitle}
               onClick={cycleTheme}
             >

--- a/src/style.css
+++ b/src/style.css
@@ -1631,7 +1631,7 @@ body {
     border-bottom: 1px solid var(--atc-line-strong);
     box-sizing: border-box;
     min-height: 44px;
-    padding: 0 12px;
+    padding: 0 16px;
 }
 
 .mobile-top-nav-link {

--- a/src/style.css
+++ b/src/style.css
@@ -1625,6 +1625,28 @@ body {
     width: 1px;
 }
 
+.mobile-top-nav {
+    align-items: center;
+    background: var(--atc-bg);
+    border-bottom: 1px solid var(--atc-line-strong);
+    box-sizing: border-box;
+    min-height: 44px;
+    padding: 0 12px;
+}
+
+.mobile-top-nav-link {
+    color: var(--atc-faint);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    transition: color 0.15s ease;
+}
+
+.mobile-top-nav-link:hover {
+    color: var(--atc-text);
+}
+
 .airport-map-menu {
     align-items: center;
     --atc-bg: #ffffff;


### PR DESCRIPTION
### Motivation
- 统一移动端所有页面顶部导航的外观以匹配机场详情页的顶部导航布局，提升移动端一致性和视觉语言。

### Description
- 新增移动端顶栏样式 `mobile-top-nav` 与 `mobile-top-nav-link` 到 `src/style.css`，定义高度、边框和字体样式以与机场详情页对齐。 
- 将搜索页的移动端顶部导航替换为统一类，修改文件 `src/components/screens/SearchScreen.jsx` 中对应的容器与链接/按钮类名。 
- 将 About 页的移动端顶部导航替换为统一类，修改文件 `src/components/screens/AboutClient.jsx` 中对应的容器与链接/按钮类名。 
- 仅改动样式类名与 CSS，未修改功能逻辑或桌面端布局。 

### Testing
- 运行构建命令 `pnpm -s build`，生产构建通过且未报错。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ed73ee888331b6a8fa97b481dfc9)