### PR TITLE
[codex] Infer active leg for round-trip routes

### DIFF
--- a/src/features/airport-explorer/airportExplorerModel.js
+++ b/src/features/airport-explorer/airportExplorerModel.js
@@ -30,7 +30,10 @@ export function enrichAircraftWithRoutes({
   const aircraftWithRoutes = aircraft.map((item) => {
     const key = normalizeCallsign(item.callsign);
     const route = routesByCallsign[key] || null;
-    const movement = resolveMovement(route, airportProfile?.icao, airportProfile?.iata);
+    const movement = resolveMovement(route, airportProfile?.icao, airportProfile?.iata, {
+      aircraft: item,
+      airport: airportProfile,
+    });
 
     return {
       ...item,

--- a/src/features/airport-explorer/airportExplorerModel.test.js
+++ b/src/features/airport-explorer/airportExplorerModel.test.js
@@ -62,3 +62,52 @@ assert.equal(enriched[1].airportContext.movement, "arrival");
 assert.equal(enriched[2].movement, UNKNOWN);
 assert.equal(enriched[2].flightRouteLabel, "JFK -> ORD");
 assert.equal(enriched[2].airportContext.movement, "unknown");
+
+const ordProfile = resolveAirportProfile({ icao: "kord" });
+const roundTripRoute = {
+  origin: { icao: "KORD", iata: "ORD" },
+  destination: { icao: "KORD", iata: "ORD" },
+  airports: [
+    { icao: "KORD", iata: "ORD", lat: 41.9786, lon: -87.9048 },
+    { icao: "KMDT", iata: "MDT", lat: 40.1935, lon: -76.763397 },
+    { icao: "KORD", iata: "ORD", lat: 41.9786, lon: -87.9048 },
+  ],
+};
+
+const roundTripEnriched = enrichAircraftWithRoutes({
+  airportProfile: ordProfile,
+  aircraft: [
+    {
+      icao24: "rt1",
+      callsign: "AAL3243",
+      lat: 42.05,
+      lon: -88.6,
+      track: 96,
+    },
+    {
+      icao24: "rt2",
+      callsign: "AAL3244",
+      lat: 42.05,
+      lon: -88.6,
+      track: 276,
+    },
+    {
+      icao24: "rt3",
+      callsign: "AAL3245",
+      lat: 42.05,
+      lon: -88.6,
+    },
+  ],
+  routesByCallsign: {
+    AAL3243: roundTripRoute,
+    AAL3244: roundTripRoute,
+    AAL3245: roundTripRoute,
+  },
+});
+
+assert.equal(roundTripEnriched[0].movement, ARRIVAL);
+assert.equal(roundTripEnriched[0].airportContext.movement, "arrival");
+assert.equal(roundTripEnriched[1].movement, DEPARTURE);
+assert.equal(roundTripEnriched[1].airportContext.movement, "departure");
+assert.equal(roundTripEnriched[2].movement, UNKNOWN);
+assert.equal(roundTripEnriched[2].airportContext.movement, "unknown");

--- a/src/utils/aircraftMovement.js
+++ b/src/utils/aircraftMovement.js
@@ -2,16 +2,118 @@ export const DEPARTURE = "DEPARTURE";
 export const ARRIVAL = "ARRIVAL";
 export const UNKNOWN = "UNKNOWN";
 
+const ROUND_TRIP_TRACK_ALIGNMENT_DEG = 75;
+
+const toFiniteNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+const toRadians = (degrees) => (degrees * Math.PI) / 180;
+
+const toDegrees = (radians) => (radians * 180) / Math.PI;
+
+const normalizeHeading = (value) => {
+  const heading = toFiniteNumber(value);
+  if (heading == null) return null;
+  return ((heading % 360) + 360) % 360;
+};
+
+const angularDelta = (a, b) => {
+  const headingA = normalizeHeading(a);
+  const headingB = normalizeHeading(b);
+  if (headingA == null || headingB == null) return null;
+  const delta = Math.abs(headingA - headingB) % 360;
+  return delta > 180 ? 360 - delta : delta;
+};
+
+const bearingDegrees = (fromLat, fromLon, toLat, toLon) => {
+  const lat1 = toFiniteNumber(fromLat);
+  const lon1 = toFiniteNumber(fromLon);
+  const lat2 = toFiniteNumber(toLat);
+  const lon2 = toFiniteNumber(toLon);
+  if (lat1 == null || lon1 == null || lat2 == null || lon2 == null) {
+    return null;
+  }
+
+  const phi1 = toRadians(lat1);
+  const phi2 = toRadians(lat2);
+  const lambdaDelta = toRadians(lon2 - lon1);
+  const y = Math.sin(lambdaDelta) * Math.cos(phi2);
+  const x =
+    Math.cos(phi1) * Math.sin(phi2) -
+    Math.sin(phi1) * Math.cos(phi2) * Math.cos(lambdaDelta);
+
+  return normalizeHeading(toDegrees(Math.atan2(y, x)));
+};
+
+const normalizeIntentMovement = (value) => {
+  const intent = String(value || "").toLowerCase();
+  if (intent === "arrival") return ARRIVAL;
+  if (intent === "departure") return DEPARTURE;
+  return UNKNOWN;
+};
+
+function resolveSameAirportMovement(route, aircraft, airport) {
+  const intentMovement = normalizeIntentMovement(aircraft?.trafficIntent);
+  if (intentMovement !== UNKNOWN) return intentMovement;
+
+  const track = normalizeHeading(aircraft?.track);
+  const aircraftLat = toFiniteNumber(aircraft?.lat);
+  const aircraftLon = toFiniteNumber(aircraft?.lon);
+  const airportLat = toFiniteNumber(
+    airport?.lat ?? route?.destination?.lat ?? route?.origin?.lat,
+  );
+  const airportLon = toFiniteNumber(
+    airport?.lon ?? route?.destination?.lon ?? route?.origin?.lon,
+  );
+  if (
+    track == null ||
+    aircraftLat == null ||
+    aircraftLon == null ||
+    airportLat == null ||
+    airportLon == null
+  ) {
+    return UNKNOWN;
+  }
+
+  const toAirport = bearingDegrees(aircraftLat, aircraftLon, airportLat, airportLon);
+  const awayFromAirport = normalizeHeading(toAirport + 180);
+  const arrivalDelta = angularDelta(track, toAirport);
+  const departureDelta = angularDelta(track, awayFromAirport);
+
+  if (
+    arrivalDelta != null &&
+    departureDelta != null &&
+    arrivalDelta <= ROUND_TRIP_TRACK_ALIGNMENT_DEG &&
+    arrivalDelta < departureDelta
+  ) {
+    return ARRIVAL;
+  }
+
+  if (
+    arrivalDelta != null &&
+    departureDelta != null &&
+    departureDelta <= ROUND_TRIP_TRACK_ALIGNMENT_DEG &&
+    departureDelta < arrivalDelta
+  ) {
+    return DEPARTURE;
+  }
+
+  return UNKNOWN;
+}
+
 /**
- * Resolve an aircraft's movement at this airport using only its flight route.
- * Origin ICAO/IATA match → DEPARTURE; destination match → ARRIVAL; else UNKNOWN.
+ * Resolve an aircraft's movement at this airport.
+ * Simple routes use origin/destination matches. Same-airport round trips use
+ * current aircraft intent/track to infer the active leg.
  *
  * @param {object|null} route - route with origin.icao/iata and destination.icao/iata
  * @param {string} currentIcao - ICAO of the viewed airport
  * @param {string|null} currentIata - IATA of the viewed airport (optional)
  * @returns {"DEPARTURE"|"ARRIVAL"|"UNKNOWN"}
  */
-export function resolveMovement(route, currentIcao, currentIata = null) {
+export function resolveMovement(route, currentIcao, currentIata = null, context = {}) {
   if (!route || !currentIcao) return UNKNOWN;
   const icao = currentIcao.toUpperCase();
   const iata = currentIata ? String(currentIata).toUpperCase() : null;
@@ -25,6 +127,14 @@ export function resolveMovement(route, currentIcao, currentIata = null) {
     originIcao === icao || (iata && originIata === iata && originIata !== "");
   const isDest =
     destIcao === icao || (iata && destIata === iata && destIata !== "");
+
+  if (isOrigin && isDest) {
+    return resolveSameAirportMovement(route, context.aircraft, {
+      ...context.airport,
+      icao,
+      iata,
+    });
+  }
 
   if (isOrigin) return DEPARTURE;
   if (isDest) return ARRIVAL;


### PR DESCRIPTION
## Summary

- Treat same-origin/same-destination flight routes as ambiguous instead of automatically marking them as departures.
- Pass aircraft position/track into route movement resolution so round-trip routes like `ORD-MDT-ORD` can infer the active leg.
- Use traffic intent first when available, then compare aircraft track against the bearing toward/away from the viewed airport.
- Add coverage for round-trip routes where track toward the viewed airport becomes `ARR`, track away becomes `DEP`, and missing track stays `UNKNOWN`.

## Validation

- `node src/features/airport-explorer/airportExplorerModel.test.js`
- `node src/features/airport-context/airportContextModel.test.js`
- `node src/utils/flightRouteDisplay.test.js`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- Live sanity check against current ORD data classified visible `AAL3243` (`ORD-MDT-ORD`) as `ARRIVAL` based on track toward ORD.