### PR TITLE
Refactor aircraft positions model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ pnpm build
 ## Tests
 
 ```bash
-pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:aviation-service-model && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:weather-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
+pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:aviation-service-model && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:weather-feature && pnpm test:aircraft-positions-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
 ```
 
 ## Runtime config

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:map-controls": "node src/features/map-controls/mapControlModel.test.js",
     "test:airport-map-feature": "node src/features/airport-map/airportMapModel.test.js",
     "test:weather-feature": "node src/features/weather/weatherModel.test.js",
+    "test:aircraft-positions-feature": "node src/features/aircraft-positions/aircraftPositionsModel.test.js",
     "test:flight-route-display": "node src/utils/flightRouteDisplay.test.js",
     "test:airport-map-display": "node src/utils/airportMapDisplay.test.js",
     "test:metar": "node src/hooks/useMetar.test.js",

--- a/src/features/aircraft-positions/aircraftPositionsModel.js
+++ b/src/features/aircraft-positions/aircraftPositionsModel.js
@@ -1,0 +1,61 @@
+import { parseAdsbPositionTime } from "../../utils/aircraftMotion.js";
+
+export function normalizeAdsbAircraft(
+  aircraft,
+  { responseNow, receiveTime = Date.now() } = {},
+) {
+  return {
+    icao24: aircraft.hex || "",
+    callsign: (aircraft.flight || aircraft.r || "").trim(),
+    lat: aircraft.lat,
+    lon: aircraft.lon,
+    altitude: aircraft.alt_baro ?? aircraft.alt_geom ?? null,
+    baroRate: aircraft.baro_rate ?? null,
+    geomRate: aircraft.geom_rate ?? null,
+    navAltitudeMcp: aircraft.nav_altitude_mcp ?? null,
+    onGround: aircraft.gnd ?? false,
+    velocity: aircraft.gs ?? null,
+    track: aircraft.track ?? 0,
+    positionTime: parseAdsbPositionTime(aircraft, responseNow, receiveTime),
+    receiveTime,
+  };
+}
+
+export function mergeAircraftSnapshots({
+  wideJson,
+  closeJson,
+  receiveTime = Date.now(),
+}) {
+  const seen = new Map();
+  const addSnapshots = (list, responseNow) => {
+    for (const aircraft of list || []) {
+      if (aircraft.lat == null || aircraft.lon == null) continue;
+      const key = aircraft.hex || "";
+      if (!key) continue;
+      seen.set(
+        key,
+        normalizeAdsbAircraft(aircraft, { responseNow, receiveTime }),
+      );
+    }
+  };
+
+  addSnapshots(closeJson?.ac, closeJson?.now);
+  addSnapshots(wideJson?.ac, wideJson?.now);
+  return [...seen.values()];
+}
+
+export function isHttp4xxOr5xx(error) {
+  const status = Number(error?.status ?? error?.statusCode);
+  if (status >= 400 && status < 600) return true;
+  const match = String(error?.message || "").match(/\bHTTP\s+(\d{3})\b/i);
+  if (!match) return false;
+  const parsed = Number(match[1]);
+  return parsed >= 400 && parsed < 600;
+}
+
+export function describeAircraftFetchError(error) {
+  const isTimeout =
+    error.name === "TimeoutError" ||
+    /timed out|signal timed out/i.test(error.message);
+  return isTimeout ? "timeout" : error.message || "unknown";
+}

--- a/src/features/aircraft-positions/aircraftPositionsModel.test.js
+++ b/src/features/aircraft-positions/aircraftPositionsModel.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+
+import {
+  isHttp4xxOr5xx,
+  mergeAircraftSnapshots,
+  normalizeAdsbAircraft,
+} from "./aircraftPositionsModel.js";
+
+const receiveTime = 1_700_000_003_200;
+const responseNow = 1_700_000_003_000;
+
+{
+  const aircraft = normalizeAdsbAircraft(
+    {
+      hex: "a1b2c3",
+      flight: " DAL123 ",
+      lat: 42,
+      lon: -71,
+      alt_baro: 12000,
+      alt_geom: 12100,
+      baro_rate: 500,
+      geom_rate: 450,
+      nav_altitude_mcp: 13000,
+      gnd: false,
+      gs: 250,
+      track: 87,
+      seen_pos: 1.25,
+    },
+    { responseNow, receiveTime },
+  );
+
+  assert.equal(aircraft.icao24, "a1b2c3");
+  assert.equal(aircraft.callsign, "DAL123");
+  assert.equal(aircraft.altitude, 12000);
+  assert.equal(aircraft.velocity, 250);
+  assert.equal(aircraft.positionTime, 1_700_000_001_750);
+  assert.equal(aircraft.receiveTime, receiveTime);
+}
+
+{
+  const merged = mergeAircraftSnapshots({
+    closeJson: {
+      now: responseNow,
+      ac: [
+        { hex: "duplicate", flight: " CLOSE ", lat: 1, lon: 2, gs: 10 },
+        { hex: "near", flight: " NEAR ", lat: 3, lon: 4 },
+      ],
+    },
+    wideJson: {
+      now: responseNow,
+      ac: [
+        { hex: "duplicate", flight: " WIDE ", lat: 5, lon: 6, gs: 20 },
+        { hex: "missing", flight: "SKIP", lat: null, lon: 9 },
+      ],
+    },
+    receiveTime,
+  });
+
+  assert.deepEqual(
+    merged.map((item) => item.icao24),
+    ["duplicate", "near"],
+  );
+  assert.equal(merged[0].callsign, "WIDE");
+  assert.equal(merged[0].velocity, 20);
+}
+
+assert.equal(isHttp4xxOr5xx({ status: 500 }), true);
+assert.equal(isHttp4xxOr5xx({ statusCode: 404 }), true);
+assert.equal(isHttp4xxOr5xx(new Error("HTTP 429")), true);
+assert.equal(isHttp4xxOr5xx(new Error("network timeout")), false);

