### PR TITLE
perf(routes): far-side-first lookup order + bump concurrency to 10

### DIFF
--- a/src/config/aviation.js
+++ b/src/config/aviation.js
@@ -35,7 +35,7 @@ export const AVIATION_REQUEST_TIMEOUT_MS = {
 export const FLIGHT_ROUTE_LOOKUP_CONFIG = {
   hitCacheMs: 6 * 60 * 60 * 1000,
   missCacheMs: 2 * 60 * 60 * 1000,
-  maxConcurrentLookups: 6,
+  maxConcurrentLookups: 10,
   maxLookupsPerPass: 18,
   maxQueueSize: 60,
   auditLogIntervalMs: 2_000,

--- a/src/features/flight-routes/flightRouteLookupModel.js
+++ b/src/features/flight-routes/flightRouteLookupModel.js
@@ -43,6 +43,60 @@ export function getLookupCallsigns(aircraft) {
   ];
 }
 
+const EARTH_RADIUS_NM = 3440.065;
+
+const haversineNm = (lat1, lon1, lat2, lon2) => {
+  const toRad = (value) => (value * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const sinLat = Math.sin(dLat / 2);
+  const sinLon = Math.sin(dLon / 2);
+  const a =
+    sinLat * sinLat +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * sinLon * sinLon;
+  return 2 * EARTH_RADIUS_NM * Math.asin(Math.min(1, Math.sqrt(a)));
+};
+
+// Ranks candidates so aircraft farthest from the focal airport are scheduled
+// first. The default map view zooms out to show the whole nearby airspace, so
+// fetching the far-side traffic first makes more route labels appear quickly
+// where the user's eye is actually looking. Falls back to source order when
+// the focal coords or aircraft coords are missing.
+export function rankCandidatesByDistance(aircraft, routeContext = {}) {
+  const focusLat = Number(routeContext.lat);
+  const focusLon = Number(routeContext.lon);
+  const haveFocus = Number.isFinite(focusLat) && Number.isFinite(focusLon);
+  const seen = new Map();
+
+  (aircraft || []).forEach((item, index) => {
+    const callsign = normalizeCallsign(item?.callsign);
+    if (!isLookupCallsign(callsign)) return;
+    const lat = Number(item?.lat);
+    const lon = Number(item?.lon);
+    const distance =
+      haveFocus && Number.isFinite(lat) && Number.isFinite(lon)
+        ? haversineNm(focusLat, focusLon, lat, lon)
+        : -1;
+    // Keep the farthest occurrence per callsign so duplicates don't pull the
+    // candidate forward by mistake.
+    const prior = seen.get(callsign);
+    if (!prior || distance > prior.distance) {
+      seen.set(callsign, { distance, index });
+    }
+  });
+
+  return [...seen.entries()]
+    .sort((left, right) => {
+      const [, leftMeta] = left;
+      const [, rightMeta] = right;
+      if (leftMeta.distance !== rightMeta.distance) {
+        return rightMeta.distance - leftMeta.distance; // farthest first
+      }
+      return leftMeta.index - rightMeta.index;
+    })
+    .map(([callsign]) => callsign);
+}
+
 export function resolvePendingRouteLookups({
   aircraft,
   cache,
@@ -52,7 +106,7 @@ export function resolvePendingRouteLookups({
   now = Date.now(),
   maxLookups = FLIGHT_ROUTE_LOOKUP_CONFIG.maxLookupsPerPass,
 }) {
-  return getLookupCallsigns(aircraft)
+  return rankCandidatesByDistance(aircraft, routeContext)
     .filter(
       (callsign) =>
         !getFreshRouteCacheEntry(cache, callsign, now, routeContext) &&

--- a/src/features/flight-routes/flightRouteLookupModel.test.js
+++ b/src/features/flight-routes/flightRouteLookupModel.test.js
@@ -5,6 +5,7 @@ import {
   buildRoutesByCallsign,
   getRouteLookupStats,
   getFreshRouteCacheEntry,
+  rankCandidatesByDistance,
   resolvePendingRouteLookups,
 } from "./flightRouteLookupModel.js";
 
@@ -110,4 +111,66 @@ const route = {
   });
 
   assert.deepEqual(routes, { DAL123: route });
+}
+
+// rankCandidatesByDistance: aircraft farthest from focal airport rank first.
+// KBOS focal -> JBU123 over Lisbon (~3000nm) outranks DAL123 over NYC (~190nm)
+// outranks UAL456 directly over KBOS (~0nm).
+{
+  const ranked = rankCandidatesByDistance(
+    [
+      { callsign: "UAL456", lat: 42.36, lon: -71.01 },
+      { callsign: "DAL123", lat: 40.64, lon: -73.78 },
+      { callsign: "JBU123", lat: 38.78, lon: -9.13 },
+    ],
+    { icao: "KBOS", lat: 42.3656, lon: -71.0096 },
+  );
+  assert.deepEqual(ranked, ["JBU123", "DAL123", "UAL456"]);
+}
+
+// Without focal coords, source order is preserved.
+{
+  const ranked = rankCandidatesByDistance(
+    [
+      { callsign: "UAL456", lat: 42, lon: -71 },
+      { callsign: "DAL123", lat: 40, lon: -73 },
+      { callsign: "JBU123", lat: 38, lon: -9 },
+    ],
+    {},
+  );
+  assert.deepEqual(ranked, ["UAL456", "DAL123", "JBU123"]);
+}
+
+// Aircraft missing lat/lon land last (treated as distance -1).
+{
+  const ranked = rankCandidatesByDistance(
+    [
+      { callsign: "UAL456" },
+      { callsign: "DAL123", lat: 40.64, lon: -73.78 },
+      { callsign: "JBU123", lat: 38.78, lon: -9.13 },
+    ],
+    { icao: "KBOS", lat: 42.3656, lon: -71.0096 },
+  );
+  assert.deepEqual(ranked, ["JBU123", "DAL123", "UAL456"]);
+}
+
+// resolvePendingRouteLookups respects the distance ranking when focal coords
+// are provided.
+{
+  const aircraft = [
+    { callsign: "UAL456", lat: 42.36, lon: -71.01 }, // ~0 nm
+    { callsign: "DAL123", lat: 40.64, lon: -73.78 }, // ~190 nm
+    { callsign: "JBU123", lat: 38.78, lon: -9.13 }, // ~3000 nm
+  ];
+  const pending = resolvePendingRouteLookups({
+    aircraft,
+    cache: new Map(),
+    inFlight: new Set(),
+    queued: new Set(),
+    routeContext: { icao: "KBOS", lat: 42.3656, lon: -71.0096 },
+    now,
+    maxLookups: 2,
+  });
+  // Farthest two first, limited to 2.
+  assert.deepEqual(pending, ["JBU123", "DAL123"]);
 }

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -72,8 +72,18 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
     () => ({
       icao: routeContextInput?.icao || "",
       iata: routeContextInput?.iata || "",
+      // Focal coords flow through to the scheduler so it can rank candidates
+      // farthest-first. They are *not* part of the cache key — see
+      // `buildRouteCacheKey` in flightRouteLookupModel.js.
+      lat: Number(routeContextInput?.lat),
+      lon: Number(routeContextInput?.lon),
     }),
-    [routeContextInput?.icao, routeContextInput?.iata],
+    [
+      routeContextInput?.icao,
+      routeContextInput?.iata,
+      routeContextInput?.lat,
+      routeContextInput?.lon,
+    ],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Two small scheduling wins for the flight-route lookup queue that drives the `AAA → BBB` labels next to nearby traffic.

## 1. Far-side-first ordering

The default airport view zooms out to cover the whole nearby airspace, so traffic near the edge of the map is what users actually scan first. Today the queue resolves in source order (effectively callsign-insertion order), so close-in traffic gets the first labels — even though it's visually the smallest thing on the map.

- New `rankCandidatesByDistance(aircraft, routeContext)` ranks pending callsigns by haversine distance from the focal airport, descending.
- `resolvePendingRouteLookups` routes through it.
- `useFlightRoutes` threads `lat`/`lon` through `routeContext`. These are **not** part of the cache key (`buildRouteCacheKey` still only uses ICAO/IATA), so existing cache entries keep hitting.
- Aircraft without coords, or with no focal coords, fall back to source order — no regression for the airport-less callsites.

## 2. Concurrency 6 → 10

`maxConcurrentLookups` in `FLIGHT_ROUTE_LOOKUP_CONFIG` bumped from 6 to 10. VRS standing-data and our `/api/proxy/flight-routes/callsign/[callsign]` proxy are CDN-cached and shrug off the fan-out; the previous cap was conservative.

No change to cache miss/hit, callsign validation, AeroDataBox fallback, or the per-second token bucket — purely a scheduling tweak.

## Test plan

- [x] `node scripts/run-tests.js` — 49 test files pass (added 4 new assertions in `flightRouteLookupModel.test.js` for distance ranking).
- [x] `npx next build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)