### PR TITLE
feat: cache callsign route proxy at Vercel CDN

### DIFF
--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
@@ -28,6 +28,20 @@ const aerodataboxRapidApiHost =
   process.env.AERODATABOX_RAPIDAPI_HOST || AERODATABOX_RAPIDAPI_HOST;
 let nextAerodataboxRequestAt = 0;
 
+const ROUTE_CACHE_TTL_SECONDS = 60 * 60;
+const ROUTE_MISS_CACHE_TTL_SECONDS = 5 * 60;
+const ROUTE_STALE_WHILE_REVALIDATE_SECONDS = 10 * 60;
+
+function buildRouteCacheHeaders(body) {
+  const ttl = body ? ROUTE_CACHE_TTL_SECONDS : ROUTE_MISS_CACHE_TTL_SECONDS;
+  const cdnValue = `public, s-maxage=${ttl}, stale-while-revalidate=${ROUTE_STALE_WHILE_REVALIDATE_SECONDS}`;
+  return {
+    "Cache-Control": "public, max-age=0, must-revalidate",
+    "CDN-Cache-Control": cdnValue,
+    "Vercel-CDN-Cache-Control": cdnValue,
+  };
+}
+
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function waitForAerodataboxSlot() {
@@ -174,7 +188,7 @@ export async function GET(request, { params }) {
 
     return Response.json(body, {
       status: body ? 200 : VRS_ROUTE_MISS_STATUS,
-      headers: buildProxyHeaders(request),
+      headers: buildProxyHeaders(request, buildRouteCacheHeaders(body)),
     });
   } catch (err) {
     console.error(`[vrs-route] error for ${callsign}:`, err);


### PR DESCRIPTION
## Summary
- Adds `CDN-Cache-Control` / `Vercel-CDN-Cache-Control` headers to `/api/proxy/flight-routes/callsign/[callsign]` so repeated lookups for the same callsign don't hit AeroDataBox/VRS on every page visit.
- Successful responses cache for 1h shared; miss responses cache for 5m to avoid sticky false negatives.
- Browser `Cache-Control` stays conservative (`max-age=0, must-revalidate`); caching is primarily at the Vercel CDN.
- Aircraft positions, METAR, nearby airports, and airport metadata caching are unchanged.

Closes #162

## Test plan
- [ ] Vercel preview build succeeds
- [ ] `curl -I '<preview>/api/proxy/flight-routes/callsign/DAL123'` shows `CDN-Cache-Control: public, s-maxage=3600, stale-while-revalidate=600` and `Cache-Control: public, max-age=0, must-revalidate`
- [ ] Repeated requests for the same callsign show `x-vercel-cache: HIT` after warmup
- [ ] Miss responses (`/api/proxy/flight-routes/callsign/ZZZ999`) show 5m `s-maxage`
- [ ] `/api/proxy/aircraft/positions/...` still responds with `no-store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)