### PR TITLE
style: improve runway annotation rendering

### DIFF
--- a/src/components/map/RunwayAnnotationLayer.jsx
+++ b/src/components/map/RunwayAnnotationLayer.jsx
@@ -40,7 +40,7 @@ const runwayLabelIcon = (ident, theme) =>
     className: `runway-end-label runway-end-label--${theme}`,
     html: `<span>${escapeHtml(ident)}</span>`,
     iconSize: [34, 18],
-    iconAnchor: [17, 9],
+    iconAnchor: [17, 22],
   });
 
 export default function RunwayAnnotationLayer({

--- a/src/config/airportMap.js
+++ b/src/config/airportMap.js
@@ -17,7 +17,7 @@ export const AIRPORT_MAP_TRAFFIC_LEGEND = [
 export const AIRPORT_MAP_PANES = {
   badge: {
     name: "airport-map-badge",
-    zIndex: 360,
+    zIndex: 420,
   },
 };
 
@@ -58,13 +58,13 @@ export const RUNWAY_ANNOTATION_STYLE_CONFIG = {
   lineStyles: {
     dark: {
       color: "#8fb7d6",
-      weight: 2,
-      opacity: 0.82,
+      weight: 3,
+      opacity: 0.5,
     },
     light: {
       color: "#244164",
-      weight: 2,
-      opacity: 0.76,
+      weight: 3,
+      opacity: 0.5,
     },
   },
   beamColors: {


### PR DESCRIPTION
## Summary

- Runway-end badges now render **above** the centerline: badge pane z-index raised from 360 → 420 (Leaflet's GeoJSON overlay pane sits at 400), and `iconAnchor` Y changed from 9 → 22 so each badge floats above its endpoint rather than being centered on the line
- Centerline `weight` 2 → 3 (bolder stroke)
- Centerline `opacity` 0.82 / 0.76 → 0.5 (half-transparent, so traffic dots pop over it)

## Test plan

- [ ] Open an airport (e.g. KBOS) at zoom levels approach → detail and confirm runway-end badges are visually above the centerlines
- [ ] Confirm centerlines appear bolder and more transparent than before
- [ ] `pnpm test:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)