### PR TITLE
Refactor flight route lookup model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ pnpm build
 ## Tests
 
 ```bash
-pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:aviation-service-model && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:weather-feature && pnpm test:aircraft-positions-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
+pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:aviation-service-model && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:weather-feature && pnpm test:aircraft-positions-feature && pnpm test:flight-routes-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
 ```
 
 ## Runtime config

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:airport-map-feature": "node src/features/airport-map/airportMapModel.test.js",
     "test:weather-feature": "node src/features/weather/weatherModel.test.js",
     "test:aircraft-positions-feature": "node src/features/aircraft-positions/aircraftPositionsModel.test.js",
+    "test:flight-routes-feature": "node src/features/flight-routes/flightRouteLookupModel.test.js",
     "test:flight-route-display": "node src/utils/flightRouteDisplay.test.js",
     "test:airport-map-display": "node src/utils/airportMapDisplay.test.js",
     "test:metar": "node src/hooks/useMetar.test.js",

--- a/src/features/flight-routes/flightRouteLookupModel.js
+++ b/src/features/flight-routes/flightRouteLookupModel.js
@@ -1,0 +1,49 @@
+import { FLIGHT_ROUTE_LOOKUP_CONFIG } from "../../config/aviation.js";
+import { isLookupCallsign, normalizeCallsign } from "../../utils/callsign.js";
+
+export function getFreshRouteCacheEntry(cache, callsign, now = Date.now()) {
+  const cached = cache.get(callsign);
+  if (!cached) return null;
+  const maxAge = cached.route
+    ? FLIGHT_ROUTE_LOOKUP_CONFIG.hitCacheMs
+    : FLIGHT_ROUTE_LOOKUP_CONFIG.missCacheMs;
+  if (now - cached.time <= maxAge) return cached;
+  cache.delete(callsign);
+  return null;
+}
+
+export function getLookupCallsigns(aircraft) {
+  return [
+    ...new Set(
+      (aircraft || [])
+        .map((item) => normalizeCallsign(item.callsign))
+        .filter(isLookupCallsign),
+    ),
+  ];
+}
+
+export function resolvePendingRouteLookups({
+  aircraft,
+  cache,
+  inFlight,
+  now = Date.now(),
+  maxLookups = FLIGHT_ROUTE_LOOKUP_CONFIG.maxLookupsPerPass,
+}) {
+  return getLookupCallsigns(aircraft)
+    .filter(
+      (callsign) =>
+        !getFreshRouteCacheEntry(cache, callsign, now) &&
+        !inFlight.has(callsign),
+    )
+    .slice(0, maxLookups);
+}
+
+export function buildRoutesByCallsign({ aircraft, cache, now = Date.now() }) {
+  const routes = {};
+  for (const item of aircraft || []) {
+    const callsign = normalizeCallsign(item.callsign);
+    const cached = getFreshRouteCacheEntry(cache, callsign, now);
+    if (cached?.route) routes[callsign] = cached.route;
+  }
+  return routes;
+}

--- a/src/features/flight-routes/flightRouteLookupModel.test.js
+++ b/src/features/flight-routes/flightRouteLookupModel.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+
+import {
+  buildRoutesByCallsign,
+  getFreshRouteCacheEntry,
+  resolvePendingRouteLookups,
+} from "./flightRouteLookupModel.js";
+
+const now = 1_700_000_000_000;
+const route = {
+  callsign: "DAL123",
+  origin: { icao: "KATL" },
+  destination: { icao: "KBOS" },
+};
+
+{
+  const cache = new Map([
+    ["DAL123", { route, time: now - 1_000 }],
+    ["MISS1", { route: null, time: now - 1_000 }],
+    ["OLD", { route, time: now - 10 * 60 * 60 * 1000 }],
+  ]);
+
+  assert.equal(getFreshRouteCacheEntry(cache, "DAL123", now)?.route, route);
+  assert.equal(getFreshRouteCacheEntry(cache, "MISS1", now)?.route, null);
+  assert.equal(getFreshRouteCacheEntry(cache, "OLD", now), null);
+  assert.equal(cache.has("OLD"), false);
+}
+
+{
+  const cache = new Map([["DAL123", { route, time: now }]]);
+  const inFlight = new Set(["UAL456"]);
+  const pending = resolvePendingRouteLookups({
+    aircraft: [
+      { callsign: " dal123 " },
+      { callsign: "UAL456" },
+      { callsign: "AAL789" },
+      { callsign: "AAL789" },
+      { callsign: "TOO-LONG-CALLSIGN" },
+      { callsign: "" },
+    ],
+    cache,
+    inFlight,
+    now,
+    maxLookups: 3,
+  });
+
+  assert.deepEqual(pending, ["AAL789"]);
+}
+
+{
+  const cache = new Map([
+    ["DAL123", { route, time: now }],
+    ["AAL789", { route: null, time: now }],
+  ]);
+  const routes = buildRoutesByCallsign({
+    aircraft: [{ callsign: "dal123" }, { callsign: "aal789" }],
+    cache,
+    now,
+  });
+
+  assert.deepEqual(routes, { DAL123: route });
+}

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -1,23 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { FLIGHT_ROUTE_LOOKUP_CONFIG } from "../config/aviation.js";
+import {
+  buildRoutesByCallsign,
+  resolvePendingRouteLookups,
+} from "../features/flight-routes/flightRouteLookupModel.js";
 import { flightRouteClient } from "../services/aviationData.js";
