### PR TITLE
Refactor airport map feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ pnpm build
 ## Tests
 
 ```bash
-pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
+pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
 ```
 
 ## Runtime config

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:airport-search": "node src/features/airport-search/airportSearchModel.test.js",
     "test:airport-explorer": "node src/features/airport-explorer/airportExplorerModel.test.js",
     "test:map-controls": "node src/features/map-controls/mapControlModel.test.js",
+    "test:airport-map-feature": "node src/features/airport-map/airportMapModel.test.js",
     "test:flight-route-display": "node src/utils/flightRouteDisplay.test.js",
     "test:airport-map-display": "node src/utils/airportMapDisplay.test.js",
     "test:metar": "node src/hooks/useMetar.test.js",

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -4,24 +4,28 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import L from "leaflet";
 import { MapContext } from "./MapContext.js";
 import MapTileLayers from "./MapTileLayers.jsx";
-import AreaMarker, { AIRPORT_AREA_RADIUS_NM } from "./AreaMarker.jsx";
+import AreaMarker from "./AreaMarker.jsx";
 import AirportMarker from "./AirportMarker.jsx";
 import GroundStatsCounter from "./GroundStatsCounter.jsx";
 import AircraftPosition from "./AircraftPosition.jsx";
-import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
-import { AIRCRAFT_COLORS } from "../../constants/aircraft.js";
-import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
-
-const trafficLegend = [
-  { id: "departure", label: "DEP", color: AIRCRAFT_COLORS.departure },
-  { id: "unknown", label: "UNKN", color: AIRCRAFT_COLORS.unknown },
-  { id: "arrival", label: "ARR", color: AIRCRAFT_COLORS.arrival },
-];
+import {
+  AIRPORT_MAP_FALLBACK_CENTER,
+  AIRPORT_MAP_TRAFFIC_LEGEND,
+} from "../../config/airportMap.js";
+import MapAttribution from "../../features/airport-map/MapAttribution.jsx";
+import MapCoordinateLabel from "../../features/airport-map/MapCoordinateLabel.jsx";
+import MapLoadingState from "../../features/airport-map/MapLoadingState.jsx";
+import MapTrafficLegend from "../../features/airport-map/MapTrafficLegend.jsx";
+import {
+  formatCoordinateLabel,
+  getMapOverlayTheme,
+  getVisibleAircraft,
+  resolveDocumentTheme,
+} from "../../features/airport-map/airportMapModel.js";
 
 const resolveCurrentTheme = () =>
