### PR TITLE
[codex] Add AeroDataBox route fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 NEXT_PUBLIC_SUPABASE_URL=https://vqjvtpqryblqwrbsaxwb.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_ieVPDaMnd4swiHGoJ66OOA_77ZOpwfr
+AERODATABOX_RAPIDAPI_KEY=
+AERODATABOX_RAPIDAPI_HOST=aerodatabox.p.rapidapi.com

--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
@@ -9,9 +9,20 @@ import {
   buildVrsRouteResponse,
   buildVrsRouteUrl,
   normalizeRouteCallsign,
+  shouldUseAerodataboxFallback,
   VRS_ROUTE_MISS_STATUS,
   VRS_ROUTE_USER_AGENT,
 } from "@/services/aviation/vrsRouteProxyModel.js";
+import {
+  AERODATABOX_RAPIDAPI_HOST,
+  buildAerodataboxFlightRouteResponse,
+  buildAerodataboxFlightUrl,
+  resolveAerodataboxDateLocal,
+} from "@/services/aviation/aerodataboxRouteProxyModel.js";
+
+const aerodataboxRapidApiKey = process.env.AERODATABOX_RAPIDAPI_KEY || "";
+const aerodataboxRapidApiHost =
+  process.env.AERODATABOX_RAPIDAPI_HOST || AERODATABOX_RAPIDAPI_HOST;
 
 async function fetchVrsStandingRoute(callsign) {
   let response;
@@ -44,6 +55,49 @@ async function fetchVrsStandingRoute(callsign) {
   return buildVrsRouteResponse(callsign, payload);
 }
 
+async function fetchAerodataboxRoute(callsign, targetAirport) {
+  if (!aerodataboxRapidApiKey) return null;
+
+  const url = buildAerodataboxFlightUrl(callsign, resolveAerodataboxDateLocal());
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "X-RapidAPI-Key": aerodataboxRapidApiKey,
+        "X-RapidAPI-Host": aerodataboxRapidApiHost,
+      },
+      signal: AbortSignal.timeout(9_000),
+    });
+  } catch (err) {
+    console.warn(`[aerodatabox-route] fetch failed for ${callsign}:`, err.message);
+    return null;
+  }
+
+  if (response.status === 204 || response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    console.warn(`[aerodatabox-route] HTTP ${response.status} for ${callsign}`);
+    return null;
+  }
+
+  const payload = await readResponseJson(response, {
+    label: "AeroDataBox flight status route",
+    maxBytes: 512 * 1024,
+  });
+  return buildAerodataboxFlightRouteResponse(callsign, payload, targetAirport);
+}
+
+function getTargetAirport(request) {
+  const params = request.nextUrl?.searchParams;
+  return {
+    icao: params?.get("airportIcao") || params?.get("airport") || "",
+    iata: params?.get("airportIata") || "",
+  };
+}
+
 const rateLimit = {
   key: "proxy:flight-routes",
   maxRequests: 360,
@@ -70,7 +124,11 @@ export async function GET(request, { params }) {
   }
 
   try {
-    const body = await fetchVrsStandingRoute(callsign);
+    const targetAirport = getTargetAirport(request);
+    let body = await fetchVrsStandingRoute(callsign);
+    if (shouldUseAerodataboxFallback(body, targetAirport)) {
+      body = (await fetchAerodataboxRoute(callsign, targetAirport)) || body;
+    }
 
     return Response.json(body, {
       status: body ? 200 : VRS_ROUTE_MISS_STATUS,

--- a/src/features/airport-explorer/useAirportExplorerData.js
+++ b/src/features/airport-explorer/useAirportExplorerData.js
@@ -24,7 +24,7 @@ export function useAirportExplorerData(airportProfile) {
     airportProfile.lon,
   );
   const { routesByCallsign, loadingCount: routeLoadingCount } =
-    useFlightRoutes(aircraft);
+    useFlightRoutes(aircraft, airportProfile);
 
   const aircraftWithRoutes = useMemo(
     () =>

--- a/src/features/flight-routes/flightRouteLookupModel.js
+++ b/src/features/flight-routes/flightRouteLookupModel.js
@@ -1,14 +1,35 @@
 import { FLIGHT_ROUTE_LOOKUP_CONFIG } from "../../config/aviation.js";
 import { isLookupCallsign, normalizeCallsign } from "../../utils/callsign.js";
 
-export function getFreshRouteCacheEntry(cache, callsign, now = Date.now()) {
-  const cached = cache.get(callsign);
+const routeContextCode = (value) =>
+  String(value || "")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+export function buildRouteCacheKey(callsign, routeContext = {}) {
+  const normalizedCallsign = normalizeCallsign(callsign);
+  if (!normalizedCallsign) return "";
+  const airportIcao = routeContextCode(routeContext.icao);
+  const airportIata = routeContextCode(routeContext.iata);
+  const suffix = [airportIcao, airportIata].filter(Boolean).join("|");
+  return suffix ? `${normalizedCallsign}|${suffix}` : normalizedCallsign;
+}
+
+export function getFreshRouteCacheEntry(
+  cache,
+  callsign,
+  now = Date.now(),
+  routeContext = {},
+) {
+  const cacheKey = buildRouteCacheKey(callsign, routeContext);
+  const cached = cache.get(cacheKey);
   if (!cached) return null;
   const maxAge = cached.route
     ? FLIGHT_ROUTE_LOOKUP_CONFIG.hitCacheMs
     : FLIGHT_ROUTE_LOOKUP_CONFIG.missCacheMs;
   if (now - cached.time <= maxAge) return cached;
-  cache.delete(callsign);
+  cache.delete(cacheKey);
   return null;
 }
 
@@ -27,13 +48,14 @@ export function resolvePendingRouteLookups({
   cache,
   inFlight,
   queued = new Set(),
+  routeContext = {},
   now = Date.now(),
   maxLookups = FLIGHT_ROUTE_LOOKUP_CONFIG.maxLookupsPerPass,
 }) {
   return getLookupCallsigns(aircraft)
     .filter(
       (callsign) =>
-        !getFreshRouteCacheEntry(cache, callsign, now) &&
+        !getFreshRouteCacheEntry(cache, callsign, now, routeContext) &&
         !inFlight.has(callsign) &&
         !queued.has(callsign),
     )
@@ -45,6 +67,7 @@ export function getRouteLookupStats({
   cache,
   queued = new Set(),
   inFlight = new Set(),
+  routeContext = {},
   now = Date.now(),
 }) {
   const callsigns = getLookupCallsigns(aircraft);
@@ -52,7 +75,7 @@ export function getRouteLookupStats({
   let notDone = 0;
 
   for (const callsign of callsigns) {
-    const cached = getFreshRouteCacheEntry(cache, callsign, now);
+    const cached = getFreshRouteCacheEntry(cache, callsign, now, routeContext);
     if (cached) {
       done += 1;
     } else if (!queued.has(callsign) && !inFlight.has(callsign)) {
@@ -68,11 +91,16 @@ export function getRouteLookupStats({
   };
 }
 
-export function buildRoutesByCallsign({ aircraft, cache, now = Date.now() }) {
+export function buildRoutesByCallsign({
+  aircraft,
+  cache,
+  routeContext = {},
+  now = Date.now(),
+}) {
   const routes = {};
   for (const item of aircraft || []) {
     const callsign = normalizeCallsign(item.callsign);
-    const cached = getFreshRouteCacheEntry(cache, callsign, now);
+    const cached = getFreshRouteCacheEntry(cache, callsign, now, routeContext);
     if (cached?.route) routes[callsign] = cached.route;
   }
   return routes;

--- a/src/features/flight-routes/flightRouteLookupModel.test.js
+++ b/src/features/flight-routes/flightRouteLookupModel.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  buildRouteCacheKey,
   buildRoutesByCallsign,
   getRouteLookupStats,
   getFreshRouteCacheEntry,
@@ -15,13 +16,32 @@ const route = {
 };
 
 {
+  assert.equal(
+    buildRouteCacheKey("dal123", { icao: "kbos", iata: "bos" }),
+    "DAL123|KBOS|BOS",
+  );
+
   const cache = new Map([
-    ["DAL123", { route, time: now - 1_000 }],
+    ["DAL123|KBOS|BOS", { route, time: now - 1_000 }],
+    ["DAL123|KJFK|JFK", { route: null, time: now - 1_000 }],
     ["MISS1", { route: null, time: now - 1_000 }],
     ["OLD", { route, time: now - 10 * 60 * 60 * 1000 }],
   ]);
 
-  assert.equal(getFreshRouteCacheEntry(cache, "DAL123", now)?.route, route);
+  assert.equal(
+    getFreshRouteCacheEntry(cache, "DAL123", now, {
+      icao: "KBOS",
+      iata: "BOS",
+    })?.route,
+    route,
+  );
+  assert.equal(
+    getFreshRouteCacheEntry(cache, "DAL123", now, {
+      icao: "KJFK",
+      iata: "JFK",
+    })?.route,
+    null,
+  );
   assert.equal(getFreshRouteCacheEntry(cache, "MISS1", now)?.route, null);
   assert.equal(getFreshRouteCacheEntry(cache, "OLD", now), null);
   assert.equal(cache.has("OLD"), false);

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  buildRouteCacheKey,
   buildRoutesByCallsign,
   getRouteLookupStats,
   resolvePendingRouteLookups,
@@ -19,6 +20,7 @@ let lastLookupStartedAt = 0;
 let lastAuditLoggedAt = 0;
 let lastAuditSnapshot = "";
 let latestAircraft = [];
+let latestRouteContext = {};
 
 function getAuditPayload() {
   const stats = getRouteLookupStats({
@@ -26,6 +28,7 @@ function getAuditPayload() {
     cache: routeCache,
     queued,
     inFlight,
+    routeContext: latestRouteContext,
     now: Date.now(),
   });
   return stats;
@@ -61,10 +64,17 @@ function auditRouteQueue() {
   console.info(formatFlightRouteQueueAudit(payload));
 }
 
-export function useFlightRoutes(aircraft) {
+export function useFlightRoutes(aircraft, routeContextInput = {}) {
   const [version, setVersion] = useState(0);
   const [loadingCount, setLoadingCount] = useState(0);
   const mountedRef = useRef(true);
+  const routeContext = useMemo(
+    () => ({
+      icao: routeContextInput?.icao || "",
+      iata: routeContextInput?.iata || "",
+    }),
+    [routeContextInput?.icao, routeContextInput?.iata],
+  );
 
   useEffect(() => {
     return () => {
@@ -74,6 +84,7 @@ export function useFlightRoutes(aircraft) {
 
   useEffect(() => {
     latestAircraft = aircraft;
+    latestRouteContext = routeContext;
 
     const bump = () => {
       if (mountedRef.current) setVersion((value) => value + 1);
@@ -96,12 +107,21 @@ export function useFlightRoutes(aircraft) {
       updateLoadingCount();
       auditRouteQueue();
       try {
-        const route = await flightRouteClient.fetchFlightRoute(callsign);
-        routeCache.set(callsign, { route, time: Date.now() });
+        const route = await flightRouteClient.fetchFlightRoute(
+          callsign,
+          routeContext,
+        );
+        routeCache.set(buildRouteCacheKey(callsign, routeContext), {
+          route,
+          time: Date.now(),
+        });
         auditRouteQueue();
       } catch (error) {
         console.warn(`Flight route lookup failed for ${callsign}:`, error.message);
-        routeCache.set(callsign, { route: null, time: Date.now() });
+        routeCache.set(buildRouteCacheKey(callsign, routeContext), {
+          route: null,
+          time: Date.now(),
+        });
         auditRouteQueue();
       } finally {
         inFlight.delete(callsign);
@@ -151,6 +171,7 @@ export function useFlightRoutes(aircraft) {
       cache: routeCache,
       inFlight,
       queued,
+      routeContext,
       now: Date.now(),
       maxLookups: Math.min(
         FLIGHT_ROUTE_LOOKUP_CONFIG.maxLookupsPerPass,
@@ -170,16 +191,17 @@ export function useFlightRoutes(aircraft) {
     }
 
     bump();
-  }, [aircraft]);
+  }, [aircraft, routeContext]);
 
   const routesByCallsign = useMemo(() => {
     version;
     return buildRoutesByCallsign({
       aircraft,
       cache: routeCache,
+      routeContext,
       now: Date.now(),
     });
-  }, [aircraft, version]);
+  }, [aircraft, routeContext, version]);
 
   return { routesByCallsign, loadingCount };
 }

--- a/src/services/aviation/aerodataboxRouteProxyModel.js
+++ b/src/services/aviation/aerodataboxRouteProxyModel.js
@@ -1,0 +1,145 @@
+export const AERODATABOX_RAPIDAPI_BASE =
+  "https://aerodatabox.p.rapidapi.com";
+
+export const AERODATABOX_RAPIDAPI_HOST = "aerodatabox.p.rapidapi.com";
+
+const cleanString = (value) => String(value || "").trim();
+
+const cleanUpper = (value) => cleanString(value).toUpperCase();
+
+const numberOrNull = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+};
+
+const inRange = (value, { min, max }) =>
+  Number.isFinite(value) && value >= min && value <= max;
+
+const sanitizeCode = (value, { min = 2, max = 4 } = {}) => {
+  const code = cleanUpper(value);
+  return new RegExp(`^[A-Z0-9]{${min},${max}}$`).test(code) ? code : "";
+};
+
+function normalizeAirport(airport) {
+  const location = airport?.location || {};
+  const lat = numberOrNull(location.lat ?? location.latitude ?? airport?.lat);
+  const lon = numberOrNull(location.lon ?? location.longitude ?? airport?.lon);
+  const icao = sanitizeCode(airport?.icao, { min: 3, max: 4 });
+  const iata = sanitizeCode(airport?.iata, { min: 3, max: 3 });
+
+  if (
+    !icao ||
+    !inRange(lat, { min: -90, max: 90 }) ||
+    !inRange(lon, { min: -180, max: 180 })
+  ) {
+    return null;
+  }
+
+  return {
+    icao,
+    iata,
+    name: cleanString(airport?.name || airport?.shortName),
+    municipality: cleanString(
+      airport?.municipalityName || airport?.municipality,
+    ),
+    country: cleanUpper(airport?.countryCode || airport?.country),
+    lat,
+    lon,
+  };
+}
+
+export function resolveAerodataboxDateLocal(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}
+
+export function buildAerodataboxFlightUrl(callsign, dateLocal) {
+  const normalizedCallsign = cleanUpper(callsign).replace(/\s+/g, "");
+  const url = new URL(
+    `/flights/CallSign/${encodeURIComponent(normalizedCallsign)}/${encodeURIComponent(dateLocal)}`,
+    AERODATABOX_RAPIDAPI_BASE,
+  );
+  url.searchParams.set("dateLocalRole", "Both");
+  url.searchParams.set("withAircraftImage", "false");
+  url.searchParams.set("withLocation", "false");
+  url.searchParams.set("withFlightPlan", "false");
+  return url.toString();
+}
+
+function airportMatchesTarget(airport, targetAirport = {}) {
+  const targetIcao = sanitizeCode(targetAirport.icao, { min: 3, max: 4 });
+  const targetIata = sanitizeCode(targetAirport.iata, { min: 3, max: 3 });
+  if (!targetIcao && !targetIata) return true;
+  return (
+    (targetIcao && airport?.icao === targetIcao) ||
+    (targetIata && airport?.iata === targetIata)
+  );
+}
+
+function flightMatchesCallsign(flight, callsign) {
+  const normalizedCallsign = cleanUpper(callsign).replace(/\s+/g, "");
+  const flightCallsign = cleanUpper(flight?.callSign).replace(/\s+/g, "");
+  return !flightCallsign || flightCallsign === normalizedCallsign;
+}
+
+function cleanFlightNumber(number, airline = {}) {
+  let normalized = cleanUpper(number).replace(/\s+/g, "");
+  const airlineCodes = [
+    sanitizeCode(airline.iata, { min: 2, max: 2 }),
+    sanitizeCode(airline.icao, { min: 2, max: 3 }),
+  ].filter(Boolean);
+  for (const code of airlineCodes) {
+    if (normalized.startsWith(code)) {
+      normalized = normalized.slice(code.length);
+      break;
+    }
+  }
+  return normalized || cleanString(number);
+}
+
+export function buildAerodataboxFlightRouteResponse(
+  callsign,
+  payload,
+  targetAirport = {},
+) {
+  const flights = Array.isArray(payload) ? payload : payload ? [payload] : [];
+  const normalizedCallsign = cleanUpper(callsign).replace(/\s+/g, "");
+  if (!normalizedCallsign) return null;
+
+  for (const flight of flights) {
+    if (!flightMatchesCallsign(flight, normalizedCallsign)) continue;
+
+    const origin = normalizeAirport(flight?.departure?.airport);
+    const destination = normalizeAirport(flight?.arrival?.airport);
+    if (!origin || !destination) continue;
+    if (
+      !airportMatchesTarget(origin, targetAirport) &&
+      !airportMatchesTarget(destination, targetAirport)
+    ) {
+      continue;
+    }
+
+    return {
+      callsign:
+        cleanUpper(flight?.callSign).replace(/\s+/g, "") || normalizedCallsign,
+      number: cleanFlightNumber(flight?.number, flight?.airline),
+      airline: {
+        icao: sanitizeCode(flight?.airline?.icao, { min: 2, max: 3 }),
+        iata: sanitizeCode(flight?.airline?.iata, { min: 2, max: 2 }),
+        name: cleanString(flight?.airline?.name),
+        callsign: "",
+        iconUrl: "",
+      },
+      origin,
+      destination,
+      route: {
+        icao: `${origin.icao}-${destination.icao}`,
+        iata: origin.iata && destination.iata ? `${origin.iata}-${destination.iata}` : "",
+      },
+      airports: [origin, destination],
+      source: "aerodatabox",
+      confidence: "flight-status",
+    };
+  }
+
+  return null;
+}

--- a/src/services/aviation/aerodataboxRouteProxyModel.test.js
+++ b/src/services/aviation/aerodataboxRouteProxyModel.test.js
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+
+import {
+  buildAerodataboxFlightRouteResponse,
+  buildAerodataboxFlightUrl,
+  resolveAerodataboxDateLocal,
+} from "./aerodataboxRouteProxyModel.js";
+
+assert.equal(
+  resolveAerodataboxDateLocal(new Date("2026-05-10T23:55:00Z")),
+  "2026-05-10",
+);
+assert.equal(
+  buildAerodataboxFlightUrl(" dal123 ", "2026-05-10"),
+  "https://aerodatabox.p.rapidapi.com/flights/CallSign/DAL123/2026-05-10?dateLocalRole=Both&withAircraftImage=false&withLocation=false&withFlightPlan=false",
+);
+
+const aerodataboxFlights = [
+  {
+    number: "BA 213",
+    callSign: "BAW213",
+    airline: {
+      name: "British Airways",
+      iata: "BA",
+      icao: "BAW",
+    },
+    departure: {
+      airport: {
+        icao: "EGLL",
+        iata: "LHR",
+        name: "London Heathrow Airport",
+        municipalityName: "London",
+        countryCode: "GB",
+        location: { lat: 51.4706, lon: -0.461941 },
+      },
+    },
+    arrival: {
+      airport: {
+        icao: "KBOS",
+        iata: "BOS",
+        name: "Boston Logan International Airport",
+        municipalityName: "Boston",
+        countryCode: "US",
+        location: { lat: 42.3643, lon: -71.0052 },
+      },
+    },
+  },
+];
+
+const route = buildAerodataboxFlightRouteResponse("BAW213", aerodataboxFlights, {
+  icao: "KBOS",
+  iata: "BOS",
+});
+
+assert.equal(route.callsign, "BAW213");
+assert.equal(route.number, "213");
+assert.equal(route.airline.icao, "BAW");
+assert.equal(route.airline.iata, "BA");
+assert.equal(route.origin.icao, "EGLL");
+assert.equal(route.destination.icao, "KBOS");
+assert.equal(route.route.icao, "EGLL-KBOS");
+assert.equal(route.route.iata, "LHR-BOS");
+assert.equal(route.airports.length, 2);
+assert.equal(route.source, "aerodatabox");
+assert.equal(route.confidence, "flight-status");
+
+assert.equal(
+  buildAerodataboxFlightRouteResponse("BAW213", aerodataboxFlights, {
+    icao: "KJFK",
+    iata: "JFK",
+  }),
+  null,
+);

--- a/src/services/aviation/flightRouteClient.js
+++ b/src/services/aviation/flightRouteClient.js
@@ -29,15 +29,26 @@ export const createFlightRouteClient = ({
 
   let consecutiveBackoffMs = 0;
 
+  const routeUrl = (callsign, targetAirport = {}) => {
+    const params = new URLSearchParams();
+    const airportIcao = normalizeCallsign(targetAirport.icao || "");
+    const airportIata = normalizeCallsign(targetAirport.iata || "");
+    if (airportIcao) params.set("airportIcao", airportIcao);
+    if (airportIata) params.set("airportIata", airportIata);
+    const query = params.toString();
+    return `${baseUrl}/${encodeURIComponent(callsign)}${query ? `?${query}` : ""}`;
+  };
+
   return {
-    async fetchFlightRoute(callsign) {
+    async fetchFlightRoute(callsign, targetAirport = {}) {
       const normalized = normalizeCallsign(callsign);
       if (!normalized) return null;
 
       await limiter.acquire();
 
+      const url = routeUrl(normalized, targetAirport);
       const response = await auditedFetch(
-        `${baseUrl}/${encodeURIComponent(normalized)}`,
+        url,
         {
           signal: createTimeoutSignal(AVIATION_REQUEST_TIMEOUT_MS.flightRoute),
           headers: {
@@ -74,7 +85,7 @@ export const createFlightRouteClient = ({
       try {
         return normalizeFlightRoute(JSON.parse(body));
       } catch {
-        throw new Error(`Expected JSON from ${baseUrl}/${normalized}`);
+        throw new Error(`Expected JSON from ${url}`);
       }
     },
   };

--- a/src/services/aviation/vrsRouteProxyModel.js
+++ b/src/services/aviation/vrsRouteProxyModel.js
@@ -69,6 +69,25 @@ const cleanRouteCode = (value) => {
   return route;
 };
 
+const airportMatchesTarget = (airport, targetAirport = {}) => {
+  const targetIcao = sanitizeAirportCode(targetAirport.icao, { min: 3, max: 4 });
+  const targetIata = sanitizeAirportCode(targetAirport.iata, { min: 3, max: 3 });
+  if (!targetIcao && !targetIata) return true;
+  return (
+    (targetIcao && airport?.icao === targetIcao) ||
+    (targetIata && airport?.iata === targetIata)
+  );
+};
+
+export function shouldUseAerodataboxFallback(route, targetAirport = {}) {
+  if (!route) return false;
+  if (Array.isArray(route.airports) && route.airports.length > 2) return true;
+  return (
+    !airportMatchesTarget(route.origin, targetAirport) &&
+    !airportMatchesTarget(route.destination, targetAirport)
+  );
+}
+
 export function buildVrsRouteResponse(callsign, payload) {
   const normalizedCallsign = normalizeRouteCallsign(
     payload?.callsign || callsign,

--- a/src/services/aviation/vrsRouteProxyModel.test.js
+++ b/src/services/aviation/vrsRouteProxyModel.test.js
@@ -4,6 +4,7 @@ import {
   buildVrsRouteResponse,
   buildVrsRouteUrl,
   normalizeRouteCallsign,
+  shouldUseAerodataboxFallback,
   VRS_ROUTE_MISS_STATUS,
 } from "./vrsRouteProxyModel.js";
 
@@ -76,6 +77,27 @@ const multiLeg = buildVrsRouteResponse("BAW123", {
 assert.equal(multiLeg.origin.icao, "EGLL");
 assert.equal(multiLeg.destination.icao, "KJFK");
 assert.equal(multiLeg.airports[1].icao, "KBOS");
+assert.equal(
+  shouldUseAerodataboxFallback(multiLeg, {
+    icao: "KBOS",
+    iata: "BOS",
+  }),
+  true,
+);
+assert.equal(
+  shouldUseAerodataboxFallback(response, {
+    icao: "EHAM",
+    iata: "AMS",
+  }),
+  false,
+);
+assert.equal(
+  shouldUseAerodataboxFallback(response, {
+    icao: "KBOS",
+    iata: "BOS",
+  }),
+  true,
+);
 
 assert.equal(
   buildVrsRouteResponse("NOPE123", {

--- a/src/services/aviationData.test.js
+++ b/src/services/aviationData.test.js
@@ -270,10 +270,16 @@ try {
     },
   });
 
-  const route = await client.fetchFlightRoute(" baw213 ");
+  const route = await client.fetchFlightRoute(" baw213 ", {
+    icao: "KBOS",
+    iata: "BOS",
+  });
 
   assert.equal(calls.length, 1);
-  assert.equal(calls[0], "/api/proxy/flight-routes/callsign/BAW213");
+  assert.equal(
+    calls[0],
+    "/api/proxy/flight-routes/callsign/BAW213?airportIcao=KBOS&airportIata=BOS",
+  );
   assert.equal(route.origin.iata, "LHR");
   assert.equal(route.destination.icao, "KBOS");
 }


### PR DESCRIPTION
## Summary
- keep VRS standing-data as the primary route source
- call AeroDataBox Flight Status through RapidAPI only when VRS returns a multileg route or route endpoints miss the current airport
- pass the airport ICAO/IATA into the route proxy while keeping the RapidAPI key server-side via AERODATABOX_RAPIDAPI_KEY
- scope route cache entries by airport context so fallback decisions do not leak across airport pages
- document the required AeroDataBox env vars in .env.example

## Validation
- pnpm test
- pnpm build
- local .env.local contains AERODATABOX_RAPIDAPI_KEY and AERODATABOX_RAPIDAPI_HOST
- Vercel env vars are configured for Production, Development, and Preview branch codex/aerodatabox-route-fallback

## Notes
- AeroDataBox endpoint used: GET /flights/CallSign/{callsign}/{dateLocal}?dateLocalRole=Both&withAircraftImage=false&withLocation=false&withFlightPlan=false
- The RapidAPI key is not committed; it is stored only in local .env.local and Vercel environment variables.