### PR TITLE
Curve procedure overlay paths

### DIFF
--- a/src/features/airport-map/procedureOverlayModel.js
+++ b/src/features/airport-map/procedureOverlayModel.js
@@ -46,21 +46,41 @@ const isDisplayLineFeature = (feature) =>
   feature?.properties?.transitionName === "FINAL" &&
   feature?.properties?.phase !== "missed";
 
-const lerp = (start, end, t) => start + (end - start) * t;
+const CURVE_STEPS_PER_LEG = 12;
 
-const smoothCoordinates = (coordinates, steps = 8) => {
+const sameCoordinate = (left, right) =>
+  Array.isArray(left) &&
+  Array.isArray(right) &&
+  Math.abs(left[0] - right[0]) < 1e-8 &&
+  Math.abs(left[1] - right[1]) < 1e-8;
+
+const catmullRom = (previous, start, end, next, t, axis) =>
+  0.5 *
+  (2 * start[axis] +
+    (-previous[axis] + end[axis]) * t +
+    (2 * previous[axis] - 5 * start[axis] + 4 * end[axis] - next[axis]) * t ** 2 +
+    (-previous[axis] + 3 * start[axis] - 3 * end[axis] + next[axis]) * t ** 3);
+
+const curveRouteCoordinates = (coordinates, steps = CURVE_STEPS_PER_LEG) => {
   if (!Array.isArray(coordinates) || coordinates.length < 2) return coordinates;
-  const smoothed = [];
+  const curved = [];
   for (let index = 0; index < coordinates.length - 1; index++) {
+    const previous = coordinates[index - 1] || coordinates[index];
     const start = coordinates[index];
     const end = coordinates[index + 1];
+    const next = coordinates[index + 2] || end;
+
     for (let step = 0; step < steps; step++) {
       const t = step / steps;
-      smoothed.push([lerp(start[0], end[0], t), lerp(start[1], end[1], t)]);
+      const splinePoint = [
+        catmullRom(previous, start, end, next, t, 0),
+        catmullRom(previous, start, end, next, t, 1),
+      ];
+      curved.push(splinePoint);
     }
   }
-  smoothed.push(coordinates.at(-1));
-  return smoothed;
+  curved.push(coordinates.at(-1));
+  return curved;
 };
 
 const segmentFadeOpacity = (progress) => Number((0.2 + progress * 0.8).toFixed(3));
@@ -86,29 +106,39 @@ const buildGradientSegments = (features) => {
 
   return [...groups.values()].flatMap((group) => {
     const sorted = group.toSorted(sortBySequence);
-    const groupSize = Math.max(sorted.length, 1);
+    const routeCoordinates = [];
+    for (const feature of sorted) {
+      const [start, end] = feature.geometry?.coordinates || [];
+      if (!start || !end) continue;
+      if (routeCoordinates.length === 0 || !sameCoordinate(routeCoordinates.at(-1), start)) {
+        routeCoordinates.push(start);
+      }
+      routeCoordinates.push(end);
+    }
 
-    return sorted.flatMap((feature, featureIndex) => {
-      const coordinates = smoothCoordinates(feature.geometry.coordinates);
-      if (!Array.isArray(coordinates) || coordinates.length < 2) return [];
+    const curvedCoordinates = curveRouteCoordinates(routeCoordinates);
+    const totalSegments = Math.max(curvedCoordinates.length - 1, 1);
 
-      return coordinates.slice(0, -1).map((start, segmentIndex) => {
-        const end = coordinates[segmentIndex + 1];
-        const localProgress = segmentIndex / Math.max(coordinates.length - 2, 1);
-        const procedureProgress = (featureIndex + localProgress) / groupSize;
-        return {
-          ...feature,
-          properties: {
-            ...feature.properties,
-            fadeOpacity: segmentFadeOpacity(procedureProgress),
-            gradientSegment: segmentIndex,
-          },
-          geometry: {
-            ...feature.geometry,
-            coordinates: [start, end],
-          },
-        };
-      });
+    return curvedCoordinates.slice(0, -1).map((start, segmentIndex) => {
+      const end = curvedCoordinates[segmentIndex + 1];
+      const sourceFeatureIndex = Math.min(
+        Math.floor((segmentIndex / totalSegments) * sorted.length),
+        sorted.length - 1,
+      );
+      const sourceFeature = sorted[sourceFeatureIndex];
+      const procedureProgress = segmentIndex / Math.max(totalSegments - 1, 1);
+      return {
+        ...sourceFeature,
+        properties: {
+          ...sourceFeature.properties,
+          fadeOpacity: segmentFadeOpacity(procedureProgress),
+          gradientSegment: segmentIndex,
+        },
+        geometry: {
+          ...sourceFeature.geometry,
+          coordinates: [start, end],
+        },
+      };
     });
   });
 };

--- a/src/features/airport-map/procedureOverlayModel.test.js
+++ b/src/features/airport-map/procedureOverlayModel.test.js
@@ -51,13 +51,20 @@ const geojson = {
 };
 
 const lineCollection = buildProcedureLineCollection(geojson);
+const lineStart = [-70.95, 42.05];
+const lineEnd = [-70.9, 42.1];
+const [curvedMidpoint] = lineCollection.features[6].geometry.coordinates;
+const midpointCrossProduct =
+  (lineEnd[0] - lineStart[0]) * (curvedMidpoint[1] - lineStart[1]) -
+  (lineEnd[1] - lineStart[1]) * (curvedMidpoint[0] - lineStart[0]);
 
 assert.equal(lineCollection.type, "FeatureCollection");
-assert.equal(lineCollection.features.length, 8);
+assert.equal(lineCollection.features.length, 12);
 assert.equal(lineCollection.features[0].properties.fixIdent, "RW04R");
 assert.equal(lineCollection.features[0].properties.fadeOpacity, 0.2);
 assert.equal(lineCollection.features.at(-1).properties.fadeOpacity, 1);
 assert.equal(lineCollection.features[0].geometry.coordinates.length, 2);
+assert.equal(Math.abs(midpointCrossProduct) < 0.000001, true);
 
 const darkStyles = getProcedureSilkStyles("dark");
 
@@ -84,7 +91,7 @@ assert.equal(darkStyles[1].weight > darkStyles[2].weight, true);
 const renderLayers = buildProcedureRenderLayers(geojson, "dark");
 
 assert.equal(renderLayers.length, 3);
-assert.equal(renderLayers[0].geojson.features.length, 8);
+assert.equal(renderLayers[0].geojson.features.length, 12);
 assert.equal(renderLayers[0].style.opacity, 0.065);
 assert.equal(renderLayers[0].geojson.features[0].properties.layerOpacity, 0.013);
 
@@ -130,9 +137,52 @@ const fadedCollection = buildProcedureLineCollection(multiSegmentGeoJson);
 assert.deepEqual(
   [
     fadedCollection.features[0].properties.fadeOpacity,
-    fadedCollection.features[7].properties.fadeOpacity,
-    fadedCollection.features[8].properties.fadeOpacity,
+    fadedCollection.features[11].properties.fadeOpacity,
+    fadedCollection.features[12].properties.fadeOpacity,
     fadedCollection.features.at(-1).properties.fadeOpacity,
   ],
-  [0.2, 0.6, 0.6, 1],
+  [0.2, 0.583, 0.617, 1],
 );
+
+const angledGeoJson = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [0, 0],
+          [1, 0],
+        ],
+      },
+      properties: {
+        procedureId: "p2",
+        transitionName: "FINAL",
+        phase: "approach",
+        sequence: 10,
+      },
+    },
+    {
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [1, 0],
+          [1, 1],
+        ],
+      },
+      properties: {
+        procedureId: "p2",
+        transitionName: "FINAL",
+        phase: "runway",
+        sequence: 20,
+      },
+    },
+  ],
+};
+
+const curvedCornerCollection = buildProcedureLineCollection(angledGeoJson);
+assert.equal(curvedCornerCollection.features.length, 24);
+assert.equal(curvedCornerCollection.features[6].geometry.coordinates[0][1] < -0.01, true);
+assert.equal(curvedCornerCollection.features[18].geometry.coordinates[0][0] > 1.01, true);


### PR DESCRIPTION
## Summary
- rebuild procedure overlays by procedure before rendering so final routes can be sampled as continuous paths
- use Catmull-Rom sampling only across route vertices: straight two-point legs stay straight, while折线/转角附近 becomes smooth
- keep the existing per-segment fade model and add regression assertions for both straight-line preservation and curved-corner smoothing

## Verification
- pnpm test:procedure-overlay
- pnpm lint
- pnpm test:all
- pnpm build
- inspected localhost:3000/kbos in Chrome