-import { isLookupCallsign, normalizeCallsign } from "../utils/callsign.js";
 
 const routeCache = new Map();
 const inFlight = new Set();
-
-const getFreshCacheEntry = (callsign, now = Date.now()) => {
-  const cached = routeCache.get(callsign);
-  if (!cached) return null;
-  const maxAge = cached.route
-    ? FLIGHT_ROUTE_LOOKUP_CONFIG.hitCacheMs
-    : FLIGHT_ROUTE_LOOKUP_CONFIG.missCacheMs;
-  if (now - cached.time <= maxAge) return cached;
-  routeCache.delete(callsign);
-  return null;
-};
 
 export function useFlightRoutes(aircraft) {
   const [version, setVersion] = useState(0);
@@ -52,20 +43,12 @@ export function useFlightRoutes(aircraft) {
       }
     };
 
-    const now = Date.now();
-    const callsigns = [
-      ...new Set(
-        aircraft
-          .map((item) => normalizeCallsign(item.callsign))
-          .filter(isLookupCallsign),
-      ),
-    ];
-    const pending = callsigns
-      .filter(
-        (callsign) =>
-          !getFreshCacheEntry(callsign, now) && !inFlight.has(callsign),
-      )
-      .slice(0, FLIGHT_ROUTE_LOOKUP_CONFIG.maxLookupsPerPass);
+    const pending = resolvePendingRouteLookups({
+      aircraft,
+      cache: routeCache,
+      inFlight,
+      now: Date.now(),
+    });
 
     pending.forEach((callsign, index) => {
       if (index === 0) lookup(callsign);
@@ -76,14 +59,11 @@ export function useFlightRoutes(aircraft) {
 
   const routesByCallsign = useMemo(() => {
     version;
-    const routes = {};
-    const now = Date.now();
-    for (const item of aircraft || []) {
-      const callsign = normalizeCallsign(item.callsign);
-      const cached = getFreshCacheEntry(callsign, now);
-      if (cached?.route) routes[callsign] = cached.route;
-    }
-    return routes;
+    return buildRoutesByCallsign({
+      aircraft,
+      cache: routeCache,
+      now: Date.now(),
+    });
   }, [aircraft, version]);
 
   return { routesByCallsign, loadingCount };


### PR DESCRIPTION
## Summary
- extract flight route cache freshness, pending lookup selection, and route projection into a pure feature model
- keep useFlightRoutes focused on cache/in-flight containers and async lookup coordination
- add model coverage for cache TTL handling, de-duped pending callsigns, and routesByCallsign output

## Verification
- pnpm test:flight-routes-feature
- pnpm test:flight-route-display && pnpm test:aviation-data
- pnpm lint
- pnpm build
- pnpm test:home-airport-directory && pnpm test:airport-directory && pnpm test:aviation-data && pnpm test:aviation-service-model && pnpm test:vercel-routing && pnpm test:airport-wiki && pnpm test:about && pnpm test:app-shell && pnpm test:airport-search && pnpm test:airport-explorer && pnpm test:map-controls && pnpm test:airport-map-feature && pnpm test:weather-feature && pnpm test:aircraft-positions-feature && pnpm test:flight-routes-feature && pnpm test:flight-route-display && pnpm test:airport-map-display && pnpm test:metar && pnpm test:aircraft-motion && pnpm test:aircraft-traffic-intent
- curl -I http://localhost:3000/
- curl -I http://localhost:3000/about
- curl -I http://localhost:3000/KBOS