--- a/src/hooks/useAircraftPositions.js
+++ b/src/hooks/useAircraftPositions.js
@@ -8,7 +8,11 @@ import {
   DEFAULT_WIDE_RANGE_NM,
 } from "../services/aviationData.js";
 import { AIRCRAFT_TRAFFIC_CONFIG } from "../config/aviation.js";
-import { parseAdsbPositionTime } from "../utils/aircraftMotion.js";
+import {
+  describeAircraftFetchError,
+  isHttp4xxOr5xx,
+  mergeAircraftSnapshots,
+} from "../features/aircraft-positions/aircraftPositionsModel.js";
 
 const HIDDEN_POLL_GRACE_MS = AIRCRAFT_TRAFFIC_CONFIG.hiddenPollGraceMs;
 
@@ -52,35 +56,13 @@ export function useAircraftPositions(icao, lat, lon) {
         ]);
         if (disposed) return;
         const receiveTime = Date.now();
-        const seen = new Map();
-        const parseAircraft = (a) => {
-          const parsed = {
-            icao24: a.hex || "",
-            callsign: (a.flight || a.r || "").trim(),
-            lat: a.lat,
-            lon: a.lon,
-            altitude: a.alt_baro ?? a.alt_geom ?? null,
-            baroRate: a.baro_rate ?? null,
-            geomRate: a.geom_rate ?? null,
-            navAltitudeMcp: a.nav_altitude_mcp ?? null,
-            onGround: a.gnd ?? false,
-            velocity: a.gs ?? null,
-            track: a.track ?? 0,
-            positionTime: parseAdsbPositionTime(a, wideJson.now, receiveTime),
+        setAircraft(
+          mergeAircraftSnapshots({
+            wideJson,
+            closeJson,
             receiveTime,
-          };
-          return parsed;
-        };
-        const addSnapshots = (list) => {
-          for (const a of list || []) {
-            if (a.lat == null || a.lon == null) continue;
-            const key = a.hex || "";
-            if (key) seen.set(key, parseAircraft(a));
-          }
-        };
-        addSnapshots(closeJson.ac);
-        addSnapshots(wideJson.ac);
-        setAircraft([...seen.values()]);
+          }),
+        );
         consecutiveFailuresRef.current = 0;
         setFeedStatus("live");
         setLastUpdated(new Date());
@@ -90,10 +72,7 @@ export function useAircraftPositions(icao, lat, lon) {
         if (isHttp4xxOr5xx(e)) {
           setFeedStatus("infer");
         }
-        const isTimeout =
-          e.name === "TimeoutError" ||
-          /timed out|signal timed out/i.test(e.message);
-        const kind = isTimeout ? "timeout" : e.message || "unknown";
+        const kind = describeAircraftFetchError(e);
         console.warn(
           `[${icao}] ADS-B fetch failed (${kind}, consecutive: ${consecutiveFailuresRef.current})`,
         );
@@ -149,13 +128,4 @@ export function useAircraftPositions(icao, lat, lon) {
   }, [icao, lat, lon]);
 
   return { aircraft, loading, initialLoading, lastUpdated, feedStatus };
-}
-
-function isHttp4xxOr5xx(error) {
-  const status = Number(error?.status ?? error?.statusCode);
-  if (status >= 400 && status < 600) return true;
-  const match = String(error?.message || "").match(/\bHTTP\s+(\d{3})\b/i);
-  if (!match) return false;
-  const parsed = Number(match[1]);
-  return parsed >= 400 && parsed < 600;
 }


### PR DESCRIPTION
## Summary
- extract ADS-B snapshot normalization, merge/dedupe behavior, and error classification from useAircraftPositions
- keep the hook focused on polling lifecycle, visibility handling, and React state
- add model coverage for raw ADS-B parsing and feed error classification

## Verification
- pnpm test:aircraft-positions-feature
- pnpm test:aircraft-motion && pnpm test:aviation-data
- pnpm lint
- pnpm build
- pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:aviation-service-model && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:weather-feature && pnpm test:aircraft-positions-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
- curl -I http://localhost:3000/
- curl -I http://localhost:3000/about
- curl -I http://localhost:3000/KBOS