### PR TITLE
Polish procedure overlay visual fade

### DIFF
--- a/src/components/map/AreaMarker.jsx
+++ b/src/components/map/AreaMarker.jsx
@@ -17,20 +17,24 @@ export default function AreaMarker({ lat, lon, zoom, theme = "dark" }) {
   useEffect(() => {
     if (!map || !map.getContainer || !lat || !lon) return undefined;
 
-    const stroke =
+    const closeStroke =
       theme === "light" ? "rgba(18,21,26,0.22)" : "rgba(255,255,255,0.28)";
-    const fill =
+    const closeFill =
       theme === "light" ? "rgba(18,21,26,0.06)" : "rgba(255,255,255,0.05)";
+    const wideStroke =
+      theme === "light" ? "rgba(18,21,26,0.12)" : "rgba(255,255,255,0.16)";
+    const wideFill =
+      theme === "light" ? "rgba(18,21,26,0.018)" : "rgba(255,255,255,0.018)";
 
     closeRef.current?.removeFrom(map);
     closeRef.current = null;
     if (shouldShowAirportArea(zoom)) {
       closeRef.current = L.circle([lat, lon], {
         radius: AIRPORT_AREA_RADIUS_NM * NM_TO_METERS,
-        color: stroke,
+        color: closeStroke,
         weight: 1,
         dashArray: "4 4",
-        fillColor: fill,
+        fillColor: closeFill,
         fillOpacity: 1,
       }).addTo(map);
     }
@@ -38,10 +42,10 @@ export default function AreaMarker({ lat, lon, zoom, theme = "dark" }) {
     wideRef.current?.removeFrom(map);
     wideRef.current = L.circle([lat, lon], {
       radius: DEFAULT_AIRCRAFT_RANGE_NM * NM_TO_METERS,
-      color: stroke,
+      color: wideStroke,
       weight: 1,
       dashArray: "6 6",
-      fillColor: fill,
+      fillColor: wideFill,
       fillOpacity: 1,
     }).addTo(map);
 

--- a/src/features/airport-map/procedureOverlayModel.js
+++ b/src/features/airport-map/procedureOverlayModel.js
@@ -2,40 +2,40 @@ const SILK_STYLES = {
   dark: [
     {
       color: "#64748b",
-      weight: 11,
-      opacity: 0.05,
+      weight: 12,
+      opacity: 0.065,
       className: "procedure-silk procedure-silk--blur",
     },
     {
-      color: "#1e5f8f",
-      weight: 5,
-      opacity: 0.08,
+      color: "#1f6f9f",
+      weight: 5.2,
+      opacity: 0.105,
       className: "procedure-silk procedure-silk--body",
     },
     {
-      color: "#9ccff0",
-      weight: 1.2,
-      opacity: 0.14,
+      color: "#a8d8f3",
+      weight: 1.15,
+      opacity: 0.18,
       className: "procedure-silk procedure-silk--thread",
     },
   ],
   light: [
     {
       color: "#94a3b8",
-      weight: 11,
-      opacity: 0.07,
+      weight: 12,
+      opacity: 0.08,
       className: "procedure-silk procedure-silk--blur",
     },
     {
       color: "#2b6f9f",
-      weight: 5,
-      opacity: 0.1,
+      weight: 5.2,
+      opacity: 0.12,
       className: "procedure-silk procedure-silk--body",
     },
     {
       color: "#4f9fcf",
-      weight: 1.2,
-      opacity: 0.14,
+      weight: 1.15,
+      opacity: 0.18,
       className: "procedure-silk procedure-silk--thread",
     },
   ],
@@ -63,7 +63,20 @@ const smoothCoordinates = (coordinates, steps = 8) => {
   return smoothed;
 };
 
-const addFadeOpacity = (features) => {
+const segmentFadeOpacity = (progress) => Number((0.2 + progress * 0.8).toFixed(3));
+
+const sortBySequence = (left, right) => {
+  const leftSequence = Number(left.properties?.sequence);
+  const rightSequence = Number(right.properties?.sequence);
+  if (Number.isFinite(leftSequence) && Number.isFinite(rightSequence)) {
+    return leftSequence - rightSequence;
+  }
+  if (Number.isFinite(leftSequence)) return -1;
+  if (Number.isFinite(rightSequence)) return 1;
+  return 0;
+};
+
+const buildGradientSegments = (features) => {
   const groups = new Map();
   for (const feature of features) {
     const key = feature.properties?.procedureId || "procedure";
@@ -71,29 +84,32 @@ const addFadeOpacity = (features) => {
     groups.get(key).push(feature);
   }
 
-  return features.map((feature) => {
-    const group = groups.get(feature.properties?.procedureId || "procedure") || [];
-    const sequences = group
-      .map((item) => Number(item.properties?.sequence))
-      .filter(Number.isFinite);
-    const min = Math.min(...sequences);
-    const max = Math.max(...sequences);
-    const sequence = Number(feature.properties?.sequence);
-    const progress =
-      Number.isFinite(sequence) && Number.isFinite(min) && Number.isFinite(max) && max > min
-        ? (sequence - min) / (max - min)
-        : 1;
-    return {
-      ...feature,
-      properties: {
-        ...feature.properties,
-        fadeOpacity: Number((0.35 + progress * 0.65).toFixed(3)),
-      },
-      geometry: {
-        ...feature.geometry,
-        coordinates: smoothCoordinates(feature.geometry.coordinates),
-      },
-    };
+  return [...groups.values()].flatMap((group) => {
+    const sorted = group.toSorted(sortBySequence);
+    const groupSize = Math.max(sorted.length, 1);
+
+    return sorted.flatMap((feature, featureIndex) => {
+      const coordinates = smoothCoordinates(feature.geometry.coordinates);
+      if (!Array.isArray(coordinates) || coordinates.length < 2) return [];
+
+      return coordinates.slice(0, -1).map((start, segmentIndex) => {
+        const end = coordinates[segmentIndex + 1];
+        const localProgress = segmentIndex / Math.max(coordinates.length - 2, 1);
+        const procedureProgress = (featureIndex + localProgress) / groupSize;
+        return {
+          ...feature,
+          properties: {
+            ...feature.properties,
+            fadeOpacity: segmentFadeOpacity(procedureProgress),
+            gradientSegment: segmentIndex,
+          },
+          geometry: {
+            ...feature.geometry,
+            coordinates: [start, end],
+          },
+        };
+      });
+    });
   });
 };
 
@@ -102,7 +118,7 @@ export function buildProcedureLineCollection(geojson) {
   return {
     type: "FeatureCollection",
     properties: geojson?.properties || {},
-    features: addFadeOpacity(features),
+    features: buildGradientSegments(features),
   };
 }
 

--- a/src/features/airport-map/procedureOverlayModel.test.js
+++ b/src/features/airport-map/procedureOverlayModel.test.js
@@ -53,17 +53,18 @@ const geojson = {
 const lineCollection = buildProcedureLineCollection(geojson);
 
 assert.equal(lineCollection.type, "FeatureCollection");
-assert.equal(lineCollection.features.length, 1);
+assert.equal(lineCollection.features.length, 8);
 assert.equal(lineCollection.features[0].properties.fixIdent, "RW04R");
-assert.equal(lineCollection.features[0].properties.fadeOpacity, 1);
-assert.equal(lineCollection.features[0].geometry.coordinates.length > 2, true);
+assert.equal(lineCollection.features[0].properties.fadeOpacity, 0.2);
+assert.equal(lineCollection.features.at(-1).properties.fadeOpacity, 1);
+assert.equal(lineCollection.features[0].geometry.coordinates.length, 2);
 
 const darkStyles = getProcedureSilkStyles("dark");
 
 assert.equal(darkStyles.length, 3);
 assert.deepEqual(
   darkStyles.map((style) => style.color),
-  ["#64748b", "#1e5f8f", "#9ccff0"],
+  ["#64748b", "#1f6f9f", "#a8d8f3"],
 );
 assert.deepEqual(
   darkStyles.map((style) => style.className),
@@ -75,7 +76,7 @@ assert.deepEqual(
 );
 assert.deepEqual(
   darkStyles.map((style) => style.opacity),
-  [0.05, 0.08, 0.14],
+  [0.065, 0.105, 0.18],
 );
 assert.equal(darkStyles[0].weight > darkStyles[1].weight, true);
 assert.equal(darkStyles[1].weight > darkStyles[2].weight, true);
@@ -83,8 +84,9 @@ assert.equal(darkStyles[1].weight > darkStyles[2].weight, true);
 const renderLayers = buildProcedureRenderLayers(geojson, "dark");
 
 assert.equal(renderLayers.length, 3);
-assert.equal(renderLayers[0].geojson.features.length, 1);
-assert.equal(renderLayers[0].style.opacity, 0.05);
+assert.equal(renderLayers[0].geojson.features.length, 8);
+assert.equal(renderLayers[0].style.opacity, 0.065);
+assert.equal(renderLayers[0].geojson.features[0].properties.layerOpacity, 0.013);
 
 const multiSegmentGeoJson = {
   type: "FeatureCollection",
@@ -126,6 +128,11 @@ const multiSegmentGeoJson = {
 
 const fadedCollection = buildProcedureLineCollection(multiSegmentGeoJson);
 assert.deepEqual(
-  fadedCollection.features.map((feature) => feature.properties.fadeOpacity),
-  [0.35, 1],
+  [
+    fadedCollection.features[0].properties.fadeOpacity,
+    fadedCollection.features[7].properties.fadeOpacity,
+    fadedCollection.features[8].properties.fadeOpacity,
+    fadedCollection.features.at(-1).properties.fadeOpacity,
+  ],
+  [0.2, 0.6, 0.6, 1],
 );

--- a/src/style.css
+++ b/src/style.css
@@ -351,16 +351,26 @@ body {
     opacity: 0.55 !important;
 }
 
+.procedure-silk {
+    mix-blend-mode: screen;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+:root[data-theme="light"] .procedure-silk {
+    mix-blend-mode: multiply;
+}
+
 .procedure-silk--blur {
-    filter: blur(4px);
+    filter: blur(5px);
 }
 
 .procedure-silk--body {
-    filter: blur(1.2px);
+    filter: blur(1.8px);
 }
 
 .procedure-silk--thread {
-    filter: blur(0.35px);
+    filter: blur(0.45px);
 }
 
 /* Transitions */


### PR DESCRIPTION
## Summary
- render procedure corridors as short gradient segments so far ends fade along each line
- tune blue/gray silk styles and blend modes so overlapping procedures read as grouped routes
- reduce the wide ADS-B range circle so it stays behind the procedure layer

## Verification
- pnpm test:procedure-overlay
- pnpm lint
- pnpm build
- pnpm test:all
- inspected localhost:3000/klax in Chrome