### PR TITLE
feat(home): bias featured airports toward dense adsb.lol coverage

### DIFF
--- a/src/config/airportSearch.js
+++ b/src/config/airportSearch.js
@@ -5,8 +5,13 @@ export const AIRPORT_SEARCH_CONFIG = {
   debounceMs: 220,
 };
 
-// Curated mix of high-traffic hubs across regions. Coordinates and naming come
-// from the OurAirports import so these match what `/api/search` returns.
+// Curated mix of high-traffic hubs in regions with dense adsb.lol receiver
+// coverage so the homepage previews always have visible nearby traffic.
+// Coverage map (https://adsb.lol/coverage) is strongest across the US, Canada,
+// Western Europe, and Hong Kong; mainland Asia and the Middle East are
+// noticeably thinner, so we intentionally bias the list toward those regions.
+// Coordinates and naming come from the OurAirports import so these match what
+// `/api/search` returns.
 export const FEATURED_AIRPORTS = [
   {
     icao: "KJFK",
@@ -53,6 +58,28 @@ export const FEATURED_AIRPORTS = [
     type_label: "Large Airport",
   },
   {
+    icao: "KBOS",
+    iata: "BOS",
+    name: "Boston Logan International Airport",
+    city: "Boston",
+    country: "US",
+    lat: 42.36197,
+    lon: -71.0079,
+    type: "large_airport",
+    type_label: "Large Airport",
+  },
+  {
+    icao: "CYYZ",
+    iata: "YYZ",
+    name: "Toronto Pearson International Airport",
+    city: "Toronto",
+    country: "CA",
+    lat: 43.675935,
+    lon: -79.629421,
+    type: "large_airport",
+    type_label: "Large Airport",
+  },
+  {
     icao: "EGLL",
     iata: "LHR",
     name: "London Heathrow Airport",
@@ -75,13 +102,13 @@ export const FEATURED_AIRPORTS = [
     type_label: "Large Airport",
   },
   {
-    icao: "RJTT",
-    iata: "HND",
-    name: "Tokyo Haneda International Airport",
-    city: "Tokyo",
-    country: "JP",
-    lat: 35.549678,
-    lon: 139.786958,
+    icao: "EDDF",
+    iata: "FRA",
+    name: "Frankfurt Main Airport",
+    city: "Frankfurt am Main",
+    country: "DE",
+    lat: 50.026706,
+    lon: 8.55835,
     type: "large_airport",
     type_label: "Large Airport",
   },
@@ -93,28 +120,6 @@ export const FEATURED_AIRPORTS = [
     country: "HK",
     lat: 22.31184,
     lon: 113.914862,
-    type: "large_airport",
-    type_label: "Large Airport",
-  },
-  {
-    icao: "OMDB",
-    iata: "DXB",
-    name: "Dubai International Airport",
-    city: "Dubai",
-    country: "AE",
-    lat: 25.24979,
-    lon: 55.370992,
-    type: "large_airport",
-    type_label: "Large Airport",
-  },
-  {
-    icao: "CYYZ",
-    iata: "YYZ",
-    name: "Toronto Pearson International Airport",
-    city: "Toronto",
-    country: "CA",
-    lat: 43.675935,
-    lon: -79.629421,
     type: "large_airport",
     type_label: "Large Airport",
   },


### PR DESCRIPTION
The homepage previews show "nearby aircraft" using the adsb.lol feed, which has the strongest receiver coverage across the US, Canada, Western Europe, and Hong Kong. The previous featured list included RJTT (Tokyo) and OMDB (Dubai), both of which sit in noticeably thinner coverage regions — a user opening one of those airports often saw an empty or sparse traffic feed despite picking a major hub.

Rebalance to ten hubs that reliably show live traffic.

## Final list

| Region | Airports |
|---|---|
| US (5) | KJFK, KLAX, KORD, KATL, **KBOS** *(new)* |
| CA (1) | CYYZ |
| EU (3) | EGLL, LFPG, **EDDF** *(new)* |
| HK (1) | VHHH |

**Dropped**: RJTT (Tokyo), OMDB (Dubai)
**Added**: KBOS (Boston), EDDF (Frankfurt)

Coordinates pulled directly from the Supabase OurAirports rows so they match what `/api/search` returns.

## Test plan

- [x] `node scripts/run-tests.js` — 49 test files pass.
- [x] `npx next build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)