### PR TITLE
fix: make flight-routes proxy actually cacheable at Vercel CDN

### DIFF
--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
@@ -32,13 +32,14 @@ const ROUTE_CACHE_TTL_SECONDS = 60 * 60;
 const ROUTE_MISS_CACHE_TTL_SECONDS = 5 * 60;
 const ROUTE_STALE_WHILE_REVALIDATE_SECONDS = 10 * 60;
 
-function buildRouteCacheHeaders(body) {
+export function buildRouteCacheHeaders(body) {
   const ttl = body ? ROUTE_CACHE_TTL_SECONDS : ROUTE_MISS_CACHE_TTL_SECONDS;
-  const cdnValue = `public, s-maxage=${ttl}, stale-while-revalidate=${ROUTE_STALE_WHILE_REVALIDATE_SECONDS}`;
+  const swr = ROUTE_STALE_WHILE_REVALIDATE_SECONDS;
+  const sharedValue = `public, s-maxage=${ttl}, stale-while-revalidate=${swr}`;
   return {
-    "Cache-Control": "public, max-age=0, must-revalidate",
-    "CDN-Cache-Control": cdnValue,
-    "Vercel-CDN-Cache-Control": cdnValue,
+    "Cache-Control": `public, max-age=0, s-maxage=${ttl}, stale-while-revalidate=${swr}`,
+    "CDN-Cache-Control": sharedValue,
+    "Vercel-CDN-Cache-Control": sharedValue,
   };
 }
 
@@ -188,7 +189,9 @@ export async function GET(request, { params }) {
 
     return Response.json(body, {
       status: body ? 200 : VRS_ROUTE_MISS_STATUS,
-      headers: buildProxyHeaders(request, buildRouteCacheHeaders(body)),
+      headers: buildProxyHeaders(request, buildRouteCacheHeaders(body), {
+        varyOrigin: false,
+      }),
     });
   } catch (err) {
     console.error(`[vrs-route] error for ${callsign}:`, err);

--- a/src/services/apiProxySecurity.js
+++ b/src/services/apiProxySecurity.js
@@ -106,7 +106,9 @@ export function buildProxyHeaders(request, headers = {}, options = {}) {
   output.set("Access-Control-Allow-Methods", DEFAULT_ALLOWED_METHODS.join(", "));
   output.set("Access-Control-Allow-Headers", "Accept, Content-Type");
   output.set("Access-Control-Max-Age", "86400");
-  output.append("Vary", "Origin");
+  if (options.varyOrigin !== false) {
+    output.append("Vary", "Origin");
+  }
   output.set("X-Content-Type-Options", "nosniff");
   return output;
 }

--- a/src/services/apiProxySecurity.test.js
+++ b/src/services/apiProxySecurity.test.js
@@ -34,6 +34,22 @@ assert.equal(
   "https://adsbao.test",
 );
 
+assert.equal(buildProxyHeaders(sameOriginRequest).get("Vary"), "Origin");
+
+assert.equal(
+  buildProxyHeaders(sameOriginRequest, {}, { varyOrigin: false }).get("Vary"),
+  null,
+);
+
+assert.equal(
+  buildProxyHeaders(
+    sameOriginRequest,
+    {},
+    { varyOrigin: false },
+  ).get("Access-Control-Allow-Origin"),
+  "https://adsbao.test",
+);
+
 assert.equal(createCorsPreflightResponse(sameOriginRequest).status, 204);
 
 const blockedOriginRequest = new Request(


### PR DESCRIPTION
## Summary

Closes #166.

Even after #163 added `Vercel-CDN-Cache-Control: s-maxage=3600` to the flight-routes proxy, repeated production requests still returned `x-vercel-cache: MISS` and `age: 0`. This PR makes the route a real hour-long shared cache.

### Investigation

Per the issue, I verified the current state directly:

- `src/app/api/proxy/flight-routes/callsign/[callsign]/route.js:35-43` does emit `s-maxage` in `CDN-Cache-Control` and `Vercel-CDN-Cache-Control`, but the primary header is `Cache-Control: public, max-age=0, must-revalidate` — which is the same string Vercel emits as its default "do not cache" signal. The codex theory that this signal interferes with CDN caching despite the targeted overrides is consistent with the observed production headers.
- `src/services/apiProxySecurity.js:102-112` unconditionally appends `Vary: Origin`. For curl with no `Origin`, both requests share the same cache variant — so `Vary: Origin` alone cannot fully explain MISS-MISS. It is, however, unnecessary fragmentation for a JSON body that does not actually depend on the request's `Origin`; only the echoed `Access-Control-Allow-Origin` header does.
- `enforceProxyRequest` already returns 403 for cross-origin requests that are not allow-listed, so in practice the only reachable variants are "no Origin" and "same-origin." Dropping `Vary: Origin` for this one route is safe.

### Changes

- `buildRouteCacheHeaders` now emits `Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=600` (300s s-maxage on misses), so shared caches see a fresh window even if `Vercel-CDN-Cache-Control` is for any reason not honored. Browsers continue to revalidate via `max-age=0`.
- `buildProxyHeaders` accepts `{ varyOrigin: false }` to omit the `Vary: Origin` append. Default behavior is unchanged for every other proxy.
- The flight-routes route opts out via `buildProxyHeaders(request, …, { varyOrigin: false })`.
- Aircraft positions (`/api/proxy/aircraft/positions/...`) is untouched and stays real-time.

### Validation

```bash
URL='https://www.adsbao.dev/api/proxy/flight-routes/callsign/DAL123'
curl -sD - -o /dev/null "$URL" | grep -iE 'cache-control|cdn-cache-control|x-vercel-cache|age|vary'
sleep 2
curl -sD - -o /dev/null "$URL" | grep -iE 'cache-control|cdn-cache-control|x-vercel-cache|age|vary'
```

Expected after deploy:

```
cache-control: public, max-age=0, s-maxage=3600, stale-while-revalidate=600
cdn-cache-control: public, s-maxage=3600, stale-while-revalidate=600
x-vercel-cache: HIT
age: >0
```

The first request from a given Vercel region may still be MISS; the second from the same region for the same URL should HIT.

## Test plan

- [x] `pnpm test` — all 43 test files pass.
- [x] `pnpm build` — production build succeeds.
- [x] New assertions in `src/services/apiProxySecurity.test.js` cover both the default `Vary: Origin` behavior and the `{ varyOrigin: false }` opt-out.
- [ ] After merge, run the curl validation above against `https://www.adsbao.dev/api/proxy/flight-routes/callsign/DAL123` and confirm second request returns `x-vercel-cache: HIT`.
