### PR TITLE
Refactor weather feature model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ pnpm build
 ## Tests
 
 ```bash
-pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
+pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:weather-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
 ```
 
 ## Runtime config

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:airport-explorer": "node src/features/airport-explorer/airportExplorerModel.test.js",
     "test:map-controls": "node src/features/map-controls/mapControlModel.test.js",
     "test:airport-map-feature": "node src/features/airport-map/airportMapModel.test.js",
+    "test:weather-feature": "node src/features/weather/weatherModel.test.js",
     "test:flight-route-display": "node src/utils/flightRouteDisplay.test.js",
     "test:airport-map-display": "node src/utils/airportMapDisplay.test.js",
     "test:metar": "node src/hooks/useMetar.test.js",

--- a/src/components/panels/WeatherPanel.jsx
+++ b/src/components/panels/WeatherPanel.jsx
@@ -1,16 +1,8 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
-import { useLocalWeather } from "../../hooks/useLocalWeather.js";
-import {
-  CeilingSlide,
-  FlightRulesSlide,
-  LocalWeatherSlide,
-  MetarSlide,
-  PressureSlide,
-  TemperatureSlide,
-  WindSlide,
-} from "../weather/WeatherSlides";
+import { useWeatherCarouselNavigation } from "../../features/weather/useWeatherCarouselNavigation.js";
+import { useWeatherSlides } from "../../features/weather/useWeatherSlides.jsx";
+import { formatObsTime } from "../../features/weather/weatherModel.js";
 
 export default function WeatherPanel({
   metar,
@@ -21,117 +13,23 @@ export default function WeatherPanel({
   airportLon = 0,
   airportCode = "",
 }) {
-  const [activeIndex, setActiveIndex] = useState(0);
-  const trackRef = useRef(null);
+  const slides = useWeatherSlides({
+    variant: "panel",
+    metar,
+    metarRaw,
+    metarLoading,
+    metarError,
+    airportCode,
+    airportLat,
+    airportLon,
+  });
   const {
-    weather: localWeather,
-    loading: localWeatherLoading,
-    error: localWeatherError,
-  } = useLocalWeather(airportLat, airportLon);
-
-  const slides = useMemo(
-    () => {
-      const ceilingFt = getCeilingFeet(metar);
-      const hasVisibility = metar?.rawVisib != null && Number.isFinite(Number(metar.rawVisib));
-      const shouldShowCeiling = ceilingFt != null || hasVisibility;
-
-      return [
-        {
-          id: "metar",
-          label: "METAR",
-          title: "METAR report",
-          eyebrow: "METAR / Weather",
-          content: (
-            <MetarSlide
-              metarRaw={metarRaw}
-              metarLoading={metarLoading}
-              metarError={metarError}
-            />
-          ),
-        },
-        {
-          id: "rules",
-          label: "Rules",
-          title: "Flight rules",
-          eyebrow: "Operational context",
-          content: <FlightRulesSlide metar={metar} />,
-        },
-        shouldShowCeiling
-          ? {
-              id: "ceiling",
-              label: "Ceiling",
-              title: "Ceiling / visibility",
-              eyebrow: "Cloud deck",
-              content: <CeilingSlide metar={metar} />,
-            }
-          : null,
-        {
-          id: "wind",
-          label: "Wind",
-          title: "Wind speed",
-          eyebrow: "Surface flow",
-          content: <WindSlide metar={metar} localWeather={localWeather} />,
-        },
-        {
-          id: "temp",
-          label: "Temp",
-          title: "Temp / dew",
-          eyebrow: "Thermal spread",
-          content: <TemperatureSlide metar={metar} localWeather={localWeather} />,
-        },
-        {
-          id: "pressure",
-          label: "Pressure",
-          title: "Pressure",
-          eyebrow: "Altimeter",
-          content: <PressureSlide metar={metar} localWeather={localWeather} />,
-        },
-        {
-          id: "local",
-          label: "Local",
-          title: "Local weather",
-          eyebrow: "Open-Meteo",
-          content: (
-            <LocalWeatherSlide
-              airportCode={airportCode}
-              localWeather={localWeather}
-              localWeatherError={localWeatherError}
-              localWeatherLoading={localWeatherLoading}
-            />
-          ),
-        },
-      ].filter(Boolean);
-    },
-    [
-      airportCode,
-      localWeather,
-      localWeatherError,
-      localWeatherLoading,
-      metar,
-      metarError,
-      metarLoading,
-      metarRaw,
-    ],
-  );
-
-  const activeSlide = slides[activeIndex] || slides[0];
-
-  const scrollToSlide = (index) => {
-    const track = trackRef.current;
-    if (!track) return;
-    track.scrollTo({
-      left: track.clientWidth * index,
-      behavior: "smooth",
-    });
-    setActiveIndex(index);
-  };
-
-  const handleScroll = () => {
-    const track = trackRef.current;
-    if (!track) return;
-    const nextIndex = Math.round(track.scrollLeft / Math.max(1, track.clientWidth));
-    setActiveIndex(Math.min(Math.max(nextIndex, 0), slides.length - 1));
-  };
+    activeIndex,
+    activeSlide,
+    trackRef,
+    scrollToSlide,
+    handleScroll,
+  } = useWeatherCarouselNavigation(slides);
 
   return (
     <section className="glass-panel weather-instrument-panel weather-carousel-panel">
@@ -178,23 +76,4 @@ export default function WeatherPanel({
       </div>
     </section>
   );
-}
-
-function getCeilingFeet(metar) {
-  const layer = metar?.rawClouds?.find((item) =>
-    ["BKN", "OVC", "VV"].includes(item.cover),
-  );
-  const number = Number(layer?.base);
-  return Number.isFinite(number) ? number : null;
-}
-
-function formatObsTime(value) {
-  if (!value) return "latest";
-  const date = new Date(Number(value) < 10_000_000_000 ? Number(value) * 1000 : value);
-  if (Number.isNaN(date.getTime())) return "latest";
-  return date.toLocaleTimeString([], {
-    hour12: false,
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }

--- a/src/components/sidebar/WeatherCarousel.jsx
+++ b/src/components/sidebar/WeatherCarousel.jsx
@@ -1,16 +1,7 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
-import { useLocalWeather } from "../../hooks/useLocalWeather.js";
-import {
-  CeilingSlide,
-  FlightRulesSlide,
-  LocalWeatherSlide,
-  MetarSlide,
-  PressureSlide,
-  TemperatureSlide,
-  WindSlide,
-} from "../weather/WeatherSlides";
+import { useWeatherCarouselNavigation } from "../../features/weather/useWeatherCarouselNavigation.js";
+import { useWeatherSlides } from "../../features/weather/useWeatherSlides.jsx";
 
 export default function WeatherCarousel({
   metar = null,
@@ -21,114 +12,23 @@ export default function WeatherCarousel({
   airportLat = 0,
   airportLon = 0,
 }) {
-  const [activeIndex, setActiveIndex] = useState(0);
-  const trackRef = useRef(null);
-  const {
-    weather: localWeather,
-    loading: localWeatherLoading,
-    error: localWeatherError,
-  } = useLocalWeather(airportLat, airportLon);
-
-  const slides = useMemo(() => {
-    const ceilingFt = getCeilingFeet(metar);
-    const hasVisibility =
-      metar?.rawVisib != null && Number.isFinite(Number(metar.rawVisib));
-    const showCeiling = ceilingFt != null || hasVisibility;
-
-    return [
-      {
-        id: "metar",
-        label: "METAR",
-        navLabel: "METAR",
-        title: "Raw METAR",
-        content: (
-          <MetarSlide
-            metarRaw={metarRaw}
-            metarLoading={metarLoading}
-            metarError={metarError}
-          />
-        ),
-      },
-      {
-        id: "rules",
-        label: "Rules",
-        navLabel: "RULE",
-        title: "Flight rules",
-        content: <FlightRulesSlide metar={metar} />,
-      },
-      showCeiling
-        ? {
-            id: "ceiling",
-            label: "Ceiling",
-            navLabel: "C/V",
-            title: "Ceiling / visibility",
-            content: <CeilingSlide metar={metar} />,
-          }
-        : null,
-      {
-        id: "wind",
-        label: "Wind",
-        navLabel: "WIND",
-        title: "Wind",
-        content: <WindSlide metar={metar} localWeather={localWeather} />,
-      },
-      {
-        id: "temp",
-        label: "Temp",
-        navLabel: "TEMP",
-        title: "Temperature",
-        content: (
-          <TemperatureSlide metar={metar} localWeather={localWeather} />
-        ),
-      },
-      {
-        id: "pressure",
-        label: "Pressure",
-        navLabel: "ALT",
-        title: "Altimeter",
-        content: <PressureSlide metar={metar} localWeather={localWeather} />,
-      },
-      {
-        id: "local",
-        label: "Local",
-        navLabel: "LOCAL",
-        title: "Local conditions",
-        content: (
-          <LocalWeatherSlide
-            airportCode={airportCode}
-            localWeather={localWeather}
-            localWeatherError={localWeatherError}
-            localWeatherLoading={localWeatherLoading}
-          />
-        ),
-      },
-    ].filter(Boolean);
-  }, [
-    airportCode,
-    localWeather,
-    localWeatherError,
-    localWeatherLoading,
+  const slides = useWeatherSlides({
+    variant: "carousel",
     metar,
-    metarError,
-    metarLoading,
     metarRaw,
-  ]);
-
-  const activeSlide = slides[activeIndex] || slides[0];
-
-  const scrollToSlide = (index) => {
-    const track = trackRef.current;
-    if (!track) return;
-    track.scrollTo({ left: track.clientWidth * index, behavior: "smooth" });
-    setActiveIndex(index);
-  };
-
-  const handleScroll = () => {
-    const track = trackRef.current;
-    if (!track) return;
-    const next = Math.round(track.scrollLeft / Math.max(1, track.clientWidth));
-    setActiveIndex(Math.min(Math.max(next, 0), slides.length - 1));
-  };
+    metarLoading,
+    metarError,
+    airportCode,
+    airportLat,
+    airportLon,
+  });
+  const {
+    activeIndex,
+    activeSlide,
+    trackRef,
+    scrollToSlide,
+    handleScroll,
+  } = useWeatherCarouselNavigation(slides);
 
   return (
     <section className="weather-carousel-section px-6 pt-4 pb-4">
@@ -176,12 +76,4 @@ export default function WeatherCarousel({
       </div>
     </section>
   );
-}
-
-function getCeilingFeet(metar) {
-  const layer = metar?.rawClouds?.find((item) =>
-    ["BKN", "OVC", "VV"].includes(item.cover),
-  );
-  const number = Number(layer?.base);
-  return Number.isFinite(number) ? number : null;
 }

--- a/src/components/weather/WeatherSlides.jsx
+++ b/src/components/weather/WeatherSlides.jsx
@@ -10,55 +10,19 @@ import {
   Sun,
   Thermometer,
 } from "lucide-react";
-
-const FLIGHT_RULES = {
-  VFR: {
-    label: "Visual Flight Rules",
-    color: "var(--atc-text)",
-    context:
-      "Skies and visibility support normal visual operations. Weather is unlikely to constrain airport capacity.",
-  },
-  MVFR: {
-    label: "Marginal Visual Flight Rules",
-    color: "var(--atc-dim)",
-    context:
-      "Visibility or ceiling is reduced. Arrivals and departures usually continue, but pilots watch weather margins closely.",
-  },
-  IFR: {
-    label: "Instrument Flight Rules",
-    color: "var(--atc-faint)",
-    context:
-      "Low clouds or limited visibility require instrument procedures. Arrival spacing can increase and delays become more likely.",
-  },
-  LIFR: {
-    label: "Low IFR",
-    color: "var(--atc-line-strong)",
-    context:
-      "Very low ceiling or visibility limits airport flow. Only aircraft and runways equipped for low-visibility operations can land reliably.",
-  },
-};
-
-const WEATHER_CODES = {
-  0: "Clear",
-  1: "Mainly clear",
-  2: "Partly cloudy",
-  3: "Overcast",
-  45: "Fog",
-  48: "Rime fog",
-  51: "Light drizzle",
-  53: "Drizzle",
-  55: "Dense drizzle",
-  61: "Light rain",
-  63: "Rain",
-  65: "Heavy rain",
-  71: "Light snow",
-  73: "Snow",
-  75: "Heavy snow",
-  80: "Rain showers",
-  81: "Rain showers",
-  82: "Heavy showers",
-  95: "Thunderstorm",
-};
+import { FLIGHT_RULE_ORDER, FLIGHT_RULES } from "../../config/weather.js";
+import {
+  clamp,
+  describeCeiling,
+  describePressure,
+  describeTemperature,
+  describeWind,
+  getCeilingFeet,
+  getMetarTokens,
+  getWeatherConditionLabel,
+  round1,
+  toNumber,
+} from "../../features/weather/weatherModel.js";
 
 export function MetarSlide({ metarRaw, metarLoading, metarError }) {
   const tokens = getMetarTokens(metarRaw);
@@ -97,7 +61,7 @@ export function FlightRulesSlide({ metar }) {
           <strong>{rules.label}</strong>
         </div>
         <div className="flight-rule-rail" aria-hidden="true">
-          {["VFR", "MVFR", "IFR", "LIFR"].map((item) => (
+          {FLIGHT_RULE_ORDER.map((item) => (
             <i
               key={item}
               className={item === code ? "active" : ""}
@@ -233,7 +197,7 @@ export function LocalWeatherSlide({
   localWeatherLoading,
 }) {
   const condition = localWeather
-    ? WEATHER_CODES[localWeather.weatherCode] || "Current conditions"
+    ? getWeatherConditionLabel(localWeather.weatherCode)
     : "Local weather pending";
   const humidity = localWeather?.humidity;
   const feelsLike = localWeather?.apparentTemperatureC;
@@ -308,57 +272,6 @@ function WeatherDescription({ children }) {
   return <p className="weather-context-copy weather-slide-description">{children}</p>;
 }
 
-function describeWind(speed, gust) {
-  const effective = Math.max(speed ?? 0, gust ?? 0);
-  if (effective >= 30) {
-    return "Strong winds or gusts can reduce arrival rates, increase go-around risk, and force stricter runway selection.";
-  }
-  if (effective >= 15) {
-    return "Moderate wind is workable, but crosswind components and gust spread can affect spacing and runway configuration.";
-  }
-  return "Light wind usually gives the airport more runway flexibility and keeps arrival and departure flow stable.";
-}
-
-function describeTemperature(temp, spread) {
-  if (spread != null && spread < 3) {
-    return "A small temperature-dewpoint spread can support fog, haze, or low cloud development near the field.";
-  }
-  if (temp != null && temp >= 32) {
-    return "Hot air reduces aircraft performance, which can lengthen takeoff rolls and affect climb margins.";
-  }
-  if (temp != null && temp <= 0) {
-    return "Cold conditions can improve density altitude, but icing, braking action, and deicing become operational concerns.";
-  }
-  return "Temperature and dewpoint are separated enough that fog risk is lower near the field.";
-}
-
-function describePressure(altim, pressure) {
-  const hpa = pressure ?? (altim != null ? altim * 33.8639 : null);
-  if (hpa == null) {
-    return "Pressure data helps crews set altimeters and judge density-altitude effects around the airport.";
-  }
-  if (hpa < 1000) {
-    return "Lower pressure increases density altitude and can come with unsettled weather, reducing performance margins.";
-  }
-  if (hpa > 1020) {
-    return "Higher pressure generally improves aircraft performance and often accompanies more stable weather.";
-  }
-  return "Pressure is near standard range, so altimeter setting is important but not a major performance driver.";
-}
-
-function describeCeiling(ceilingFt, visibility) {
-  if (ceilingFt == null && visibility == null) {
-    return "No limiting ceiling or visibility value is available in the current METAR.";
-  }
-  if (ceilingFt != null && ceilingFt < 1000) {
-    return "Low ceiling can push arrivals toward instrument procedures and reduce visual runway flexibility.";
-  }
-  if (visibility != null && visibility < 3) {
-    return "Reduced visibility can increase spacing and make surface movement more dependent on tower guidance.";
-  }
-  return "Ceiling and visibility are comfortably above the usual VFR thresholds for airport operations.";
-}
-
 function MetricLine({ label, value, icon = null }) {
   return (
     <div className="weather-metric-line">
@@ -370,40 +283,3 @@ function MetricLine({ label, value, icon = null }) {
     </div>
   );
 }
-
-function getMetarTokens(raw) {
-  const parts = String(raw || "")
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean);
-  if (!parts.length) return [];
-  const reportPrefix = /^(METAR|SPECI)$/i.test(parts[0]);
-  const station = reportPrefix ? parts[1] : parts[0];
-  const issued = reportPrefix ? parts[2] : parts[1];
-
-  const wind = parts.find((item) => /^(VRB|\d{3})\d{2,3}(G\d{2,3})?KT$/.test(item));
-  const visibility = parts.find((item) => /^(\d{1,2}|\d{1,2}SM|P\d{1,2}SM|\d\/\dSM)$/.test(item));
-
-  return [
-    { label: "Station", value: station || "-" },
-    { label: "Issued", value: issued || "-" },
-    { label: "Wind", value: wind || "-" },
-    { label: "Vis", value: visibility || "-" },
-  ];
-}
-
-function getCeilingFeet(metar) {
-  const layer = metar?.rawClouds?.find((item) =>
-    ["BKN", "OVC", "VV"].includes(item.cover),
-  );
-  return toNumber(layer?.base);
-}
-
-const toNumber = (value) => {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : null;
-};
-
-const round1 = (value) => Number(value).toFixed(1);
-
-const clamp = (value, min, max) => Math.min(max, Math.max(min, value));

--- a/src/config/weather.js
+++ b/src/config/weather.js
@@ -1,0 +1,103 @@
+export const FLIGHT_RULES = {
+  VFR: {
+    label: "Visual Flight Rules",
+    color: "var(--atc-text)",
+    context:
+      "Skies and visibility support normal visual operations. Weather is unlikely to constrain airport capacity.",
+  },
+  MVFR: {
+    label: "Marginal Visual Flight Rules",
+    color: "var(--atc-dim)",
+    context:
+      "Visibility or ceiling is reduced. Arrivals and departures usually continue, but pilots watch weather margins closely.",
+  },
+  IFR: {
+    label: "Instrument Flight Rules",
+    color: "var(--atc-faint)",
+    context:
+      "Low clouds or limited visibility require instrument procedures. Arrival spacing can increase and delays become more likely.",
+  },
+  LIFR: {
+    label: "Low IFR",
+    color: "var(--atc-line-strong)",
+    context:
+      "Very low ceiling or visibility limits airport flow. Only aircraft and runways equipped for low-visibility operations can land reliably.",
+  },
+};
+
+export const FLIGHT_RULE_ORDER = ["VFR", "MVFR", "IFR", "LIFR"];
+
+export const WEATHER_CODES = {
+  0: "Clear",
+  1: "Mainly clear",
+  2: "Partly cloudy",
+  3: "Overcast",
+  45: "Fog",
+  48: "Rime fog",
+  51: "Light drizzle",
+  53: "Drizzle",
+  55: "Dense drizzle",
+  61: "Light rain",
+  63: "Rain",
+  65: "Heavy rain",
+  71: "Light snow",
+  73: "Snow",
+  75: "Heavy snow",
+  80: "Rain showers",
+  81: "Rain showers",
+  82: "Heavy showers",
+  95: "Thunderstorm",
+};
+
+export const WEATHER_SLIDE_COPY = {
+  panel: {
+    metar: {
+      label: "METAR",
+      title: "METAR report",
+      eyebrow: "METAR / Weather",
+    },
+    rules: {
+      label: "Rules",
+      title: "Flight rules",
+      eyebrow: "Operational context",
+    },
+    ceiling: {
+      label: "Ceiling",
+      title: "Ceiling / visibility",
+      eyebrow: "Cloud deck",
+    },
+    wind: {
+      label: "Wind",
+      title: "Wind speed",
+      eyebrow: "Surface flow",
+    },
+    temp: {
+      label: "Temp",
+      title: "Temp / dew",
+      eyebrow: "Thermal spread",
+    },
+    pressure: {
+      label: "Pressure",
+      title: "Pressure",
+      eyebrow: "Altimeter",
+    },
+    local: {
+      label: "Local",
+      title: "Local weather",
+      eyebrow: "Open-Meteo",
+    },
+  },
+  carousel: {
+    metar: { label: "METAR", navLabel: "METAR", title: "Raw METAR" },
+    rules: { label: "Rules", navLabel: "RULE", title: "Flight rules" },
+    ceiling: {
+      label: "Ceiling",
+      navLabel: "C/V",
+      title: "Ceiling / visibility",
+    },
+    wind: { label: "Wind", navLabel: "WIND", title: "Wind" },
+    temp: { label: "Temp", navLabel: "TEMP", title: "Temperature" },
+    pressure: { label: "Pressure", navLabel: "ALT", title: "Altimeter" },
+    local: { label: "Local", navLabel: "LOCAL", title: "Local conditions" },
+  },
+};

--- a/src/features/weather/useWeatherCarouselNavigation.js
+++ b/src/features/weather/useWeatherCarouselNavigation.js
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export function useWeatherCarouselNavigation(slides) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const trackRef = useRef(null);
+  const activeSlide = slides[activeIndex] || slides[0];
+
+  useEffect(() => {
+    setActiveIndex((current) =>
+      Math.min(Math.max(current, 0), Math.max(slides.length - 1, 0)),
+    );
+  }, [slides.length]);
+
+  const scrollToSlide = (index) => {
+    const track = trackRef.current;
+    if (!track) return;
+    track.scrollTo({ left: track.clientWidth * index, behavior: "smooth" });
+    setActiveIndex(index);
+  };
+
+  const handleScroll = () => {
+    const track = trackRef.current;
+    if (!track) return;
+    const nextIndex = Math.round(track.scrollLeft / Math.max(1, track.clientWidth));
+    setActiveIndex(Math.min(Math.max(nextIndex, 0), slides.length - 1));
+  };
+
+  return {
+    activeIndex,
+    activeSlide,
+    trackRef,
+    scrollToSlide,
+    handleScroll,
+  };
+}

--- a/src/features/weather/useWeatherSlides.jsx
+++ b/src/features/weather/useWeatherSlides.jsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useMemo } from "react";
+import { WEATHER_SLIDE_COPY } from "../../config/weather.js";
+import { useLocalWeather } from "../../hooks/useLocalWeather.js";
+import {
+  CeilingSlide,
+  FlightRulesSlide,
+  LocalWeatherSlide,
+  MetarSlide,
+  PressureSlide,
+  TemperatureSlide,
+  WindSlide,
+} from "../../components/weather/WeatherSlides";
+import { shouldShowCeilingSlide } from "./weatherModel.js";
+
+export function useWeatherSlides({
+  variant,
+  metar,
+  metarRaw,
+  metarLoading,
+  metarError,
+  airportCode,
+  airportLat,
+  airportLon,
+}) {
+  const {
+    weather: localWeather,
+    loading: localWeatherLoading,
+    error: localWeatherError,
+  } = useLocalWeather(airportLat, airportLon);
+
+  return useMemo(() => {
+    const copy = WEATHER_SLIDE_COPY[variant];
+    const withContent = (id, content) => ({
+      id,
+      ...copy[id],
+      content,
+    });
+
+    return [
+      withContent(
+        "metar",
+        <MetarSlide
+          metarRaw={metarRaw}
+          metarLoading={metarLoading}
+          metarError={metarError}
+        />,
+      ),
+      withContent("rules", <FlightRulesSlide metar={metar} />),
+      shouldShowCeilingSlide(metar)
+        ? withContent("ceiling", <CeilingSlide metar={metar} />)
+        : null,
+      withContent(
+        "wind",
+        <WindSlide metar={metar} localWeather={localWeather} />,
+      ),
+      withContent(
+        "temp",
+        <TemperatureSlide metar={metar} localWeather={localWeather} />,
+      ),
+      withContent(
+        "pressure",
+        <PressureSlide metar={metar} localWeather={localWeather} />,
+      ),
+      withContent(
+        "local",
+        <LocalWeatherSlide
+          airportCode={airportCode}
+          localWeather={localWeather}
+          localWeatherError={localWeatherError}
+          localWeatherLoading={localWeatherLoading}
+        />,
+      ),
+    ].filter(Boolean);
+  }, [
+    airportCode,
+    localWeather,
+    localWeatherError,
+    localWeatherLoading,
+    metar,
+    metarError,
+    metarLoading,
+    metarRaw,
+    variant,
+  ]);
+}

--- a/src/features/weather/weatherModel.js
+++ b/src/features/weather/weatherModel.js
@@ -1,0 +1,117 @@
+import { WEATHER_CODES } from "../../config/weather.js";
+
+export function getCeilingFeet(metar) {
+  const layer = metar?.rawClouds?.find((item) =>
+    ["BKN", "OVC", "VV"].includes(item.cover),
+  );
+  return toNumber(layer?.base);
+}
+
+export function shouldShowCeilingSlide(metar) {
+  const ceilingFt = getCeilingFeet(metar);
+  const hasVisibility =
+    metar?.rawVisib != null && Number.isFinite(Number(metar.rawVisib));
+  return ceilingFt != null || hasVisibility;
+}
+
+export function formatObsTime(value) {
+  if (!value) return "latest";
+  const date = new Date(
+    Number(value) < 10_000_000_000 ? Number(value) * 1000 : value,
+  );
+  if (Number.isNaN(date.getTime())) return "latest";
+  return date.toLocaleTimeString([], {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function getWeatherConditionLabel(code) {
+  return WEATHER_CODES[code] || "Current conditions";
+}
+
+export function getMetarTokens(raw) {
+  const parts = String(raw || "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (!parts.length) return [];
+  const reportPrefix = /^(METAR|SPECI)$/i.test(parts[0]);
+  const station = reportPrefix ? parts[1] : parts[0];
+  const issued = reportPrefix ? parts[2] : parts[1];
+
+  const wind = parts.find((item) =>
+    /^(VRB|\d{3})\d{2,3}(G\d{2,3})?KT$/.test(item),
+  );
+  const visibility = parts.find((item) =>
+    /^(\d{1,2}|\d{1,2}SM|P\d{1,2}SM|\d\/\dSM)$/.test(item),
+  );
+
+  return [
+    { label: "Station", value: station || "-" },
+    { label: "Issued", value: issued || "-" },
+    { label: "Wind", value: wind || "-" },
+    { label: "Vis", value: visibility || "-" },
+  ];
+}
+
+export function describeWind(speed, gust) {
+  const effective = Math.max(speed ?? 0, gust ?? 0);
+  if (effective >= 30) {
+    return "Strong winds or gusts can reduce arrival rates, increase go-around risk, and force stricter runway selection.";
+  }
+  if (effective >= 15) {
+    return "Moderate wind is workable, but crosswind components and gust spread can affect spacing and runway configuration.";
+  }
+  return "Light wind usually gives the airport more runway flexibility and keeps arrival and departure flow stable.";
+}
+
+export function describeTemperature(temp, spread) {
+  if (spread != null && spread < 3) {
+    return "A small temperature-dewpoint spread can support fog, haze, or low cloud development near the field.";
+  }
+  if (temp != null && temp >= 32) {
+    return "Hot air reduces aircraft performance, which can lengthen takeoff rolls and affect climb margins.";
+  }
+  if (temp != null && temp <= 0) {
+    return "Cold conditions can improve density altitude, but icing, braking action, and deicing become operational concerns.";
+  }
+  return "Temperature and dewpoint are separated enough that fog risk is lower near the field.";
+}
+
+export function describePressure(altim, pressure) {
+  const hpa = pressure ?? (altim != null ? altim * 33.8639 : null);
+  if (hpa == null) {
+    return "Pressure data helps crews set altimeters and judge density-altitude effects around the airport.";
+  }
+  if (hpa < 1000) {
+    return "Lower pressure increases density altitude and can come with unsettled weather, reducing performance margins.";
+  }
+  if (hpa > 1020) {
+    return "Higher pressure generally improves aircraft performance and often accompanies more stable weather.";
+  }
+  return "Pressure is near standard range, so altimeter setting is important but not a major performance driver.";
+}
+
+export function describeCeiling(ceilingFt, visibility) {
+  if (ceilingFt == null && visibility == null) {
+    return "No limiting ceiling or visibility value is available in the current METAR.";
+  }
+  if (ceilingFt != null && ceilingFt < 1000) {
+    return "Low ceiling can push arrivals toward instrument procedures and reduce visual runway flexibility.";
+  }
+  if (visibility != null && visibility < 3) {
+    return "Reduced visibility can increase spacing and make surface movement more dependent on tower guidance.";
+  }
+  return "Ceiling and visibility are comfortably above the usual VFR thresholds for airport operations.";
+}
+
+export const toNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+export const round1 = (value) => Number(value).toFixed(1);
+
+export const clamp = (value, min, max) => Math.min(max, Math.max(min, value));

--- a/src/features/weather/weatherModel.test.js
+++ b/src/features/weather/weatherModel.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+
+import {
+  describeCeiling,
+  describePressure,
+  describeTemperature,
+  describeWind,
+  formatObsTime,
+  getCeilingFeet,
+  getMetarTokens,
+  getWeatherConditionLabel,
+  shouldShowCeilingSlide,
+  toNumber,
+} from "./weatherModel.js";
+
+const metar = {
+  rawClouds: [
+    { cover: "SCT", base: "2500" },
+    { cover: "BKN", base: "1200" },
+  ],
+  rawVisib: "10",
+};
+
+assert.equal(toNumber("12.5"), 12.5);
+assert.equal(toNumber("abc"), null);
+assert.equal(getCeilingFeet(metar), 1200);
+assert.equal(shouldShowCeilingSlide(metar), true);
+assert.equal(shouldShowCeilingSlide({ rawClouds: [], rawVisib: "bad" }), false);
+
+assert.deepEqual(getMetarTokens("METAR KBOS 051854Z 08012KT 10SM FEW040"), [
+  { label: "Station", value: "KBOS" },
+  { label: "Issued", value: "051854Z" },
+  { label: "Wind", value: "08012KT" },
+  { label: "Vis", value: "10SM" },
+]);
+
+assert.equal(getWeatherConditionLabel(0), "Clear");
+assert.equal(getWeatherConditionLabel(999), "Current conditions");
+assert.equal(formatObsTime(null), "latest");
+assert.match(formatObsTime(1_714_934_400), /^\d{2}:\d{2}$/);
+
+assert.match(describeWind(31, null), /Strong winds/);
+assert.match(describeTemperature(15, 2), /fog/);
+assert.match(describePressure(null, 999), /Lower pressure/);
+assert.match(describeCeiling(800, 10), /Low ceiling/);


### PR DESCRIPTION
## Summary
- centralize flight rules, weather codes, and weather slide copy in config
- extract weather model helpers and shared weather carousel state into feature hooks
- dedupe WeatherPanel and WeatherCarousel slide construction while preserving their layout shells

## Verification
- pnpm test:weather-feature
- pnpm lint
- pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:weather-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
- pnpm build
- curl -I http://localhost:3000/
- curl -I http://localhost:3000/about
- curl -I http://localhost:3000/KBOS