### PR TITLE
Add mobile viewport, prevent background scrolling, and disable map interactions in Airport Explorer

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -55,6 +55,14 @@ export const metadata = {
   },
 };
 
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: "cover",
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -72,7 +80,7 @@ export default function RootLayout({ children }) {
       </head>
       <body>
         <ThemeBootScript />
-        <div className="min-h-screen bg-atc-bg text-atc-text">{children}</div>
+        <div className="min-h-dvh bg-atc-bg text-atc-text">{children}</div>
         <Toaster
           theme="system"
           position="top-center"

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -72,6 +72,11 @@ export default function AirportMap({
       attributionControl: false,
       scrollWheelZoom: false,
       dragging: false,
+      touchZoom: false,
+      doubleClickZoom: false,
+      boxZoom: false,
+      keyboard: false,
+      tap: false,
     });
     mapRef.current = map;
     setMapInstance(map);

--- a/src/features/airport-explorer/AirportExplorer.jsx
+++ b/src/features/airport-explorer/AirportExplorer.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import AirportSidebar from "@/components/sidebar/AirportSidebar";
 import {
   AirportExplorerUiProvider,
@@ -47,6 +47,28 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   const { weather, traffic } = useAirportExplorerData(airportProfile);
   const procedures = useAirportProcedures(airportProfile.icao);
 
+  useEffect(() => {
+    if (!isMobile) return undefined;
+
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalHtmlOverflow = document.documentElement.style.overflow;
+    const originalBodyOverscroll = document.body.style.overscrollBehavior;
+    const originalHtmlOverscroll =
+      document.documentElement.style.overscrollBehavior;
+
+    document.body.style.overflow = "hidden";
+    document.documentElement.style.overflow = "hidden";
+    document.body.style.overscrollBehavior = "none";
+    document.documentElement.style.overscrollBehavior = "none";
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.documentElement.style.overflow = originalHtmlOverflow;
+      document.body.style.overscrollBehavior = originalBodyOverscroll;
+      document.documentElement.style.overscrollBehavior = originalHtmlOverscroll;
+    };
+  }, [isMobile]);
+
   const sidebarProps = {
     icao: airportProfile.icao,
     iata: airportProfile.iata,
@@ -66,7 +88,13 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   };
 
   return (
-    <div className="flex h-dvh overflow-hidden font-sans text-atc-text">
+    <div
+      className={`font-sans text-atc-text ${
+        isMobile
+          ? "fixed inset-0 z-0 flex overflow-hidden overscroll-none"
+          : "flex h-dvh overflow-hidden"
+      }`}
+    >
       {!isMobile && (
         <div
           className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"


### PR DESCRIPTION
### Motivation
- Improve mobile UX by using viewport-safe heights and explicit viewport metadata to avoid layout/zoom issues on mobile devices.
- Prevent page scrolling and overscroll interactions while the Airport Explorer is active on mobile to keep the UI fixed and immersive.
- Disable map gestures that conflict with page scrolling and pinch/zoom behavior on mobile devices.

### Description
- Export `viewport` in `src/app/layout.js` and replace `min-h-screen` with `min-h-dvh` for the main container to use device viewport height.
- Update `src/components/map/AirportMap.jsx` to disable interactive map gestures by setting `touchZoom`, `doubleClickZoom`, `boxZoom`, `keyboard`, and `tap` to `false` when initializing the Leaflet map.
- Update `src/features/airport-explorer/AirportExplorer.jsx` to import `useEffect`, add a `useEffect` that locks `document.body` and `document.documentElement` `overflow` and `overscrollBehavior` when `isMobile` is `true`, and change the root explorer container to a conditional fixed `inset-0` layout on mobile to avoid background scrolling.

### Testing
- No automated tests were run for these UI/behavior changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faac245834833197aee63514083a30)