-  typeof document !== "undefined" &&
-  document.documentElement.getAttribute("data-theme") === "light"
-    ? "light"
+  typeof document !== "undefined"
+    ? resolveDocumentTheme(document.documentElement)
     : "dark";
 
 export default function AirportMap({
@@ -57,7 +61,10 @@ export default function AirportMap({
   useEffect(() => {
     if (!mapEl.current || mapRef.current) return undefined;
     const map = L.map(mapEl.current, {
-      center: [lat || 33.9416, lon || -118.4085],
+      center: [
+        lat || AIRPORT_MAP_FALLBACK_CENTER.lat,
+        lon || AIRPORT_MAP_FALLBACK_CENTER.lon,
+      ],
       zoom,
       zoomControl: false,
       attributionControl: false,
@@ -88,26 +95,18 @@ export default function AirportMap({
     }
   }, [lat, lon, zoom]);
 
-  const atApproachZoom = Number(zoom) === ZOOM_APPROACH;
   const visibleAircraft = useMemo(() => {
-    return aircraft.filter((ac) => {
-      if (ac.lat == null || ac.lon == null) return false;
-      if (!atApproachZoom) return true;
-      const distNm = getDistanceNm(lat, lon, ac.lat, ac.lon);
-      return distNm == null || distNm > AIRPORT_AREA_RADIUS_NM;
+    return getVisibleAircraft({
+      aircraft,
+      airportLat: lat,
+      airportLon: lon,
+      zoom,
     });
-  }, [aircraft, atApproachZoom, lat, lon]);
+  }, [aircraft, lat, lon, zoom]);
 
-  const latStr = lat
-    ? `${Math.abs(lat).toFixed(2)}${lat >= 0 ? "N" : "S"}`
-    : "";
-  const lonStr = lon
-    ? `${Math.abs(lon).toFixed(2)}${lon >= 0 ? "E" : "W"}`
-    : "";
-  const mapLabelShadowColor =
-    currentTheme === "light" ? "rgba(250,249,245,0.95)" : "#041a38";
-  const mapAttributionColor =
-    currentTheme === "light" ? "rgba(14,26,43,0.45)" : "rgba(245,247,250,0.3)";
+  const latitudeLabel = formatCoordinateLabel(lat, "lat");
+  const longitudeLabel = formatCoordinateLabel(lon, "lon");
+  const overlayTheme = getMapOverlayTheme(currentTheme);
 
   return (
     <div className="relative h-full w-full bg-atc-bg">
@@ -148,48 +147,22 @@ export default function AirportMap({
 
       {mapInstance && (
         <>
-          <div
-            className="pointer-events-none absolute left-3.5 top-[56px] font-mono text-[10px] font-semibold tracking-[2px]"
-            style={{
-              color: accent,
-              textShadow: `0 0 6px ${mapLabelShadowColor}`,
-            }}
-          >
-            * {icao} / {latStr} {lonStr}
-          </div>
-          <div
-            className="pointer-events-none absolute bottom-3 right-3 whitespace-nowrap font-sans text-[9px]"
-            style={{
-              color: mapAttributionColor,
-              textShadow: `0 0 6px ${mapLabelShadowColor}`,
-            }}
-          >
-            OpenStreetMap / CartoDB
-          </div>
-          <div className="map-traffic-legend pointer-events-none absolute right-3 top-[168px] flex max-w-[calc(100%-24px)] flex-wrap gap-2 rounded px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.8px]">
-            {trafficLegend.map((item) => (
-              <span key={item.id} className="inline-flex items-center gap-1.5">
-                <span
-                  className="h-1.5 w-1.5 rounded-full"
-                  style={{
-                    background: item.color,
-                    boxShadow: `0 0 6px ${item.color}`,
-                  }}
-                />
-                {item.label}
-              </span>
-            ))}
-          </div>
+          <MapCoordinateLabel
+            icao={icao}
+            latitudeLabel={latitudeLabel}
+            longitudeLabel={longitudeLabel}
+            color={accent}
+            shadowColor={overlayTheme.labelShadowColor}
+          />
+          <MapAttribution
+            color={overlayTheme.attributionColor}
+            shadowColor={overlayTheme.labelShadowColor}
+          />
+          <MapTrafficLegend items={AIRPORT_MAP_TRAFFIC_LEGEND} />
         </>
       )}
 
-      {!mapInstance && (
-        <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-atc-card">
-          <div className="font-mono text-[11px] tracking-widest text-atc-faint">
-            LOADING MAP...
-          </div>
-        </div>
-      )}
+      {!mapInstance && <MapLoadingState />}
     </div>
   );
 }

--- a/src/components/map/AreaMarker.jsx
+++ b/src/components/map/AreaMarker.jsx
@@ -3,10 +3,10 @@
 import { useEffect, useRef } from "react";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext.js";
+import { AIRPORT_AREA_RADIUS_NM } from "../../config/airportMap.js";
 import { shouldShowAirportArea } from "../../utils/airportMapDisplay.js";
 import { DEFAULT_WIDE_RANGE_NM } from "../../services/aviationData.js";
 
-export const AIRPORT_AREA_RADIUS_NM = 2.2;
 const NM_TO_METERS = 1852;
 
 export default function AreaMarker({ lat, lon, zoom, theme = "dark" }) {

--- a/src/components/map/GroundStatsCounter.jsx
+++ b/src/components/map/GroundStatsCounter.jsx
@@ -5,8 +5,8 @@ import { createPortal } from "react-dom";
 import NumberFlow from "@number-flow/react";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext.js";
+import { AIRPORT_AREA_RADIUS_NM } from "../../config/airportMap.js";
 import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
-import { AIRPORT_AREA_RADIUS_NM } from "./AreaMarker.jsx";
 import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
 
 export default function GroundStatsCounter({ lat, lon, zoom, icao = "", aircraft = [] }) {

--- a/src/config/airportMap.js
+++ b/src/config/airportMap.js
@@ -1,0 +1,14 @@
+import { AIRCRAFT_COLORS } from "../constants/aircraft.js";
+
+export const AIRPORT_MAP_FALLBACK_CENTER = {
+  lat: 33.9416,
+  lon: -118.4085,
+};
+
+export const AIRPORT_AREA_RADIUS_NM = 2.2;
+
+export const AIRPORT_MAP_TRAFFIC_LEGEND = [
+  { id: "departure", label: "DEP", color: AIRCRAFT_COLORS.departure },
+  { id: "unknown", label: "UNKN", color: AIRCRAFT_COLORS.unknown },
+  { id: "arrival", label: "ARR", color: AIRCRAFT_COLORS.arrival },
+];

--- a/src/features/airport-map/MapAttribution.jsx
+++ b/src/features/airport-map/MapAttribution.jsx
@@ -1,0 +1,15 @@
+"use client";
+
+export default function MapAttribution({ color, shadowColor }) {
+  return (
+    <div
+      className="pointer-events-none absolute bottom-3 right-3 whitespace-nowrap font-sans text-[9px]"
+      style={{
+        color,
+        textShadow: `0 0 6px ${shadowColor}`,
+      }}
+    >
+      OpenStreetMap / CartoDB
+    </div>
+  );
+}

--- a/src/features/airport-map/MapCoordinateLabel.jsx
+++ b/src/features/airport-map/MapCoordinateLabel.jsx
@@ -1,0 +1,21 @@
+"use client";
+
+export default function MapCoordinateLabel({
+  icao,
+  latitudeLabel,
+  longitudeLabel,
+  color,
+  shadowColor,
+}) {
+  return (
+    <div
+      className="pointer-events-none absolute left-3.5 top-[56px] font-mono text-[10px] font-semibold tracking-[2px]"
+      style={{
+        color,
+        textShadow: `0 0 6px ${shadowColor}`,
+      }}
+    >
+      * {icao} / {latitudeLabel} {longitudeLabel}
+    </div>
+  );
+}

--- a/src/features/airport-map/MapLoadingState.jsx
+++ b/src/features/airport-map/MapLoadingState.jsx
@@ -1,0 +1,11 @@
+"use client";
+
+export default function MapLoadingState() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-atc-card">
+      <div className="font-mono text-[11px] tracking-widest text-atc-faint">
+        LOADING MAP...
+      </div>
+    </div>
+  );
+}

--- a/src/features/airport-map/MapTrafficLegend.jsx
+++ b/src/features/airport-map/MapTrafficLegend.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+export default function MapTrafficLegend({ items }) {
+  return (
+    <div className="map-traffic-legend pointer-events-none absolute right-3 top-[168px] flex max-w-[calc(100%-24px)] flex-wrap gap-2 rounded px-2.5 py-1.5 font-mono text-[9px] uppercase tracking-[0.8px]">
+      {items.map((item) => (
+        <span key={item.id} className="inline-flex items-center gap-1.5">
+          <span
+            className="h-1.5 w-1.5 rounded-full"
+            style={{
+              background: item.color,
+              boxShadow: `0 0 6px ${item.color}`,
+            }}
+          />
+          {item.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/features/airport-map/airportMapModel.js
+++ b/src/features/airport-map/airportMapModel.js
@@ -1,0 +1,40 @@
+import { AIRPORT_AREA_RADIUS_NM } from "../../config/airportMap.js";
+import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
+import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
+
+export const resolveDocumentTheme = (documentElement) =>
+  documentElement?.getAttribute("data-theme") === "light" ? "light" : "dark";
+
+export const getMapOverlayTheme = (theme) =>
+  theme === "light"
+    ? {
+        labelShadowColor: "rgba(250,249,245,0.95)",
+        attributionColor: "rgba(14,26,43,0.45)",
+      }
+    : {
+        labelShadowColor: "#041a38",
+        attributionColor: "rgba(245,247,250,0.3)",
+      };
+
+export const formatCoordinateLabel = (value, axis) => {
+  if (!value) return "";
+  const positiveSuffix = axis === "lat" ? "N" : "E";
+  const negativeSuffix = axis === "lat" ? "S" : "W";
+  return `${Math.abs(value).toFixed(2)}${value >= 0 ? positiveSuffix : negativeSuffix}`;
+};
+
+export const getVisibleAircraft = ({
+  aircraft,
+  airportLat,
+  airportLon,
+  zoom,
+}) => {
+  const atApproachZoom = Number(zoom) === ZOOM_APPROACH;
+
+  return aircraft.filter((ac) => {
+    if (ac.lat == null || ac.lon == null) return false;
+    if (!atApproachZoom) return true;
+    const distNm = getDistanceNm(airportLat, airportLon, ac.lat, ac.lon);
+    return distNm == null || distNm > AIRPORT_AREA_RADIUS_NM;
+  });
+};

--- a/src/features/airport-map/airportMapModel.test.js
+++ b/src/features/airport-map/airportMapModel.test.js
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+
+import { ZOOM_AIRPORT, ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
+import {
+  formatCoordinateLabel,
+  getMapOverlayTheme,
+  getVisibleAircraft,
+  resolveDocumentTheme,
+} from "./airportMapModel.js";
+
+const aircraft = [
+  { icao24: "near", lat: 42.3657, lon: -71.0097 },
+  { icao24: "far", lat: 42.55, lon: -71.22 },
+  { icao24: "missing", lat: null, lon: -71.22 },
+];
+
+assert.equal(resolveDocumentTheme({ getAttribute: () => "light" }), "light");
+assert.equal(resolveDocumentTheme({ getAttribute: () => "dark" }), "dark");
+assert.equal(resolveDocumentTheme({ getAttribute: () => null }), "dark");
+
+assert.equal(formatCoordinateLabel(42.3656, "lat"), "42.37N");
+assert.equal(formatCoordinateLabel(-71.0096, "lon"), "71.01W");
+assert.equal(formatCoordinateLabel(0, "lat"), "");
+
+assert.deepEqual(
+  getVisibleAircraft({ aircraft, airportLat: 42.3656, airportLon: -71.0096, zoom: ZOOM_AIRPORT })
+    .map((item) => item.icao24),
+  ["near", "far"],
+);
+
+assert.deepEqual(
+  getVisibleAircraft({ aircraft, airportLat: 42.3656, airportLon: -71.0096, zoom: ZOOM_APPROACH })
+    .map((item) => item.icao24),
+  ["far"],
+);
+
+assert.equal(
+  getMapOverlayTheme("light").labelShadowColor,
+  "rgba(250,249,245,0.95)",
+);
+assert.equal(getMapOverlayTheme("dark").attributionColor, "rgba(245,247,250,0.3)");


### PR DESCRIPTION
## Summary
- centralize airport map constants for fallback center, near-airport radius, and traffic legend
- extract map overlay components and pure airport map model helpers from AirportMap
- keep Leaflet lifecycle and marker composition in AirportMap while adding model coverage

## Verification
- pnpm test:airport-map-feature
- pnpm lint
- pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
- pnpm build
- curl -I http://localhost:3000/
- curl -I http://localhost:3000/about
- curl -I http://localhost:3000/KBOS