### PR TITLE
Soften procedure corridor rendering

### DIFF
--- a/src/components/map/ProcedureOverlay.jsx
+++ b/src/components/map/ProcedureOverlay.jsx
@@ -3,10 +3,7 @@
 import { useEffect, useRef } from "react";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext.js";
-import {
-  buildProcedureLineCollection,
-  getProcedureSilkStyles,
-} from "../../features/airport-map/procedureOverlayModel.js";
+import { buildProcedureRenderLayers } from "../../features/airport-map/procedureOverlayModel.js";
 
 export default function ProcedureOverlay({ geojson, theme = "dark" }) {
   const map = useMapInstance();
@@ -14,17 +11,22 @@ export default function ProcedureOverlay({ geojson, theme = "dark" }) {
 
   useEffect(() => {
     if (!map || !geojson) return undefined;
-    const lineCollection = buildProcedureLineCollection(geojson);
-    if (lineCollection.features.length === 0) return undefined;
+    const renderLayers = buildProcedureRenderLayers(geojson, theme);
+    if (renderLayers.every((layer) => layer.geojson.features.length === 0)) {
+      return undefined;
+    }
 
     const layer = L.layerGroup(
-      getProcedureSilkStyles(theme).map((style) =>
-        L.geoJSON(lineCollection, {
+      renderLayers.map(({ geojson: layerGeoJson, style }) =>
+        L.geoJSON(layerGeoJson, {
           interactive: false,
-          style: {
-            ...style,
-            lineCap: "round",
-            lineJoin: "round",
+          style(feature) {
+            return {
+              ...style,
+              opacity: feature.properties?.layerOpacity ?? style.opacity,
+              lineCap: "round",
+              lineJoin: "round",
+            };
           },
         }),
       ),

--- a/src/features/airport-map/procedureOverlayModel.js
+++ b/src/features/airport-map/procedureOverlayModel.js
@@ -1,13 +1,43 @@
 const SILK_STYLES = {
   dark: [
-    { color: "#64748b", weight: 10, opacity: 0.05 },
-    { color: "#1e5f8f", weight: 4.5, opacity: 0.08 },
-    { color: "#9ccff0", weight: 1.2, opacity: 0.14 },
+    {
+      color: "#64748b",
+      weight: 11,
+      opacity: 0.05,
+      className: "procedure-silk procedure-silk--blur",
+    },
+    {
+      color: "#1e5f8f",
+      weight: 5,
+      opacity: 0.08,
+      className: "procedure-silk procedure-silk--body",
+    },
+    {
+      color: "#9ccff0",
+      weight: 1.2,
+      opacity: 0.14,
+      className: "procedure-silk procedure-silk--thread",
+    },
   ],
   light: [
-    { color: "#94a3b8", weight: 10, opacity: 0.07 },
-    { color: "#2b6f9f", weight: 4.5, opacity: 0.1 },
-    { color: "#4f9fcf", weight: 1.2, opacity: 0.14 },
+    {
+      color: "#94a3b8",
+      weight: 11,
+      opacity: 0.07,
+      className: "procedure-silk procedure-silk--blur",
+    },
+    {
+      color: "#2b6f9f",
+      weight: 5,
+      opacity: 0.1,
+      className: "procedure-silk procedure-silk--body",
+    },
+    {
+      color: "#4f9fcf",
+      weight: 1.2,
+      opacity: 0.14,
+      className: "procedure-silk procedure-silk--thread",
+    },
   ],
 };
 
@@ -16,14 +46,85 @@ const isDisplayLineFeature = (feature) =>
   feature?.properties?.transitionName === "FINAL" &&
   feature?.properties?.phase !== "missed";
 
+const lerp = (start, end, t) => start + (end - start) * t;
+
+const smoothCoordinates = (coordinates, steps = 8) => {
+  if (!Array.isArray(coordinates) || coordinates.length < 2) return coordinates;
+  const smoothed = [];
+  for (let index = 0; index < coordinates.length - 1; index++) {
+    const start = coordinates[index];
+    const end = coordinates[index + 1];
+    for (let step = 0; step < steps; step++) {
+      const t = step / steps;
+      smoothed.push([lerp(start[0], end[0], t), lerp(start[1], end[1], t)]);
+    }
+  }
+  smoothed.push(coordinates.at(-1));
+  return smoothed;
+};
+
+const addFadeOpacity = (features) => {
+  const groups = new Map();
+  for (const feature of features) {
+    const key = feature.properties?.procedureId || "procedure";
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(feature);
+  }
+
+  return features.map((feature) => {
+    const group = groups.get(feature.properties?.procedureId || "procedure") || [];
+    const sequences = group
+      .map((item) => Number(item.properties?.sequence))
+      .filter(Number.isFinite);
+    const min = Math.min(...sequences);
+    const max = Math.max(...sequences);
+    const sequence = Number(feature.properties?.sequence);
+    const progress =
+      Number.isFinite(sequence) && Number.isFinite(min) && Number.isFinite(max) && max > min
+        ? (sequence - min) / (max - min)
+        : 1;
+    return {
+      ...feature,
+      properties: {
+        ...feature.properties,
+        fadeOpacity: Number((0.35 + progress * 0.65).toFixed(3)),
+      },
+      geometry: {
+        ...feature.geometry,
+        coordinates: smoothCoordinates(feature.geometry.coordinates),
+      },
+    };
+  });
+};
+
 export function buildProcedureLineCollection(geojson) {
+  const features = (geojson?.features || []).filter(isDisplayLineFeature);
   return {
     type: "FeatureCollection",
     properties: geojson?.properties || {},
-    features: (geojson?.features || []).filter(isDisplayLineFeature),
+    features: addFadeOpacity(features),
   };
 }
 
 export function getProcedureSilkStyles(theme = "dark") {
   return SILK_STYLES[theme] || SILK_STYLES.dark;
+}
+
+export function buildProcedureRenderLayers(geojson, theme = "dark") {
+  const lineCollection = buildProcedureLineCollection(geojson);
+  return getProcedureSilkStyles(theme).map((style) => ({
+    style,
+    geojson: {
+      ...lineCollection,
+      features: lineCollection.features.map((feature) => ({
+        ...feature,
+        properties: {
+          ...feature.properties,
+          layerOpacity: Number(
+            (style.opacity * (feature.properties?.fadeOpacity ?? 1)).toFixed(4),
+          ),
+        },
+      })),
+    },
+  }));
 }

--- a/src/features/airport-map/procedureOverlayModel.test.js
+++ b/src/features/airport-map/procedureOverlayModel.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import {
   buildProcedureLineCollection,
+  buildProcedureRenderLayers,
   getProcedureSilkStyles,
 } from "./procedureOverlayModel.js";
 
@@ -54,6 +55,8 @@ const lineCollection = buildProcedureLineCollection(geojson);
 assert.equal(lineCollection.type, "FeatureCollection");
 assert.equal(lineCollection.features.length, 1);
 assert.equal(lineCollection.features[0].properties.fixIdent, "RW04R");
+assert.equal(lineCollection.features[0].properties.fadeOpacity, 1);
+assert.equal(lineCollection.features[0].geometry.coordinates.length > 2, true);
 
 const darkStyles = getProcedureSilkStyles("dark");
 
@@ -63,8 +66,66 @@ assert.deepEqual(
   ["#64748b", "#1e5f8f", "#9ccff0"],
 );
 assert.deepEqual(
+  darkStyles.map((style) => style.className),
+  [
+    "procedure-silk procedure-silk--blur",
+    "procedure-silk procedure-silk--body",
+    "procedure-silk procedure-silk--thread",
+  ],
+);
+assert.deepEqual(
   darkStyles.map((style) => style.opacity),
   [0.05, 0.08, 0.14],
 );
 assert.equal(darkStyles[0].weight > darkStyles[1].weight, true);
 assert.equal(darkStyles[1].weight > darkStyles[2].weight, true);
+
+const renderLayers = buildProcedureRenderLayers(geojson, "dark");
+
+assert.equal(renderLayers.length, 3);
+assert.equal(renderLayers[0].geojson.features.length, 1);
+assert.equal(renderLayers[0].style.opacity, 0.05);
+
+const multiSegmentGeoJson = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-71.2, 42.0],
+          [-71.1, 42.1],
+        ],
+      },
+      properties: {
+        procedureId: "p1",
+        transitionName: "FINAL",
+        phase: "approach",
+        sequence: 10,
+      },
+    },
+    {
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-71.1, 42.1],
+          [-71.0, 42.2],
+        ],
+      },
+      properties: {
+        procedureId: "p1",
+        transitionName: "FINAL",
+        phase: "runway",
+        sequence: 30,
+      },
+    },
+  ],
+};
+
+const fadedCollection = buildProcedureLineCollection(multiSegmentGeoJson);
+assert.deepEqual(
+  fadedCollection.features.map((feature) => feature.properties.fadeOpacity),
+  [0.35, 1],
+);

--- a/src/style.css
+++ b/src/style.css
@@ -351,6 +351,18 @@ body {
     opacity: 0.55 !important;
 }
 
+.procedure-silk--blur {
+    filter: blur(4px);
+}
+
+.procedure-silk--body {
+    filter: blur(1.2px);
+}
+
+.procedure-silk--thread {
+    filter: blur(0.35px);
+}
+
 /* Transitions */
 .screen-enter-active,
 .screen-leave-active {


### PR DESCRIPTION
## Summary
- render procedure corridors as three fuzzy SVG layers with blur classes instead of crisp strokes
- smooth sampled line coordinates so short straight segments read as softer continuous belts
- add per-procedure fade opacity so the far end is much more transparent and the runway end remains slightly more visible

## Behavior check
- KBOS live payload still renders 33 final-corridor display lines
- blur layer opacity now fades from about 0.0175 at far ends to 0.05 near runway ends
- each rendered segment is sampled into intermediate coordinates for smoother visual continuity

## Verification
- pnpm test:procedure-overlay
- pnpm lint
- pnpm build
- pnpm test:all
- local render-layer check against /api/proxy/procedures/US/KBOS
