### PR TITLE
feat: enrich FlightAware route rows

### DIFF
--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
@@ -36,7 +36,7 @@ async function scrapeFlightAware(callsign) {
 
   const html = await readResponseText(response, {
     label: "FlightAware route page",
-    maxBytes: 512 * 1024,
+    maxBytes: 2 * 1024 * 1024,
   });
   return extractFlightAwareTargeting(html);
 }

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -119,6 +119,7 @@ function AircraftRow({
   const airlineName = aircraft.flightRoute?.airlineName || "";
   const airlineIconUrl = aircraft.flightRoute?.airlineIconUrl || "";
   const flightNumber = formatFlightNumberLabel(aircraft.flightRoute, callsign);
+  const hasFlightInfo = Boolean(airlineIconUrl || airlineName || flightNumber);
   const movementLabel = getMovementTagLabel(aircraft);
   const gsValue = toNumber(aircraft.velocity);
   const altValue = toNumber(aircraft.altitude);
@@ -157,19 +158,27 @@ function AircraftRow({
                   }}
                 />
               )}
-              {airlineName && (
-                <span className="max-w-[112px] flex-none truncate text-[11px] text-atc-dim">
-                  {airlineName}
-                </span>
-              )}
-              {flightNumber && (
-                <span className="flex-none text-[11px] text-atc-dim">
-                  {flightNumber}
-                </span>
-              )}
-              <span className="truncate text-[11px] text-atc-dim">
-                {route}
-              </span>
+              <div
+                className={`aircraft-table-route-cycle min-w-0 flex-1 ${
+                  hasFlightInfo ? "aircraft-table-route-cycle--alternate" : ""
+                }`}
+              >
+                {hasFlightInfo && (
+                  <div className="aircraft-table-route-face aircraft-table-route-face--flight">
+                    {airlineName && (
+                      <span className="max-w-[112px] flex-none truncate">
+                        {airlineName}
+                      </span>
+                    )}
+                    {flightNumber && (
+                      <span className="flex-none">{flightNumber}</span>
+                    )}
+                  </div>
+                )}
+                <div className="aircraft-table-route-face aircraft-table-route-face--route">
+                  <span className="truncate">{route}</span>
+                </div>
+              </div>
             </div>
           ) : null}
         </div>

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -171,12 +171,12 @@ function AircraftRow({
                       </span>
                     )}
                     {flightNumber && (
-                      <span className="flex-none">{flightNumber}</span>
+                      <span className="flex-none text-[10px]">{flightNumber}</span>
                     )}
                   </div>
                 )}
                 <div className="aircraft-table-route-face aircraft-table-route-face--route">
-                  <span className="truncate">{route}</span>
+                  <span className="truncate text-[10px]">{route}</span>
                 </div>
               </div>
             </div>

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -3,11 +3,11 @@
 import NumberFlow from "@number-flow/react";
 import {
   getAircraftIdentity,
-  getContextTagLabel,
   getMovementTagLabel,
   groupAircraftByAirportContext,
   resolveAircraftContextEmphasis,
 } from "../../features/airport-context/airportContextUiModel.js";
