### PR TITLE
[codex] Update airport sidebar layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@number-flow/react": "^0.5.0",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-separator':
         specifier: ^1.1.8
         version: 1.1.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -74,7 +74,7 @@ export default function RootLayout({ children }) {
           crossOrigin=""
         />
         <link
-          href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Manrope:wght@200..800&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Manrope:wght@200..800&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -4,6 +4,15 @@ import { useMemo, useState } from "react";
 import NumberFlow from "@number-flow/react";
 import { Search } from "lucide-react";
 import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import {
   getAircraftIdentity,
   getContextTagLabel,
   getAircraftContextGroup,
@@ -90,35 +99,27 @@ export default function AircraftTable({
               ))}
             </div>
             <div className="aircraft-filter-select-row">
-              <label className="aircraft-filter-select">
-                <span>Type</span>
-                <select
-                  value={typeFilter}
-                  onChange={(event) => setTypeFilter(event.target.value)}
-                  aria-label="Filter by aircraft type"
-                >
-                  <option value="all">All types</option>
-                  {aircraftTypes.map((type) => (
-                    <option key={type} value={type}>
-                      {type}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="aircraft-filter-select aircraft-filter-select--wide">
-                <span>Altitude</span>
-                <select
-                  value={altitudeLevel}
-                  onChange={(event) => setAltitudeLevel(event.target.value)}
-                  aria-label="Filter by altitude level"
-                >
-                  {ALTITUDE_LEVELS.map((level) => (
-                    <option key={level.value} value={level.value}>
-                      {level.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
+              <AircraftFilterSelect
+                label="Type"
+                value={typeFilter}
+                onValueChange={setTypeFilter}
+                options={[
+                  { value: "all", label: "All types" },
+                  ...aircraftTypes.map((type) => ({
+                    value: type,
+                    label: type,
+                  })),
+                ]}
+                ariaLabel="Filter by aircraft type"
+                contentClassName="max-h-44"
+              />
+              <AircraftFilterSelect
+                label="Altitude"
+                value={altitudeLevel}
+                onValueChange={setAltitudeLevel}
+                options={ALTITUDE_LEVELS}
+                ariaLabel="Filter by altitude level"
+              />
             </div>
           </div>
         </div>
@@ -161,6 +162,44 @@ export default function AircraftTable({
           </ul>
         )}
       </div>
+    </div>
+  );
+}
+
+function AircraftFilterSelect({
+  label,
+  value,
+  onValueChange,
+  options,
+  ariaLabel,
+  contentClassName = "",
+}) {
+  return (
+    <div className="aircraft-filter-select">
+      <span>{label}</span>
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger
+          aria-label={ariaLabel}
+          className="aircraft-filter-select-trigger"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent
+          className={cn("aircraft-filter-select-content", contentClassName)}
+        >
+          <SelectGroup>
+            {options.map((option) => (
+              <SelectItem
+                key={option.value}
+                value={option.value}
+                className="aircraft-filter-select-item"
+              >
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
     </div>
   );
 }

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -20,8 +20,7 @@ const TRAFFIC_FILTERS = [
 const ALTITUDE_LEVELS = [
   { value: "all", label: "Any altitude" },
   { value: "ground", label: "Ground" },
-  { value: "surface", label: "Surface" },
-  { value: "approaching", label: "Approaching" },
+  { value: "climb-descent", label: "Climb / descent" },
   { value: "high", label: "High" },
 ];
 
@@ -317,8 +316,9 @@ function matchesAltitudeLevel(aircraft, altitudeLevel) {
   const altitude = aircraft.onGround ? 0 : toNumber(aircraft.altitude);
   if (altitudeLevel === "ground") return altitude == null || altitude < 100;
   if (altitude == null) return false;
-  if (altitudeLevel === "surface") return altitude >= 100 && altitude < 2500;
-  if (altitudeLevel === "approaching") return altitude >= 2500 && altitude < 12000;
+  if (altitudeLevel === "climb-descent") {
+    return altitude >= 100 && altitude < 12000;
+  }
   if (altitudeLevel === "high") return altitude >= 12000;
   return true;
 }

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -1,13 +1,29 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import NumberFlow from "@number-flow/react";
+import { Search } from "lucide-react";
 import {
   getAircraftIdentity,
+  getContextTagLabel,
+  getAircraftContextGroup,
   getMovementTagLabel,
-  groupAircraftByAirportContext,
   resolveAircraftContextEmphasis,
 } from "../../features/airport-context/airportContextUiModel.js";
 import { formatFlightRouteMunicipalityLabel } from "../../utils/flightRouteDisplay.js";
+
+const TRAFFIC_FILTERS = [
+  { value: "all", label: "All" },
+  { value: "routed", label: "Routes only" },
+];
+
+const ALTITUDE_LEVELS = [
+  { value: "all", label: "Any altitude" },
+  { value: "ground", label: "Ground" },
+  { value: "surface", label: "Surface" },
+  { value: "approaching", label: "Approaching" },
+  { value: "high", label: "High" },
+];
 
 export default function AircraftTable({
   aircraft = [],
@@ -17,21 +33,98 @@ export default function AircraftTable({
   onSelectAircraft,
   fill = true,
 }) {
-  const grouped = groupAircraftByAirportContext(aircraft);
+  const [query, setQuery] = useState("");
+  const [trafficFilter, setTrafficFilter] = useState("all");
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [altitudeLevel, setAltitudeLevel] = useState("all");
+  const aircraftTypes = useMemo(() => getAircraftTypes(aircraft), [aircraft]);
+  const rows = useMemo(
+    () =>
+      filterAndSortAircraft({
+        aircraft,
+        altitudeLevel,
+        query,
+        trafficFilter,
+        typeFilter,
+      }),
+    [aircraft, altitudeLevel, query, trafficFilter, typeFilter],
+  );
 
   return (
     <div className={`flex flex-col ${fill ? "h-full" : ""}`}>
       <div className="flex-none">
-        <div className="flex items-baseline justify-between px-6 pt-4 pb-2.5">
-          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint">
+        <div className="flex items-baseline justify-between px-[var(--airport-sidebar-inset)] pt-4 pb-2.5">
+          <div className="text-[10px] font-semibold uppercase tracking-normal text-atc-faint">
             Aircraft
           </div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-atc-dim">
+          <div className="text-[10px] font-semibold uppercase tracking-normal text-atc-dim tabular-nums">
+            <NumberFlow value={rows.length} />
+            <span> / </span>
             <NumberFlow value={aircraft.length} suffix=" nearby" />
           </div>
         </div>
 
-        <div className="grid grid-cols-[minmax(0,1fr)_58px_78px] items-center gap-3 border-y border-[var(--atc-line)] px-6 py-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-atc-faint">
+        <div className="px-[var(--airport-sidebar-inset)] pb-3">
+          <label className="aircraft-search-box">
+            <Search size={14} aria-hidden="true" />
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search callsign, ICAO, route"
+              aria-label="Search aircraft"
+            />
+          </label>
+
+          <div className="aircraft-filter-stack" aria-label="Aircraft filter">
+            <div className="aircraft-filter-tabs">
+              {TRAFFIC_FILTERS.map((filter) => (
+                <button
+                  key={filter.value}
+                  type="button"
+                  className={trafficFilter === filter.value ? "active" : ""}
+                  aria-pressed={trafficFilter === filter.value}
+                  onClick={() => setTrafficFilter(filter.value)}
+                >
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+            <div className="aircraft-filter-select-row">
+              <label className="aircraft-filter-select">
+                <span>Type</span>
+                <select
+                  value={typeFilter}
+                  onChange={(event) => setTypeFilter(event.target.value)}
+                  aria-label="Filter by aircraft type"
+                >
+                  <option value="all">All types</option>
+                  {aircraftTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="aircraft-filter-select aircraft-filter-select--wide">
+                <span>Altitude</span>
+                <select
+                  value={altitudeLevel}
+                  onChange={(event) => setAltitudeLevel(event.target.value)}
+                  aria-label="Filter by altitude level"
+                >
+                  {ALTITUDE_LEVELS.map((level) => (
+                    <option key={level.value} value={level.value}>
+                      {level.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-[minmax(0,1fr)_54px_70px] items-center gap-3 border-y border-[var(--atc-line)] px-[var(--airport-sidebar-inset)] py-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-atc-faint">
           <span>Callsign / Route</span>
           <span className="text-right">GS</span>
           <span className="text-right">ALT</span>
@@ -39,71 +132,37 @@ export default function AircraftTable({
       </div>
 
       <div className={fill ? "flex-1 overflow-y-auto" : "overflow-visible"}>
-        {grouped.length === 0 ? (
-          <div className="px-6 py-8 text-center font-mono text-[11px] uppercase tracking-[0.12em] text-atc-faint">
-            No aircraft in range
+        {rows.length === 0 ? (
+          <div className="px-[var(--airport-sidebar-inset)] py-8 text-center text-[11px] font-semibold uppercase tracking-normal text-atc-faint">
+            {aircraft.length ? "No aircraft match" : "No aircraft in range"}
           </div>
         ) : (
-          <div>
-            {grouped.map((section) => (
-              <AircraftContextSection
-                key={section.group}
-                section={section}
-                altitudeFocus={altitudeFocus}
-                showAirspaceContext={showAirspaceContext}
-                selectedAircraftId={selectedAircraftId}
-                onSelectAircraft={onSelectAircraft}
-              />
-            ))}
-          </div>
+          <ul className="divide-y divide-[var(--atc-line)]">
+            {rows.map((item) => {
+              const aircraftId = getAircraftIdentity(item);
+              const selected = aircraftId && aircraftId === selectedAircraftId;
+              const emphasis = resolveAircraftContextEmphasis({
+                aircraft: item,
+                altitudeFocus,
+                contextEnabled: showAirspaceContext,
+                selected,
+              });
+
+              return (
+                <AircraftRow
+                  key={`${aircraftId || "anon"}-${item.callsign || ""}`}
+                  aircraft={item}
+                  aircraftId={aircraftId}
+                  emphasis={emphasis}
+                  selected={selected}
+                  onSelectAircraft={onSelectAircraft}
+                />
+              );
+            })}
+          </ul>
         )}
       </div>
     </div>
-  );
-}
-
-function AircraftContextSection({
-  section,
-  altitudeFocus,
-  showAirspaceContext,
-  selectedAircraftId,
-  onSelectAircraft,
-}) {
-  return (
-    <section className="border-b border-[var(--atc-line)]">
-      <div className="sticky top-0 z-10 flex items-baseline justify-between border-b border-[var(--atc-line)] bg-atc-bg/95 px-6 py-2 backdrop-blur-sm">
-        <h3 className="font-mono text-[9.5px] font-semibold uppercase tracking-[0.14em] text-atc-dim">
-          {section.group}
-        </h3>
-        <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-atc-faint">
-          <NumberFlow value={section.aircraft.length} />
-        </span>
-      </div>
-
-      <ul className="divide-y divide-[var(--atc-line)]">
-        {section.aircraft.map((item) => {
-          const aircraftId = getAircraftIdentity(item);
-          const selected = aircraftId && aircraftId === selectedAircraftId;
-          const emphasis = resolveAircraftContextEmphasis({
-            aircraft: item,
-            altitudeFocus,
-            contextEnabled: showAirspaceContext,
-            selected,
-          });
-
-          return (
-            <AircraftRow
-              key={`${aircraftId || "anon"}-${item.callsign || ""}`}
-              aircraft={item}
-              aircraftId={aircraftId}
-              emphasis={emphasis}
-              selected={selected}
-              onSelectAircraft={onSelectAircraft}
-            />
-          );
-        })}
-      </ul>
-    </section>
   );
 }
 
@@ -123,6 +182,8 @@ function AircraftRow({
     routeMunicipalities && routeMunicipalities !== route,
   );
   const movementLabel = getMovementTagLabel(aircraft);
+  const visibleBadge =
+    movementLabel === "DEP" || movementLabel === "ARR" ? movementLabel : "";
   const gsValue = toNumber(aircraft.velocity);
   const altValue = toNumber(aircraft.altitude);
   const rowOpacity = selected ? 1 : emphasis.opacity;
@@ -131,7 +192,7 @@ function AircraftRow({
     <li>
       <button
         type="button"
-        className={`grid w-full grid-cols-[minmax(0,1fr)_58px_78px] items-center gap-3 px-6 py-2.5 text-left transition-[background,color,opacity] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] ${
+        className={`grid w-full grid-cols-[minmax(0,1fr)_54px_70px] items-center gap-3 px-[var(--airport-sidebar-inset)] py-2.5 text-left transition-[background,color,opacity] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] ${
           selected ? "bg-[color-mix(in_oklab,var(--atc-accent)_11%,transparent)]" : ""
         }`}
         style={{ opacity: rowOpacity }}
@@ -143,7 +204,7 @@ function AircraftRow({
             <span className="truncate font-mono text-[12.5px] font-semibold tracking-[0.02em] text-atc-text">
               {callsign}
             </span>
-            {movementLabel && <AircraftTag>{movementLabel}</AircraftTag>}
+            {visibleBadge && <AircraftTag>{visibleBadge}</AircraftTag>}
           </div>
           {route ? (
             <div className="mt-1 flex min-w-0 items-center">
@@ -187,9 +248,15 @@ function AircraftRow({
   );
 }
 
-function AircraftTag({ children }) {
+function AircraftTag({ children, subtle = false }) {
   return (
-    <span className="flex-none rounded-[4px] border border-[color-mix(in_oklab,var(--atc-accent)_34%,transparent)] bg-[color-mix(in_oklab,var(--atc-accent)_10%,transparent)] px-1.5 py-0.5 font-mono text-[8px] font-bold uppercase tracking-[0.08em] text-atc-accent">
+    <span
+      className={`flex-none rounded-[4px] border px-1.5 py-0.5 font-mono text-[8px] font-bold uppercase tracking-[0.08em] ${
+        subtle
+          ? "border-[var(--atc-line)] bg-transparent text-atc-faint"
+          : "border-[color-mix(in_oklab,var(--atc-accent)_34%,transparent)] bg-[color-mix(in_oklab,var(--atc-accent)_10%,transparent)] text-atc-accent"
+      }`}
+    >
       {children}
     </span>
   );
@@ -209,4 +276,94 @@ function NumberWithUnit({ value, unit }) {
 function toNumber(value) {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
+}
+
+function filterAndSortAircraft({
+  aircraft = [],
+  altitudeLevel = "all",
+  query = "",
+  trafficFilter = "all",
+  typeFilter = "all",
+}) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return [...aircraft]
+    .filter((item) => matchesTrafficFilter(item, trafficFilter))
+    .filter((item) => matchesTypeFilter(item, typeFilter))
+    .filter((item) => matchesAltitudeLevel(item, altitudeLevel))
+    .filter((item) =>
+      normalizedQuery ? aircraftSearchText(item).includes(normalizedQuery) : true,
+    )
+    .sort(sortAircraftByAltitude);
+}
+
+function matchesTrafficFilter(aircraft, trafficFilter) {
+  if (trafficFilter === "airborne") return !aircraft.onGround;
+  if (trafficFilter === "ground") return Boolean(aircraft.onGround);
+  if (trafficFilter === "routed") {
+    return Boolean(aircraft.flightRouteLabel || aircraft.flightRoute);
+  }
+  return true;
+}
+
+function matchesTypeFilter(aircraft, typeFilter) {
+  if (typeFilter === "all") return true;
+  return aircraftTypeLabel(aircraft) === typeFilter;
+}
+
+function matchesAltitudeLevel(aircraft, altitudeLevel) {
+  if (altitudeLevel === "all") return true;
+
+  const altitude = aircraft.onGround ? 0 : toNumber(aircraft.altitude);
+  if (altitudeLevel === "ground") return altitude == null || altitude < 100;
+  if (altitude == null) return false;
+  if (altitudeLevel === "surface") return altitude >= 100 && altitude < 2500;
+  if (altitudeLevel === "approaching") return altitude >= 2500 && altitude < 12000;
+  if (altitudeLevel === "high") return altitude >= 12000;
+  return true;
+}
+
+function aircraftSearchText(aircraft = {}) {
+  const routeMunicipalities = formatFlightRouteMunicipalityLabel(
+    aircraft.flightRoute,
+  );
+
+  return [
+    aircraft.callsign,
+    aircraft.icao24,
+    aircraft.registration,
+    aircraftTypeLabel(aircraft),
+    aircraft.flightRouteLabel,
+    routeMunicipalities,
+    getAircraftContextGroup(aircraft),
+    getContextTagLabel(aircraft),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function sortAircraftByAltitude(a, b) {
+  const altitudeDelta = altitudeSortValue(b) - altitudeSortValue(a);
+  if (altitudeDelta !== 0) return altitudeDelta;
+
+  const speedDelta = (toNumber(b.velocity) ?? -1) - (toNumber(a.velocity) ?? -1);
+  if (speedDelta !== 0) return speedDelta;
+
+  return getAircraftIdentity(a).localeCompare(getAircraftIdentity(b));
+}
+
+function altitudeSortValue(aircraft = {}) {
+  if (aircraft.onGround) return -1;
+  return toNumber(aircraft.altitude) ?? -2;
+}
+
+function getAircraftTypes(aircraft = []) {
+  return [...new Set(aircraft.map(aircraftTypeLabel).filter(Boolean))].sort(
+    (a, b) => a.localeCompare(b),
+  );
+}
+
+function aircraftTypeLabel(aircraft = {}) {
+  return String(aircraft.type || aircraft.category || "").trim();
 }

--- a/src/components/sidebar/AirportIdentity.jsx
+++ b/src/components/sidebar/AirportIdentity.jsx
@@ -15,8 +15,8 @@ export default function AirportIdentity({
   const coordLine = formatCoord(lat, lon);
 
   return (
-    <div className="px-6 pt-7 pb-6">
-      <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-atc-faint">
+    <div className="airport-sidebar-identity">
+      <div className="text-[10px] font-semibold uppercase tracking-normal text-atc-faint">
         Airport
       </div>
       <div className="mt-3 flex items-baseline gap-3">

--- a/src/components/sidebar/AirportSidebar.jsx
+++ b/src/components/sidebar/AirportSidebar.jsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import AircraftTable from "./AircraftTable";
 import AirportIdentity from "./AirportIdentity";
-import StatsStrip from "./StatsStrip";
-import WeatherCarousel from "./WeatherCarousel";
+import SidebarViewSwitch from "./SidebarViewSwitch";
+import WeatherBriefingStack from "./WeatherBriefingStack";
 
 export default function AirportSidebar({
   icao = "",
@@ -29,6 +30,7 @@ export default function AirportSidebar({
 }) {
   const isMobileOverlay = Boolean(onClose);
   const updatedLabel = formatUpdated(lastUpdated, feedStatus);
+  const [activeView, setActiveView] = useState("traffic");
 
   return (
     <div
@@ -40,7 +42,7 @@ export default function AirportSidebar({
         <button
           type="button"
           onClick={onBack}
-          className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text"
+          className="text-[10px] font-semibold uppercase tracking-normal text-atc-faint transition-colors hover:text-atc-text"
         >
           ← ADSBao
         </button>
@@ -48,14 +50,14 @@ export default function AirportSidebar({
           <button
             type="button"
             onClick={onClose}
-            className="font-mono text-[10px] uppercase tracking-[0.14em] text-atc-faint transition-colors hover:text-atc-text"
+            className="text-[10px] font-semibold uppercase tracking-normal text-atc-faint transition-colors hover:text-atc-text"
           >
             Map →
           </button>
         ) : (
           <span
             key={updatedLabel}
-            className={`airport-feed-status airport-feed-status--${feedStatus} font-mono text-[10px] uppercase tracking-[0.12em] text-atc-dim`}
+            className={`airport-feed-status airport-feed-status--${feedStatus} text-[10px] font-semibold uppercase tracking-normal text-atc-dim tabular-nums`}
           >
             {updatedLabel}
           </span>
@@ -79,15 +81,11 @@ export default function AirportSidebar({
             lat={lat}
             lon={lon}
           />
-          <StatsStrip metar={metar} aircraftCount={aircraft.length} />
-          <WeatherCarousel
+          <SidebarViewSwitch
+            activeView={activeView}
+            onViewChange={setActiveView}
             metar={metar}
-            metarRaw={metarRaw}
-            metarLoading={metarLoading}
-            metarError={metarError}
-            airportCode={iata || icao}
-            airportLat={lat}
-            airportLon={lon}
+            aircraftCount={aircraft.length}
           />
         </div>
         <div
@@ -97,14 +95,31 @@ export default function AirportSidebar({
               : "flex-1 overflow-y-auto"
           }
         >
-          <AircraftTable
-            aircraft={aircraft}
-            altitudeFocus={altitudeFocus}
-            showAirspaceContext={showAirspaceContext}
-            selectedAircraftId={selectedAircraftId}
-            onSelectAircraft={onSelectAircraft}
-            fill={!isMobileOverlay}
-          />
+          {activeView === "briefing" ? (
+            <WeatherBriefingStack
+              icao={icao}
+              iata={iata}
+              name={name}
+              city={city}
+              country={country}
+              metar={metar}
+              metarRaw={metarRaw}
+              metarLoading={metarLoading}
+              metarError={metarError}
+              airportCode={iata || icao}
+              airportLat={lat}
+              airportLon={lon}
+            />
+          ) : (
+            <AircraftTable
+              aircraft={aircraft}
+              altitudeFocus={altitudeFocus}
+              showAirspaceContext={showAirspaceContext}
+              selectedAircraftId={selectedAircraftId}
+              onSelectAircraft={onSelectAircraft}
+              fill={!isMobileOverlay}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/sidebar/SidebarViewSwitch.jsx
+++ b/src/components/sidebar/SidebarViewSwitch.jsx
@@ -1,0 +1,64 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
+
+export default function SidebarViewSwitch({
+  activeView = "briefing",
+  onViewChange,
+  metar = null,
+  aircraftCount = 0,
+}) {
+  const temperature = formatTemperature(metar);
+  const rule = metar?.flightCategory?.toUpperCase() || "WX";
+
+  return (
+    <div className="airport-sidebar-view-switch" role="tablist" aria-label="Airport sidebar views">
+      <SwitchButton
+        active={activeView === "briefing"}
+        label="Weather"
+        value={temperature.value}
+        unit={temperature.unit}
+        onClick={() => onViewChange?.("briefing")}
+      />
+      <SwitchButton
+        active={activeView === "traffic"}
+        label="Flights"
+        value={<NumberFlow value={aircraftCount} />}
+        unit={`${rule} / ADS-B`}
+        divided
+        onClick={() => onViewChange?.("traffic")}
+      />
+    </div>
+  );
+}
+
+function SwitchButton({
+  active = false,
+  label,
+  value,
+  unit = "",
+  divided = false,
+  onClick,
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      className={`airport-sidebar-view-switch__button ${
+        active ? "airport-sidebar-view-switch__button--active" : ""
+      } ${divided ? "airport-sidebar-view-switch__button--divided" : ""}`}
+      onClick={onClick}
+    >
+      <span>{label}</span>
+      <strong>{value}</strong>
+      {unit ? <small>{unit}</small> : null}
+    </button>
+  );
+}
+
+function formatTemperature(metar) {
+  const temp = Number(metar?.rawTemp);
+  if (!Number.isFinite(temp)) return { value: "—", unit: "°C" };
+  return { value: Math.round(temp), unit: "°C" };
+}

--- a/src/components/sidebar/WeatherBriefingStack.jsx
+++ b/src/components/sidebar/WeatherBriefingStack.jsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAirportWiki } from "../../hooks/useAirportWiki.js";
+import { useWeatherSlides } from "../../features/weather/useWeatherSlides.jsx";
+
+export default function WeatherBriefingStack({
+  icao = "",
+  iata = "",
+  name = "",
+  city = "",
+  country = "",
+  metar = null,
+  metarRaw = "",
+  metarLoading = false,
+  metarError = null,
+  airportCode = "",
+  airportLat = 0,
+  airportLon = 0,
+}) {
+  const wikiAirport = useMemo(
+    () => ({ icao, iata, name, city, country }),
+    [icao, iata, name, city, country],
+  );
+  const slides = useWeatherSlides({
+    variant: "carousel",
+    metar,
+    metarRaw,
+    metarLoading,
+    metarError,
+    airportCode,
+    airportLat,
+    airportLon,
+  });
+  const wiki = useAirportWiki(wikiAirport);
+
+  return (
+    <div className="airport-briefing-stack">
+      {slides.map((slide) => (
+        <section key={slide.id} className="airport-briefing-card">
+          <div className="airport-briefing-card__heading">
+            <span>{slide.navLabel || slide.label}</span>
+          </div>
+          {slide.content}
+        </section>
+      ))}
+
+      <section className="airport-briefing-card airport-briefing-card--wiki">
+        <div className="airport-briefing-card__heading">
+          <span>Wiki</span>
+        </div>
+        <p className="wiki-copy">
+          {wiki.summary?.extract
+            ? wiki.summary.extract
+            : wiki.loading
+              ? "Loading airport introduction..."
+              : "No Wikipedia summary was found for this airport."}
+        </p>
+        {wiki.error ? <div className="panel-error">{wiki.error}</div> : null}
+        {wiki.summary?.url ? (
+          <a
+            className="airport-briefing-card__link"
+            href={wiki.summary.url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open Wikipedia
+          </a>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -1,0 +1,119 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}>
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}>
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}>
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef(({ className, children, position = "popper", viewportClassName, ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}>
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn("p-1", position === "popper" &&
+          "w-full min-w-[var(--radix-select-trigger-width)]", viewportClassName)}>
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props} />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}>
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props} />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/config/about.js
+++ b/src/config/about.js
@@ -1,5 +1,5 @@
 export const ABOUT_BUILD_META = [
-  { label: "Version", value: "0.8.0" },
+  { label: "Version", value: "0.9.0" },
   { label: "Release", value: "Next.js Web" },
   { label: "Stack", value: "React 19 · Next 16 · Leaflet" },
   { label: "Scope", value: "Maps · Weather · Traffic" },

--- a/src/config/aviation.js
+++ b/src/config/aviation.js
@@ -5,7 +5,7 @@ export const AIRPORT_MAP_ZOOM = {
 };
 
 export const AIRPORT_EXPLORER_UI_CONFIG = {
-  desktopSidebarWidth: "25rem",
+  desktopSidebarWidth: "var(--app-sidebar-width)",
   mobileBreakpointPx: 768,
   adsbLoadingFadeMs: 1100,
   telemetryAutoDisableAircraftLimit: 50,

--- a/src/features/app-shell/DitherPageShell.jsx
+++ b/src/features/app-shell/DitherPageShell.jsx
@@ -20,7 +20,7 @@ export default function DitherPageShell({
     <div
       className={`dither-page-shell flex h-screen text-atc-text ${className}`.trim()}
     >
-      <div className="dither-page-panel flex w-[400px] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
+      <div className="dither-page-panel flex w-[var(--app-sidebar-width)] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
         <MobileTopNav
           left={mobileLeft}
           right={renderThemeToggle?.("mobile-top-nav-link flex items-center gap-1.5")}

--- a/src/style.css
+++ b/src/style.css
@@ -113,6 +113,7 @@
 
     /* Light: white canvas with navy ink — neutral grays for surface hierarchy,
        no warm cream tint. */
+    --app-sidebar-width: 22.5rem;
     --atc-bg: #ffffff;
     --atc-card: #f4f4f4;
     --atc-elev: #ebebeb;
@@ -646,7 +647,7 @@ body {
 }
 
 .airport-desktop-sidebar {
-    width: 25rem;
+    width: var(--app-sidebar-width);
 }
 
 @media (max-width: 767px) {
@@ -2841,11 +2842,11 @@ body {
     height: 100dvh;
     /* min-width: 0 is required: as a flex item, the default min-width is
        auto (= min-content), which long unbroken METAR strings would push
-       past the 400px width and squeeze the map to zero. */
+       past the sidebar width and squeeze the map to zero. */
     min-width: 0;
     overflow-y: auto;
     overscroll-behavior-y: contain;
-    width: 400px;
+    width: var(--app-sidebar-width);
 }
 
 /* Dark sidebar steps up one surface level so it reads as visible navy blue
@@ -2907,6 +2908,376 @@ body {
 
 .airport-feed-status--infer {
     color: var(--atc-faint);
+}
+
+.airport-sidebar-panel {
+    --airport-sidebar-inset: 28px;
+    --airport-sidebar-sans: "Inter", var(--font-sans);
+    font-family: var(--airport-sidebar-sans);
+}
+
+.airport-sidebar-identity {
+    padding: 28px var(--airport-sidebar-inset) 24px;
+}
+
+.airport-sidebar-view-switch {
+    border-bottom: 1px solid var(--atc-line);
+    border-top: 1px solid var(--atc-line);
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.airport-sidebar-view-switch__button {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: var(--atc-text);
+    cursor: pointer;
+    align-content: center;
+    display: grid;
+    gap: 8px;
+    grid-template-rows: 16px 38px 14px;
+    min-height: 112px;
+    min-width: 0;
+    padding: 22px var(--airport-sidebar-inset) 20px;
+    text-align: left;
+    transition:
+        background 0.18s ease,
+        box-shadow 0.18s ease,
+        color 0.18s ease;
+}
+
+.airport-sidebar-view-switch__button--divided {
+    border-left: 1px solid var(--atc-line);
+}
+
+.airport-sidebar-view-switch__button span,
+.airport-sidebar-view-switch__button small {
+    color: var(--atc-faint);
+    font-family: var(--airport-sidebar-sans);
+    text-transform: uppercase;
+}
+
+.airport-sidebar-view-switch__button span {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+.airport-sidebar-view-switch__button strong {
+    align-items: center;
+    color: var(--atc-text);
+    display: flex;
+    font-family: var(--font-mono);
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: 0;
+    line-height: 1;
+    min-height: 38px;
+}
+
+.airport-sidebar-view-switch__button small {
+    display: block;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0;
+    line-height: 14px;
+    min-height: 14px;
+}
+
+.airport-sidebar-view-switch__button:hover,
+.airport-sidebar-view-switch__button--active {
+    background: color-mix(in oklab, var(--atc-card) 58%, transparent);
+}
+
+.airport-sidebar-view-switch__button--active {
+    box-shadow: inset 0 -2px 0 var(--atc-accent);
+}
+
+.airport-sidebar-view-switch__button:focus {
+    outline: none;
+}
+
+.airport-sidebar-view-switch__button:focus-visible {
+    box-shadow:
+        inset 0 0 0 1px var(--atc-line-strong),
+        inset 0 -2px 0 var(--atc-accent);
+}
+
+.airport-briefing-stack {
+    display: grid;
+    gap: 0;
+    padding: 0;
+}
+
+.airport-briefing-card {
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--atc-line-strong);
+    border-radius: 0;
+    min-width: 0;
+    padding: 24px var(--airport-sidebar-inset) 26px;
+}
+
+.airport-briefing-card__heading {
+    align-items: baseline;
+    display: flex;
+    gap: 12px;
+    justify-content: flex-start;
+    margin-bottom: 20px;
+    min-width: 0;
+}
+
+.airport-briefing-card__heading span,
+.airport-briefing-card__link {
+    color: var(--atc-faint);
+    font-family: var(--airport-sidebar-sans);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.airport-briefing-card__heading strong {
+    color: var(--atc-dim);
+    font-family: var(--airport-sidebar-sans);
+    font-size: 12px;
+    letter-spacing: 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.airport-briefing-card .weather-slide-readout {
+    min-height: 0;
+    padding-block: 0 10px;
+}
+
+.airport-briefing-card .metar-token-strip {
+    gap: 12px 18px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.airport-briefing-card .metar-token-strip strong {
+    font-family: var(--font-mono);
+    font-size: 17px;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: nowrap;
+}
+
+.airport-briefing-card .metar-token-strip small,
+.airport-briefing-card .weather-metar-code {
+    font-family: var(--font-mono);
+}
+
+.airport-briefing-card .weather-slide-stack {
+    gap: 16px;
+    height: auto;
+    justify-content: start;
+}
+
+.airport-briefing-card .weather-metar-code {
+    max-height: none;
+}
+
+.airport-briefing-card .flight-rule-banner {
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+}
+
+.airport-briefing-card .flight-rule-banner strong {
+    font-family: var(--airport-sidebar-sans);
+    font-size: 20px;
+    min-width: 0;
+}
+
+.airport-briefing-card .flight-rule-rail {
+    margin-bottom: 0;
+}
+
+.airport-briefing-card .weather-context-copy.weather-slide-description {
+    margin-top: 0;
+}
+
+.airport-briefing-card .weather-visual-layout,
+.airport-briefing-card .local-weather-row {
+    min-height: 0;
+}
+
+.airport-briefing-card .ceiling-readouts,
+.airport-briefing-card .pressure-strip,
+.airport-briefing-card .temperature-strip {
+    gap: 14px;
+}
+
+.airport-briefing-card .temperature-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.airport-briefing-card .temperature-strip .weather-metric-line:last-child {
+    grid-column: 1 / -1;
+}
+
+.airport-briefing-card .weather-metric-line strong,
+.airport-briefing-card .wind-vector-card strong {
+    font-family: var(--airport-sidebar-sans);
+    font-size: 18px;
+}
+
+.airport-briefing-card .weather-metric-line span,
+.airport-briefing-card .wind-vector-card span,
+.airport-briefing-card .thermal-band span,
+.airport-briefing-card .local-weather-meta span {
+    font-family: var(--airport-sidebar-sans);
+    font-weight: 600;
+    letter-spacing: 0;
+}
+
+.airport-briefing-card .local-weather-meta .font-mono {
+    font-family: var(--airport-sidebar-sans);
+}
+
+.airport-briefing-card .wind-vector-card {
+    grid-template-columns: 56px repeat(3, minmax(0, 1fr));
+}
+
+.airport-briefing-card .wind-vector-card > div:not(.wind-compass) {
+    padding-inline: 6px;
+}
+
+.airport-briefing-card .wiki-copy {
+    font-size: 15px;
+    line-height: 1.58;
+    max-height: none;
+}
+
+.airport-briefing-card__link {
+    border-top: 1px solid var(--atc-line);
+    display: block;
+    margin-top: 14px;
+    padding-top: 12px;
+    text-decoration: none;
+}
+
+.aircraft-search-box {
+    align-items: center;
+    border: 1px solid var(--atc-line);
+    color: var(--atc-faint);
+    display: flex;
+    gap: 8px;
+    min-width: 0;
+    padding: 8px 10px;
+}
+
+.aircraft-search-box:focus-within {
+    border-color: color-mix(in oklab, var(--atc-accent) 44%, var(--atc-line));
+    color: var(--atc-accent);
+}
+
+.aircraft-search-box input {
+    background: transparent;
+    border: 0;
+    color: var(--atc-text);
+    font-family: var(--airport-sidebar-sans);
+    font-size: 10px;
+    font-weight: 600;
+    min-width: 0;
+    outline: none;
+    width: 100%;
+}
+
+.aircraft-search-box input::placeholder {
+    color: var(--atc-faint);
+    opacity: 0.8;
+    text-transform: uppercase;
+}
+
+.aircraft-filter-stack {
+    border: 1px solid var(--atc-line);
+    border-top: 0;
+    display: grid;
+}
+
+.aircraft-filter-tabs,
+.aircraft-filter-select-row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.aircraft-filter-select-row {
+    border-top: 1px solid var(--atc-line);
+}
+
+.aircraft-filter-tabs button,
+.aircraft-filter-select {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    border-right: 1px solid var(--atc-line);
+    color: var(--atc-faint);
+    cursor: pointer;
+    font-family: var(--airport-sidebar-sans);
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0;
+    min-width: 0;
+    padding: 7px 4px;
+    text-align: left;
+    text-transform: uppercase;
+}
+
+.aircraft-filter-select {
+    align-items: center;
+    display: grid;
+    gap: 2px;
+    justify-items: start;
+    padding: 5px 12px 6px;
+}
+
+.aircraft-filter-tabs button {
+    padding-inline: 12px;
+}
+
+.aircraft-filter-tabs button:last-child,
+.aircraft-filter-select-row .aircraft-filter-select:last-child {
+    border-right: 0;
+}
+
+.aircraft-filter-tabs button:hover,
+.aircraft-filter-tabs button.active {
+    background: color-mix(in oklab, var(--atc-accent) 10%, transparent);
+    color: var(--atc-text);
+}
+
+.aircraft-filter-select span {
+    color: var(--atc-faint);
+    font-family: var(--airport-sidebar-sans);
+    font-size: 7px;
+    font-weight: 800;
+    letter-spacing: 0;
+    line-height: 1;
+    text-transform: uppercase;
+}
+
+.aircraft-filter-select select {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: var(--atc-text);
+    cursor: pointer;
+    font-family: var(--airport-sidebar-sans);
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0;
+    min-width: 0;
+    outline: none;
+    text-align: left;
+    text-transform: uppercase;
+    width: 100%;
 }
 
 @keyframes airport-feed-status-fade {

--- a/src/style.css
+++ b/src/style.css
@@ -3263,21 +3263,71 @@ body {
     text-transform: uppercase;
 }
 
-.aircraft-filter-select select {
-    appearance: none;
+.aircraft-filter-select-trigger {
     background: transparent;
     border: 0;
+    border-radius: 0;
+    box-shadow: none;
     color: var(--atc-text);
     cursor: pointer;
+    display: inline-flex;
     font-family: var(--airport-sidebar-sans);
     font-size: 9px;
     font-weight: 800;
+    gap: 4px;
+    height: auto;
+    justify-content: flex-start;
     letter-spacing: 0;
+    line-height: 1.1;
     min-width: 0;
     outline: none;
+    padding: 0;
     text-align: left;
     text-transform: uppercase;
     width: 100%;
+}
+
+.aircraft-filter-select-trigger:hover,
+.aircraft-filter-select-trigger:focus,
+.aircraft-filter-select-trigger[data-state="open"] {
+    background: transparent;
+    box-shadow: none;
+}
+
+.aircraft-filter-select-trigger > span {
+    color: var(--atc-text);
+    font-size: 9px;
+    line-height: 1.1;
+}
+
+.aircraft-filter-select-trigger svg {
+    color: var(--atc-faint);
+    height: 10px;
+    opacity: 0.75;
+    width: 10px;
+}
+
+.aircraft-filter-select-content {
+    background: var(--atc-bg);
+    border-color: var(--atc-line);
+    border-radius: 0;
+    color: var(--atc-text);
+    font-family: var(--airport-sidebar-sans);
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.aircraft-filter-select-item {
+    border-radius: 0;
+    cursor: pointer;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0;
+}
+
+.aircraft-filter-select-item:focus {
+    background: color-mix(in oklab, var(--atc-accent) 14%, transparent);
+    color: var(--atc-text);
 }
 
 @keyframes airport-feed-status-fade {


### PR DESCRIPTION
## Summary
- Reworks the airport detail sidebar into Weather and Flights views, with Flights shown by default.
- Adds aircraft search plus All / Routes only, Type, and Altitude filters, including aircraft type filtering for issue #149.
- Unifies sidebar width across airport detail and app shell pages, and tunes sidebar typography/layout spacing.

## Details
- Weather content is now a vertical briefing stack instead of a carousel.
- Aircraft rows are sorted by altitude, keep only DEP/ARR badges, and treat unknown altitude as Ground for altitude filtering.
- Sidebar stats use mono numerals while UI labels and controls use Inter with default letter spacing.

Closes #149

## Validation
- pnpm lint
- pnpm test
- Chrome visual checks on / and /KBOS
