### PR TITLE
Reduce procedure overlay visual clutter

### DIFF
--- a/src/features/airport-map/procedureOverlayModel.js
+++ b/src/features/airport-map/procedureOverlayModel.js
@@ -1,18 +1,19 @@
 const SILK_STYLES = {
   dark: [
-    { color: "#64748b", weight: 9, opacity: 0.1 },
-    { color: "#1e5f8f", weight: 4.5, opacity: 0.16 },
-    { color: "#9ccff0", weight: 1.4, opacity: 0.28 },
+    { color: "#64748b", weight: 10, opacity: 0.05 },
+    { color: "#1e5f8f", weight: 4.5, opacity: 0.08 },
+    { color: "#9ccff0", weight: 1.2, opacity: 0.14 },
   ],
   light: [
-    { color: "#94a3b8", weight: 9, opacity: 0.12 },
-    { color: "#2b6f9f", weight: 4.5, opacity: 0.18 },
-    { color: "#4f9fcf", weight: 1.4, opacity: 0.24 },
+    { color: "#94a3b8", weight: 10, opacity: 0.07 },
+    { color: "#2b6f9f", weight: 4.5, opacity: 0.1 },
+    { color: "#4f9fcf", weight: 1.2, opacity: 0.14 },
   ],
 };
 
 const isDisplayLineFeature = (feature) =>
   feature?.geometry?.type === "LineString" &&
+  feature?.properties?.transitionName === "FINAL" &&
   feature?.properties?.phase !== "missed";
 
 export function buildProcedureLineCollection(geojson) {

--- a/src/features/airport-map/procedureOverlayModel.test.js
+++ b/src/features/airport-map/procedureOverlayModel.test.js
@@ -22,7 +22,18 @@ const geojson = {
           [-70.9, 42.1],
         ],
       },
-      properties: { fixIdent: "RW04R", phase: "runway" },
+      properties: { fixIdent: "AAALL", phase: "approach", transitionName: "NUNZO" },
+    },
+    {
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-70.95, 42.05],
+          [-70.9, 42.1],
+        ],
+      },
+      properties: { fixIdent: "RW04R", phase: "runway", transitionName: "FINAL" },
     },
     {
       type: "Feature",
@@ -33,7 +44,7 @@ const geojson = {
           [-70.8, 42.2],
         ],
       },
-      properties: { fixIdent: "WAXEN", phase: "missed" },
+      properties: { fixIdent: "WAXEN", phase: "missed", transitionName: "FINAL" },
     },
   ],
 };
@@ -53,7 +64,7 @@ assert.deepEqual(
 );
 assert.deepEqual(
   darkStyles.map((style) => style.opacity),
-  [0.1, 0.16, 0.28],
+  [0.05, 0.08, 0.14],
 );
 assert.equal(darkStyles[0].weight > darkStyles[1].weight, true);
 assert.equal(darkStyles[1].weight > darkStyles[2].weight, true);


### PR DESCRIPTION
## Summary
- reduce procedure overlay opacity further while keeping the blue/gray silk palette
- only render FINAL transition approach/runway line segments by default
- continue filtering missed-approach segments and all point/fix dots from the map layer

## Behavior check
- KBOS live payload still has 12 approaches and 62 line features
- display layer now renders 33 final-corridor line segments and 0 missed line segments

## Verification
- pnpm test:procedure-overlay
- pnpm lint
- pnpm build
- pnpm test:all
- local live payload check against /api/proxy/procedures/US/KBOS