+import { formatFlightNumberLabel } from "../../utils/flightRouteDisplay.js";
 
 export default function AircraftTable({
   aircraft = [],
@@ -32,7 +32,7 @@ export default function AircraftTable({
         </div>
 
         <div className="grid grid-cols-[minmax(0,1fr)_58px_78px] items-center gap-3 border-y border-[var(--atc-line)] px-6 py-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-atc-faint">
-          <span>Callsign / Context</span>
+          <span>Callsign / Route</span>
           <span className="text-right">GS</span>
           <span className="text-right">ALT</span>
         </div>
@@ -115,11 +115,11 @@ function AircraftRow({
   onSelectAircraft,
 }) {
   const callsign = aircraft.callsign?.trim() || aircraft.icao24 || "-";
-  const route =
-    aircraft.flightRouteLabel ||
-    (aircraft.onGround ? "On ground" : "Track unknown");
+  const route = aircraft.flightRouteLabel || "";
+  const airlineName = aircraft.flightRoute?.airlineName || "";
+  const airlineIconUrl = aircraft.flightRoute?.airlineIconUrl || "";
+  const flightNumber = formatFlightNumberLabel(aircraft.flightRoute, callsign);
   const movementLabel = getMovementTagLabel(aircraft);
-  const contextLabel = getContextTagLabel(aircraft);
   const gsValue = toNumber(aircraft.velocity);
   const altValue = toNumber(aircraft.altitude);
   const rowOpacity = selected ? 1 : emphasis.opacity;
@@ -142,13 +142,36 @@ function AircraftRow({
             </span>
             {movementLabel && <AircraftTag>{movementLabel}</AircraftTag>}
           </div>
-          <div className="mt-1 flex min-w-0 items-center gap-1.5">
-            <span className="truncate text-[11px] text-atc-dim">{route}</span>
-            <span className="h-1 w-1 flex-none rounded-full bg-[var(--atc-line-strong)]" />
-            <span className="flex-none truncate font-mono text-[9.5px] uppercase tracking-[0.08em] text-atc-faint">
-              {contextLabel}
-            </span>
-          </div>
+          {route ? (
+            <div className="mt-1 flex min-w-0 items-center gap-1.5">
+              {airlineIconUrl && (
+                // eslint-disable-next-line @next/next/no-img-element -- FlightAware logo URLs are dynamic.
+                <img
+                  src={airlineIconUrl}
+                  alt={airlineName ? `${airlineName} logo` : ""}
+                  className="h-4 w-4 flex-none rounded-[3px] border border-[var(--atc-line)] bg-white object-contain p-[1px]"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                  onError={(event) => {
+                    event.currentTarget.style.display = "none";
+                  }}
+                />
+              )}
+              {airlineName && (
+                <span className="max-w-[112px] flex-none truncate text-[11px] text-atc-dim">
+                  {airlineName}
+                </span>
+              )}
+              {flightNumber && (
+                <span className="flex-none text-[11px] text-atc-dim">
+                  {flightNumber}
+                </span>
+              )}
+              <span className="truncate text-[11px] text-atc-dim">
+                {route}
+              </span>
+            </div>
+          ) : null}
         </div>
         <div className="text-right font-mono text-[12px] font-semibold text-atc-text">
           {gsValue == null ? (

--- a/src/services/aviation/aviationServiceModel.test.js
+++ b/src/services/aviation/aviationServiceModel.test.js
@@ -18,7 +18,11 @@ import { normalizeLocalWeather } from "./localWeatherNormalizer.js";
       flightroute: {
         callsign: " dal123 ",
         callsign_icao: "dal123",
-        airline: { name: "Delta Air Lines", icao: "dal" },
+        airline: {
+          name: "Delta Air Lines",
+          icao: "dal",
+          icon_url: "https://www.flightaware.com/images/airline_logos/180px/DAL.png",
+        },
         origin: {
           icao_code: "egll",
           iata_code: "lhr",
@@ -39,6 +43,10 @@ import { normalizeLocalWeather } from "./localWeatherNormalizer.js";
 
   assert.equal(route.callsign, "DAL123");
   assert.equal(route.airlineIcao, "DAL");
+  assert.equal(
+    route.airlineIconUrl,
+    "https://www.flightaware.com/images/airline_logos/180px/DAL.png",
+  );
   assert.equal(route.origin.iata, "LHR");
   assert.equal(route.destination.icao, "KBOS");
   assert.equal(route.source, "flightaware");

--- a/src/services/aviation/flightAwareProxyModel.js
+++ b/src/services/aviation/flightAwareProxyModel.js
@@ -11,6 +11,13 @@ const TARGETING_KEYS = new Set([
   "destination_IATA",
 ]);
 
+const cleanString = (value) => String(value || "").trim();
+
+const numberOrNull = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+};
+
 export function normalizeRouteCallsign(rawCallsign) {
   const callsign = String(rawCallsign || "")
     .trim()
@@ -31,7 +38,126 @@ export function sanitizeFlightAwareAirportCode(value, { length }) {
   return new RegExp(`^[A-Z0-9]{${length}}$`).test(code) ? code : "";
 }
 
+function sanitizeFlightAwareUrl(value) {
+  const raw = cleanString(value);
+  if (!raw) return "";
+
+  try {
+    const url = new URL(raw, "https://www.flightaware.com");
+    return ["http:", "https:"].includes(url.protocol) ? url.toString() : "";
+  } catch {
+    return "";
+  }
+}
+
+function extractBalancedObject(source, startIndex) {
+  if (startIndex < 0 || source[startIndex] !== "{") return "";
+
+  let depth = 0;
+  let inString = false;
+  let stringQuote = "";
+  let escaped = false;
+
+  for (let i = startIndex; i < source.length; i += 1) {
+    const char = source[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === stringQuote) {
+        inString = false;
+        stringQuote = "";
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      inString = true;
+      stringQuote = char;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(startIndex, i + 1);
+      }
+    }
+  }
+
+  return "";
+}
+
+function parseTrackpollBootstrap(html) {
+  const assignmentIndex = html.indexOf("var trackpollBootstrap");
+  if (assignmentIndex < 0) return null;
+
+  const objectStart = html.indexOf("{", assignmentIndex);
+  const objectSource = extractBalancedObject(html, objectStart);
+  if (!objectSource) return null;
+
+  try {
+    return JSON.parse(objectSource);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeFlightAwareAirport(airport) {
+  const coord = Array.isArray(airport?.coord) ? airport.coord : [];
+  const longitude = numberOrNull(coord[0]);
+  const latitude = numberOrNull(coord[1]);
+
+  return {
+    icao: sanitizeFlightAwareAirportCode(airport?.icao, { length: 4 }),
+    iata: sanitizeFlightAwareAirportCode(airport?.iata, { length: 3 }),
+    name: cleanString(airport?.friendlyName || airport?.name),
+    municipality: cleanString(airport?.friendlyLocation || airport?.municipality),
+    latitude,
+    longitude,
+  };
+}
+
+function extractTrackpollRoute(html) {
+  const bootstrap = parseTrackpollBootstrap(html);
+  const flights = bootstrap?.flights && typeof bootstrap.flights === "object"
+    ? Object.values(bootstrap.flights)
+    : [];
+  const flight = flights.find((item) => item?.origin || item?.destination);
+  if (!flight) return null;
+
+  const airline = flight.airline || flight.codeShare?.airline || {};
+  const thumbnail = flight.thumbnail || flight.codeShare?.thumbnail || {};
+  const origin = normalizeFlightAwareAirport(flight.origin);
+  const destination = normalizeFlightAwareAirport(flight.destination);
+
+  if (!origin.icao && !destination.icao) return null;
+
+  return {
+    origin,
+    destination,
+    airline: {
+      name: cleanString(airline.shortName || airline.fullName || airline.name),
+      icao: sanitizeFlightAwareAirportCode(airline.icao, { length: 3 }),
+      iata: sanitizeFlightAwareAirportCode(airline.iata, { length: 2 }),
+      callsign: cleanString(airline.callsign),
+      iconUrl: sanitizeFlightAwareUrl(thumbnail.imageUrl),
+    },
+    callsignIcao: cleanString(flight.displayIdent || flight.ident).toUpperCase(),
+    callsignIata: cleanString(flight.iataIdent || flight.codeShare?.iataIdent)
+      .toUpperCase(),
+    friendlyIdent: cleanString(flight.friendlyIdent || flight.codeShare?.friendlyIdent),
+  };
+}
+
 export function extractFlightAwareTargeting(html) {
+  const trackpollRoute = extractTrackpollRoute(html);
+  if (trackpollRoute) return trackpollRoute;
+
   const targeting = {};
   let match;
   TARGETING_RE.lastIndex = 0;
@@ -62,35 +188,40 @@ export function extractFlightAwareTargeting(html) {
   };
 }
 
+function buildAirportResponse(airport = {}) {
+  const latitude = numberOrNull(airport.latitude);
+  const longitude = numberOrNull(airport.longitude);
+
+  return {
+    icao_code: airport.icao || "",
+    iata_code: airport.iata || "",
+    name: airport.name || "",
+    municipality: airport.municipality || "",
+    country_name: airport.country || "",
+    latitude: latitude ?? 0,
+    longitude: longitude ?? 0,
+  };
+}
+
 export function buildFlightAwareRouteResponse(callsign, scraped) {
   if (!scraped) return { response: null };
+
+  const normalizedCallsign = callsign.toUpperCase();
 
   return {
     response: {
       flightroute: {
-        callsign: callsign.toUpperCase(),
-        origin: {
-          icao_code: scraped.origin.icao,
-          iata_code: scraped.origin.iata,
-          name: "",
-          municipality: "",
-          country_name: "",
-          latitude: 0,
-          longitude: 0,
-        },
-        destination: {
-          icao_code: scraped.destination.icao,
-          iata_code: scraped.destination.iata,
-          name: "",
-          municipality: "",
-          country_name: "",
-          latitude: 0,
-          longitude: 0,
-        },
+        callsign: normalizedCallsign,
+        callsign_icao: scraped.callsignIcao || normalizedCallsign,
+        callsign_iata: scraped.callsignIata || "",
+        origin: buildAirportResponse(scraped.origin),
+        destination: buildAirportResponse(scraped.destination),
         airline: {
-          name: "",
-          icao: callsign.slice(0, 3).toUpperCase(),
-          iata: "",
+          name: scraped.airline?.name || "",
+          icao: scraped.airline?.icao || callsign.slice(0, 3).toUpperCase(),
+          iata: scraped.airline?.iata || "",
+          callsign: scraped.airline?.callsign || "",
+          icon_url: scraped.airline?.iconUrl || "",
         },
       },
     },

--- a/src/services/aviation/flightAwareProxyModel.test.js
+++ b/src/services/aviation/flightAwareProxyModel.test.js
@@ -43,6 +43,57 @@ assert.deepEqual(
   },
 );
 
+const trackpollHtml = `
+  <script>
+    var trackpollBootstrap = {
+      "flights": {
+        "AAL873-1778047830-airline-138p:0": {
+          "origin": {
+            "iata": "BOS",
+            "icao": "KBOS",
+            "friendlyName": "Boston Logan Intl",
+            "friendlyLocation": "Boston, MA",
+            "coord": [-71.0064, 42.3629]
+          },
+          "destination": {
+            "iata": "MIA",
+            "icao": "KMIA",
+            "friendlyName": "Miami Intl",
+            "friendlyLocation": "Miami, FL",
+            "coord": [-80.2901, 25.7954]
+          },
+          "airline": {
+            "fullName": "American Airlines Inc.",
+            "shortName": "American Airlines",
+            "icao": "AAL",
+            "iata": "AA",
+            "callsign": "American"
+          },
+          "thumbnail": {
+            "imageUrl": "https://www.flightaware.com/images/airline_logos/180px/AAL.png"
+          },
+          "displayIdent": "AAL873",
+          "iataIdent": "AA873",
+          "friendlyIdent": "American Airlines 873"
+        }
+      }
+    };
+  </script>
+`;
+
+const richScrape = extractFlightAwareTargeting(trackpollHtml);
+
+assert.equal(richScrape.origin.name, "Boston Logan Intl");
+assert.equal(richScrape.origin.latitude, 42.3629);
+assert.equal(richScrape.destination.municipality, "Miami, FL");
+assert.equal(richScrape.airline.name, "American Airlines");
+assert.equal(richScrape.airline.iata, "AA");
+assert.equal(
+  richScrape.airline.iconUrl,
+  "https://www.flightaware.com/images/airline_logos/180px/AAL.png",
+);
+assert.equal(richScrape.callsignIata, "AA873");
+
 assert.deepEqual(buildFlightAwareRouteResponse("BAW213", null), {
   response: null,
 });
@@ -56,3 +107,15 @@ assert.equal(response.response.flightroute.callsign, "BAW213");
 assert.equal(response.response.flightroute.origin.icao_code, "EGLL");
 assert.equal(response.response.flightroute.destination.iata_code, "BOS");
 assert.equal(response.response.flightroute.airline.icao, "BAW");
+
+const richResponse = buildFlightAwareRouteResponse("AAL873", richScrape);
+
+assert.equal(richResponse.response.flightroute.callsign_iata, "AA873");
+assert.equal(richResponse.response.flightroute.origin.name, "Boston Logan Intl");
+assert.equal(richResponse.response.flightroute.origin.latitude, 42.3629);
+assert.equal(richResponse.response.flightroute.destination.longitude, -80.2901);
+assert.equal(richResponse.response.flightroute.airline.name, "American Airlines");
+assert.equal(
+  richResponse.response.flightroute.airline.icon_url,
+  "https://www.flightaware.com/images/airline_logos/180px/AAL.png",
+);

--- a/src/services/aviation/flightRouteNormalizer.js
+++ b/src/services/aviation/flightRouteNormalizer.js
@@ -47,6 +47,8 @@ export const normalizeFlightRoute = (payload) => {
     airlineIata: String(route.airline?.iata || "")
       .trim()
       .toUpperCase(),
+    airlineIconUrl: String(route.airline?.icon_url || route.airline?.iconUrl || "")
+      .trim(),
     origin,
     destination,
     source: "flightaware",

--- a/src/style.css
+++ b/src/style.css
@@ -2490,6 +2490,63 @@ body {
     }
 }
 
+.aircraft-table-route-cycle {
+    color: var(--atc-dim);
+    font-size: 11px;
+    height: 16px;
+    line-height: 16px;
+    overflow: hidden;
+    position: relative;
+}
+
+.aircraft-table-route-face {
+    align-items: center;
+    display: flex;
+    gap: 6px;
+    inset: 0;
+    min-width: 0;
+    opacity: 1;
+    position: absolute;
+    transition: opacity 0.36s cubic-bezier(0.25, 1, 0.5, 1);
+    width: 100%;
+}
+
+.aircraft-table-route-face--route span {
+    min-width: 0;
+}
+
+.aircraft-table-route-cycle--alternate .aircraft-table-route-face--flight {
+    animation: aircraft-table-flight-fade 7.2s infinite;
+}
+
+.aircraft-table-route-cycle--alternate .aircraft-table-route-face--route {
+    animation: aircraft-table-route-fade 7.2s infinite;
+}
+
+@keyframes aircraft-table-flight-fade {
+    0%,
+    42%,
+    100% {
+        opacity: 1;
+    }
+    50%,
+    84% {
+        opacity: 0;
+    }
+}
+
+@keyframes aircraft-table-route-fade {
+    0%,
+    42%,
+    100% {
+        opacity: 0;
+    }
+    50%,
+    84% {
+        opacity: 1;
+    }
+}
+
 .aircraft-telemetry {
     align-items: baseline;
     color: var(--map-telemetry-color);

--- a/src/style.css
+++ b/src/style.css
@@ -2493,6 +2493,7 @@ body {
 .aircraft-table-route-cycle {
     color: var(--atc-dim);
     font-size: 11px;
+    font-weight: 600;
     height: 16px;
     line-height: 16px;
     overflow: hidden;

--- a/src/utils/flightRouteDisplay.js
+++ b/src/utils/flightRouteDisplay.js
@@ -17,9 +17,29 @@ const airportMatches = (routeAirport, airport) => {
     .some((code) => localCodes.has(code))
 }
 
+const sameAirport = (a, b) => {
+  const aCodes = airportCodes(a)
+  const bCodes = airportCodes(b)
+  return [...aCodes].some((code) => bCodes.has(code))
+}
+
+const flightNumberFromIdent = (ident) => {
+  const match = String(ident || '').trim().toUpperCase().match(/^[A-Z]{2,3}(\d{1,5}[A-Z]?)$/)
+  return match?.[1] || ''
+}
+
+export const formatFlightNumberLabel = (route, fallbackCallsign = '') =>
+  flightNumberFromIdent(route?.callsignIata)
+  || flightNumberFromIdent(route?.callsignIcao)
+  || flightNumberFromIdent(route?.callsign)
+  || flightNumberFromIdent(fallbackCallsign)
+
 export const formatFlightRouteLabel = (route) => {
   const origin = airportCode(route?.origin)
   const destination = airportCode(route?.destination)
+  if (origin && destination && sameAirport(route.origin, route.destination)) {
+    return ''
+  }
   return origin && destination ? `${origin} -> ${destination}` : ''
 }
 

--- a/src/utils/flightRouteDisplay.test.js
+++ b/src/utils/flightRouteDisplay.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 
 import {
   formatFlightRouteLabel,
+  formatFlightNumberLabel,
   formatLocalFlightRouteLabel,
 } from './flightRouteDisplay.js'
 import { ARRIVAL, DEPARTURE, UNKNOWN } from './aircraftMovement.js'
@@ -27,6 +28,29 @@ import { ARRIVAL, DEPARTURE, UNKNOWN } from './aircraftMovement.js'
 {
   assert.equal(formatFlightRouteLabel(null), '')
   assert.equal(formatFlightRouteLabel({ origin: { iata: 'BOS' } }), '')
+}
+
+{
+  assert.equal(
+    formatFlightNumberLabel({ callsignIata: 'AA873', callsignIcao: 'AAL873' }),
+    '873',
+  )
+  assert.equal(
+    formatFlightNumberLabel({ callsignIcao: 'DAL1234' }),
+    '1234',
+  )
+  assert.equal(formatFlightNumberLabel(null, 'JBU456'), '456')
+  assert.equal(formatFlightNumberLabel(null, 'N156QX'), '')
+}
+
+{
+  assert.equal(
+    formatFlightRouteLabel({
+      origin: { iata: 'BOS', icao: 'KBOS' },
+      destination: { iata: 'BOS', icao: 'KBOS' },
+    }),
+    '',
+  )
 }
 
 {
@@ -65,6 +89,18 @@ import { ARRIVAL, DEPARTURE, UNKNOWN } from './aircraftMovement.js'
   const route = {
     origin: { iata: 'PHX', icao: 'KPHX' },
     destination: { iata: 'MIA', icao: 'KMIA' },
+  }
+
+  assert.equal(
+    formatLocalFlightRouteLabel(route, { iata: 'BOS', icao: 'KBOS' }, UNKNOWN),
+    '',
+  )
+}
+
+{
+  const route = {
+    origin: { iata: 'BOS', icao: 'KBOS' },
+    destination: { iata: 'BOS', icao: 'KBOS' },
   }
 
   assert.equal(


### PR DESCRIPTION
## Summary
- Parse FlightAware trackpollBootstrap data for airline metadata, airline logo URL, IATA/ICAO idents, and richer origin/destination airport details
- Hide the aircraft table second line when no valid FlightAware route exists, and rename the column to Callsign / Route
- Render route rows as airline logo, airline name, flight number, and origin/destination using the non-mono row font

## Verification
- pnpm lint
- pnpm test:flight-route-display
- pnpm test:flightaware-proxy-model
- pnpm test:aviation-service-model
- pnpm test:aviation-data
- pnpm test:airport-explorer
- pnpm test:flight-routes-feature
- pnpm build

## Notes
- Also verified the live FlightAware AAL873 page parser returns BOS/MIA, American Airlines, AA873, and the FlightAware airline logo URL.