### PR TITLE
Refactor map control feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ pnpm build
 ## Tests
 
 ```bash
-pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
+pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
 ```
 
 ## Runtime config

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:app-shell": "node src/features/app-shell/themePreference.test.js",
     "test:airport-search": "node src/features/airport-search/airportSearchModel.test.js",
     "test:airport-explorer": "node src/features/airport-explorer/airportExplorerModel.test.js",
+    "test:map-controls": "node src/features/map-controls/mapControlModel.test.js",
     "test:flight-route-display": "node src/utils/flightRouteDisplay.test.js",
     "test:airport-map-display": "node src/utils/airportMapDisplay.test.js",
     "test:metar": "node src/hooks/useMetar.test.js",

--- a/src/components/ui/MapControlBar.jsx
+++ b/src/components/ui/MapControlBar.jsx
@@ -1,41 +1,19 @@
 "use client";
 
+import { useCallback, useMemo, useRef, useState } from "react";
+import { MAP_ZOOM_OPTIONS } from "../../config/mapControls.js";
+import { useThemePreference } from "../../features/app-shell/useThemePreference.js";
+import MapControlRail from "../../features/map-controls/MapControlRail.jsx";
+import MapZoomDrawer from "../../features/map-controls/MapZoomDrawer.jsx";
 import {
-  AudioLines,
-  Crosshair,
-  Gauge,
-  Monitor,
-  Moon,
-  PlaneLanding,
-  SlidersHorizontal,
-  Sun,
-  TowerControl,
-  Type,
-} from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  ZOOM_AIRPORT,
-  ZOOM_APPROACH,
-  ZOOM_DETAIL,
-} from "../../utils/airportMapDisplay.js";
-import {
-  THEME_DARK,
-  THEME_LIGHT,
-  THEME_SYSTEM,
-  applyThemePreference,
-  initThemePreference,
-  nextTheme,
-  writeStoredTheme,
-} from "../../utils/theme.js";
-import { Button } from "./button.jsx";
+  getNextZoomValue,
+  resolveZoomOption,
+} from "../../features/map-controls/mapControlModel.js";
+import { useDismissibleDrawer } from "../../features/map-controls/useDismissibleDrawer.js";
+import { useFocusAudio } from "../../features/map-controls/useFocusAudio.js";
+import { ZOOM_AIRPORT } from "../../utils/airportMapDisplay.js";
 
