### PR TITLE
[codex] Add Supabase airport cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://vqjvtpqryblqwrbsaxwb.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_ieVPDaMnd4swiHGoJ66OOA_77ZOpwfr

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The repo includes `vercel.json` for Git-triggered Vercel builds with same-origin
 vercel
 ```
 
-The deployment path intentionally keeps upstream ownership visible: airport search goes to airportsapi.com from the browser, `/api/proxy/metar/:icao` rewrites to AviationWeather, `/api/proxy/aircraft/positions/:lat/:lon/:dist` rewrites to adsb.lol, and `/api/proxy/flight-routes/callsign/:callsign` routes through the Next.js Route Handler.
+The deployment path intentionally keeps upstream ownership visible: airport search goes to airportsapi.com from the browser, `/api/proxy/metar/:icao` rewrites to AviationWeather, `/api/proxy/aircraft/positions/:lat/:lon/:dist` rewrites to adsb.lol, and `/api/proxy/flight-routes/callsign/:callsign` routes through the Next.js Route Handler. Nearby-airport overlay responses and normalized airport metadata can be persisted in Supabase for 90 days when Vercel provides the publishable-key env vars from `.env.example`.
 
 ### Verification
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,10 @@ The app uses same-origin Vercel paths for upstream aviation sources that are not
 
 These paths are implemented as Next.js Route Handlers under `src/app/api/proxy/**`. The handlers keep upstream access same-origin, validate route and query parameters, apply lightweight per-IP rate limits, reject disallowed browser origins, and cap upstream response body sizes before parsing.
 
+The nearby-airport proxy can also use Supabase as a persistent response cache. When `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` are configured in Vercel, `/api/proxy/airports/nearby` reads and writes `public.nearby_airport_cache` records with a 90-day `expires_at` TTL. The migration grants the `anon` role only the select/insert/update permissions needed for this public cache table, with RLS policies restricted to `nearby-airports:%` cache keys. Cache failures are non-fatal: the handler falls back to AIRAC and logs the Supabase read/write error server-side.
+
+Airport identity metadata is cached separately in `public.airport_metadata_cache`. Search and browse responses write normalized rows for ICAO/IATA/code, display name, city, state, country, airport type, latitude, longitude, elevation, and source. Direct airport resolution checks this table first before calling airportsapi.com. The nearby-airport proxy also writes metadata for airports returned by the AIRAC overlay path.
+
 ### Vercel security posture
 
 Vercel's platform DDoS mitigation remains enabled automatically for the deployment. The repository does not depend on paid Vercel WAF rate limiting for normal operation; proxy throttling lives in application code so the default deployment path does not require a new paid feature.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-three/fiber": "^9.6.1",
     "@react-three/postprocessing": "^3.0.4",
+    "@supabase/supabase-js": "^2.105.4",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@react-three/postprocessing':
         specifier: ^3.0.4
         version: 3.0.4(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0))(@types/three@0.184.0)(react@19.2.5)(three@0.184.0)
+      '@supabase/supabase-js':
+        specifier: ^2.105.4
+        version: 2.105.4
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue-router@4.6.4(vue@3.5.26(typescript@6.0.3)))(vue@3.5.26(typescript@6.0.3))
@@ -1274,6 +1277,33 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@supabase/auth-js@2.105.4':
+    resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.105.4':
+    resolution: {integrity: sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+
+  '@supabase/postgrest-js@2.105.4':
+    resolution: {integrity: sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.105.4':
+    resolution: {integrity: sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.105.4':
+    resolution: {integrity: sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.105.4':
+    resolution: {integrity: sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2201,6 +2231,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -4240,6 +4274,38 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@supabase/auth-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.2': {}
+
+  '@supabase/postgrest-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.105.4':
+    dependencies:
+      '@supabase/phoenix': 0.4.2
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.105.4':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.105.4':
+    dependencies:
+      '@supabase/auth-js': 2.105.4
+      '@supabase/functions-js': 2.105.4
+      '@supabase/postgrest-js': 2.105.4
+      '@supabase/realtime-js': 2.105.4
+      '@supabase/storage-js': 2.105.4
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -5293,6 +5359,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  iceberg-js@0.8.1: {}
 
   ieee754@1.2.1: {}
 

--- a/src/app/api/proxy/airports/nearby/route.js
+++ b/src/app/api/proxy/airports/nearby/route.js
@@ -9,7 +9,12 @@ import {
   fetchAiracAirportDetail,
   fetchAiracAirportIndex,
 } from "@/services/airports/nearbyAirportDataClient.js";
+import { createAirportMetadataSupabaseCacheFromEnv } from "@/services/airports/airportMetadataSupabaseCache.js";
 import { filterNearbyAirports } from "@/services/airports/nearbyAirportModel.js";
+import {
+  buildNearbyAirportCacheKey,
+  createNearbyAirportSupabaseCacheFromEnv,
+} from "@/services/airports/nearbyAirportSupabaseCache.js";
 import { toFiniteNumber } from "@/utils/math.js";
 
 const rateLimit = {
@@ -32,7 +37,7 @@ export function OPTIONS(request) {
   return createCorsPreflightResponse(request);
 }
 
-const cacheKey = ({ country, minRunwayLength }) =>
+const indexCacheKey = ({ country, minRunwayLength }) =>
   `${country}:${minRunwayLength}`;
 
 const queryNumber = (searchParams, key) => {
@@ -41,7 +46,7 @@ const queryNumber = (searchParams, key) => {
 };
 
 async function getCachedAirportIndex({ country, minRunwayLength, now = Date.now }) {
-  const key = cacheKey({ country, minRunwayLength });
+  const key = indexCacheKey({ country, minRunwayLength });
   const currentTime = now();
   const cached = indexCache.get(key);
   if (cached && cached.expiresAt > currentTime) return cached.promise;
@@ -78,6 +83,24 @@ async function attachRunwayMaps(airports) {
     runwayMap: details[index]?.runwayMap || null,
   }));
 }
+
+const nearbyCacheHeaders = {
+  "Cache-Control": "public, s-maxage=21600, stale-while-revalidate=86400",
+};
+
+const logSupabaseCacheWarning = (action, error) => {
+  console.warn(`[airports/nearby] Supabase cache ${action} failed`, error);
+};
+
+const writeAirportMetadata = async (airports) => {
+  const metadataCache = createAirportMetadataSupabaseCacheFromEnv();
+  if (!metadataCache) return;
+  try {
+    await metadataCache.writeMany(airports);
+  } catch (error) {
+    console.warn("[airports/nearby] Supabase metadata cache write failed", error);
+  }
+};
 
 export async function GET(request) {
   const securityResponse = enforceProxyRequest(request, { rateLimit });
@@ -122,6 +145,31 @@ export async function GET(request) {
   }
 
   try {
+    const cacheQuery = {
+      country,
+      minRunwayLength,
+      icao,
+      lat,
+      lon,
+      radiusNm,
+      limit,
+    };
+    const airportCache = createNearbyAirportSupabaseCacheFromEnv();
+    const airportCacheKey = buildNearbyAirportCacheKey(cacheQuery);
+
+    if (airportCache) {
+      try {
+        const cachedPayload = await airportCache.read(airportCacheKey);
+        if (cachedPayload) {
+          return jsonProxyResponse(request, cachedPayload, {
+            headers: nearbyCacheHeaders,
+          });
+        }
+      } catch (error) {
+        logSupabaseCacheWarning("read", error);
+      }
+    }
+
     const index = await getCachedAirportIndex({ country, minRunwayLength });
     const nearbyAirports = filterNearbyAirports({
       focus: { icao, lat, lon },
@@ -129,22 +177,31 @@ export async function GET(request) {
       radiusNm,
       limit,
     });
+    await writeAirportMetadata(nearbyAirports);
     const airports = await attachRunwayMaps(nearbyAirports);
 
-    return jsonProxyResponse(
-      request,
-      {
-        airports,
-        source: index.source,
-        radiusNm,
-        limit,
-      },
-      {
-        headers: {
-          "Cache-Control": "public, s-maxage=21600, stale-while-revalidate=86400",
-        },
-      },
-    );
+    const payload = {
+      airports,
+      source: index.source,
+      radiusNm,
+      limit,
+    };
+
+    if (airportCache) {
+      try {
+        await airportCache.write({
+          cacheKey: airportCacheKey,
+          query: cacheQuery,
+          response: payload,
+        });
+      } catch (error) {
+        logSupabaseCacheWarning("write", error);
+      }
+    }
+
+    return jsonProxyResponse(request, payload, {
+      headers: nearbyCacheHeaders,
+    });
   } catch (error) {
     console.error("[airports/nearby] AIRAC airport index load failed", error);
     return jsonProxyResponse(

--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
@@ -9,6 +9,7 @@ import {
   buildVrsRouteResponse,
   buildVrsRouteUrl,
   normalizeRouteCallsign,
+  VRS_ROUTE_MISS_STATUS,
   VRS_ROUTE_USER_AGENT,
 } from "@/services/aviation/vrsRouteProxyModel.js";
 
@@ -24,6 +25,10 @@ async function fetchVrsStandingRoute(callsign) {
     });
   } catch (err) {
     console.warn(`[vrs-route] fetch failed for ${callsign}:`, err.message);
+    return null;
+  }
+
+  if (response.status === 404) {
     return null;
   }
 
@@ -68,7 +73,7 @@ export async function GET(request, { params }) {
     const body = await fetchVrsStandingRoute(callsign);
 
     return Response.json(body, {
-      status: body ? 200 : 404,
+      status: body ? 200 : VRS_ROUTE_MISS_STATUS,
       headers: buildProxyHeaders(request),
     });
   } catch (err) {

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -31,6 +31,10 @@ function getAuditPayload() {
   return stats;
 }
 
+export function formatFlightRouteQueueAudit(stats) {
+  return `[audit:flight-route-queue]: done=${stats.done},in_queue=${stats.in_queue},inflight=${stats.inflight},not_do=${stats.not_do}`;
+}
+
 function auditRouteQueue() {
   const payload = getAuditPayload();
   const snapshot = JSON.stringify(payload);
@@ -54,7 +58,7 @@ function auditRouteQueue() {
 
   lastAuditSnapshot = snapshot;
   lastAuditLoggedAt = now;
-  console.info("[audit:flight-routes]", payload);
+  console.info(formatFlightRouteQueueAudit(payload));
 }
 
 export function useFlightRoutes(aircraft) {

--- a/src/hooks/useFlightRoutes.test.js
+++ b/src/hooks/useFlightRoutes.test.js
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+
+import { formatFlightRouteQueueAudit } from "./useFlightRoutes.js";
+
+assert.equal(
+  formatFlightRouteQueueAudit({
+    done: 50,
+    in_queue: 1,
+    inflight: 0,
+    not_do: 0,
+  }),
+  "[audit:flight-route-queue]: done=50,in_queue=1,inflight=0,not_do=0",
+);

--- a/src/services/airport-directory/airportDirectoryClient.js
+++ b/src/services/airport-directory/airportDirectoryClient.js
@@ -1,4 +1,5 @@
 import { withAuditLogging } from "../../utils/apiLogger.js";
+import { createAirportMetadataSupabaseCacheFromEnv } from "../airports/airportMetadataSupabaseCache.js";
 import { readResponseJson } from "../apiProxySecurity.js";
 import { createAirportDirectoryCache } from "./airportDirectoryCache.js";
 import {
@@ -21,6 +22,7 @@ export const createAirportDirectoryClient = ({
   storage,
   now = () => Date.now(),
   ttlMs,
+  metadataCache = createAirportMetadataSupabaseCacheFromEnv({ now }),
 } = {}) => {
   if (!fetchImpl) {
     throw new Error("Airport directory client requires fetch support");
@@ -33,6 +35,15 @@ export const createAirportDirectoryClient = ({
   });
 
   const auditedFetch = withAuditLogging(fetchImpl, { service: "airportsapi.com" });
+
+  const writeAirportMetadata = async (airports) => {
+    if (!metadataCache) return;
+    try {
+      await metadataCache.writeMany(airports);
+    } catch (error) {
+      console.warn("[airport-directory] Supabase metadata cache write failed", error);
+    }
+  };
 
   const fetchJson = async (url, { allow404 = false } = {}) => {
     const response = await auditedFetch(url, {
@@ -116,10 +127,12 @@ export const createAirportDirectoryClient = ({
       ),
     ).slice(0, limit);
 
-    return setCached(cacheKey, {
+    const payload = {
       airports,
       source: "airportsapi.com",
-    });
+    };
+    await writeAirportMetadata(airports);
+    return setCached(cacheKey, payload);
   };
 
   const searchAirports = async ({ query, country = "", kind = "all", limit = 60 }) => {
@@ -185,10 +198,12 @@ export const createAirportDirectoryClient = ({
       trimmed,
     ).slice(0, limit);
 
-    return setCached(cacheKey, {
+    const payload = {
       airports,
       source: "airportsapi.com",
-    });
+    };
+    await writeAirportMetadata(airports);
+    return setCached(cacheKey, payload);
   };
 
   return {
@@ -204,12 +219,23 @@ export const createAirportDirectoryClient = ({
         throw new Error("Airport code is required");
       }
 
+      if (metadataCache) {
+        try {
+          const cachedAirport = await metadataCache.read(trimmed);
+          if (cachedAirport) return cachedAirport;
+        } catch (error) {
+          console.warn("[airport-directory] Supabase metadata cache read failed", error);
+        }
+      }
+
       const exactPayload = await fetchJson(
         `${AIRPORT_DIRECTORY_API_BASE_URL}/airports/${trimmed}`,
         { allow404: true },
       );
       if (exactPayload?.data) {
-        return normalizeAirport(exactPayload.data);
+        const airport = normalizeAirport(exactPayload.data);
+        await writeAirportMetadata([airport]);
+        return airport;
       }
 
       const result = await searchAirports({ query: trimmed, limit: 1 });

--- a/src/services/airportDirectory.test.js
+++ b/src/services/airportDirectory.test.js
@@ -185,3 +185,59 @@ const makeRecord = (code, overrides = {}) => ({
   assert.equal(airport.name, 'Boston Logan International Airport')
   assert.equal(airport.city, 'Boston')
 }
+
+{
+  const writes = []
+  const client = createAirportDirectoryClient({
+    fetchImpl: async () => createJsonResponse({
+      data: [makeRecord('KBOS', { name: 'Boston Logan International Airport', municipality: 'Boston' })],
+      links: [],
+    }),
+    now: () => 6_000,
+    metadataCache: {
+      async writeMany(airports) {
+        writes.push(airports)
+      },
+    },
+  })
+
+  await client.loadAirports({ country: 'US', kind: 'large_airport', limit: 13 })
+
+  assert.equal(writes.length, 1)
+  assert.equal(writes[0][0].icao, 'KBOS')
+  assert.equal(writes[0][0].name, 'Boston Logan International Airport')
+}
+
+{
+  const calls = []
+  const client = createAirportDirectoryClient({
+    fetchImpl: async (url) => {
+      calls.push(url)
+      throw new Error(`Unexpected URL: ${url}`)
+    },
+    now: () => 7_000,
+    metadataCache: {
+      async read(code) {
+        assert.equal(code, 'KBOS')
+        return {
+          icao: 'KBOS',
+          iata: 'BOS',
+          code: 'KBOS',
+          name: 'Boston Logan International Airport',
+          city: 'Boston',
+          country: 'US',
+          lat: 42.3656,
+          lon: -71.0096,
+          source: 'supabase',
+        }
+      },
+      async writeMany() {},
+    },
+  })
+
+  const airport = await client.resolveAirport('kbos')
+
+  assert.equal(calls.length, 0)
+  assert.equal(airport.icao, 'KBOS')
+  assert.equal(airport.source, 'supabase')
+}

--- a/src/services/airportWiki.js
+++ b/src/services/airportWiki.js
@@ -58,9 +58,6 @@ export const fetchAirportWikiSummary = async (airport, fetchImpl = fetch) => {
   const candidates = getAirportWikiTitleCandidates(airport)
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: 'Wikipedia',
-    getParams(url) {
-      return { title: decodeURIComponent(url.split('/').pop() || '') }
-    },
   })
 
   for (const title of candidates) {

--- a/src/services/airports/airportMetadataSupabaseCache.js
+++ b/src/services/airports/airportMetadataSupabaseCache.js
@@ -1,0 +1,139 @@
+import { createClient } from "@supabase/supabase-js";
+
+import { toFiniteNumber } from "../../utils/math.js";
+
+const TABLE_NAME = "airport_metadata_cache";
+const AIRPORT_METADATA_COLUMNS =
+  "airport_key,icao,iata,code,name,city,state,country,type,type_label,lat,lon,elevation_ft,source,metadata,expires_at";
+
+export const AIRPORT_METADATA_SUPABASE_CACHE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+const cleanString = (value) => String(value || "").trim();
+const cleanUpper = (value) => cleanString(value).toUpperCase();
+
+export function airportMetadataKey(airport) {
+  return cleanUpper(airport?.icao || airport?.code || airport?.iata || airport?.name);
+}
+
+export function normalizeAirportMetadataRow(airport) {
+  const airportKey = airportMetadataKey(airport);
+  const lat = toFiniteNumber(airport?.lat);
+  const lon = toFiniteNumber(airport?.lon);
+  if (!airportKey || !Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+
+  const icao = cleanUpper(airport?.icao || airport?.code || airportKey);
+  const code = cleanUpper(airport?.code || icao || airportKey);
+
+  return {
+    airport_key: airportKey,
+    icao,
+    iata: cleanUpper(airport?.iata),
+    code,
+    name: cleanString(airport?.name || code),
+    city: cleanString(airport?.city),
+    state: cleanUpper(airport?.state),
+    country: cleanUpper(airport?.country),
+    type: cleanString(airport?.type),
+    type_label: cleanString(airport?.type_label),
+    lat,
+    lon,
+    elevation_ft: toFiniteNumber(airport?.elevationFt ?? airport?.elevation_ft),
+    source: cleanString(airport?.source),
+    metadata: airport?.metadata && typeof airport.metadata === "object" ? airport.metadata : {},
+  };
+}
+
+export function normalizeAirportMetadataAirport(row) {
+  if (!row) return null;
+  return {
+    icao: row.icao || row.code || row.airport_key,
+    iata: row.iata || "",
+    code: row.code || row.icao || row.airport_key,
+    name: row.name || row.icao || row.airport_key,
+    city: row.city || "",
+    state: row.state || "",
+    country: row.country || "",
+    type: row.type || "",
+    type_label: row.type_label || "",
+    lat: toFiniteNumber(row.lat),
+    lon: toFiniteNumber(row.lon),
+    elevationFt: toFiniteNumber(row.elevation_ft),
+    source: row.source || "supabase",
+    ...(row.metadata && typeof row.metadata === "object" ? row.metadata : {}),
+  };
+}
+
+export function createAirportMetadataSupabaseCache({
+  supabaseUrl,
+  supabaseKey,
+  createClientImpl = createClient,
+  now = Date.now,
+} = {}) {
+  if (!supabaseUrl || !supabaseKey || !createClientImpl) return null;
+
+  const client = createClientImpl(supabaseUrl, supabaseKey, {
+    auth: {
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+      persistSession: false,
+    },
+  });
+
+  return {
+    async read(code) {
+      const key = cleanUpper(code);
+      if (!key) return null;
+
+      const { data, error } = await client
+        .from(TABLE_NAME)
+        .select(AIRPORT_METADATA_COLUMNS)
+        .eq("airport_key", key)
+        .gt("expires_at", new Date(now()).toISOString())
+        .limit(1)
+        .maybeSingle();
+
+      if (error) {
+        throw new Error(`Supabase airport metadata cache read failed (${error.message})`);
+      }
+
+      return normalizeAirportMetadataAirport(data);
+    },
+
+    async writeMany(airports = []) {
+      const expiresAt = new Date(
+        now() + AIRPORT_METADATA_SUPABASE_CACHE_TTL_MS,
+      ).toISOString();
+      const rows = airports
+        .map(normalizeAirportMetadataRow)
+        .filter(Boolean)
+        .map((row) => ({ ...row, expires_at: expiresAt }));
+
+      if (rows.length === 0) return;
+
+      const { error } = await client
+        .from(TABLE_NAME)
+        .upsert(rows, { onConflict: "airport_key" });
+
+      if (error) {
+        throw new Error(`Supabase airport metadata cache write failed (${error.message})`);
+      }
+    },
+  };
+}
+
+export function createAirportMetadataSupabaseCacheFromEnv({
+  env = process.env,
+  createClientImpl = createClient,
+  now = Date.now,
+} = {}) {
+  return createAirportMetadataSupabaseCache({
+    supabaseUrl: env.NEXT_PUBLIC_SUPABASE_URL || env.SUPABASE_URL,
+    supabaseKey:
+      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
+      env.SUPABASE_PUBLISHABLE_KEY ||
+      env.SUPABASE_SECRET_KEY ||
+      env.SUPABASE_SERVICE_ROLE_KEY,
+    createClientImpl,
+    now,
+  });
+}

--- a/src/services/airports/airportMetadataSupabaseCache.test.js
+++ b/src/services/airports/airportMetadataSupabaseCache.test.js
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+
+import {
+  AIRPORT_METADATA_SUPABASE_CACHE_TTL_MS,
+  createAirportMetadataSupabaseCache,
+  createAirportMetadataSupabaseCacheFromEnv,
+  normalizeAirportMetadataRow,
+} from "./airportMetadataSupabaseCache.js";
+
+const now = () => Date.parse("2026-05-10T12:00:00.000Z");
+
+function createFakeSupabaseClient({ readData = null, readError = null, writeError = null } = {}) {
+  const calls = [];
+  const createClientImpl = (supabaseUrl, supabaseKey, options) => {
+    calls.push({ type: "createClient", supabaseUrl, supabaseKey, options });
+    return {
+      from(table) {
+        calls.push({ type: "from", table });
+        return {
+          select(columns) {
+            calls.push({ type: "select", columns });
+            return this;
+          },
+          eq(column, value) {
+            calls.push({ type: "eq", column, value });
+            return this;
+          },
+          gt(column, value) {
+            calls.push({ type: "gt", column, value });
+            return this;
+          },
+          limit(count) {
+            calls.push({ type: "limit", count });
+            return this;
+          },
+          async maybeSingle() {
+            calls.push({ type: "maybeSingle" });
+            return { data: readData, error: readError };
+          },
+          async upsert(rows, options) {
+            calls.push({ type: "upsert", rows, options });
+            return { error: writeError };
+          },
+        };
+      },
+    };
+  };
+  return { calls, createClientImpl };
+}
+
+assert.equal(AIRPORT_METADATA_SUPABASE_CACHE_TTL_MS, 90 * 24 * 60 * 60 * 1000);
+
+assert.deepEqual(
+  normalizeAirportMetadataRow({
+    icao: "kbos",
+    iata: "bos",
+    name: "Boston Logan International Airport",
+    city: "Boston",
+    state: "MA",
+    country: "us",
+    type: "large_airport",
+    type_label: "Large Airport",
+    lat: "42.3656",
+    lon: "-71.0096",
+    elevationFt: "20",
+    source: "airportsapi.com",
+  }),
+  {
+    airport_key: "KBOS",
+    icao: "KBOS",
+    iata: "BOS",
+    code: "KBOS",
+    name: "Boston Logan International Airport",
+    city: "Boston",
+    state: "MA",
+    country: "US",
+    type: "large_airport",
+    type_label: "Large Airport",
+    lat: 42.3656,
+    lon: -71.0096,
+    elevation_ft: 20,
+    source: "airportsapi.com",
+    metadata: {},
+  },
+);
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    readData: {
+      airport_key: "KBOS",
+      icao: "KBOS",
+      iata: "BOS",
+      code: "KBOS",
+      name: "Boston Logan International Airport",
+      city: "Boston",
+      state: "MA",
+      country: "US",
+      type: "large_airport",
+      type_label: "Large Airport",
+      lat: 42.3656,
+      lon: -71.0096,
+      elevation_ft: 20,
+      source: "airportsapi.com",
+      metadata: {},
+      expires_at: "2026-08-08T12:00:00.000Z",
+    },
+  });
+  const cache = createAirportMetadataSupabaseCache({
+    supabaseUrl: "https://vqjvtpqryblqwrbsaxwb.supabase.co",
+    supabaseKey: "sb_publishable_test",
+    createClientImpl,
+    now,
+  });
+
+  const airport = await cache.read("kbos");
+
+  assert.deepEqual(airport, {
+    icao: "KBOS",
+    iata: "BOS",
+    code: "KBOS",
+    name: "Boston Logan International Airport",
+    city: "Boston",
+    state: "MA",
+    country: "US",
+    type: "large_airport",
+    type_label: "Large Airport",
+    lat: 42.3656,
+    lon: -71.0096,
+    elevationFt: 20,
+    source: "airportsapi.com",
+  });
+  assert.deepEqual(
+    calls.filter((call) => call.type !== "createClient"),
+    [
+      { type: "from", table: "airport_metadata_cache" },
+      {
+        type: "select",
+        columns:
+          "airport_key,icao,iata,code,name,city,state,country,type,type_label,lat,lon,elevation_ft,source,metadata,expires_at",
+      },
+      { type: "eq", column: "airport_key", value: "KBOS" },
+      { type: "gt", column: "expires_at", value: "2026-05-10T12:00:00.000Z" },
+      { type: "limit", count: 1 },
+      { type: "maybeSingle" },
+    ],
+  );
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient();
+  const cache = createAirportMetadataSupabaseCache({
+    supabaseUrl: "https://vqjvtpqryblqwrbsaxwb.supabase.co",
+    supabaseKey: "sb_publishable_test",
+    createClientImpl,
+    now,
+  });
+
+  await cache.writeMany([
+    {
+      icao: "KJFK",
+      iata: "JFK",
+      name: "John F Kennedy International Airport",
+      city: "New York",
+      country: "US",
+      lat: 40.639928,
+      lon: -73.778692,
+      source: "airac.net",
+    },
+    {
+      icao: "",
+      name: "",
+    },
+  ]);
+
+  const upsertCall = calls.find((call) => call.type === "upsert");
+  assert.equal(upsertCall.rows.length, 1);
+  assert.equal(upsertCall.rows[0].airport_key, "KJFK");
+  assert.equal(upsertCall.rows[0].expires_at, "2026-08-08T12:00:00.000Z");
+  assert.equal(upsertCall.rows[0].lat, 40.639928);
+  assert.equal(upsertCall.rows[0].lon, -73.778692);
+  assert.deepEqual(upsertCall.options, { onConflict: "airport_key" });
+}
+
+assert.equal(
+  createAirportMetadataSupabaseCacheFromEnv({
+    env: {},
+    createClientImpl: () => ({}),
+  }),
+  null,
+);

--- a/src/services/airports/nearbyAirportSupabaseCache.js
+++ b/src/services/airports/nearbyAirportSupabaseCache.js
@@ -1,0 +1,111 @@
+import { createClient } from "@supabase/supabase-js";
+
+import { toFiniteNumber } from "../../utils/math.js";
+
+const TABLE_NAME = "nearby_airport_cache";
+
+export const NEARBY_AIRPORT_SUPABASE_CACHE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+const roundedNumber = (value, precision = 6) => {
+  const number = toFiniteNumber(value);
+  if (!Number.isFinite(number)) return "";
+  const rounded = number.toFixed(precision);
+  return precision === 0 ? rounded : rounded.replace(/\.?0+$/, "");
+};
+
+export function buildNearbyAirportCacheKey({
+  lat,
+  lon,
+  icao = "",
+  radiusNm,
+  limit,
+  country = "US",
+  minRunwayLength,
+} = {}) {
+  return [
+    "nearby-airports",
+    String(country || "").trim().toUpperCase(),
+    roundedNumber(minRunwayLength, 0),
+    String(icao || "").trim().toUpperCase(),
+    roundedNumber(lat),
+    roundedNumber(lon),
+    roundedNumber(radiusNm, 2),
+    roundedNumber(limit, 0),
+  ].join(":");
+}
+
+export function createNearbyAirportSupabaseCache({
+  supabaseUrl,
+  supabaseKey,
+  createClientImpl = createClient,
+  now = Date.now,
+} = {}) {
+  if (!supabaseUrl || !supabaseKey || !createClientImpl) return null;
+
+  const client = createClientImpl(supabaseUrl, supabaseKey, {
+    auth: {
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+      persistSession: false,
+    },
+  });
+
+  return {
+    async read(cacheKey) {
+      const { data, error } = await client
+        .from(TABLE_NAME)
+        .select("response,expires_at")
+        .eq("cache_key", cacheKey)
+        .gt("expires_at", new Date(now()).toISOString())
+        .limit(1)
+        .maybeSingle();
+
+      if (error) {
+        throw new Error(
+          `Supabase nearby airport cache read failed (${error.message})`,
+        );
+      }
+
+      return data?.response || null;
+    },
+
+    async write({ cacheKey, query, response }) {
+      const expiresAt = new Date(
+        now() + NEARBY_AIRPORT_SUPABASE_CACHE_TTL_MS,
+      ).toISOString();
+
+      const { error } = await client.from(TABLE_NAME).upsert(
+        {
+          cache_key: cacheKey,
+          query,
+          response,
+          expires_at: expiresAt,
+        },
+        { onConflict: "cache_key" },
+      );
+
+      if (error) {
+        throw new Error(
+          `Supabase nearby airport cache write failed (${error.message})`,
+        );
+      }
+    },
+  };
+}
+
+export function createNearbyAirportSupabaseCacheFromEnv({
+  env = process.env,
+  createClientImpl = createClient,
+  now = Date.now,
+} = {}) {
+  return createNearbyAirportSupabaseCache({
+    supabaseUrl: env.NEXT_PUBLIC_SUPABASE_URL || env.SUPABASE_URL,
+    supabaseKey:
+      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
+      env.SUPABASE_PUBLISHABLE_KEY ||
+      env.SUPABASE_SECRET_KEY ||
+      env.SUPABASE_SERVICE_ROLE_KEY,
+    createClientImpl,
+    now,
+  });
+}

--- a/src/services/airports/nearbyAirportSupabaseCache.test.js
+++ b/src/services/airports/nearbyAirportSupabaseCache.test.js
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+
+import {
+  NEARBY_AIRPORT_SUPABASE_CACHE_TTL_MS,
+  buildNearbyAirportCacheKey,
+  createNearbyAirportSupabaseCache,
+  createNearbyAirportSupabaseCacheFromEnv,
+} from "./nearbyAirportSupabaseCache.js";
+
+const now = () => Date.parse("2026-05-10T12:00:00.000Z");
+
+function createFakeSupabaseClient({ readData = null, readError = null, writeError = null } = {}) {
+  const calls = [];
+  const createClientImpl = (supabaseUrl, supabaseKey, options) => {
+    calls.push({ type: "createClient", supabaseUrl, supabaseKey, options });
+    return {
+      from(table) {
+        calls.push({ type: "from", table });
+        return {
+          select(columns) {
+            calls.push({ type: "select", columns });
+            return this;
+          },
+          eq(column, value) {
+            calls.push({ type: "eq", column, value });
+            return this;
+          },
+          gt(column, value) {
+            calls.push({ type: "gt", column, value });
+            return this;
+          },
+          limit(count) {
+            calls.push({ type: "limit", count });
+            return this;
+          },
+          async maybeSingle() {
+            calls.push({ type: "maybeSingle" });
+            return { data: readData, error: readError };
+          },
+          async upsert(row, options) {
+            calls.push({ type: "upsert", row, options });
+            return { error: writeError };
+          },
+        };
+      },
+    };
+  };
+  return { calls, createClientImpl };
+}
+
+assert.equal(NEARBY_AIRPORT_SUPABASE_CACHE_TTL_MS, 90 * 24 * 60 * 60 * 1000);
+
+assert.equal(
+  buildNearbyAirportCacheKey({
+    lat: 40.6399284,
+    lon: -73.7786918,
+    icao: "kjfk",
+    radiusNm: 30,
+    limit: 6,
+    country: "us",
+    minRunwayLength: 5000,
+  }),
+  "nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6",
+);
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    readData: {
+      response: { airports: [{ icao: "KLGA" }], source: "airac.net" },
+      expires_at: "2026-08-08T12:00:00.000Z",
+    },
+  });
+  const cache = createNearbyAirportSupabaseCache({
+    supabaseUrl: "https://vqjvtpqryblqwrbsaxwb.supabase.co",
+    supabaseKey: "sb_publishable_test",
+    createClientImpl,
+    now,
+  });
+
+  const payload = await cache.read("nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6");
+
+  assert.deepEqual(payload, {
+    airports: [{ icao: "KLGA" }],
+    source: "airac.net",
+  });
+  assert.deepEqual(calls[0], {
+    type: "createClient",
+    supabaseUrl: "https://vqjvtpqryblqwrbsaxwb.supabase.co",
+    supabaseKey: "sb_publishable_test",
+    options: {
+      auth: {
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+        persistSession: false,
+      },
+    },
+  });
+  assert.deepEqual(
+    calls.filter((call) => call.type !== "createClient"),
+    [
+      { type: "from", table: "nearby_airport_cache" },
+      { type: "select", columns: "response,expires_at" },
+      {
+        type: "eq",
+        column: "cache_key",
+        value: "nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6",
+      },
+      { type: "gt", column: "expires_at", value: "2026-05-10T12:00:00.000Z" },
+      { type: "limit", count: 1 },
+      { type: "maybeSingle" },
+    ],
+  );
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient();
+  const cache = createNearbyAirportSupabaseCache({
+    supabaseUrl: "https://vqjvtpqryblqwrbsaxwb.supabase.co/",
+    supabaseKey: "sb_publishable_test",
+    createClientImpl,
+    now,
+  });
+
+  await cache.write({
+    cacheKey: "nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6",
+    query: {
+      country: "US",
+      minRunwayLength: 5000,
+      icao: "KJFK",
+      lat: 40.639928,
+      lon: -73.778692,
+      radiusNm: 30,
+      limit: 6,
+    },
+    response: { airports: [{ icao: "KLGA" }], source: "airac.net" },
+  });
+
+  const upsertCall = calls.find((call) => call.type === "upsert");
+  assert.equal(upsertCall.row.cache_key, "nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6");
+  assert.equal(upsertCall.row.expires_at, "2026-08-08T12:00:00.000Z");
+  assert.deepEqual(upsertCall.row.response.airports, [{ icao: "KLGA" }]);
+  assert.deepEqual(upsertCall.options, { onConflict: "cache_key" });
+}
+
+assert.equal(
+  createNearbyAirportSupabaseCache({
+    supabaseUrl: "",
+    supabaseKey: "sb_publishable_test",
+    createClientImpl: () => ({}),
+  }),
+  null,
+);
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient();
+  const cache = createNearbyAirportSupabaseCacheFromEnv({
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: "https://vqjvtpqryblqwrbsaxwb.supabase.co",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_test",
+    },
+    createClientImpl,
+    now,
+  });
+
+  await cache.read("cache-key");
+  assert.equal(calls[0].supabaseKey, "sb_publishable_test");
+}

--- a/src/services/aviation/aircraftPositionClient.js
+++ b/src/services/aviation/aircraftPositionClient.js
@@ -24,14 +24,6 @@ export const createAircraftPositionClient = ({
 
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: "adsb.lol/Aircraft",
-    getParams(url) {
-      const p = url.split("/");
-      return {
-        lat: p[p.length - 3],
-        lon: p[p.length - 2],
-        distNm: p[p.length - 1],
-      };
-    },
   });
 
   return {

--- a/src/services/aviation/flightRouteClient.js
+++ b/src/services/aviation/flightRouteClient.js
@@ -20,9 +20,6 @@ export const createFlightRouteClient = ({
 
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: "vrs-standing-data/FlightRoute",
-    getParams(url) {
-      return { callsign: decodeURIComponent(url.split("/").pop() || "") };
-    },
   });
 
   const limiter = createRateLimiter({

--- a/src/services/aviation/flightRouteClient.js
+++ b/src/services/aviation/flightRouteClient.js
@@ -47,7 +47,7 @@ export const createFlightRouteClient = ({
         },
       );
 
-      if (response.status === 400 || response.status === 404) {
+      if (response.status === 400) {
         limiter.release();
         return null;
       }

--- a/src/services/aviation/localWeatherClient.js
+++ b/src/services/aviation/localWeatherClient.js
@@ -17,13 +17,6 @@ export const createLocalWeatherClient = ({
 
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: "Open-Meteo/CurrentWeather",
-    getParams(url) {
-      const p = url.split("/");
-      return {
-        lat: p[p.length - 2],
-        lon: p[p.length - 1],
-      };
-    },
   });
 
   return {

--- a/src/services/aviation/metarClient.js
+++ b/src/services/aviation/metarClient.js
@@ -15,9 +15,6 @@ export const createMetarClient = ({
 
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: "AviationWeather/METAR",
-    getParams(url) {
-      return { icao: decodeURIComponent(url.split("/").pop() || "") };
-    },
   });
 
   return {

--- a/src/services/aviation/vrsRouteProxyModel.js
+++ b/src/services/aviation/vrsRouteProxyModel.js
@@ -4,6 +4,8 @@ export const VRS_STANDING_DATA_BASE =
 export const VRS_ROUTE_USER_AGENT =
   "ADSBao/0.9.0 (+https://github.com/orriduck/ADSBao) VRS-standing-data/1.0";
 
+export const VRS_ROUTE_MISS_STATUS = 200;
+
 const cleanString = (value) => String(value || "").trim();
 
 const cleanUpper = (value) => cleanString(value).toUpperCase();

--- a/src/services/aviation/vrsRouteProxyModel.test.js
+++ b/src/services/aviation/vrsRouteProxyModel.test.js
@@ -4,6 +4,7 @@ import {
   buildVrsRouteResponse,
   buildVrsRouteUrl,
   normalizeRouteCallsign,
+  VRS_ROUTE_MISS_STATUS,
 } from "./vrsRouteProxyModel.js";
 
 const italyToAmsterdam = {
@@ -40,6 +41,7 @@ assert.equal(
   buildVrsRouteUrl("ity110"),
   "https://vrs-standing-data.adsb.lol/routes/IT/ITY110.json",
 );
+assert.equal(VRS_ROUTE_MISS_STATUS, 200);
 
 const response = buildVrsRouteResponse("ity110", italyToAmsterdam);
 

--- a/src/services/aviationData.test.js
+++ b/src/services/aviationData.test.js
@@ -280,8 +280,7 @@ try {
 
 {
   const client = createFlightRouteClient({
-    fetchImpl: async () =>
-      createJsonResponse({ response: "unknown callsign" }, 404),
+    fetchImpl: async () => createJsonResponse(null, 200),
   });
 
   assert.equal(await client.fetchFlightRoute("NOPE123"), null);
@@ -289,10 +288,14 @@ try {
 
 {
   const client = createFlightRouteClient({
-    fetchImpl: async () => createJsonResponse(null, 200),
+    fetchImpl: async () =>
+      createJsonResponse({ response: "unknown callsign" }, 404),
   });
 
-  assert.equal(await client.fetchFlightRoute("NOPE123"), null);
+  await assert.rejects(
+    () => client.fetchFlightRoute("NOPE123"),
+    /HTTP 404/,
+  );
 }
 
 {

--- a/src/services/aviationData.test.js
+++ b/src/services/aviationData.test.js
@@ -288,6 +288,14 @@ try {
 }
 
 {
+  const client = createFlightRouteClient({
+    fetchImpl: async () => createJsonResponse(null, 200),
+  });
+
+  assert.equal(await client.fetchFlightRoute("NOPE123"), null);
+}
+
+{
   // 429 should throw with rate-limited message
   const calls = [];
   const client = createFlightRouteClient({

--- a/src/utils/apiLogger.js
+++ b/src/utils/apiLogger.js
@@ -1,24 +1,40 @@
-export const withAuditLogging = (fetchImpl, { service = 'API', getParams } = {}) => {
+const endpointPathFromUrl = (url) => {
+  try {
+    return new URL(String(url), "http://localhost").pathname;
+  } catch {
+    return String(url || "");
+  }
+};
+
+export const formatAuditLogLine = ({
+  endpointPath,
+  status,
+  durationMs,
+}) =>
+  `[audit:${endpointPath || "/"}]: ${status} +${Math.round(
+    durationMs,
+  )}ms`;
+
+export const withAuditLogging = (fetchImpl, { service = 'API' } = {}) => {
   return async (url, options) => {
     const start = performance.now()
+    const endpointPath = endpointPathFromUrl(url) || service
     try {
       const response = await fetchImpl(url, options)
-      const duration_ms = Math.round(performance.now() - start)
-      const params = typeof getParams === 'function' ? getParams(url) : null
-      console.log("[audit:api]", {
-        service,
-        ...(params ? { params } : {}),
+      const durationMs = Math.round(performance.now() - start)
+      console.log(formatAuditLogLine({
+        endpointPath,
         status: response.status,
-        duration_ms,
-      })
+        durationMs,
+      }))
       return response
     } catch (err) {
-      const duration_ms = Math.round(performance.now() - start)
-      console.log("[audit:api]", {
-        service,
-        error: err.message,
-        duration_ms,
-      })
+      const durationMs = Math.round(performance.now() - start)
+      console.log(formatAuditLogLine({
+        endpointPath,
+        status: "ERROR",
+        durationMs,
+      }))
       throw err
     }
   }

--- a/src/utils/apiLogger.test.js
+++ b/src/utils/apiLogger.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { withAuditLogging } from "./apiLogger.js";
+import { formatAuditLogLine, withAuditLogging } from "./apiLogger.js";
 
 const originalConsoleLog = console.log;
 const logs = [];
@@ -10,19 +10,26 @@ console.log = (...args) => {
 };
 
 try {
+  assert.equal(
+    formatAuditLogLine({
+      endpointPath: "/api/proxy/flight-routes/callsign/DAL123",
+      status: 200,
+      durationMs: 14,
+    }),
+    "[audit:/api/proxy/flight-routes/callsign/DAL123]: 200 +14ms",
+  );
+
   const okFetch = async () => ({ status: 200 });
   const auditedOkFetch = withAuditLogging(okFetch, {
     service: "example",
-    getParams: () => ({ callsign: "DAL123" }),
   });
 
   const response = await auditedOkFetch("/route/DAL123");
   assert.equal(response.status, 200);
-  assert.equal(logs[0][0], "[audit:api]");
-  assert.equal(logs[0][1].service, "example");
-  assert.deepEqual(logs[0][1].params, { callsign: "DAL123" });
-  assert.equal(logs[0][1].status, 200);
-  assert.equal(typeof logs[0][1].duration_ms, "number");
+  assert.match(
+    logs[0][0],
+    /^\[audit:\/route\/DAL123\]: 200 \+\d+ms$/,
+  );
 
   const auditedErrorFetch = withAuditLogging(
     async () => {
@@ -32,13 +39,7 @@ try {
   );
 
   await assert.rejects(() => auditedErrorFetch("/broken"), /network failed/);
-  assert.equal(logs[1][0], "[audit:api]");
-  assert.deepEqual(logs[1][1], {
-    service: "broken",
-    error: "network failed",
-    duration_ms: logs[1][1].duration_ms,
-  });
-  assert.equal(typeof logs[1][1].duration_ms, "number");
+  assert.match(logs[1][0], /^\[audit:\/broken\]: ERROR \+\d+ms$/);
 } finally {
   console.log = originalConsoleLog;
 }

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,408 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "ADSBao"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260510223214_create_nearby_airport_cache.sql
+++ b/supabase/migrations/20260510223214_create_nearby_airport_cache.sql
@@ -1,0 +1,77 @@
+create table if not exists public.nearby_airport_cache (
+  cache_key text primary key,
+  query jsonb not null,
+  response jsonb not null,
+  expires_at timestamptz not null,
+  inserted_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists nearby_airport_cache_expires_at_idx
+  on public.nearby_airport_cache (expires_at);
+
+alter table public.nearby_airport_cache enable row level security;
+
+grant select, insert, update, delete on table public.nearby_airport_cache to service_role;
+grant select, insert, update on table public.nearby_airport_cache to anon;
+
+drop policy if exists "Nearby airport cache entries are readable"
+  on public.nearby_airport_cache;
+
+create policy "Nearby airport cache entries are readable"
+on public.nearby_airport_cache
+for select
+to anon
+using (cache_key like 'nearby-airports:%');
+
+drop policy if exists "Nearby airport cache entries can be inserted"
+  on public.nearby_airport_cache;
+
+create policy "Nearby airport cache entries can be inserted"
+on public.nearby_airport_cache
+for insert
+to anon
+with check (
+  cache_key like 'nearby-airports:%'
+  and jsonb_typeof(query) = 'object'
+  and jsonb_typeof(response) = 'object'
+  and expires_at > timezone('utc', now())
+  and expires_at <= timezone('utc', now()) + interval '90 days' + interval '5 minutes'
+);
+
+drop policy if exists "Nearby airport cache entries can be updated"
+  on public.nearby_airport_cache;
+
+create policy "Nearby airport cache entries can be updated"
+on public.nearby_airport_cache
+for update
+to anon
+using (cache_key like 'nearby-airports:%')
+with check (
+  cache_key like 'nearby-airports:%'
+  and jsonb_typeof(query) = 'object'
+  and jsonb_typeof(response) = 'object'
+  and expires_at > timezone('utc', now())
+  and expires_at <= timezone('utc', now()) + interval '90 days' + interval '5 minutes'
+);
+
+create or replace function public.set_nearby_airport_cache_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+revoke execute on function public.set_nearby_airport_cache_updated_at()
+  from public, anon, authenticated;
+
+drop trigger if exists nearby_airport_cache_set_updated_at
+  on public.nearby_airport_cache;
+
+create trigger nearby_airport_cache_set_updated_at
+before update on public.nearby_airport_cache
+for each row
+execute function public.set_nearby_airport_cache_updated_at();

--- a/supabase/migrations/20260510232810_create_airport_metadata_cache.sql
+++ b/supabase/migrations/20260510232810_create_airport_metadata_cache.sql
@@ -1,0 +1,108 @@
+create table if not exists public.airport_metadata_cache (
+  airport_key text primary key,
+  icao text not null,
+  iata text not null default '',
+  code text not null default '',
+  name text not null,
+  city text not null default '',
+  state text not null default '',
+  country text not null default '',
+  type text not null default '',
+  type_label text not null default '',
+  lat double precision not null,
+  lon double precision not null,
+  elevation_ft double precision,
+  source text not null default '',
+  metadata jsonb not null default '{}'::jsonb,
+  expires_at timestamptz not null,
+  inserted_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint airport_metadata_cache_key_format
+    check (airport_key ~ '^[A-Z0-9][A-Z0-9 -]{1,120}$'),
+  constraint airport_metadata_cache_icao_format
+    check (icao = '' or icao ~ '^[A-Z0-9]{3,6}$'),
+  constraint airport_metadata_cache_iata_format
+    check (iata = '' or iata ~ '^[A-Z0-9]{2,5}$'),
+  constraint airport_metadata_cache_country_format
+    check (country = '' or country ~ '^[A-Z]{2}$'),
+  constraint airport_metadata_cache_location_range
+    check (lat between -90 and 90 and lon between -180 and 180)
+);
+
+create index if not exists airport_metadata_cache_expires_at_idx
+  on public.airport_metadata_cache (expires_at);
+
+create index if not exists airport_metadata_cache_country_type_idx
+  on public.airport_metadata_cache (country, type);
+
+alter table public.airport_metadata_cache enable row level security;
+
+grant select, insert, update, delete on table public.airport_metadata_cache to service_role;
+grant select, insert, update on table public.airport_metadata_cache to anon;
+
+drop policy if exists "Airport metadata cache rows are readable"
+  on public.airport_metadata_cache;
+
+create policy "Airport metadata cache rows are readable"
+on public.airport_metadata_cache
+for select
+to anon
+using (true);
+
+drop policy if exists "Airport metadata cache rows can be inserted"
+  on public.airport_metadata_cache;
+
+create policy "Airport metadata cache rows can be inserted"
+on public.airport_metadata_cache
+for insert
+to anon
+with check (
+  airport_key ~ '^[A-Z0-9][A-Z0-9 -]{1,120}$'
+  and icao ~ '^[A-Z0-9]{3,6}$'
+  and name <> ''
+  and jsonb_typeof(metadata) = 'object'
+  and lat between -90 and 90
+  and lon between -180 and 180
+  and expires_at > timezone('utc', now())
+  and expires_at <= timezone('utc', now()) + interval '90 days' + interval '5 minutes'
+);
+
+drop policy if exists "Airport metadata cache rows can be updated"
+  on public.airport_metadata_cache;
+
+create policy "Airport metadata cache rows can be updated"
+on public.airport_metadata_cache
+for update
+to anon
+using (airport_key ~ '^[A-Z0-9][A-Z0-9 -]{1,120}$')
+with check (
+  airport_key ~ '^[A-Z0-9][A-Z0-9 -]{1,120}$'
+  and icao ~ '^[A-Z0-9]{3,6}$'
+  and name <> ''
+  and jsonb_typeof(metadata) = 'object'
+  and lat between -90 and 90
+  and lon between -180 and 180
+  and expires_at > timezone('utc', now())
+  and expires_at <= timezone('utc', now()) + interval '90 days' + interval '5 minutes'
+);
+
+create or replace function public.set_airport_metadata_cache_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+revoke execute on function public.set_airport_metadata_cache_updated_at()
+  from public, anon, authenticated;
+
+drop trigger if exists airport_metadata_cache_set_updated_at
+  on public.airport_metadata_cache;
+
+create trigger airport_metadata_cache_set_updated_at
+before update on public.airport_metadata_cache
+for each row
+execute function public.set_airport_metadata_cache_updated_at();


### PR DESCRIPTION
## Summary

- Add Supabase-backed caches for nearby-airport responses and airport metadata, with 90-day TTL handling and project migrations.
- Wire the nearby airport proxy and airport directory client through the cache layer while preserving public-source fallbacks.
- Normalize audit log output to `[audit:{endpoint_path}]: {response_code} +{latency}ms` and simplify the flight-route queue log text.
- Document required Supabase env vars and architecture notes for Vercel Preview/Production.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- Supabase migrations were pushed to project `vqjvtpqryblqwrbsaxwb` earlier in this branch setup.
- Vercel env vars `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` are present for Production and Preview.