### PR TITLE
[codex] Share search and about app shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ pnpm build
 ## Tests
 
 ```bash
-pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:airport-explorer && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
+pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:app-shell && pnpm test:airport-explorer && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
 ```
 
 ## Runtime config

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:aviation-data": "node src/services/aviationData.test.js",
     "test:vercel-routing": "node src/config/vercelRouting.test.js",
     "test:airport-wiki": "node src/services/airportWiki.test.js",
+    "test:app-shell": "node src/features/app-shell/themePreference.test.js",
     "test:airport-explorer": "node src/features/airport-explorer/airportExplorerModel.test.js",
     "test:flight-route-display": "node src/utils/flightRouteDisplay.test.js",
     "test:airport-map-display": "node src/utils/airportMapDisplay.test.js",

--- a/src/components/screens/AboutClient.jsx
+++ b/src/components/screens/AboutClient.jsx
@@ -1,21 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowUpRight, Github, Monitor, Moon, Sun } from "lucide-react";
-import { useEffect, useMemo, useState, useRef } from "react";
-import { SITE_DESCRIPTION } from "../../config/site.js";
-import {
-  THEME_DARK,
-  THEME_LIGHT,
-  THEME_SYSTEM,
-  applyThemePreference,
-  initThemePreference,
-  nextTheme,
-  writeStoredTheme,
-} from "../../utils/theme.js";
-import DitherBackground from "../effects/DitherBackground.jsx";
-import Logo from "../brand/Logo.jsx";
-import MobileTopNav from "../navigation/MobileTopNav.jsx";
+import { ArrowUpRight, Github } from "lucide-react";
+import DitherPageShell from "../../features/app-shell/DitherPageShell.jsx";
+import ThemeToggle from "../../features/app-shell/ThemeToggle.jsx";
+import { useThemePreference } from "../../features/app-shell/useThemePreference.js";
 
 const buildMeta = [
   { label: "Version", value: "0.8.0" },
@@ -80,45 +69,8 @@ const dataSources = [
 ];
 
 export default function AboutClient() {
-  const [themePreference, setThemePreference] = useState(THEME_SYSTEM);
-  const mediaQueryList = useRef(null);
-
-  useEffect(() => {
-    mediaQueryList.current = window.matchMedia("(prefers-color-scheme: dark)");
-    setThemePreference(
-      initThemePreference({ mediaQueryList: mediaQueryList.current }).preference,
-    );
-    const listener = () => {
-      if (themePreference === THEME_SYSTEM) {
-        applyThemePreference({
-          theme: THEME_SYSTEM,
-          mediaQueryList: mediaQueryList.current,
-        });
-      }
-    };
-    mediaQueryList.current.addEventListener("change", listener);
-    return () => mediaQueryList.current?.removeEventListener("change", listener);
-  }, [themePreference]);
-
-  const themeTitle = useMemo(() => {
-    if (themePreference === THEME_LIGHT) return "Theme: Light (click to switch)";
-    if (themePreference === THEME_DARK) return "Theme: Dark (click to switch)";
-    return "Theme: System (click to switch)";
-  }, [themePreference]);
-
-  const ThemeIcon =
-    themePreference === THEME_LIGHT
-      ? Sun
-      : themePreference === THEME_DARK
-        ? Moon
-        : Monitor;
-
-  const cycleTheme = () => {
-    const next = nextTheme(themePreference);
-    setThemePreference(next);
-    writeStoredTheme(next);
-    applyThemePreference({ theme: next, mediaQueryList: mediaQueryList.current });
-  };
+  const { themePreference, themeTitle, themeIconKey, cycleTheme } =
+    useThemePreference();
 
   const openExternalLink = (event, href) => {
     const opened = window.open(href, "_blank");
@@ -127,160 +79,119 @@ export default function AboutClient() {
     event.preventDefault();
   };
 
+  const backLink = (
+    <Link
+      href="/"
+      className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text"
+    >
+      ← ADSBao
+    </Link>
+  );
+
+  const renderThemeToggle = (className) => (
+    <ThemeToggle
+      className={className}
+      iconKey={themeIconKey}
+      preference={themePreference}
+      title={themeTitle}
+      onClick={cycleTheme}
+    />
+  );
+
   return (
-    <div className="dither-page-shell flex h-screen text-atc-text">
-      <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
-        <MobileTopNav
-          left={
-            <Link
-              href="/"
-              className="mobile-top-nav-link"
-            >
-              ← ADSBao
-            </Link>
-          }
-          right={
-            <button
-              type="button"
-              className="mobile-top-nav-link flex items-center gap-1.5"
-              title={themeTitle}
-              onClick={cycleTheme}
-            >
-              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-              <span>{themePreference}</span>
-            </button>
-          }
-        />
-
-        <div className="flex-none px-6 pt-7 pb-6">
-          <div className="flex items-center gap-3 max-[720px]:hidden">
-            <Logo size={28} className="text-atc-text" />
-            <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
-              About
-            </div>
-          </div>
-          <div className="mt-3 flex items-baseline gap-3">
-            <span className="font-mono text-[22px] font-semibold tracking-[0.04em] text-atc-text">
-              ADSBao
+    <DitherPageShell
+      sectionLabel="About"
+      mobileLeft={
+        <Link href="/" className="mobile-top-nav-link">
+          ← ADSBao
+        </Link>
+      }
+      footerLeft={backLink}
+      footerThemeToggleClassName="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+      renderThemeToggle={renderThemeToggle}
+    >
+      <div className="flex-none grid grid-cols-2 gap-px mx-6 overflow-hidden border border-[var(--atc-line)] bg-[var(--atc-line)]">
+        {buildMeta.map((item) => (
+          <div
+            key={item.label}
+            className="flex min-w-0 flex-col gap-0.5 bg-atc-bg px-3 py-2.5"
+          >
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-atc-faint">
+              {item.label}
             </span>
-            <span
-              aria-hidden="true"
-              className="h-px flex-1 bg-[var(--atc-line-strong)]"
-            />
-          </div>
-          <h1 className="mt-4 text-[26px] font-semibold leading-[1.1] tracking-[-0.01em] text-atc-text">
-            Airport explorer
-          </h1>
-          <p className="mt-3 text-[13px] leading-relaxed text-atc-dim">
-            {SITE_DESCRIPTION}
-          </p>
-        </div>
-
-        <div className="flex-none grid grid-cols-2 gap-px mx-6 overflow-hidden border border-[var(--atc-line)] bg-[var(--atc-line)]">
-          {buildMeta.map((item) => (
-            <div
-              key={item.label}
-              className="flex min-w-0 flex-col gap-0.5 bg-atc-bg px-3 py-2.5"
-            >
-              <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-atc-faint">
-                {item.label}
-              </span>
-              <span className="truncate text-[12px] font-semibold text-atc-text">
-                {item.value}
-              </span>
-            </div>
-          ))}
-        </div>
-
-        <div className="flex-none px-6 pt-6 pb-3">
-          <div className="flex items-baseline justify-between border-b border-[var(--atc-line)] pb-2.5 font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
-            <span>Data sources</span>
-            <span className="tracking-[0.18em] text-atc-dim">
-              {dataSources.length} feeds
+            <span className="truncate text-[12px] font-semibold text-atc-text">
+              {item.value}
             </span>
           </div>
+        ))}
+      </div>
+
+      <div className="flex-none px-6 pt-6 pb-3">
+        <div className="flex items-baseline justify-between border-b border-[var(--atc-line)] pb-2.5 font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
+          <span>Data sources</span>
+          <span className="tracking-[0.18em] text-atc-dim">
+            {dataSources.length} feeds
+          </span>
         </div>
+      </div>
 
-        <div className="flex-1 overflow-y-auto">
-          <ol className="px-6 divide-y divide-[var(--atc-line)]">
-            {dataSources.map((source) => (
-              <li key={source.glyph}>
-                <a
-                  href={source.href}
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={(event) => openExternalLink(event, source.href)}
-                  className="group grid grid-cols-[56px_minmax(0,1fr)] items-center gap-3 py-3 transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] -mx-6 px-6"
-                >
-                  <span className="font-mono text-[16px] font-bold leading-[1] tracking-[0.02em] text-atc-orange">
-                    {source.glyph}
-                  </span>
-                  <span className="min-w-0">
-                    <strong className="block truncate text-[13px] font-semibold text-atc-text">
-                      {source.title}
-                    </strong>
-                    <small className="mt-0.5 block truncate text-[11.5px] text-atc-dim">
-                      {source.description}
-                    </small>
-                  </span>
-                </a>
-              </li>
-            ))}
-          </ol>
-
-          <div className="px-6 pt-6 pb-6">
-            <a
-              href="https://github.com/orriduck/ADSBao"
-              target="_blank"
-              rel="noreferrer"
-              onClick={(event) =>
-                openExternalLink(event, "https://github.com/orriduck/ADSBao")
-              }
-              className="group flex items-center justify-between gap-3 border border-[var(--atc-line)] px-4 py-3.5 transition-colors hover:border-[var(--atc-line-strong)]"
-            >
-              <div className="flex items-center gap-3">
-                <span className="grid h-8 w-8 place-items-center rounded-full border border-[var(--atc-line)] text-atc-text">
-                  <Github className="h-3.5 w-3.5" aria-hidden="true" />
+      <div className="flex-1 overflow-y-auto">
+        <ol className="px-6 divide-y divide-[var(--atc-line)]">
+          {dataSources.map((source) => (
+            <li key={source.glyph}>
+              <a
+                href={source.href}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(event) => openExternalLink(event, source.href)}
+                className="group grid grid-cols-[56px_minmax(0,1fr)] items-center gap-3 py-3 transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] -mx-6 px-6"
+              >
+                <span className="font-mono text-[16px] font-bold leading-[1] tracking-[0.02em] text-atc-orange">
+                  {source.glyph}
                 </span>
-                <div>
-                  <strong className="block text-[13px] font-semibold text-atc-text">
-                    orriduck / ADSBao
+                <span className="min-w-0">
+                  <strong className="block truncate text-[13px] font-semibold text-atc-text">
+                    {source.title}
                   </strong>
-                  <small className="mt-0.5 block text-[11.5px] text-atc-dim">
-                    MIT License
+                  <small className="mt-0.5 block truncate text-[11.5px] text-atc-dim">
+                    {source.description}
                   </small>
-                </div>
+                </span>
+              </a>
+            </li>
+          ))}
+        </ol>
+
+        <div className="px-6 pt-6 pb-6">
+          <a
+            href="https://github.com/orriduck/ADSBao"
+            target="_blank"
+            rel="noreferrer"
+            onClick={(event) =>
+              openExternalLink(event, "https://github.com/orriduck/ADSBao")
+            }
+            className="group flex items-center justify-between gap-3 border border-[var(--atc-line)] px-4 py-3.5 transition-colors hover:border-[var(--atc-line-strong)]"
+          >
+            <div className="flex items-center gap-3">
+              <span className="grid h-8 w-8 place-items-center rounded-full border border-[var(--atc-line)] text-atc-text">
+                <Github className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
+              <div>
+                <strong className="block text-[13px] font-semibold text-atc-text">
+                  orriduck / ADSBao
+                </strong>
+                <small className="mt-0.5 block text-[11.5px] text-atc-dim">
+                  MIT License
+                </small>
               </div>
-              <ArrowUpRight
-                className="h-4 w-4 text-atc-faint transition-colors group-hover:text-atc-orange"
-                aria-hidden="true"
-              />
-            </a>
-          </div>
-        </div>
-
-        <div className="flex-none items-center justify-between border-t border-[var(--atc-line)] px-6 py-3 max-[720px]:hidden sm:flex">
-          <Link
-            href="/"
-            className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text"
-          >
-            ← ADSBao
-          </Link>
-          <button
-            type="button"
-            className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
-            title={themeTitle}
-            onClick={cycleTheme}
-          >
-            <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>{themePreference}</span>
-          </button>
+            </div>
+            <ArrowUpRight
+              className="h-4 w-4 text-atc-faint transition-colors group-hover:text-atc-orange"
+              aria-hidden="true"
+            />
+          </a>
         </div>
       </div>
-
-      <div className="dither-page-background relative flex-1">
-        <DitherBackground />
-      </div>
-    </div>
+    </DitherPageShell>
   );
 }

--- a/src/components/screens/SearchScreen.jsx
+++ b/src/components/screens/SearchScreen.jsx
@@ -1,25 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { Info, Monitor, Moon, Search, Sun } from "lucide-react";
+import { Info, Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { HOME_AIRPORT_COUNTRY } from "../../config/homeAirportDirectory.js";
-import { SITE_DESCRIPTION } from "../../config/site.js";
+import DitherPageShell from "../../features/app-shell/DitherPageShell.jsx";
+import ThemeToggle from "../../features/app-shell/ThemeToggle.jsx";
+import { useThemePreference } from "../../features/app-shell/useThemePreference.js";
 import { airportDirectoryClient } from "../../services/airportDirectory.js";
 import { airportSubtitle } from "../../utils/airport.js";
-import {
-  THEME_DARK,
-  THEME_LIGHT,
-  THEME_SYSTEM,
-  applyThemePreference,
-  initThemePreference,
-  nextTheme,
-  writeStoredTheme,
-} from "../../utils/theme.js";
 import { Input } from "../ui/input.jsx";
-import DitherBackground from "../effects/DitherBackground.jsx";
-import Logo from "../brand/Logo.jsx";
-import MobileTopNav from "../navigation/MobileTopNav.jsx";
 
 const featuredAirports = [
   {
@@ -95,52 +85,9 @@ export default function SearchScreen({ onOpenAirport }) {
   const [results, setResults] = useState([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState(null);
-  const [themePreference, setThemePreference] = useState(THEME_SYSTEM);
+  const { themePreference, themeTitle, themeIconKey, cycleTheme } =
+    useThemePreference();
   const activeRequestId = useRef(0);
-  const mediaQueryList = useRef(null);
-
-  useEffect(() => {
-    mediaQueryList.current = window.matchMedia("(prefers-color-scheme: dark)");
-    setThemePreference(
-      initThemePreference({ mediaQueryList: mediaQueryList.current })
-        .preference,
-    );
-    const listener = () => {
-      if (themePreference === THEME_SYSTEM) {
-        applyThemePreference({
-          theme: THEME_SYSTEM,
-          mediaQueryList: mediaQueryList.current,
-        });
-      }
-    };
-    mediaQueryList.current.addEventListener("change", listener);
-    return () =>
-      mediaQueryList.current?.removeEventListener("change", listener);
-  }, [themePreference]);
-
-  const themeTitle = useMemo(() => {
-    if (themePreference === THEME_LIGHT)
-      return "Theme: Light (click to switch)";
-    if (themePreference === THEME_DARK) return "Theme: Dark (click to switch)";
-    return "Theme: System (click to switch)";
-  }, [themePreference]);
-
-  const ThemeIcon =
-    themePreference === THEME_LIGHT
-      ? Sun
-      : themePreference === THEME_DARK
-        ? Moon
-        : Monitor;
-
-  const cycleTheme = () => {
-    const next = nextTheme(themePreference);
-    setThemePreference(next);
-    writeStoredTheme(next);
-    applyThemePreference({
-      theme: next,
-      mediaQueryList: mediaQueryList.current,
-    });
-  };
 
   const searchRows = useMemo(() => {
     const query = q.trim().toUpperCase();
@@ -232,113 +179,77 @@ export default function SearchScreen({ onOpenAirport }) {
     openAirport(exact || searchRows[0]);
   };
 
+  const mobileAboutLink = (
+    <Link
+      href="/about"
+      title="About ADSBao"
+      className="mobile-top-nav-link flex items-center gap-1.5"
+    >
+      <Info className="h-3.5 w-3.5" aria-hidden="true" />
+      <span>About</span>
+    </Link>
+  );
+
+  const footerAboutLink = (
+    <Link
+      href="/about"
+      title="About ADSBao"
+      className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
+    >
+      <Info className="h-3.5 w-3.5" aria-hidden="true" />
+      <span>About</span>
+    </Link>
+  );
+
+  const renderThemeToggle = (className) => (
+    <ThemeToggle
+      className={className}
+      iconKey={themeIconKey}
+      preference={themePreference}
+      title={themeTitle}
+      onClick={cycleTheme}
+    />
+  );
+
   return (
-    <div className="dither-page-shell search-screen flex h-screen text-atc-text">
-      <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
-        <MobileTopNav
-          left={
-            <Link
-              href="/about"
-              title="About ADSBao"
-              className="mobile-top-nav-link flex items-center gap-1.5"
-            >
-              <Info className="h-3.5 w-3.5" aria-hidden="true" />
-              <span>About</span>
-            </Link>
-          }
-          right={
-            <button
-              type="button"
-              className="mobile-top-nav-link flex items-center gap-1.5"
-              title={themeTitle}
-              onClick={cycleTheme}
-            >
-              <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-              <span>{themePreference}</span>
-            </button>
-          }
+    <DitherPageShell
+      className="search-screen"
+      sectionLabel="Airport search"
+      mobileLeft={mobileAboutLink}
+      footerLeft={footerAboutLink}
+      renderThemeToggle={renderThemeToggle}
+    >
+      <form
+        onSubmit={doSearch}
+        className="flex-none mx-6 flex items-center gap-3 py-3.5"
+      >
+        <Search className="h-5 w-5 shrink-0 text-atc-orange" />
+        <Input
+          value={q}
+          onChange={(event) => setQ(event.target.value)}
+          className="flex-1 p-0 text-base font-semibold tracking-normal text-atc-text"
+          placeholder="Search ICAO, IATA, city, or name"
         />
+        <kbd className="hidden shrink-0 items-center px-2 py-1 font-mono text-[10px] uppercase tracking-[0.04em] text-atc-dim sm:inline-flex">
+          {searchLoading ? "..." : "enter"}
+        </kbd>
+      </form>
 
-        <div className="flex-none px-6 pt-7 pb-6">
-          <div className="flex items-center gap-3 max-[720px]:hidden">
-            <Logo size={28} className="text-atc-text" />
-            <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
-              Airport search
-            </div>
-          </div>
-          <div className="mt-3 flex items-baseline gap-3">
-            <span className="font-mono text-[22px] font-semibold tracking-[0.04em] text-atc-text">
-              ADSBao
-            </span>
-            <span
-              aria-hidden="true"
-              className="h-px flex-1 bg-[var(--atc-line-strong)]"
-            />
-          </div>
-          <h1 className="mt-4 text-[26px] font-semibold leading-[1.1] tracking-[-0.01em] text-atc-text">
-            Airport explorer
-          </h1>
-          <p className="mt-3 text-[13px] leading-relaxed text-atc-dim">
-            {SITE_DESCRIPTION}
-          </p>
-        </div>
-
-        <form
-          onSubmit={doSearch}
-          className="flex-none mx-6 flex items-center gap-3 py-3.5"
-        >
-          <Search className="h-5 w-5 shrink-0 text-atc-orange" />
-          <Input
-            value={q}
-            onChange={(event) => setQ(event.target.value)}
-            className="flex-1 p-0 text-base font-semibold tracking-normal text-atc-text"
-            placeholder="Search ICAO, IATA, city, or name"
+      <div className="flex-1 overflow-y-auto">
+        {q.trim() ? (
+          <SearchResults
+            q={q}
+            rows={searchRows}
+            loading={searchLoading}
+            error={searchError}
+            countLabel={resultCountLabel}
+            onOpen={openAirport}
           />
-          <kbd className="hidden shrink-0 items-center px-2 py-1 font-mono text-[10px] uppercase tracking-[0.04em] text-atc-dim sm:inline-flex">
-            {searchLoading ? "..." : "enter"}
-          </kbd>
-        </form>
-
-        <div className="flex-1 overflow-y-auto">
-          {q.trim() ? (
-            <SearchResults
-              q={q}
-              rows={searchRows}
-              loading={searchLoading}
-              error={searchError}
-              countLabel={resultCountLabel}
-              onOpen={openAirport}
-            />
-          ) : (
-            <FeaturedAirports onOpen={openAirport} />
-          )}
-        </div>
-
-        <div className="flex-none items-center justify-between border-t border-[var(--atc-line)] px-6 py-3 max-[720px]:hidden sm:flex">
-          <Link
-            href="/about"
-            title="About ADSBao"
-            className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
-          >
-            <Info className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>About</span>
-          </Link>
-          <button
-            type="button"
-            className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5"
-            title={themeTitle}
-            onClick={cycleTheme}
-          >
-            <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>{themePreference}</span>
-          </button>
-        </div>
+        ) : (
+          <FeaturedAirports onOpen={openAirport} />
+        )}
       </div>
-
-      <div className="dither-page-background relative flex-1">
-        <DitherBackground />
-      </div>
-    </div>
+    </DitherPageShell>
   );
 }
 

--- a/src/features/app-shell/DitherPageShell.jsx
+++ b/src/features/app-shell/DitherPageShell.jsx
@@ -1,0 +1,66 @@
+"use client";
+
+import DitherBackground from "@/components/effects/DitherBackground.jsx";
+import Logo from "@/components/brand/Logo.jsx";
+import MobileTopNav from "@/components/navigation/MobileTopNav.jsx";
+import { SITE_DESCRIPTION } from "@/config/site.js";
+
+export default function DitherPageShell({
+  className = "",
+  sectionLabel,
+  title = "Airport explorer",
+  description = SITE_DESCRIPTION,
+  mobileLeft,
+  footerLeft,
+  footerThemeToggleClassName = "font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5",
+  renderThemeToggle,
+  children,
+}) {
+  return (
+    <div
+      className={`dither-page-shell flex h-screen text-atc-text ${className}`.trim()}
+    >
+      <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
+        <MobileTopNav
+          left={mobileLeft}
+          right={renderThemeToggle?.("mobile-top-nav-link flex items-center gap-1.5")}
+        />
+
+        <div className="flex-none px-6 pt-7 pb-6">
+          <div className="flex items-center gap-3 max-[720px]:hidden">
+            <Logo size={28} className="text-atc-text" />
+            <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
+              {sectionLabel}
+            </div>
+          </div>
+          <div className="mt-3 flex items-baseline gap-3">
+            <span className="font-mono text-[22px] font-semibold tracking-[0.04em] text-atc-text">
+              ADSBao
+            </span>
+            <span
+              aria-hidden="true"
+              className="h-px flex-1 bg-[var(--atc-line-strong)]"
+            />
+          </div>
+          <h1 className="mt-4 text-[26px] font-semibold leading-[1.1] tracking-[-0.01em] text-atc-text">
+            {title}
+          </h1>
+          <p className="mt-3 text-[13px] leading-relaxed text-atc-dim">
+            {description}
+          </p>
+        </div>
+
+        {children}
+
+        <div className="flex-none items-center justify-between border-t border-[var(--atc-line)] px-6 py-3 max-[720px]:hidden sm:flex">
+          {footerLeft}
+          {renderThemeToggle?.(footerThemeToggleClassName)}
+        </div>
+      </div>
+
+      <div className="dither-page-background relative flex-1">
+        <DitherBackground />
+      </div>
+    </div>
+  );
+}

--- a/src/features/app-shell/ThemeToggle.jsx
+++ b/src/features/app-shell/ThemeToggle.jsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Monitor, Moon, Sun } from "lucide-react";
+
+const THEME_ICONS = {
+  monitor: Monitor,
+  moon: Moon,
+  sun: Sun,
+};
+
+export default function ThemeToggle({
+  className,
+  iconKey = "monitor",
+  preference = "system",
+  title,
+  onClick,
+}) {
+  const ThemeIcon = THEME_ICONS[iconKey] || Monitor;
+
+  return (
+    <button type="button" className={className} title={title} onClick={onClick}>
+      <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+      <span>{preference}</span>
+    </button>
+  );
+}

--- a/src/features/app-shell/themePreference.js
+++ b/src/features/app-shell/themePreference.js
@@ -1,0 +1,20 @@
+import {
+  THEME_DARK,
+  THEME_LIGHT,
+  THEME_SYSTEM,
+  sanitizeTheme,
+} from "../../utils/theme.js";
+
+export const getThemeTitle = (theme) => {
+  const safeTheme = sanitizeTheme(theme);
+  if (safeTheme === THEME_LIGHT) return "Theme: Light (click to switch)";
+  if (safeTheme === THEME_DARK) return "Theme: Dark (click to switch)";
+  return "Theme: System (click to switch)";
+};
+
+export const getThemeIconKey = (theme) => {
+  const safeTheme = sanitizeTheme(theme);
+  if (safeTheme === THEME_LIGHT) return "sun";
+  if (safeTheme === THEME_DARK) return "moon";
+  return "monitor";
+};

--- a/src/features/app-shell/themePreference.test.js
+++ b/src/features/app-shell/themePreference.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+
+import {
+  getThemeIconKey,
+  getThemeTitle,
+} from "./themePreference.js";
+import {
+  THEME_DARK,
+  THEME_LIGHT,
+  THEME_SYSTEM,
+} from "../../utils/theme.js";
+
+assert.equal(getThemeTitle(THEME_LIGHT), "Theme: Light (click to switch)");
+assert.equal(getThemeTitle(THEME_DARK), "Theme: Dark (click to switch)");
+assert.equal(getThemeTitle(THEME_SYSTEM), "Theme: System (click to switch)");
+assert.equal(getThemeTitle("invalid"), "Theme: System (click to switch)");
+
+assert.equal(getThemeIconKey(THEME_LIGHT), "sun");
+assert.equal(getThemeIconKey(THEME_DARK), "moon");
+assert.equal(getThemeIconKey(THEME_SYSTEM), "monitor");
+assert.equal(getThemeIconKey("invalid"), "monitor");

--- a/src/features/app-shell/useThemePreference.js
+++ b/src/features/app-shell/useThemePreference.js
@@ -1,0 +1,63 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  THEME_SYSTEM,
+  applyThemePreference,
+  initThemePreference,
+  nextTheme,
+  writeStoredTheme,
+} from "../../utils/theme.js";
+import { getThemeIconKey, getThemeTitle } from "./themePreference.js";
+
+export function useThemePreference() {
+  const [themePreference, setThemePreference] = useState(THEME_SYSTEM);
+  const mediaQueryList = useRef(null);
+  const themePreferenceRef = useRef(THEME_SYSTEM);
+
+  useEffect(() => {
+    themePreferenceRef.current = themePreference;
+  }, [themePreference]);
+
+  useEffect(() => {
+    mediaQueryList.current = window.matchMedia("(prefers-color-scheme: dark)");
+    const initialized = initThemePreference({
+      mediaQueryList: mediaQueryList.current,
+    });
+    setThemePreference(initialized.preference);
+    themePreferenceRef.current = initialized.preference;
+
+    const listener = () => {
+      if (themePreferenceRef.current === THEME_SYSTEM) {
+        applyThemePreference({
+          theme: THEME_SYSTEM,
+          mediaQueryList: mediaQueryList.current,
+        });
+      }
+    };
+
+    mediaQueryList.current.addEventListener("change", listener);
+    return () => mediaQueryList.current?.removeEventListener("change", listener);
+  }, []);
+
+  const cycleTheme = useCallback(() => {
+    const next = nextTheme(themePreferenceRef.current);
+    themePreferenceRef.current = next;
+    setThemePreference(next);
+    writeStoredTheme(next);
+    applyThemePreference({
+      theme: next,
+      mediaQueryList: mediaQueryList.current,
+    });
+  }, []);
+
+  return useMemo(
+    () => ({
+      themePreference,
+      themeTitle: getThemeTitle(themePreference),
+      themeIconKey: getThemeIconKey(themePreference),
+      cycleTheme,
+    }),
+    [cycleTheme, themePreference],
+  );
+}


### PR DESCRIPTION
## Summary

- Added a shared app-shell layer for dither-backed pages: `DitherPageShell`, `ThemeToggle`, and `useThemePreference`.
- Moved repeated theme label/icon presentation into `themePreference.js` with a focused Node test.
- Refactored `SearchScreen` and `AboutClient` to use the shared shell while preserving their existing panel content, nav targets, footer controls, and dither background.
- Added `pnpm test:app-shell` to the package scripts and local agent validation chain.

## Why

Search and About had duplicated layout, header, mobile nav, desktop footer, and theme-cycle logic. This PR establishes the reusable app-shell pattern before the next feature-level refactors, reducing duplication without touching airport explorer data or map behavior.

## Validation

- `pnpm test:home-airport-directory`
- `pnpm test:airport-directory`
- `pnpm test:aviation-data`
- `pnpm test:vercel-routing`
- `pnpm test:airport-wiki`
- `pnpm test:app-shell`
- `pnpm test:airport-explorer`
- `pnpm test:flight-route-display`
- `pnpm test:airport-map-display`
- `pnpm test:metar`
- `pnpm test:aircraft-motion`
- `pnpm test:aircraft-traffic-intent`
- `pnpm lint`
- `pnpm build`
- `curl -I http://localhost:3000/` returned `HTTP/1.1 200 OK`
- `curl -I http://localhost:3000/about` returned `HTTP/1.1 200 OK`
- `curl -I http://localhost:3000/KBOS` returned `HTTP/1.1 200 OK`