### PR TITLE
feat: runway layer toggle toolbar button

### DIFF
--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -40,6 +40,8 @@ export default function AirportMap({
   airport = null,
   showMapLabels = true,
   showTelemetry = true,
+  showRunwayBeams = true,
+  showRunwayBadges = true,
   runwayMap = null,
   runwayProcedures = null,
   procedureFixLabelRunwayProcedures = runwayProcedures,
@@ -148,6 +150,8 @@ export default function AirportMap({
             runwayMap={runwayMap}
             theme={currentTheme}
             zoom={zoom}
+            showBeams={showRunwayBeams}
+            showBadges={showRunwayBadges}
           />
           <GroundStatsCounter
             lat={lat}

--- a/src/components/map/RunwayAnnotationLayer.jsx
+++ b/src/components/map/RunwayAnnotationLayer.jsx
@@ -69,11 +69,11 @@ export default function RunwayAnnotationLayer({
     });
 
     const sublayers = [lineLayer];
-    let removeGradients = () => {};
+    let beamLayer = null;
 
     if (showBeams) {
       const beams = buildRunwayApproachBeamCollection(runwayMap, { zoom });
-      const beamLayer = L.geoJSON(beams, {
+      beamLayer = L.geoJSON(beams, {
         interactive: false,
         style() {
           return {
@@ -87,11 +87,6 @@ export default function RunwayAnnotationLayer({
         },
       });
       sublayers.unshift(beamLayer);
-      removeGradients = createRunwayBeamGradientController({
-        map,
-        beamLayer,
-        theme,
-      });
     }
 
     if (showBadges) {
@@ -111,6 +106,10 @@ export default function RunwayAnnotationLayer({
 
     const layer = L.layerGroup(sublayers).addTo(map);
     layerRef.current = layer;
+
+    const removeGradients = beamLayer
+      ? createRunwayBeamGradientController({ map, beamLayer, theme })
+      : () => {};
 
     return () => {
       removeGradients();

--- a/src/components/map/RunwayAnnotationLayer.jsx
+++ b/src/components/map/RunwayAnnotationLayer.jsx
@@ -47,6 +47,8 @@ export default function RunwayAnnotationLayer({
   runwayMap,
   theme = "dark",
   zoom,
+  showBeams = true,
+  showBadges = true,
 }) {
   const map = useMapInstance();
   const layerRef = useRef(null);
@@ -54,26 +56,7 @@ export default function RunwayAnnotationLayer({
   useEffect(() => {
     if (!map || !runwayMap?.runways?.length) return undefined;
 
-    const beams = buildRunwayApproachBeamCollection(runwayMap, { zoom });
     const centerlines = buildRunwayCenterlineCollection(runwayMap);
-    const labels = buildRunwayEndLabels(runwayMap, { zoom });
-    if (!beams.features.length && !centerlines.features.length && !labels.length) {
-      return undefined;
-    }
-
-    const beamLayer = L.geoJSON(beams, {
-      interactive: false,
-      style() {
-        return {
-          className: "runway-approach-beam",
-          fill: true,
-          fillColor: runwayBeamColor(theme),
-          fillOpacity: 1,
-          opacity: 0,
-          stroke: false,
-        };
-      },
-    });
     const lineLayer = L.geoJSON(centerlines, {
       interactive: false,
       style() {
@@ -84,22 +67,49 @@ export default function RunwayAnnotationLayer({
         };
       },
     });
-    const labelLayer = L.layerGroup(
-      labels.map((label) =>
-        L.marker([label.lat, label.lon], {
-          interactive: false,
-          keyboard: false,
-          icon: runwayLabelIcon(label.ident, theme),
-          pane: ensureAirportMapPane(map, AIRPORT_MAP_PANES.badge),
-        }),
-      ),
-    );
-    const layer = L.layerGroup([beamLayer, lineLayer, labelLayer]).addTo(map);
-    const removeGradients = createRunwayBeamGradientController({
-      map,
-      beamLayer,
-      theme,
-    });
+
+    const sublayers = [lineLayer];
+    let removeGradients = () => {};
+
+    if (showBeams) {
+      const beams = buildRunwayApproachBeamCollection(runwayMap, { zoom });
+      const beamLayer = L.geoJSON(beams, {
+        interactive: false,
+        style() {
+          return {
+            className: "runway-approach-beam",
+            fill: true,
+            fillColor: runwayBeamColor(theme),
+            fillOpacity: 1,
+            opacity: 0,
+            stroke: false,
+          };
+        },
+      });
+      sublayers.unshift(beamLayer);
+      removeGradients = createRunwayBeamGradientController({
+        map,
+        beamLayer,
+        theme,
+      });
+    }
+
+    if (showBadges) {
+      const labels = buildRunwayEndLabels(runwayMap, { zoom });
+      const labelLayer = L.layerGroup(
+        labels.map((label) =>
+          L.marker([label.lat, label.lon], {
+            interactive: false,
+            keyboard: false,
+            icon: runwayLabelIcon(label.ident, theme),
+            pane: ensureAirportMapPane(map, AIRPORT_MAP_PANES.badge),
+          }),
+        ),
+      );
+      sublayers.push(labelLayer);
+    }
+
+    const layer = L.layerGroup(sublayers).addTo(map);
     layerRef.current = layer;
 
     return () => {
@@ -107,7 +117,7 @@ export default function RunwayAnnotationLayer({
       layer.remove();
       layerRef.current = null;
     };
-  }, [map, runwayMap, theme, zoom]);
+  }, [map, runwayMap, theme, zoom, showBeams, showBadges]);
 
   return null;
 }

--- a/src/components/map/RunwayAnnotationLayer.jsx
+++ b/src/components/map/RunwayAnnotationLayer.jsx
@@ -70,10 +70,16 @@ export default function RunwayAnnotationLayer({
 
     const sublayers = [lineLayer];
     let beamLayer = null;
+    let beamRenderer = null;
 
     if (showBeams) {
+      // Use a dedicated renderer with extra padding so beams that extend
+      // beyond the viewport edge are not clipped by the default SVG canvas.
+      // At ZOOM_AIRPORT beams reach ~408 px; default padding (0.1) is ~80 px.
+      beamRenderer = L.svg({ padding: 1 });
       const beams = buildRunwayApproachBeamCollection(runwayMap, { zoom });
       beamLayer = L.geoJSON(beams, {
+        renderer: beamRenderer,
         interactive: false,
         style() {
           return {
@@ -114,6 +120,7 @@ export default function RunwayAnnotationLayer({
     return () => {
       removeGradients();
       layer.remove();
+      beamRenderer?.remove();
       layerRef.current = null;
     };
   }, [map, runwayMap, theme, zoom, showBeams, showBadges]);

--- a/src/components/ui/MapControlBar.jsx
+++ b/src/components/ui/MapControlBar.jsx
@@ -5,6 +5,7 @@ import { MAP_ZOOM_OPTIONS } from "../../config/mapControls.js";
 import { useThemePreference } from "../../features/app-shell/useThemePreference.js";
 import MapControlRail from "../../features/map-controls/MapControlRail.jsx";
 import MapZoomDrawer from "../../features/map-controls/MapZoomDrawer.jsx";
+import RunwayLayerDrawer from "../../features/map-controls/RunwayLayerDrawer.jsx";
 import {
   getNextZoomValue,
   resolveZoomOption,
@@ -14,17 +15,23 @@ import { useFocusAudio } from "../../features/map-controls/useFocusAudio.js";
 import { ZOOM_AIRPORT } from "../../utils/airportMapDisplay.js";
 
 const DRAWER_ID = "map-action-drawer";
+const RUNWAY_DRAWER_ID = "map-runway-drawer";
 
 export default function MapControlBar({
   activeZoom = ZOOM_AIRPORT,
   showMapLabels = true,
   showTelemetry = true,
+  showRunwayBeams = true,
+  showRunwayBadges = true,
   onZoom,
   onToggleMapLabels,
   onToggleTelemetry,
+  onToggleRunwayBeams,
+  onToggleRunwayBadges,
 }) {
   const controlZone = useRef(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [runwayDrawerOpen, setRunwayDrawerOpen] = useState(false);
   const { themePreference, themeTitle, cycleTheme } = useThemePreference();
   const { playerHost, playing, audioReady, toggleAudio } = useFocusAudio();
 
@@ -37,10 +44,20 @@ export default function MapControlBar({
     setDrawerOpen(false);
   }, []);
 
+  const closeRunwayDrawer = useCallback(() => {
+    setRunwayDrawerOpen(false);
+  }, []);
+
   useDismissibleDrawer({
     open: drawerOpen,
     containerRef: controlZone,
     onClose: closeDrawer,
+  });
+
+  useDismissibleDrawer({
+    open: runwayDrawerOpen,
+    containerRef: controlZone,
+    onClose: closeRunwayDrawer,
   });
 
   const selectZoom = (zoom) => {
@@ -52,10 +69,29 @@ export default function MapControlBar({
     onZoom?.(getNextZoomValue(activeZoom, MAP_ZOOM_OPTIONS));
   };
 
+  const toggleDrawer = () => {
+    setDrawerOpen((value) => !value);
+    setRunwayDrawerOpen(false);
+  };
+
+  const toggleRunwayDrawer = () => {
+    setRunwayDrawerOpen((value) => !value);
+    setDrawerOpen(false);
+  };
+
   return (
     <>
       <div ref={playerHost} className="yt-sink" aria-hidden="true" />
       <div ref={controlZone} className="map-ctrl-zone">
+        <RunwayLayerDrawer
+          id={RUNWAY_DRAWER_ID}
+          open={runwayDrawerOpen}
+          showBeams={showRunwayBeams}
+          showBadges={showRunwayBadges}
+          onToggleBeams={onToggleRunwayBeams}
+          onToggleBadges={onToggleRunwayBadges}
+        />
+
         <MapZoomDrawer
           id={DRAWER_ID}
           open={drawerOpen}
@@ -69,17 +105,20 @@ export default function MapControlBar({
           currentTheme={themePreference}
           themeTitle={themeTitle}
           drawerOpen={drawerOpen}
+          runwayDrawerOpen={runwayDrawerOpen}
           playing={playing}
           audioReady={audioReady}
           showMapLabels={showMapLabels}
           showTelemetry={showTelemetry}
           drawerId={DRAWER_ID}
+          runwayDrawerId={RUNWAY_DRAWER_ID}
           onCycleZoom={cycleZoom}
           onToggleAudio={toggleAudio}
           onCycleTheme={cycleTheme}
           onToggleMapLabels={onToggleMapLabels}
           onToggleTelemetry={onToggleTelemetry}
-          onToggleDrawer={() => setDrawerOpen((value) => !value)}
+          onToggleDrawer={toggleDrawer}
+          onToggleRunwayDrawer={toggleRunwayDrawer}
         />
       </div>
     </>

--- a/src/features/airport-explorer/AirportExplorer.jsx
+++ b/src/features/airport-explorer/AirportExplorer.jsx
@@ -38,6 +38,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     mapZoom,
     showMapLabels,
     showTelemetry,
+    showRunwayBeams,
+    showRunwayBadges,
     closeSidebar,
   } = useAirportExplorerUi();
   const airportProfile = useMemo(
@@ -119,6 +121,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
           airport={airport}
           showMapLabels={showMapLabels}
           showTelemetry={showTelemetry}
+          showRunwayBeams={showRunwayBeams}
+          showRunwayBadges={showRunwayBadges}
           runwayMap={procedures.runwayMap}
           runwayProcedures={null}
           procedureFixLabelRunwayProcedures={procedures.runwayProcedures}

--- a/src/features/airport-explorer/AirportExplorerMapMenu.jsx
+++ b/src/features/airport-explorer/AirportExplorerMapMenu.jsx
@@ -10,10 +10,14 @@ export default function AirportExplorerMapMenu() {
     mapZoom,
     showMapLabels,
     showTelemetry,
+    showRunwayBeams,
+    showRunwayBadges,
     setMapZoom,
     toggleSidebar,
     toggleMapLabels,
     toggleTelemetry,
+    toggleRunwayBeams,
+    toggleRunwayBadges,
   } = useAirportExplorerUi();
 
   return (
@@ -35,9 +39,13 @@ export default function AirportExplorerMapMenu() {
         activeZoom={mapZoom}
         showMapLabels={showMapLabels}
         showTelemetry={showTelemetry}
+        showRunwayBeams={showRunwayBeams}
+        showRunwayBadges={showRunwayBadges}
         onZoom={setMapZoom}
         onToggleMapLabels={toggleMapLabels}
         onToggleTelemetry={toggleTelemetry}
+        onToggleRunwayBeams={toggleRunwayBeams}
+        onToggleRunwayBadges={toggleRunwayBadges}
       />
     </div>
   );

--- a/src/features/airport-explorer/AirportExplorerUiContext.jsx
+++ b/src/features/airport-explorer/AirportExplorerUiContext.jsx
@@ -25,6 +25,8 @@ export function AirportExplorerUiProvider({ children }) {
   const [mapZoom, setMapZoom] = useState(ZOOM_APPROACH);
   const [showMapLabels, setShowMapLabels] = useState(true);
   const [showTelemetry, setShowTelemetry] = useState(true);
+  const [showRunwayBeams, setShowRunwayBeams] = useState(true);
+  const [showRunwayBadges, setShowRunwayBadges] = useState(true);
   const isMobile = sidebarMode === "mobile";
 
   useEffect(() => {
@@ -61,6 +63,14 @@ export function AirportExplorerUiProvider({ children }) {
     setShowTelemetry((value) => !value);
   }, []);
 
+  const toggleRunwayBeams = useCallback(() => {
+    setShowRunwayBeams((value) => !value);
+  }, []);
+
+  const toggleRunwayBadges = useCallback(() => {
+    setShowRunwayBadges((value) => !value);
+  }, []);
+
   const value = useMemo(
     () => ({
       desktopSidebarWidth: AIRPORT_EXPLORER_UI_CONFIG.desktopSidebarWidth,
@@ -70,11 +80,15 @@ export function AirportExplorerUiProvider({ children }) {
       mapZoom,
       showMapLabels,
       showTelemetry,
+      showRunwayBeams,
+      showRunwayBadges,
       setMapZoom,
       toggleSidebar,
       closeSidebar,
       toggleMapLabels,
       toggleTelemetry,
+      toggleRunwayBeams,
+      toggleRunwayBadges,
     }),
     [
       sidebarMode,
@@ -83,10 +97,14 @@ export function AirportExplorerUiProvider({ children }) {
       mapZoom,
       showMapLabels,
       showTelemetry,
+      showRunwayBeams,
+      showRunwayBadges,
       toggleSidebar,
       closeSidebar,
       toggleMapLabels,
       toggleTelemetry,
+      toggleRunwayBeams,
+      toggleRunwayBadges,
     ],
   );
 

--- a/src/features/airport-map/runwayBeamGradientController.js
+++ b/src/features/airport-map/runwayBeamGradientController.js
@@ -100,7 +100,15 @@ const appendBeamGradientStops = (gradient, color, beamOpacity) => {
 };
 
 export function createRunwayBeamGradientController({ map, beamLayer, theme }) {
-  const svg = map.getPanes().overlayPane.querySelector("svg");
+  // Prefer the beam layer's own renderer SVG so that gradient coordinates
+  // are in the same coordinate space as the beam paths. The beam layer uses
+  // a custom SVG renderer with extra padding; its SVG may not be the first
+  // one returned by querySelector when multiple renderers share the pane.
+  let svg = null;
+  beamLayer.eachLayer((pathLayer) => {
+    if (!svg) svg = pathLayer._renderer?._container ?? null;
+  });
+  if (!svg) svg = map.getPanes().overlayPane.querySelector("svg");
   if (!svg) return () => {};
 
   const defs = document.createElementNS(SVG_NS, "defs");

--- a/src/features/map-controls/MapControlRail.jsx
+++ b/src/features/map-controls/MapControlRail.jsx
@@ -6,6 +6,7 @@ import { MapControlIcon } from "./mapControlIcons.jsx";
 
 const AUDIO_ICON_KEY = "audioLines";
 const GAUGE_ICON_KEY = "gauge";
+const LAYERS_ICON_KEY = "layers";
 const MORE_ICON_KEY = "slidersHorizontal";
 const TYPE_ICON_KEY = "type";
 
@@ -14,17 +15,20 @@ export default function MapControlRail({
   currentTheme,
   themeTitle,
   drawerOpen,
+  runwayDrawerOpen,
   playing,
   audioReady,
   showMapLabels,
   showTelemetry,
   drawerId,
+  runwayDrawerId,
   onCycleZoom,
   onToggleAudio,
   onCycleTheme,
   onToggleMapLabels,
   onToggleTelemetry,
   onToggleDrawer,
+  onToggleRunwayDrawer,
 }) {
   return (
     <div className="map-ctrl-bar">
@@ -88,6 +92,19 @@ export default function MapControlRail({
         type="button"
       >
         <MapControlIcon iconKey={GAUGE_ICON_KEY} />
+      </Button>
+
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className={`ctrl-btn ${runwayDrawerOpen ? "active" : ""}`}
+        aria-expanded={runwayDrawerOpen}
+        aria-controls={runwayDrawerId}
+        title="Runway layers"
+        onClick={onToggleRunwayDrawer}
+        type="button"
+      >
+        <MapControlIcon iconKey={LAYERS_ICON_KEY} />
       </Button>
 
       <Button

--- a/src/features/map-controls/RunwayLayerDrawer.jsx
+++ b/src/features/map-controls/RunwayLayerDrawer.jsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Button } from "../../components/ui/button.jsx";
+import { MapControlIcon } from "./mapControlIcons.jsx";
+
+const BEAM_ICON_KEY = "planeLanding";
+const BADGE_ICON_KEY = "towerControl";
+
+export default function RunwayLayerDrawer({
+  id,
+  open,
+  showBeams,
+  showBadges,
+  onToggleBeams,
+  onToggleBadges,
+}) {
+  return (
+    <div
+      id={id}
+      className={`map-action-drawer ${open ? "open" : ""}`}
+      aria-hidden={!open}
+    >
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className={`ctrl-btn drawer-btn ${showBeams ? "active" : ""}`}
+        aria-pressed={showBeams}
+        title={showBeams ? "Hide approach beams" : "Show approach beams"}
+        onClick={onToggleBeams}
+        type="button"
+      >
+        <MapControlIcon iconKey={BEAM_ICON_KEY} />
+      </Button>
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className={`ctrl-btn drawer-btn ${showBadges ? "active" : ""}`}
+        aria-pressed={showBadges}
+        title={showBadges ? "Hide runway badges" : "Show runway badges"}
+        onClick={onToggleBadges}
+        type="button"
+      >
+        <MapControlIcon iconKey={BADGE_ICON_KEY} />
+      </Button>
+    </div>
+  );
+}

--- a/src/features/map-controls/mapControlIcons.jsx
+++ b/src/features/map-controls/mapControlIcons.jsx
@@ -4,6 +4,7 @@ import {
   AudioLines,
   Crosshair,
   Gauge,
+  Layers,
   Monitor,
   Moon,
   PlaneLanding,
@@ -17,6 +18,7 @@ export const MAP_CONTROL_ICONS = {
   audioLines: AudioLines,
   crosshair: Crosshair,
   gauge: Gauge,
+  layers: Layers,
   monitor: Monitor,
   moon: Moon,
   planeLanding: PlaneLanding,
@@ -37,6 +39,8 @@ export function MapControlIcon({ iconKey }) {
       return <Crosshair />;
     case "gauge":
       return <Gauge />;
+    case "layers":
+      return <Layers />;
     case "monitor":
       return <Monitor />;
     case "moon":


### PR DESCRIPTION
## Summary

- Adds a **Layers** button to the map toolbar (between telemetry and the existing zoom-drawer button)
- Clicking it opens a sub-drawer with two independent toggles:
  - **PlaneLanding icon** — approach beams on/off
  - **TowerControl icon** — runway-end badges on/off
- Both drawers are mutually exclusive: opening one closes the other; clicking outside both or pressing Escape dismisses

## Data flow

```
AirportExplorerUiContext
  showRunwayBeams / showRunwayBadges  (default true)
  toggleRunwayBeams / toggleRunwayBadges
    ↓
AirportExplorerMapMenu → MapControlBar
  → RunwayLayerDrawer (new, mirrors MapZoomDrawer pattern)
  → MapControlRail (new Layers button)
    ↓
AirportExplorer → AirportMap → RunwayAnnotationLayer
  showBeams / showBadges props gate each Leaflet sub-layer
```

## Test plan

- [ ] Open an airport (e.g. KBOS) — both beams and badges render by default
- [ ] Click Layers button → sub-drawer appears with two active (highlighted) icons
- [ ] Toggle beams off → approach light polygons disappear; centerlines and badges remain
- [ ] Toggle badges off → runway-end labels disappear; beams/centerlines remain
- [ ] Click outside drawer → drawer closes without changing toggle state
- [ ] Click zoom-drawer (sliders) button while runway drawer is open → runway drawer closes, zoom drawer opens (mutual exclusion)
- [ ] `pnpm test:all` and `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)