### PR TITLE
Reduce aircraft polling to one 30nm request

### DIFF
--- a/src/components/map/AreaMarker.jsx
+++ b/src/components/map/AreaMarker.jsx
@@ -5,7 +5,7 @@ import L from "leaflet";
 import { useMapInstance } from "./MapContext.js";
 import { AIRPORT_AREA_RADIUS_NM } from "../../config/airportMap.js";
 import { shouldShowAirportArea } from "../../utils/airportMapDisplay.js";
-import { DEFAULT_WIDE_RANGE_NM } from "../../services/aviationData.js";
+import { DEFAULT_AIRCRAFT_RANGE_NM } from "../../services/aviationData.js";
 
 const NM_TO_METERS = 1852;
 
@@ -37,7 +37,7 @@ export default function AreaMarker({ lat, lon, zoom, theme = "dark" }) {
 
     wideRef.current?.removeFrom(map);
     wideRef.current = L.circle([lat, lon], {
-      radius: DEFAULT_WIDE_RANGE_NM * NM_TO_METERS,
+      radius: DEFAULT_AIRCRAFT_RANGE_NM * NM_TO_METERS,
       color: stroke,
       weight: 1,
       dashArray: "6 6",

--- a/src/config/aviation.js
+++ b/src/config/aviation.js
@@ -12,8 +12,7 @@ export const AIRPORT_EXPLORER_UI_CONFIG = {
 
 export const AIRCRAFT_TRAFFIC_CONFIG = {
   pollMs: 3_000,
-  wideRangeNm: 20,
-  closeRangeNm: 3,
+  rangeNm: 30,
   hiddenPollGraceMs: 5_000,
 };
 

--- a/src/features/aircraft-positions/aircraftPositionsModel.js
+++ b/src/features/aircraft-positions/aircraftPositionsModel.js
@@ -21,27 +21,19 @@ export function normalizeAdsbAircraft(
   };
 }
 
-export function mergeAircraftSnapshots({
-  wideJson,
-  closeJson,
+export function normalizeAircraftSnapshot({
+  json,
   receiveTime = Date.now(),
 }) {
-  const seen = new Map();
-  const addSnapshots = (list, responseNow) => {
-    for (const aircraft of list || []) {
-      if (aircraft.lat == null || aircraft.lon == null) continue;
-      const key = aircraft.hex || "";
-      if (!key) continue;
-      seen.set(
-        key,
-        normalizeAdsbAircraft(aircraft, { responseNow, receiveTime }),
-      );
-    }
-  };
-
-  addSnapshots(closeJson?.ac, closeJson?.now);
-  addSnapshots(wideJson?.ac, wideJson?.now);
-  return [...seen.values()];
+  return (json?.ac || [])
+    .filter((aircraft) => aircraft.lat != null && aircraft.lon != null)
+    .filter((aircraft) => aircraft.hex)
+    .map((aircraft) =>
+      normalizeAdsbAircraft(aircraft, {
+        responseNow: json?.now,
+        receiveTime,
+      }),
+    );
 }
 
 export function isHttp4xxOr5xx(error) {

--- a/src/features/aircraft-positions/aircraftPositionsModel.test.js
+++ b/src/features/aircraft-positions/aircraftPositionsModel.test.js
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 
 import {
   isHttp4xxOr5xx,
-  mergeAircraftSnapshots,
   normalizeAdsbAircraft,
+  normalizeAircraftSnapshot,
 } from "./aircraftPositionsModel.js";
 
 const receiveTime = 1_700_000_003_200;
@@ -38,30 +38,26 @@ const responseNow = 1_700_000_003_000;
 }
 
 {
-  const merged = mergeAircraftSnapshots({
-    closeJson: {
+  const normalized = normalizeAircraftSnapshot({
+    json: {
       now: responseNow,
       ac: [
-        { hex: "duplicate", flight: " CLOSE ", lat: 1, lon: 2, gs: 10 },
+        { hex: "wide", flight: " WIDE ", lat: 5, lon: 6, gs: 20 },
         { hex: "near", flight: " NEAR ", lat: 3, lon: 4 },
-      ],
-    },
-    wideJson: {
-      now: responseNow,
-      ac: [
-        { hex: "duplicate", flight: " WIDE ", lat: 5, lon: 6, gs: 20 },
         { hex: "missing", flight: "SKIP", lat: null, lon: 9 },
+        { flight: "NOHEX", lat: 7, lon: 8 },
       ],
     },
     receiveTime,
   });
 
   assert.deepEqual(
-    merged.map((item) => item.icao24),
-    ["duplicate", "near"],
+    normalized.map((item) => item.icao24),
+    ["wide", "near"],
   );
-  assert.equal(merged[0].callsign, "WIDE");
-  assert.equal(merged[0].velocity, 20);
+  assert.equal(normalized[0].callsign, "WIDE");
+  assert.equal(normalized[0].velocity, 20);
+  assert.equal(normalized[0].positionTime, responseNow);
 }
 
 assert.equal(isHttp4xxOr5xx({ status: 500 }), true);

--- a/src/hooks/useAircraftPositions.js
+++ b/src/hooks/useAircraftPositions.js
@@ -3,15 +3,14 @@
 import { useEffect, useRef, useState } from "react";
 import {
   aircraftPositionClient,
+  DEFAULT_AIRCRAFT_RANGE_NM,
   DEFAULT_AIRCRAFT_POLL_MS,
-  DEFAULT_CLOSE_RANGE_NM,
-  DEFAULT_WIDE_RANGE_NM,
 } from "../services/aviationData.js";
 import { AIRCRAFT_TRAFFIC_CONFIG } from "../config/aviation.js";
 import {
   describeAircraftFetchError,
   isHttp4xxOr5xx,
-  mergeAircraftSnapshots,
+  normalizeAircraftSnapshot,
 } from "../features/aircraft-positions/aircraftPositionsModel.js";
 
 const HIDDEN_POLL_GRACE_MS = AIRCRAFT_TRAFFIC_CONFIG.hiddenPollGraceMs;
@@ -42,24 +41,16 @@ export function useAircraftPositions(icao, lat, lon) {
       if (!lat || !lon) return;
       setLoading(true);
       try {
-        const [wideJson, closeJson] = await Promise.all([
-          aircraftPositionClient.fetchNearbyAircraft({
-            lat,
-            lon,
-            distNm: DEFAULT_WIDE_RANGE_NM,
-          }),
-          aircraftPositionClient.fetchNearbyAircraft({
-            lat,
-            lon,
-            distNm: DEFAULT_CLOSE_RANGE_NM,
-          }),
-        ]);
+        const aircraftJson = await aircraftPositionClient.fetchNearbyAircraft({
+          lat,
+          lon,
+          distNm: DEFAULT_AIRCRAFT_RANGE_NM,
+        });
         if (disposed) return;
         const receiveTime = Date.now();
         setAircraft(
-          mergeAircraftSnapshots({
-            wideJson,
-            closeJson,
+          normalizeAircraftSnapshot({
+            json: aircraftJson,
             receiveTime,
           }),
         );

--- a/src/services/aviation/aircraftPositionClient.js
+++ b/src/services/aviation/aircraftPositionClient.js
@@ -33,7 +33,7 @@ export const createAircraftPositionClient = ({
     fetchNearbyAircraft({
       lat,
       lon,
-      distNm = AIRCRAFT_TRAFFIC_CONFIG.wideRangeNm,
+      distNm = AIRCRAFT_TRAFFIC_CONFIG.rangeNm,
     }) {
       const encodedLat = encodeURIComponent(String(lat));
       const encodedLon = encodeURIComponent(String(lon));

--- a/src/services/aviationData.js
+++ b/src/services/aviationData.js
@@ -13,8 +13,7 @@ export { createMetarClient } from "./aviation/metarClient.js";
 export { createRateLimiter } from "./aviation/rateLimiter.js";
 
 export const DEFAULT_AIRCRAFT_POLL_MS = AIRCRAFT_TRAFFIC_CONFIG.pollMs;
-export const DEFAULT_WIDE_RANGE_NM = AIRCRAFT_TRAFFIC_CONFIG.wideRangeNm;
-export const DEFAULT_CLOSE_RANGE_NM = AIRCRAFT_TRAFFIC_CONFIG.closeRangeNm;
+export const DEFAULT_AIRCRAFT_RANGE_NM = AIRCRAFT_TRAFFIC_CONFIG.rangeNm;
 
 export const metarClient = createMetarClient();
 export const aircraftPositionClient = createAircraftPositionClient();

--- a/src/services/aviationData.test.js
+++ b/src/services/aviationData.test.js
@@ -7,6 +7,7 @@ import {
   createMetarClient,
   createRateLimiter,
   DEFAULT_AIRCRAFT_POLL_MS,
+  DEFAULT_AIRCRAFT_RANGE_NM,
   normalizeFlightRoute,
 } from "./aviationData.js";
 
@@ -152,6 +153,24 @@ try {
   assert.equal(calls.length, 1);
   assert.equal(calls[0], "/api/proxy/aircraft/positions/42.3656/-71.0096/15");
   assert.equal(payload.ac[0].hex, "a1b2c3");
+}
+
+{
+  const calls = [];
+  const client = createAircraftPositionClient({
+    fetchImpl: async (url) => {
+      calls.push(url);
+      return createJsonResponse({ ac: [] });
+    },
+  });
+
+  await client.fetchNearbyAircraft({
+    lat: 42.3656,
+    lon: -71.0096,
+  });
+
+  assert.equal(DEFAULT_AIRCRAFT_RANGE_NM, 30);
+  assert.equal(calls[0], "/api/proxy/aircraft/positions/42.3656/-71.0096/30");
 }
 
 {


### PR DESCRIPTION
## Summary
- replace the previous 20nm + 3nm ADS-B polling pair with one centrally configured 30nm request
- update aircraft snapshot normalization so the hook consumes a single provider payload
- keep the airport traffic range ring tied to the same centralized radius

## Data check
- KBOS live sample via local proxy: 3nm=21 aircraft, 20nm=32 aircraft, 30nm=40 aircraft
- 3nm was a full subset of both 20nm and 30nm, and 20nm was a full subset of 30nm

## Verification
- pnpm test:aircraft-positions-feature
- pnpm test:aviation-data
- pnpm test:airport-map-feature
- pnpm lint
- pnpm build
- pnpm test:all