-const VIDEO_ID = "JDQiaRYmTGk";
-
-const zoomOptions = [
-  { value: ZOOM_APPROACH, title: "Approaching view", Icon: PlaneLanding },
-  { value: ZOOM_AIRPORT, title: "Airport view", Icon: TowerControl },
-  { value: ZOOM_DETAIL, title: "Detail view", Icon: Crosshair },
-];
+const DRAWER_ID = "map-action-drawer";
 
 export default function MapControlBar({
   activeZoom = ZOOM_AIRPORT,
@@ -46,109 +24,24 @@ export default function MapControlBar({
   onToggleTelemetry,
 }) {
   const controlZone = useRef(null);
-  const playerHost = useRef(null);
-  const [playing, setPlaying] = useState(false);
-  const [audioReady, setAudioReady] = useState(false);
-  const [currentTheme, setCurrentTheme] = useState(THEME_SYSTEM);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const player = useRef(null);
-  const mediaQueryList = useRef(null);
+  const { themePreference, themeTitle, cycleTheme } = useThemePreference();
+  const { playerHost, playing, audioReady, toggleAudio } = useFocusAudio();
 
   const currentZoomOption = useMemo(
-    () => zoomOptions.find((option) => option.value === activeZoom) || zoomOptions[1],
+    () => resolveZoomOption(activeZoom, MAP_ZOOM_OPTIONS),
     [activeZoom],
   );
 
-  const themeTitle = useMemo(() => {
-    if (currentTheme === THEME_LIGHT) return "Theme: Light (click to switch)";
-    if (currentTheme === THEME_DARK) return "Theme: Dark (click to switch)";
-    return "Theme: System (click to switch)";
-  }, [currentTheme]);
-
-  useEffect(() => {
-    const closeDrawer = () => setDrawerOpen(false);
-    const handlePointerDown = (event) => {
-      if (!drawerOpen || controlZone.current?.contains(event.target)) return;
-      closeDrawer();
-    };
-    const handleKeydown = (event) => {
-      if (event.key === "Escape") closeDrawer();
-    };
-    window.addEventListener("pointerdown", handlePointerDown);
-    window.addEventListener("keydown", handleKeydown);
-    return () => {
-      window.removeEventListener("pointerdown", handlePointerDown);
-      window.removeEventListener("keydown", handleKeydown);
-    };
-  }, [drawerOpen]);
-
-  useEffect(() => {
-    mediaQueryList.current = window.matchMedia("(prefers-color-scheme: dark)");
-    setCurrentTheme(
-      initThemePreference({ mediaQueryList: mediaQueryList.current }).preference,
-    );
-    const listener = () => {
-      if (currentTheme === THEME_SYSTEM) {
-        applyThemePreference({
-          theme: THEME_SYSTEM,
-          mediaQueryList: mediaQueryList.current,
-        });
-      }
-    };
-    mediaQueryList.current.addEventListener("change", listener);
-    return () => mediaQueryList.current?.removeEventListener("change", listener);
-  }, [currentTheme]);
-
-  useEffect(() => {
-    const playerHostEl = playerHost.current;
-    if (!playerHostEl) return undefined;
-
-    let cancelled = false;
-    let playerTarget = null;
-
-    loadYouTubeApi().then(() => {
-      if (cancelled) return;
-
-      playerTarget = document.createElement("div");
-      playerHostEl.replaceChildren(playerTarget);
-
-      player.current = new window.YT.Player(playerTarget, {
-        height: 1,
-        width: 1,
-        videoId: VIDEO_ID,
-        playerVars: {
-          autoplay: 0,
-          loop: 1,
-          playlist: VIDEO_ID,
-          controls: 0,
-          playsinline: 1,
-          rel: 0,
-        },
-        events: {
-          onReady() {
-            setAudioReady(true);
-          },
-          onStateChange(e) {
-            setPlaying(e.data === window.YT.PlayerState.PLAYING);
-          },
-        },
-      });
-    });
-    return () => {
-      cancelled = true;
-      player.current?.destroy();
-      player.current = null;
-      playerTarget?.remove();
-      playerHostEl.replaceChildren();
-    };
+  const closeDrawer = useCallback(() => {
+    setDrawerOpen(false);
   }, []);
 
-  const cycleTheme = () => {
-    const next = nextTheme(currentTheme);
-    setCurrentTheme(next);
-    writeStoredTheme(next);
-    applyThemePreference({ theme: next, mediaQueryList: mediaQueryList.current });
-  };
+  useDismissibleDrawer({
+    open: drawerOpen,
+    containerRef: controlZone,
+    onClose: closeDrawer,
+  });
 
   const selectZoom = (zoom) => {
     onZoom?.(zoom);
@@ -156,145 +49,39 @@ export default function MapControlBar({
   };
 
   const cycleZoom = () => {
-    const currentIndex = zoomOptions.findIndex((option) => option.value === activeZoom);
-    const nextIndex = (currentIndex + 1) % zoomOptions.length;
-    onZoom?.(zoomOptions[nextIndex].value);
+    onZoom?.(getNextZoomValue(activeZoom, MAP_ZOOM_OPTIONS));
   };
-
-  const toggleAudio = () => {
-    if (!player.current || !audioReady) return;
-    if (playing) player.current.pauseVideo();
-    else player.current.playVideo();
-  };
-
-  const CurrentIcon = currentZoomOption.Icon;
-  const ThemeIcon =
-    currentTheme === THEME_LIGHT
-      ? Sun
-      : currentTheme === THEME_DARK
-        ? Moon
-        : Monitor;
 
   return (
     <>
       <div ref={playerHost} className="yt-sink" aria-hidden="true" />
       <div ref={controlZone} className="map-ctrl-zone">
-        <div
-          id="map-action-drawer"
-          className={`map-action-drawer ${drawerOpen ? "open" : ""}`}
-          aria-hidden={!drawerOpen}
-        >
-          {zoomOptions.map(({ value, title, Icon }) => (
-            <Button
-              key={value}
-              variant="atcIcon"
-              size="icon"
-              className={`ctrl-btn drawer-btn ${activeZoom === value ? "active" : ""}`}
-              title={title}
-              onClick={() => selectZoom(value)}
-              type="button"
-            >
-              <Icon />
-            </Button>
-          ))}
-        </div>
+        <MapZoomDrawer
+          id={DRAWER_ID}
+          open={drawerOpen}
+          options={MAP_ZOOM_OPTIONS}
+          activeZoom={activeZoom}
+          onSelect={selectZoom}
+        />
 
-        <div className="map-ctrl-bar">
-          <Button
-            variant="atcIcon"
-            size="icon"
-            className="ctrl-btn ctrl-view active"
-            title={`${currentZoomOption.title} (click to cycle)`}
-            onClick={cycleZoom}
-            type="button"
-          >
-            <CurrentIcon />
-          </Button>
-
-          <div className="ctrl-sep" />
-
-          <Button
-            variant="atcIcon"
-            size="icon"
-            className={`ctrl-btn ctrl-audio ${playing ? "playing" : ""} ${
-              !audioReady ? "loading" : ""
-            }`}
-            aria-pressed={playing}
-            title={playing ? "Pause Focus mode" : "Start Focus mode"}
-            onClick={toggleAudio}
-            type="button"
-          >
-            <AudioLines />
-          </Button>
-
-          <Button
-            variant="atcIcon"
-            size="icon"
-            className="ctrl-btn ctrl-theme"
-            title={themeTitle}
-            onClick={cycleTheme}
-            type="button"
-          >
-            <ThemeIcon />
-          </Button>
-
-          <Button
-            variant="atcIcon"
-            size="icon"
-            className={`ctrl-btn ${showMapLabels ? "active" : ""}`}
-            aria-pressed={showMapLabels}
-            title={showMapLabels ? "Hide map labels" : "Show map labels"}
-            onClick={onToggleMapLabels}
-            type="button"
-          >
-            <Type />
-          </Button>
-
-          <Button
-            variant="atcIcon"
-            size="icon"
-            className={`ctrl-btn ${showTelemetry ? "active" : ""}`}
-            aria-pressed={showTelemetry}
-            title={showTelemetry ? "Hide speed/altitude" : "Show speed/altitude"}
-            onClick={onToggleTelemetry}
-            type="button"
-          >
-            <Gauge />
-          </Button>
-
-          <Button
-            variant="atcIcon"
-            size="icon"
-            className={`ctrl-btn ctrl-more ${drawerOpen ? "active" : ""}`}
-            aria-expanded={drawerOpen}
-            aria-controls="map-action-drawer"
-            title="Map controls"
-            onClick={() => setDrawerOpen((value) => !value)}
-            type="button"
-          >
-            <SlidersHorizontal />
-          </Button>
-        </div>
+        <MapControlRail
+          currentZoomOption={currentZoomOption}
+          currentTheme={themePreference}
+          themeTitle={themeTitle}
+          drawerOpen={drawerOpen}
+          playing={playing}
+          audioReady={audioReady}
+          showMapLabels={showMapLabels}
+          showTelemetry={showTelemetry}
+          drawerId={DRAWER_ID}
+          onCycleZoom={cycleZoom}
+          onToggleAudio={toggleAudio}
+          onCycleTheme={cycleTheme}
+          onToggleMapLabels={onToggleMapLabels}
+          onToggleTelemetry={onToggleTelemetry}
+          onToggleDrawer={() => setDrawerOpen((value) => !value)}
+        />
       </div>
     </>
   );
-}
-
-function loadYouTubeApi() {
-  return new Promise((resolve) => {
-    if (window.YT?.Player) {
-      resolve();
-      return;
-    }
-    const prev = window.onYouTubeIframeAPIReady;
-    window.onYouTubeIframeAPIReady = () => {
-      prev?.();
-      resolve();
-    };
-    if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
-      const script = document.createElement("script");
-      script.src = "https://www.youtube.com/iframe_api";
-      document.head.appendChild(script);
-    }
-  });
 }

--- a/src/config/mapControls.js
+++ b/src/config/mapControls.js
@@ -1,0 +1,13 @@
+import {
+  ZOOM_AIRPORT,
+  ZOOM_APPROACH,
+  ZOOM_DETAIL,
+} from "../utils/airportMapDisplay.js";
+
+export const MAP_FOCUS_VIDEO_ID = "JDQiaRYmTGk";
+
+export const MAP_ZOOM_OPTIONS = [
+  { value: ZOOM_APPROACH, title: "Approaching view", iconKey: "planeLanding" },
+  { value: ZOOM_AIRPORT, title: "Airport view", iconKey: "towerControl" },
+  { value: ZOOM_DETAIL, title: "Detail view", iconKey: "crosshair" },
+];

--- a/src/features/map-controls/MapControlRail.jsx
+++ b/src/features/map-controls/MapControlRail.jsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { getThemeIconKey } from "../app-shell/themePreference.js";
+import { Button } from "../../components/ui/button.jsx";
+import { MapControlIcon } from "./mapControlIcons.jsx";
+
+const AUDIO_ICON_KEY = "audioLines";
+const GAUGE_ICON_KEY = "gauge";
+const MORE_ICON_KEY = "slidersHorizontal";
+const TYPE_ICON_KEY = "type";
+
+export default function MapControlRail({
+  currentZoomOption,
+  currentTheme,
+  themeTitle,
+  drawerOpen,
+  playing,
+  audioReady,
+  showMapLabels,
+  showTelemetry,
+  drawerId,
+  onCycleZoom,
+  onToggleAudio,
+  onCycleTheme,
+  onToggleMapLabels,
+  onToggleTelemetry,
+  onToggleDrawer,
+}) {
+  return (
+    <div className="map-ctrl-bar">
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className="ctrl-btn ctrl-view active"
+        title={`${currentZoomOption.title} (click to cycle)`}
+        onClick={onCycleZoom}
+        type="button"
+      >
+        <MapControlIcon iconKey={currentZoomOption.iconKey} />
+      </Button>
+
+      <div className="ctrl-sep" />
+
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className={`ctrl-btn ctrl-audio ${playing ? "playing" : ""} ${
+          !audioReady ? "loading" : ""
+        }`}
+        aria-pressed={playing}
+        title={playing ? "Pause Focus mode" : "Start Focus mode"}
+        onClick={onToggleAudio}
+        type="button"
+      >
+        <MapControlIcon iconKey={AUDIO_ICON_KEY} />
+      </Button>
+
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className="ctrl-btn ctrl-theme"
+        title={themeTitle}
+        onClick={onCycleTheme}
+        type="button"
+      >
+        <MapControlIcon iconKey={getThemeIconKey(currentTheme)} />
+      </Button>
+
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className={`ctrl-btn ${showMapLabels ? "active" : ""}`}
+        aria-pressed={showMapLabels}
+        title={showMapLabels ? "Hide map labels" : "Show map labels"}
+        onClick={onToggleMapLabels}
+        type="button"
+      >
+        <MapControlIcon iconKey={TYPE_ICON_KEY} />
+      </Button>
+
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className={`ctrl-btn ${showTelemetry ? "active" : ""}`}
+        aria-pressed={showTelemetry}
+        title={showTelemetry ? "Hide speed/altitude" : "Show speed/altitude"}
+        onClick={onToggleTelemetry}
+        type="button"
+      >
+        <MapControlIcon iconKey={GAUGE_ICON_KEY} />
+      </Button>
+
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className={`ctrl-btn ctrl-more ${drawerOpen ? "active" : ""}`}
+        aria-expanded={drawerOpen}
+        aria-controls={drawerId}
+        title="Map controls"
+        onClick={onToggleDrawer}
+        type="button"
+      >
+        <MapControlIcon iconKey={MORE_ICON_KEY} />
+      </Button>
+    </div>
+  );
+}

--- a/src/features/map-controls/MapZoomDrawer.jsx
+++ b/src/features/map-controls/MapZoomDrawer.jsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button } from "../../components/ui/button.jsx";
+import { MapControlIcon } from "./mapControlIcons.jsx";
+
+export default function MapZoomDrawer({
+  id,
+  open,
+  options,
+  activeZoom,
+  onSelect,
+}) {
+  return (
+    <div
+      id={id}
+      className={`map-action-drawer ${open ? "open" : ""}`}
+      aria-hidden={!open}
+    >
+      {options.map(({ value, title, iconKey }) => (
+        <Button
+          key={value}
+          variant="atcIcon"
+          size="icon"
+          className={`ctrl-btn drawer-btn ${activeZoom === value ? "active" : ""}`}
+          title={title}
+          onClick={() => onSelect(value)}
+          type="button"
+        >
+          <MapControlIcon iconKey={iconKey} />
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/map-controls/mapControlIcons.jsx
+++ b/src/features/map-controls/mapControlIcons.jsx
@@ -1,0 +1,56 @@
+"use client";
+
+import {
+  AudioLines,
+  Crosshair,
+  Gauge,
+  Monitor,
+  Moon,
+  PlaneLanding,
+  SlidersHorizontal,
+  Sun,
+  TowerControl,
+  Type,
+} from "lucide-react";
+
+export const MAP_CONTROL_ICONS = {
+  audioLines: AudioLines,
+  crosshair: Crosshair,
+  gauge: Gauge,
+  monitor: Monitor,
+  moon: Moon,
+  planeLanding: PlaneLanding,
+  slidersHorizontal: SlidersHorizontal,
+  sun: Sun,
+  towerControl: TowerControl,
+  type: Type,
+};
+
+export const getMapControlIcon = (iconKey) =>
+  MAP_CONTROL_ICONS[iconKey] || SlidersHorizontal;
+
+export function MapControlIcon({ iconKey }) {
+  switch (iconKey) {
+    case "audioLines":
+      return <AudioLines />;
+    case "crosshair":
+      return <Crosshair />;
+    case "gauge":
+      return <Gauge />;
+    case "monitor":
+      return <Monitor />;
+    case "moon":
+      return <Moon />;
+    case "planeLanding":
+      return <PlaneLanding />;
+    case "sun":
+      return <Sun />;
+    case "towerControl":
+      return <TowerControl />;
+    case "type":
+      return <Type />;
+    case "slidersHorizontal":
+    default:
+      return <SlidersHorizontal />;
+  }
+}

--- a/src/features/map-controls/mapControlModel.js
+++ b/src/features/map-controls/mapControlModel.js
@@ -1,0 +1,12 @@
+export const resolveZoomOption = (activeZoom, options = []) =>
+  options.find((option) => option.value === activeZoom) ||
+  options[1] ||
+  options[0] ||
+  null;
+
+export const getNextZoomValue = (activeZoom, options = []) => {
+  if (!options.length) return activeZoom;
+  const currentIndex = options.findIndex((option) => option.value === activeZoom);
+  const nextIndex = (currentIndex + 1) % options.length;
+  return options[nextIndex].value;
+};

--- a/src/features/map-controls/mapControlModel.test.js
+++ b/src/features/map-controls/mapControlModel.test.js
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+
+import {
+  getNextZoomValue,
+  resolveZoomOption,
+} from "./mapControlModel.js";
+
+const options = [
+  { value: 10, title: "Approach" },
+  { value: 13, title: "Airport" },
+  { value: 14, title: "Detail" },
+];
+
+assert.deepEqual(resolveZoomOption(10, options), options[0]);
+assert.deepEqual(resolveZoomOption(999, options), options[1]);
+assert.equal(getNextZoomValue(10, options), 13);
+assert.equal(getNextZoomValue(13, options), 14);
+assert.equal(getNextZoomValue(14, options), 10);
+assert.equal(getNextZoomValue(999, options), 10);

--- a/src/features/map-controls/useDismissibleDrawer.js
+++ b/src/features/map-controls/useDismissibleDrawer.js
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function useDismissibleDrawer({ open, containerRef, onClose }) {
+  useEffect(() => {
+    const handlePointerDown = (event) => {
+      if (!open || containerRef.current?.contains(event.target)) return;
+      onClose();
+    };
+    const handleKeydown = (event) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeydown);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  }, [containerRef, onClose, open]);
+}

--- a/src/features/map-controls/useFocusAudio.js
+++ b/src/features/map-controls/useFocusAudio.js
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { MAP_FOCUS_VIDEO_ID } from "../../config/mapControls.js";
+
+export function useFocusAudio() {
+  const playerHost = useRef(null);
+  const player = useRef(null);
+  const [playing, setPlaying] = useState(false);
+  const [audioReady, setAudioReady] = useState(false);
+
+  useEffect(() => {
+    const playerHostEl = playerHost.current;
+    if (!playerHostEl) return undefined;
+
+    let cancelled = false;
+    let playerTarget = null;
+
+    loadYouTubeApi().then(() => {
+      if (cancelled) return;
+
+      playerTarget = document.createElement("div");
+      playerHostEl.replaceChildren(playerTarget);
+
+      player.current = new window.YT.Player(playerTarget, {
+        height: 1,
+        width: 1,
+        videoId: MAP_FOCUS_VIDEO_ID,
+        playerVars: {
+          autoplay: 0,
+          loop: 1,
+          playlist: MAP_FOCUS_VIDEO_ID,
+          controls: 0,
+          playsinline: 1,
+          rel: 0,
+        },
+        events: {
+          onReady() {
+            setAudioReady(true);
+          },
+          onStateChange(e) {
+            setPlaying(e.data === window.YT.PlayerState.PLAYING);
+          },
+        },
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      player.current?.destroy();
+      player.current = null;
+      playerTarget?.remove();
+      playerHostEl.replaceChildren();
+    };
+  }, []);
+
+  const toggleAudio = () => {
+    if (!player.current || !audioReady) return;
+    if (playing) player.current.pauseVideo();
+    else player.current.playVideo();
+  };
+
+  return { playerHost, playing, audioReady, toggleAudio };
+}
+
+function loadYouTubeApi() {
+  return new Promise((resolve) => {
+    if (window.YT?.Player) {
+      resolve();
+      return;
+    }
+
+    const prev = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = () => {
+      prev?.();
+      resolve();
+    };
+
+    if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
+      const script = document.createElement("script");
+      script.src = "https://www.youtube.com/iframe_api";
+      document.head.appendChild(script);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- extract map control constants into centralized config
- split map control rail, zoom drawer, focus audio, and dismissible drawer behavior into feature modules
- keep MapControlBar as a thin orchestrator and add model coverage for zoom selection

## Verification
- pnpm test:map-controls
- pnpm lint
- pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:app-shell && pnpm test:about && pnpm test:airport-search && pnpm test:map-controls && pnpm test:airport-explorer && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
- pnpm build
- curl -I http://localhost:3000/
- curl -I http://localhost:3000/about
- curl -I http://localhost:3000/KBOS