### PR TITLE
v0.11.0 — Selected-aircraft trace, focused revalidation, route consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
 
+## v0.11.0 — Selected-aircraft trace, focused revalidation, route consistency
+
+### Added
+- Selected-aircraft trace renders the last few minutes of the focused plane's path as a Leaflet polyline with an SVG `linearGradient` core (tail 20% → head 95% opacity) and timestamped fade-in label cards. Trail and labels share a `SelectedAircraftTraceProvider` so the focused-flight state lives outside the marker map and survives the periodic ADS-B refresh without tearing down or re-flashing.
+- When the focused aircraft is classified as `DEPARTURE` or `ARRIVAL`, the trail and label accents pick up the same color the marker uses — orange for departures, teal/blue for arrivals — instead of the neutral theme accent.
+- Clicking an already-focused aircraft marker now triggers an AeroDataBox revalidation of its route (`?force=aerodatabox` on the callsign proxy, `Cache-Control: no-store`) so the user can refresh stale or unresolved routes on demand. The revalidate path only overwrites the route cache when AeroDataBox returns a route with both origin and destination, so a partial response can't clobber a complete VRS entry already in cache.
+
+### Changed
+- `enrichAircraftWithRoutes` now ties `movement` to a renderable `flightRouteLabel`: if the route is missing either endpoint (and therefore has no label to render), the aircraft is classified `UNKNOWN` instead of being colored `DEPARTURE`/`ARRIVAL` with an empty sidebar row. This was the source of ENY3573 / GJS4391 showing as orange "departing" markers with no route text.
+- Map overlays removed: the top-left ICAO + coordinate label and the right-edge DEP/UNKN/ARR traffic legend are gone. Both were holdovers from the earlier console design that the current marker color encoding already communicates.
+- Trail label cards hug their content (`width: max-content`) instead of inheriting the Leaflet `divIcon` 56-px box, and the latest marker stacks on top via `zIndexOffset`. Label re-renders use a stable signature so unchanged labels stay mounted across the 3-second poll instead of fading in every cycle.
+
+### Fixed
+- ADS-B provider failover: the proxy now retries against `airplanes.live` whenever `adsb.lol` returns 5xx, 429, or times out, with a per-process cool-down so we don't hammer a degraded provider. The audit log records the exact provider attempted per outgoing request.
+- Trail and labels no longer briefly flash a previous aircraft's path when switching focus: `committedTracePoints` resets atomically on `aircraftHex` change and the live-position append is gated on `!loading` so the first frame can't ship a half-resolved geometry.
+
 ## v0.10.0 — Global airport data layer + richer silhouettes
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Use the current ADSBao web release line:
 | `v0.8.0` | Next.js Vercel refactor |
 | `v0.9.0` | Navy tracking console redesign |
 | `v0.10.0` | Global airport data layer (OurAirports + Supabase) and richer aircraft silhouettes |
+| `v0.11.0` | Selected-aircraft trace + multi-provider failover + AeroDataBox revalidation |
 
 `v0.3.x` and earlier are legacy desktop-app history. Do not use those releases as the current ADSBao web product line.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A modern airport-monitoring HUD with dynamic airport search, METAR context, and 
 ## Overview
 ADSBao provides a search-first airport operations view with weather context and aircraft position overlays. Airport search is backed by public airport directory data.
 
-Current web app version: **0.10.0**. See `CHANGELOG.md` for product version history and the legacy desktop release split.
+Current web app version: **0.11.0**. See `CHANGELOG.md` for product version history and the legacy desktop release split.
 
 ## Tech Stack
 - **Frontend**: React on Next.js App Router, Tailwind CSS v4, DaisyUI, Lucide Icons.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,5 +73,6 @@ The current ADSBao web line starts at `v0.4.0`.
 | `v0.8.0` | Next.js Vercel refactor |
 | `v0.9.0` | Navy tracking console redesign |
 | `v0.10.0` | Global airport data layer (OurAirports + Supabase) and richer aircraft silhouettes |
+| `v0.11.0` | Selected-aircraft trace + multi-provider failover + AeroDataBox revalidation |
 
 `v0.3.x` and earlier are legacy desktop-app history and should not be used as the current ADSBao web product line.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
@@ -174,22 +174,41 @@ export async function GET(request, { params }) {
 
   try {
     const targetAirport = getTargetAirport(request);
-    let body = await fetchVrsStandingRoute(callsign);
-    if (shouldUseAerodataboxFallback(body, targetAirport)) {
+    const forceAerodatabox =
+      request.nextUrl?.searchParams.get("force") === "aerodatabox";
+
+    let body;
+    if (forceAerodatabox) {
+      // Explicit user-initiated revalidation: skip VRS standing-data and go
+      // straight to AeroDataBox so the freshest authoritative result lands
+      // even if our cache has the VRS answer already.
       const aerodataboxResult = await fetchAerodataboxRoute(
         callsign,
         targetAirport,
       );
-      if (aerodataboxResult.route) {
-        body = aerodataboxResult.route;
-      } else if (aerodataboxResult.suppressVrsRoute) {
-        body = null;
+      body = aerodataboxResult.route;
+    } else {
+      body = await fetchVrsStandingRoute(callsign);
+      if (shouldUseAerodataboxFallback(body, targetAirport)) {
+        const aerodataboxResult = await fetchAerodataboxRoute(
+          callsign,
+          targetAirport,
+        );
+        if (aerodataboxResult.route) {
+          body = aerodataboxResult.route;
+        } else if (aerodataboxResult.suppressVrsRoute) {
+          body = null;
+        }
       }
     }
 
+    const cacheHeaders = forceAerodatabox
+      ? { "Cache-Control": "no-store" }
+      : buildRouteCacheHeaders(body);
+
     return Response.json(body, {
       status: body ? 200 : VRS_ROUTE_MISS_STATUS,
-      headers: buildProxyHeaders(request, buildRouteCacheHeaders(body), {
+      headers: buildProxyHeaders(request, cacheHeaders, {
         varyOrigin: false,
       }),
     });

--- a/src/components/map/AircraftPosition.jsx
+++ b/src/components/map/AircraftPosition.jsx
@@ -42,7 +42,15 @@ export default function AircraftPosition({
   selectionActive = false,
   traceActive = false,
   onSelectAircraft,
+  onRevalidateRoute,
 }) {
+  const selectedRef = useRef(selected);
+  selectedRef.current = selected;
+  const callsignRef = useRef("");
+  callsignRef.current =
+    typeof aircraft?.callsign === "string" ? aircraft.callsign.trim() : "";
+  const onRevalidateRouteRef = useRef(onRevalidateRoute);
+  onRevalidateRouteRef.current = onRevalidateRoute;
   const map = useMapInstance();
   const motionRef = useRef(null);
   const markerRef = useRef(null);
@@ -60,6 +68,16 @@ export default function AircraftPosition({
 
     const handleSelect = (event) => {
       event.stopPropagation();
+      // Clicking the already-focused plane shouldn't toggle it off — that
+      // role belongs to the empty-map click. Instead, route the click to
+      // an explicit AeroDataBox revalidation of the current callsign so
+      // the user can refresh the trail's labeling on demand.
+      if (selectedRef.current && typeof onRevalidateRouteRef.current === "function") {
+        if (callsignRef.current) {
+          onRevalidateRouteRef.current(callsignRef.current);
+        }
+        return;
+      }
       onSelectAircraft(aircraftId);
     };
 

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -44,6 +44,7 @@ export default function AirportMap({
   altitudeLevel = "all",
   selectedAircraftId = "",
   onSelectAircraft,
+  onRevalidateRoute,
   runwayMap = null,
   runwayProcedures = null,
   procedureFixLabelRunwayProcedures = runwayProcedures,
@@ -210,6 +211,7 @@ export default function AirportMap({
               selectionActive={selectionActive}
               traceActive={selectionActive}
               onSelectAircraft={onSelectAircraft}
+              onRevalidateRoute={onRevalidateRoute}
             />
           ))}
         </MapContext.Provider>

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -12,18 +12,12 @@ import AircraftPosition from "./AircraftPosition.jsx";
 import SelectedAircraftTrace from "./SelectedAircraftTrace.jsx";
 import RunwayAnnotationLayer from "./RunwayAnnotationLayer.jsx";
 import ProcedureSegmentLayer from "./ProcedureSegmentLayer.jsx";
-import {
-  AIRPORT_MAP_FALLBACK_CENTER,
-  AIRPORT_MAP_TRAFFIC_LEGEND,
-} from "../../config/airportMap.js";
+import { AIRPORT_MAP_FALLBACK_CENTER } from "../../config/airportMap.js";
 import MapAttribution from "../../features/airport-map/MapAttribution.jsx";
-import MapCoordinateLabel from "../../features/airport-map/MapCoordinateLabel.jsx";
 import MapLoadingState from "../../features/airport-map/MapLoadingState.jsx";
-import MapTrafficLegend from "../../features/airport-map/MapTrafficLegend.jsx";
 import { getAircraftIdentity } from "../../features/airport-context/airportContextUiModel.js";
 import { aircraftMatchesFilters } from "../../features/aircraft-filters/aircraftFilters.js";
 import {
-  formatCoordinateLabel,
   getMapOverlayTheme,
   getVisibleAircraft,
   resolveDocumentTheme,
@@ -39,7 +33,6 @@ export default function AirportMap({
   lat = 0,
   lon = 0,
   zoom = 13,
-  accent = "var(--atc-accent)",
   aircraft = [],
   nearbyAirports = [],
   airport = null,
@@ -152,8 +145,6 @@ export default function AirportMap({
   );
   const selectionActive = Boolean(selectedAircraftId && selectedAircraft);
 
-  const latitudeLabel = formatCoordinateLabel(lat, "lat");
-  const longitudeLabel = formatCoordinateLabel(lon, "lon");
   const overlayTheme = getMapOverlayTheme(currentTheme);
 
   return (
@@ -225,20 +216,10 @@ export default function AirportMap({
       )}
 
       {mapInstance && (
-        <>
-          <MapCoordinateLabel
-            icao={icao}
-            latitudeLabel={latitudeLabel}
-            longitudeLabel={longitudeLabel}
-            color={accent}
-            shadowColor={overlayTheme.labelShadowColor}
-          />
-          <MapAttribution
-            color={overlayTheme.attributionColor}
-            shadowColor={overlayTheme.labelShadowColor}
-          />
-          <MapTrafficLegend items={AIRPORT_MAP_TRAFFIC_LEGEND} />
-        </>
+        <MapAttribution
+          color={overlayTheme.attributionColor}
+          shadowColor={overlayTheme.labelShadowColor}
+        />
       )}
 
       {!mapInstance && <MapLoadingState />}

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -204,11 +204,7 @@ export default function AirportMap({
             icao={icao}
             aircraft={aircraft}
           />
-          <SelectedAircraftTrace
-            aircraft={selectedAircraft}
-            tracePoints={selectedAircraftTrace}
-            theme={currentTheme}
-          />
+          <SelectedAircraftTrace theme={currentTheme} />
           {visibleAircraft.map((ac) => (
             <AircraftPosition
               key={getAircraftIdentity(ac)}

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -50,7 +50,6 @@ export default function AirportMap({
   typeFilter = "all",
   altitudeLevel = "all",
   selectedAircraftId = "",
-  selectedAircraftTrace = [],
   onSelectAircraft,
   runwayMap = null,
   runwayProcedures = null,

--- a/src/components/map/SelectedAircraftTrace.jsx
+++ b/src/components/map/SelectedAircraftTrace.jsx
@@ -16,6 +16,8 @@ import {
   shouldRenderCommittedTrace,
 } from "../../features/aircraft-trace/traceRevealModel.js";
 import { useSelectedAircraftTrace } from "../../features/aircraft-trace/SelectedAircraftTraceContext.jsx";
+import { AIRCRAFT_COLORS } from "../../constants/aircraft.js";
+import { ARRIVAL, DEPARTURE } from "../../utils/aircraftMovement.js";
 
 const TRACE_GROWTH_DURATION_MS = 900;
 const TRACE_LABEL_FADE_STAGGER_MS = 70;
@@ -83,8 +85,11 @@ function ensureSvgDefs(svg) {
 function addGradientStop(gradient, offset, color, opacity) {
   const stop = document.createElementNS(SVG_NS, "stop");
   stop.setAttribute("offset", offset);
-  stop.setAttribute("stop-color", color);
-  stop.setAttribute("stop-opacity", String(opacity));
+  // Inline style instead of attribute so CSS variables work — the
+  // aircraft accent colors live in --aircraft-departure / --aircraft-
+  // arrival and the gradient needs to resolve them at render time.
+  stop.style.stopColor = color;
+  stop.style.stopOpacity = String(opacity);
   gradient.append(stop);
 }
 
@@ -136,7 +141,7 @@ function makeLabelKey(labelPoints) {
 }
 
 export default function SelectedAircraftTrace({ theme = "dark" }) {
-  const { aircraftHex, tracePoints } = useSelectedAircraftTrace();
+  const { aircraftHex, movement, tracePoints } = useSelectedAircraftTrace();
   const map = useMapInstance();
   const lineLayersRef = useRef([]);
   const labelMarkersRef = useRef([]);
@@ -202,6 +207,15 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
     [aircraftHex, committedTrace.tracePoints],
   );
 
+  // Accent color tracks the aircraft marker's color when its movement
+  // is recognized — trail visually pairs with its plane. Falls back to
+  // null (theme default) when the aircraft hasn't been classified.
+  const accentColor = useMemo(() => {
+    if (movement === DEPARTURE) return AIRCRAFT_COLORS.departure;
+    if (movement === ARRIVAL) return AIRCRAFT_COLORS.arrival;
+    return null;
+  }, [movement]);
+
   // labelKey is a string derived from labelPoints. As long as the historic
   // sample set is stable (same timestamps + altitudes), the key is the
   // same string and the label-effect dep doesn't change — labels stay
@@ -248,13 +262,16 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
 
     const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.trace);
     const traceStyle = getTraceStyle(theme);
+    const lineColor = accentColor || traceStyle.lineColor;
+    const glowColor = accentColor || traceStyle.glowColor;
+    const dotColor = accentColor || traceStyle.pointColor;
     const layers = [];
     const gradientEls = [];
     const gradientBase = `${gradientIdPart(aircraftHex)}-${Date.now().toString(36)}`;
 
     const corePolyline = L.polyline(geometry.curve.slice().reverse(), {
       pane,
-      color: traceStyle.lineColor,
+      color: lineColor,
       opacity: 1,
       weight: traceStyle.lineWeight,
       interactive: false,
@@ -269,7 +286,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
         polyline: corePolyline,
         curve: geometry.curve,
         gradientId: `aircraft-trace-core-${gradientBase}`,
-        color: traceStyle.lineColor,
+        color: lineColor,
         tailOpacity: TRACE_CORE_TAIL_OPACITY,
         midOpacity: TRACE_CORE_MID_OPACITY,
         headOpacity: TRACE_CORE_HEAD_OPACITY,
@@ -278,7 +295,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
 
     const glowPolyline = L.polyline(geometry.curve.slice().reverse(), {
       pane,
-      color: traceStyle.glowColor,
+      color: glowColor,
       opacity: 1,
       weight: traceStyle.glowWeight,
       interactive: false,
@@ -293,7 +310,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
         polyline: glowPolyline,
         curve: geometry.curve,
         gradientId: `aircraft-trace-glow-${gradientBase}`,
-        color: traceStyle.glowColor,
+        color: glowColor,
         tailOpacity: 0,
         midOpacity: traceStyle.glowOpacity * 0.38,
         headOpacity: traceStyle.glowOpacity,
@@ -308,7 +325,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
           pane,
           radius: traceStyle.pointRadius,
           stroke: false,
-          fillColor: traceStyle.pointColor,
+          fillColor: dotColor,
           fillOpacity: traceStyle.pointFillOpacity * (0.3 + emphasis * 0.7),
           interactive: false,
           className: "aircraft-trace-point",
@@ -406,7 +423,15 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
       removeElements(gradientElsRef.current);
       gradientElsRef.current = [];
     };
-  }, [map, theme, geometry, aircraftHex, reducedMotion, traceRevealKey]);
+  }, [
+    map,
+    theme,
+    geometry,
+    aircraftHex,
+    accentColor,
+    reducedMotion,
+    traceRevealKey,
+  ]);
 
   // -------------------------------------------------------------------
   // Effect 2: historic time/altitude labels. Keyed by labelKey so it only

--- a/src/components/map/SelectedAircraftTrace.jsx
+++ b/src/components/map/SelectedAircraftTrace.jsx
@@ -24,6 +24,16 @@ const TRACE_REVEAL_EASING = "cubic-bezier(0.25, 1, 0.5, 1)";
 const TRACE_REVEAL_SETTLE_MS = 80;
 const SVG_NS = "http://www.w3.org/2000/svg";
 
+// Core trace gradient opacity envelope. Tail floor keeps the oldest segment
+// visible (20%) rather than fading completely to invisible; head ceiling
+// stays just under fully opaque (95%) so the live aircraft marker still
+// reads as the brightest thing on the trail.
+const TRACE_CORE_TAIL_OPACITY = 0.2;
+const TRACE_CORE_HEAD_OPACITY = 0.95;
+const TRACE_CORE_MID_OPACITY =
+  TRACE_CORE_TAIL_OPACITY +
+  (TRACE_CORE_HEAD_OPACITY - TRACE_CORE_TAIL_OPACITY) * 0.34;
+
 function formatTraceLabelTime(timestampMs) {
   if (!Number.isFinite(timestampMs)) return "";
   const d = new Date(timestampMs);
@@ -234,9 +244,9 @@ export default function SelectedAircraftTrace({
         curve: geometry.curve,
         gradientId: `aircraft-trace-core-${gradientBase}`,
         color: traceStyle.lineColor,
-        tailOpacity: 0,
-        midOpacity: traceStyle.lineOpacity * 0.34,
-        headOpacity: traceStyle.lineOpacity,
+        tailOpacity: TRACE_CORE_TAIL_OPACITY,
+        midOpacity: TRACE_CORE_MID_OPACITY,
+        headOpacity: TRACE_CORE_HEAD_OPACITY,
       }),
     );
 
@@ -347,14 +357,13 @@ export default function SelectedAircraftTrace({
       pendingTraceRef.current = null;
       setCommittedTrace(pending);
     };
-    const finishReveal = (segments = []) => {
+    const finishReveal = (paths = []) => {
       rafIdRef.current = null;
       revealTimeoutRef.current = null;
       isAnimatingRef.current = false;
-      segments.forEach((seg) => {
-        seg.path.style.transition = "";
-        seg.path.style.strokeDasharray = "";
-        seg.path.style.strokeDashoffset = "";
+      paths.forEach((path) => {
+        path.style.transition = "";
+        path.style.opacity = "";
       });
       completedRevealKeyRef.current = traceRevealKey;
       flushPendingTrace();
@@ -375,71 +384,55 @@ export default function SelectedAircraftTrace({
       };
     }
 
-    // Synchronously hide all reveal paths via visibility:hidden so the
-    // user doesn't see a flash of the full trace during the one-frame
-    // defer below. visibility (vs opacity / display) doesn't trigger
-    // reflow and is cheap to flip.
-    const initialPaths = revealPolylines
+    // Resolve the SVG <path> elements for the core + glow polylines. Any
+    // path that isn't ready (canvas renderer, unmounted) just renders at
+    // full state — same fallback as before, no animation.
+    const revealPaths = revealPolylines
       .map((polyline) => polyline.getElement?.())
       .filter(Boolean);
-    initialPaths.forEach((path) => {
-      path.style.visibility = "hidden";
-    });
+
+    if (revealPaths.length === 0) {
+      revealLabels(true);
+      completedRevealKeyRef.current = traceRevealKey;
+      flushPendingTrace();
+      return () => {
+        if (rafIdRef.current) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        removeLayers(layersRef.current, map);
+        layersRef.current = [];
+        removeElements(gradientElsRef.current);
+        gradientElsRef.current = [];
+      };
+    }
 
     isAnimatingRef.current = true;
 
-    // Defer the actual dash setup + animation start by one rAF tick.
-    // Leaflet's SVG renderer flushes path geometry on the next animation
-    // frame after addTo; calling getTotalLength immediately can return 0
-    // for a brief window (the symptom: animation block is reached but
-    // every segment is filtered out and the polylines just appear at
-    // full state). One rAF gets us past that.
+    // Stage: paths at opacity 0 with transitions off so the next paint
+    // commits the hidden state without interpolating from the implicit
+    // default of 1.
+    revealPaths.forEach((path) => {
+      path.style.transition = "none";
+      path.style.opacity = "0";
+    });
+
+    // One rAF later, flip transition on and opacity to 1 — the browser
+    // sees the committed 0 state, schedules the GPU transition, and runs
+    // the fade natively. No per-frame JS, no stroke-dasharray gymnastics.
     rafIdRef.current = requestAnimationFrame(() => {
-      const segments = revealPolylines
-        .map((polyline) => {
-          const path = polyline.getElement?.();
-          const length = path?.getTotalLength?.();
-          if (!path || !Number.isFinite(length) || length <= 0) return null;
-          return { path, pathLength: length };
-        })
-        .filter(Boolean);
-
-      // Re-show paths (we'll control visibility via dashoffset from here).
-      initialPaths.forEach((path) => {
-        path.style.visibility = "";
+      revealPaths.forEach((path) => {
+        path.style.transition = `opacity ${TRACE_GROWTH_DURATION_MS}ms ${TRACE_REVEAL_EASING}`;
+        path.style.opacity = "1";
       });
-
-      if (segments.length === 0) {
-        rafIdRef.current = null;
-        isAnimatingRef.current = false;
-        revealLabels(true);
-        completedRevealKeyRef.current = traceRevealKey;
-        flushPendingTrace();
-        return;
-      }
-
-      // Stage: full reveal paths hidden via full dashoffset. Let CSS own
-      // interpolation so the browser can schedule the paint without a JS
-      // requestAnimationFrame loop writing strokeDashoffset every frame.
-      segments.forEach((seg) => {
-        seg.path.style.strokeDasharray = `${seg.pathLength}`;
-        seg.path.style.strokeDashoffset = `${seg.pathLength}`;
-        seg.path.style.transition = `stroke-dashoffset ${TRACE_GROWTH_DURATION_MS}ms ${TRACE_REVEAL_EASING}`;
-      });
-      // Labels fade in one-by-one while the trace is still drawing, so the
-      // text reads as attached to the same reveal instead of arriving as a
-      // separate overlay after the line has finished.
+      // Labels fade in mid-trace-fade so the text reads as attached to
+      // the same reveal instead of arriving as a separate overlay.
       revealLabels(false);
 
-      rafIdRef.current = requestAnimationFrame(() => {
-        segments.forEach((seg) => {
-          seg.path.style.strokeDashoffset = "0";
-        });
-        revealTimeoutRef.current = setTimeout(
-          () => finishReveal(segments),
-          TRACE_GROWTH_DURATION_MS + TRACE_REVEAL_SETTLE_MS,
-        );
-      });
+      revealTimeoutRef.current = setTimeout(
+        () => finishReveal(revealPaths),
+        TRACE_GROWTH_DURATION_MS + TRACE_REVEAL_SETTLE_MS,
+      );
     });
 
     return () => {
@@ -451,10 +444,11 @@ export default function SelectedAircraftTrace({
         clearTimeout(revealTimeoutRef.current);
         revealTimeoutRef.current = null;
       }
-      // Restore visibility in case we tore down mid-defer before the rAF
-      // callback got to re-show.
-      initialPaths.forEach((path) => {
-        path.style.visibility = "";
+      // Restore inline styles if we tore down mid-fade — otherwise stale
+      // opacity:0 / transition values can carry over to the next render.
+      revealPaths.forEach((path) => {
+        path.style.transition = "";
+        path.style.opacity = "";
       });
       isAnimatingRef.current = false;
       removeLayers(layersRef.current, map);

--- a/src/components/map/SelectedAircraftTrace.jsx
+++ b/src/components/map/SelectedAircraftTrace.jsx
@@ -10,11 +10,19 @@ import {
 } from "../../config/airportMap.js";
 import { ensureAirportMapPane } from "../../features/airport-map/mapPane.js";
 import { computeTraceGeometry } from "../../features/aircraft-trace/traceGeometry.js";
+import {
+  getTraceLabelRevealDelay,
+  getTraceRevealKey,
+  shouldRenderCommittedTrace,
+} from "../../features/aircraft-trace/traceRevealModel.js";
 import { getAircraftIdentity } from "../../features/airport-context/airportContextUiModel.js";
 
 const TRACE_GROWTH_DURATION_MS = 900;
 const TRACE_LABEL_FADE_STAGGER_MS = 70;
 const TRACE_LABEL_FADE_DURATION_MS = 360;
+const TRACE_REVEAL_EASING = "cubic-bezier(0.25, 1, 0.5, 1)";
+const TRACE_REVEAL_SETTLE_MS = 80;
+const SVG_NS = "http://www.w3.org/2000/svg";
 
 function formatTraceLabelTime(timestampMs) {
   if (!Number.isFinite(timestampMs)) return "";
@@ -45,11 +53,64 @@ function removeLayers(layers = [], map) {
   });
 }
 
-// Cubic ease-in-out — gentle on both ends, fast in the middle. Reads as
-// "the trail is being unfurled" rather than "snap then crawl" that plain
-// ease-out produced when most of the path drew in the first 100ms.
-const easeInOutCubic = (t) =>
-  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+function removeElements(elements = []) {
+  elements.forEach((element) => element?.remove?.());
+}
+
+function gradientIdPart(value) {
+  return String(value || "trace").replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function ensureSvgDefs(svg) {
+  let defs = svg.querySelector("defs");
+  if (!defs) {
+    defs = document.createElementNS(SVG_NS, "defs");
+    svg.prepend(defs);
+  }
+  return defs;
+}
+
+function addGradientStop(gradient, offset, color, opacity) {
+  const stop = document.createElementNS(SVG_NS, "stop");
+  stop.setAttribute("offset", offset);
+  stop.setAttribute("stop-color", color);
+  stop.setAttribute("stop-opacity", String(opacity));
+  gradient.append(stop);
+}
+
+function applyTraceGradient({
+  map,
+  polyline,
+  curve,
+  gradientId,
+  color,
+  tailOpacity,
+  midOpacity,
+  headOpacity,
+}) {
+  const path = polyline.getElement?.();
+  const svg = path?.ownerSVGElement;
+  const tail = curve[0];
+  const head = curve.at(-1);
+  if (!path || !svg || !tail || !head) return null;
+
+  const tailPoint = map.latLngToLayerPoint(L.latLng(tail[0], tail[1]));
+  const headPoint = map.latLngToLayerPoint(L.latLng(head[0], head[1]));
+  const gradient = document.createElementNS(SVG_NS, "linearGradient");
+  gradient.setAttribute("id", gradientId);
+  gradient.setAttribute("gradientUnits", "userSpaceOnUse");
+  gradient.setAttribute("x1", String(tailPoint.x));
+  gradient.setAttribute("y1", String(tailPoint.y));
+  gradient.setAttribute("x2", String(headPoint.x));
+  gradient.setAttribute("y2", String(headPoint.y));
+  addGradientStop(gradient, "0%", color, tailOpacity);
+  addGradientStop(gradient, "52%", color, midOpacity);
+  addGradientStop(gradient, "100%", color, headOpacity);
+  ensureSvgDefs(svg).append(gradient);
+
+  path.setAttribute("stroke", `url(#${gradientId})`);
+  return gradient;
+}
 
 export default function SelectedAircraftTrace({
   aircraft = null,
@@ -58,52 +119,72 @@ export default function SelectedAircraftTrace({
 }) {
   const map = useMapInstance();
   const layersRef = useRef([]);
+  const gradientElsRef = useRef([]);
   const rafIdRef = useRef(null);
-  const previousHexRef = useRef(null);
+  const revealTimeoutRef = useRef(null);
+  const completedRevealKeyRef = useRef("");
   const isAnimatingRef = useRef(false);
-  const pendingTracePointsRef = useRef(null);
+  const pendingTraceRef = useRef(null);
   const reducedMotion = useReducedMotion();
   const aircraftHex = aircraft ? getAircraftIdentity(aircraft) || null : null;
 
-  // Local "committed" tracePoints decouples render from prop. While the
+  // Local "committed" trace points decouple render from prop. While the
   // growth animation is running, live poll appends are held in
-  // pendingTracePointsRef and applied once the animation settles. This is
-  // the key fix for the "two segments" feel: previously each 3-second
-  // poll triggered a full layer rebuild mid-animation, restarting the
-  // reveal from the new state.
-  const [committedTracePoints, setCommittedTracePoints] = useState(tracePoints);
+  // pendingTraceRef and applied once the animation settles. Keeping the
+  // aircraft id on the committed payload prevents a one-frame stale trace
+  // flash when the user switches selections quickly.
+  const [committedTrace, setCommittedTrace] = useState({
+    aircraftHex: aircraftHex || "",
+    tracePoints: [],
+  });
 
-  // Sync prop → committed when not animating. When animating, stash for later.
+  // Sync prop → committed when not animating. When animating, stash the
+  // aircraft id with the points so a later selection change can't flush
+  // the previous aircraft's trace into the new selection.
   useEffect(() => {
-    if (isAnimatingRef.current) {
-      pendingTracePointsRef.current = tracePoints;
+    const nextTrace = {
+      aircraftHex: aircraftHex || "",
+      tracePoints,
+    };
+
+    if (!aircraftHex) {
+      pendingTraceRef.current = null;
+      setCommittedTrace(nextTrace);
       return;
     }
-    setCommittedTracePoints(tracePoints);
-  }, [tracePoints]);
 
-  // On aircraft change (including initial selection / deselection), reset
-  // committed to empty so the next live-sync fires with whatever
-  // useAircraftTrace publishes for the new aircraft. Skipping this would
-  // leave stale geometry from the previous selection visible (and
-  // animating!) for one render until useAircraftTrace's hex effect clears
-  // it — that's the "trace appears with B's shape under A's selection,
-  // then snaps to A's data" race.
-  useEffect(() => {
-    pendingTracePointsRef.current = null;
-    setCommittedTracePoints([]);
-  }, [aircraftHex]);
+    if (isAnimatingRef.current) {
+      pendingTraceRef.current = nextTrace;
+      return;
+    }
+    pendingTraceRef.current = null;
+    setCommittedTrace(nextTrace);
+  }, [aircraftHex, tracePoints]);
 
   // Pre-computed render geometry. Pure function of committed trace points.
-  const geometry = useMemo(
+  const geometry = useMemo(() => {
+    if (
+      !shouldRenderCommittedTrace({
+        aircraftHex,
+        committedAircraftHex: committedTrace.aircraftHex,
+        tracePoints: committedTrace.tracePoints,
+      })
+    ) {
+      return null;
+    }
+
+    return computeTraceGeometry({
+      tracePoints: committedTrace.tracePoints,
+      maxRenderPoints: SELECTED_AIRCRAFT_TRACE_STYLE.maxRenderPoints,
+    });
+  }, [aircraftHex, committedTrace.aircraftHex, committedTrace.tracePoints]);
+  const traceRevealKey = useMemo(
     () =>
-      computeTraceGeometry({
-        tracePoints: committedTracePoints,
-        maxRenderPoints: SELECTED_AIRCRAFT_TRACE_STYLE.maxRenderPoints,
-        bandCount: SELECTED_AIRCRAFT_TRACE_STYLE.bandCount,
-        sweepTailRatio: SELECTED_AIRCRAFT_TRACE_STYLE.sweepTailRatio,
+      getTraceRevealKey({
+        aircraftHex,
+        tracePoints: committedTrace.tracePoints,
       }),
-    [committedTracePoints],
+    [aircraftHex, committedTrace.tracePoints],
   );
 
   useEffect(() => {
@@ -111,54 +192,58 @@ export default function SelectedAircraftTrace({
       cancelAnimationFrame(rafIdRef.current);
       rafIdRef.current = null;
     }
+    if (revealTimeoutRef.current) {
+      clearTimeout(revealTimeoutRef.current);
+      revealTimeoutRef.current = null;
+    }
     removeLayers(layersRef.current, map);
     layersRef.current = [];
+    removeElements(gradientElsRef.current);
+    gradientElsRef.current = [];
 
     if (!map || !geometry) {
-      previousHexRef.current = null;
+      if (!aircraftHex) completedRevealKeyRef.current = "";
       isAnimatingRef.current = false;
       return undefined;
     }
 
-    const isFreshSelection = previousHexRef.current !== aircraftHex;
-    previousHexRef.current = aircraftHex;
+    const shouldAnimateReveal =
+      traceRevealKey && completedRevealKeyRef.current !== traceRevealKey;
 
     const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.trace);
     const traceStyle = getTraceStyle(theme);
     const layers = [];
-    // Reveal-eligible polylines (bands + glow). Each carries its
-    // [startIndex, endIndex] within geometry.curve so the animation can
-    // drive every polyline from a single back-cursor in curve-index space —
-    // they all show the same visible curve range at any moment, which is
-    // what makes a 7-band trail look like one unfurling line instead of
-    // staggered segments.
-    const reveal = [];
+    const gradientEls = [];
+    const gradientBase = `${gradientIdPart(aircraftHex)}-${Date.now().toString(36)}`;
 
-    geometry.bands.forEach((band) => {
-      const opacity = 0.08 + band.emphasis * traceStyle.lineOpacity;
-      const weight = traceStyle.lineWeight * (0.82 + band.emphasis * 0.28);
-      const polyline = L.polyline(band.coords.slice().reverse(), {
-        pane,
+    const corePolyline = L.polyline(geometry.curve.slice().reverse(), {
+      pane,
+      color: traceStyle.lineColor,
+      opacity: 1,
+      weight: traceStyle.lineWeight,
+      interactive: false,
+      lineCap: "round",
+      lineJoin: "round",
+      className: "aircraft-trace aircraft-trace--core",
+    }).addTo(map);
+    layers.push(corePolyline);
+    gradientEls.push(
+      applyTraceGradient({
+        map,
+        polyline: corePolyline,
+        curve: geometry.curve,
+        gradientId: `aircraft-trace-core-${gradientBase}`,
         color: traceStyle.lineColor,
-        opacity,
-        weight,
-        interactive: false,
-        lineCap: "round",
-        lineJoin: "round",
-        className: "aircraft-trace aircraft-trace--band",
-      }).addTo(map);
-      layers.push(polyline);
-      reveal.push({
-        polyline,
-        startIndex: band.startIndex,
-        endIndex: band.endIndex,
-      });
-    });
+        tailOpacity: 0,
+        midOpacity: traceStyle.lineOpacity * 0.34,
+        headOpacity: traceStyle.lineOpacity,
+      }),
+    );
 
     const glowPolyline = L.polyline(geometry.curve.slice().reverse(), {
       pane,
       color: traceStyle.glowColor,
-      opacity: traceStyle.glowOpacity,
+      opacity: 1,
       weight: traceStyle.glowWeight,
       interactive: false,
       lineCap: "round",
@@ -166,27 +251,19 @@ export default function SelectedAircraftTrace({
       className: "aircraft-trace aircraft-trace--glow",
     }).addTo(map);
     layers.push(glowPolyline);
-    reveal.push({
-      polyline: glowPolyline,
-      startIndex: 0,
-      endIndex: geometry.headIndex,
-    });
-
-    if (geometry.sweepCoords.length >= 2) {
-      layers.push(
-        L.polyline(geometry.sweepCoords, {
-          pane,
-          color: traceStyle.sweepColor,
-          opacity: traceStyle.sweepOpacity,
-          weight: traceStyle.sweepWeight,
-          interactive: false,
-          lineCap: "round",
-          lineJoin: "round",
-          dashArray: "12 18",
-          className: "aircraft-trace aircraft-trace--sweep",
-        }).addTo(map),
-      );
-    }
+    gradientEls.push(
+      applyTraceGradient({
+        map,
+        polyline: glowPolyline,
+        curve: geometry.curve,
+        gradientId: `aircraft-trace-glow-${gradientBase}`,
+        color: traceStyle.glowColor,
+        tailOpacity: 0,
+        midOpacity: traceStyle.glowOpacity * 0.38,
+        headOpacity: traceStyle.glowOpacity,
+      }),
+    );
+    const revealPolylines = [corePolyline, glowPolyline];
 
     geometry.samplePoints.forEach((point, index) => {
       const emphasis = (index + 1) / geometry.samplePoints.length;
@@ -232,13 +309,22 @@ export default function SelectedAircraftTrace({
       }).addTo(map);
       const el = marker.getElement?.();
       if (el) {
-        el.style.transitionDelay = `${index * TRACE_LABEL_FADE_STAGGER_MS}ms`;
+        el.style.transitionDuration = reducedMotion
+          ? "0ms"
+          : `${TRACE_LABEL_FADE_DURATION_MS}ms`;
+        el.style.transitionDelay = `${getTraceLabelRevealDelay({
+          index,
+          growthDurationMs: TRACE_GROWTH_DURATION_MS,
+          staggerMs: TRACE_LABEL_FADE_STAGGER_MS,
+          reducedMotion,
+        })}ms`;
       }
       labelMarkers.push(marker);
       layers.push(marker);
     });
 
     layersRef.current = layers;
+    gradientElsRef.current = gradientEls.filter(Boolean);
 
     // Helper: flip all label markers to visible. Used for both the
     // immediate (non-fresh / reduced-motion) path and the deferred
@@ -255,9 +341,28 @@ export default function SelectedAircraftTrace({
         }
       });
     };
+    const flushPendingTrace = () => {
+      if (pendingTraceRef.current?.aircraftHex !== aircraftHex) return;
+      const pending = pendingTraceRef.current;
+      pendingTraceRef.current = null;
+      setCommittedTrace(pending);
+    };
+    const finishReveal = (segments = []) => {
+      rafIdRef.current = null;
+      revealTimeoutRef.current = null;
+      isAnimatingRef.current = false;
+      segments.forEach((seg) => {
+        seg.path.style.transition = "";
+        seg.path.style.strokeDasharray = "";
+        seg.path.style.strokeDashoffset = "";
+      });
+      completedRevealKeyRef.current = traceRevealKey;
+      flushPendingTrace();
+    };
 
-    if (!isFreshSelection || reducedMotion) {
+    if (!shouldAnimateReveal || reducedMotion) {
       revealLabels(true);
+      if (traceRevealKey) completedRevealKeyRef.current = traceRevealKey;
       return () => {
         if (rafIdRef.current) {
           cancelAnimationFrame(rafIdRef.current);
@@ -265,6 +370,8 @@ export default function SelectedAircraftTrace({
         }
         removeLayers(layersRef.current, map);
         layersRef.current = [];
+        removeElements(gradientElsRef.current);
+        gradientElsRef.current = [];
       };
     }
 
@@ -272,15 +379,14 @@ export default function SelectedAircraftTrace({
     // user doesn't see a flash of the full trace during the one-frame
     // defer below. visibility (vs opacity / display) doesn't trigger
     // reflow and is cheap to flip.
-    const initialPaths = reveal
-      .map((entry) => entry.polyline.getElement?.())
+    const initialPaths = revealPolylines
+      .map((polyline) => polyline.getElement?.())
       .filter(Boolean);
     initialPaths.forEach((path) => {
       path.style.visibility = "hidden";
     });
 
     isAnimatingRef.current = true;
-    const { headIndex } = geometry;
 
     // Defer the actual dash setup + animation start by one rAF tick.
     // Leaflet's SVG renderer flushes path geometry on the next animation
@@ -289,12 +395,12 @@ export default function SelectedAircraftTrace({
     // every segment is filtered out and the polylines just appear at
     // full state). One rAF gets us past that.
     rafIdRef.current = requestAnimationFrame(() => {
-      const segments = reveal
-        .map((entry) => {
-          const path = entry.polyline.getElement?.();
+      const segments = revealPolylines
+        .map((polyline) => {
+          const path = polyline.getElement?.();
           const length = path?.getTotalLength?.();
           if (!path || !Number.isFinite(length) || length <= 0) return null;
-          return { ...entry, path, pathLength: length };
+          return { path, pathLength: length };
         })
         .filter(Boolean);
 
@@ -306,71 +412,44 @@ export default function SelectedAircraftTrace({
       if (segments.length === 0) {
         rafIdRef.current = null;
         isAnimatingRef.current = false;
+        revealLabels(true);
+        completedRevealKeyRef.current = traceRevealKey;
+        flushPendingTrace();
         return;
       }
 
-      // Stage: every path hidden via full dashoffset.
+      // Stage: full reveal paths hidden via full dashoffset. Let CSS own
+      // interpolation so the browser can schedule the paint without a JS
+      // requestAnimationFrame loop writing strokeDashoffset every frame.
       segments.forEach((seg) => {
         seg.path.style.strokeDasharray = `${seg.pathLength}`;
         seg.path.style.strokeDashoffset = `${seg.pathLength}`;
+        seg.path.style.transition = `stroke-dashoffset ${TRACE_GROWTH_DURATION_MS}ms ${TRACE_REVEAL_EASING}`;
       });
+      // Labels fade in one-by-one while the trace is still drawing, so the
+      // text reads as attached to the same reveal instead of arriving as a
+      // separate overlay after the line has finished.
+      revealLabels(false);
 
-      const startTime =
-        typeof performance !== "undefined" ? performance.now() : Date.now();
-
-      // Single back-cursor in curve-index space drives every polyline.
-      // Cursor starts at headIndex (no reveal) and walks toward 0 (full
-      // reveal). Each polyline reveals only the part of its index range
-      // the cursor has swept past, so the head band and the glow draw the
-      // SAME curve segment at the SAME time, no matter their independent
-      // path lengths.
-      const tick = (now) => {
-        const elapsed = now - startTime;
-        const t = Math.min(1, elapsed / TRACE_GROWTH_DURATION_MS);
-        const cursor = headIndex * (1 - easeInOutCubic(t));
-
+      rafIdRef.current = requestAnimationFrame(() => {
         segments.forEach((seg) => {
-          if (cursor <= seg.startIndex) {
-            seg.path.style.strokeDashoffset = "0";
-          } else if (cursor >= seg.endIndex) {
-            seg.path.style.strokeDashoffset = `${seg.pathLength}`;
-          } else {
-            const f =
-              (cursor - seg.startIndex) / (seg.endIndex - seg.startIndex);
-            seg.path.style.strokeDashoffset = `${f * seg.pathLength}`;
-          }
+          seg.path.style.strokeDashoffset = "0";
         });
-
-        if (t < 1) {
-          rafIdRef.current = requestAnimationFrame(tick);
-          return;
-        }
-
-        rafIdRef.current = null;
-        isAnimatingRef.current = false;
-        // Clear inline dash styles so next-poll rebuilds inherit a clean
-        // path, otherwise the freshly-built paths inherit stale values.
-        segments.forEach((seg) => {
-          seg.path.style.strokeDasharray = "";
-          seg.path.style.strokeDashoffset = "";
-        });
-        // Labels were created at opacity 0 with staggered transitionDelay;
-        // flipping each to opacity 1 here triggers the CSS transition.
-        revealLabels(false);
-        // Flush any deferred trace updates that arrived during animation.
-        if (pendingTracePointsRef.current) {
-          const pending = pendingTracePointsRef.current;
-          pendingTracePointsRef.current = null;
-          setCommittedTracePoints(pending);
-        }
-      };
-      rafIdRef.current = requestAnimationFrame(tick);
+        revealTimeoutRef.current = setTimeout(
+          () => finishReveal(segments),
+          TRACE_GROWTH_DURATION_MS + TRACE_REVEAL_SETTLE_MS,
+        );
+      });
     });
 
     return () => {
       if (rafIdRef.current) {
         cancelAnimationFrame(rafIdRef.current);
         rafIdRef.current = null;
+      }
+      if (revealTimeoutRef.current) {
+        clearTimeout(revealTimeoutRef.current);
+        revealTimeoutRef.current = null;
       }
       // Restore visibility in case we tore down mid-defer before the rAF
       // callback got to re-show.
@@ -380,8 +459,10 @@ export default function SelectedAircraftTrace({
       isAnimatingRef.current = false;
       removeLayers(layersRef.current, map);
       layersRef.current = [];
+      removeElements(gradientElsRef.current);
+      gradientElsRef.current = [];
     };
-  }, [map, theme, geometry, aircraftHex, reducedMotion]);
+  }, [map, theme, geometry, aircraftHex, reducedMotion, traceRevealKey]);
 
   return null;
 }

--- a/src/components/map/SelectedAircraftTrace.jsx
+++ b/src/components/map/SelectedAircraftTrace.jsx
@@ -210,6 +210,13 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
     () => (geometry ? makeLabelKey(geometry.labelPoints) : ""),
     [geometry],
   );
+  // Latest labelPoints stay in a ref so the label effect can read them
+  // without subscribing to geometry's reference. geometry is a fresh
+  // object every poll (because the curve extends with the live head),
+  // and including it in deps would re-fire the label effect on every
+  // poll even though the label set is stable.
+  const labelPointsRef = useRef(geometry?.labelPoints || []);
+  labelPointsRef.current = geometry?.labelPoints || [];
 
   // -------------------------------------------------------------------
   // Effect 1: line + glow + sample dots. Re-runs on every geometry change
@@ -415,11 +422,15 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
     removeLayers(labelMarkersRef.current, map);
     labelMarkersRef.current = [];
 
-    if (!map || !geometry || !labelKey) return undefined;
+    if (!map || !labelKey) return undefined;
+    const labelPoints = labelPointsRef.current;
+    if (!Array.isArray(labelPoints) || labelPoints.length === 0) {
+      return undefined;
+    }
 
     const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.trace);
     const labelMarkers = [];
-    [...geometry.labelPoints].reverse().forEach((point, index) => {
+    [...labelPoints].reverse().forEach((point, index) => {
       const time = formatTraceLabelTime(point.timestampMs);
       const altitude = formatTraceLabelAltitude(point);
       if (!time && !altitude) return;
@@ -442,7 +453,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
         }),
         interactive: false,
         keyboard: false,
-        zIndexOffset: (geometry.labelPoints.length - index) * 10,
+        zIndexOffset: (labelPoints.length - index) * 10,
       }).addTo(map);
       const el = marker.getElement?.();
       if (el) {
@@ -506,7 +517,11 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
       removeLayers(labelMarkersRef.current, map);
       labelMarkersRef.current = [];
     };
-  }, [map, labelKey, reducedMotion, geometry]);
+    // labelPoints is intentionally accessed via ref so we don't subscribe
+    // to geometry's per-poll reference churn. labelKey changes iff the
+    // sample set actually shifts, at which point the ref's value is the
+    // new set.
+  }, [map, labelKey, reducedMotion]);
 
   return null;
 }

--- a/src/components/map/SelectedAircraftTrace.jsx
+++ b/src/components/map/SelectedAircraftTrace.jsx
@@ -15,7 +15,7 @@ import {
   getTraceRevealKey,
   shouldRenderCommittedTrace,
 } from "../../features/aircraft-trace/traceRevealModel.js";
-import { getAircraftIdentity } from "../../features/airport-context/airportContextUiModel.js";
+import { useSelectedAircraftTrace } from "../../features/aircraft-trace/SelectedAircraftTraceContext.jsx";
 
 const TRACE_GROWTH_DURATION_MS = 900;
 const TRACE_LABEL_FADE_STAGGER_MS = 70;
@@ -122,47 +122,53 @@ function applyTraceGradient({
   return gradient;
 }
 
-export default function SelectedAircraftTrace({
-  aircraft = null,
-  tracePoints = [],
-  theme = "dark",
-}) {
+// Stable signature of the label set: same string ⇒ same set of historic
+// sample points (positions and altitudes), so the label-effect dep stays
+// referentially equal across polls and the labels don't tear down / rebuild.
+function makeLabelKey(labelPoints) {
+  if (!Array.isArray(labelPoints) || labelPoints.length === 0) return "";
+  return labelPoints
+    .map(
+      (p) =>
+        `${Number(p?.timestampMs) || 0}|${Math.round(p?.altitude || 0)}|${p?.onGround ? 1 : 0}`,
+    )
+    .join("·");
+}
+
+export default function SelectedAircraftTrace({ theme = "dark" }) {
+  const { aircraftHex, tracePoints } = useSelectedAircraftTrace();
   const map = useMapInstance();
-  const layersRef = useRef([]);
+  const lineLayersRef = useRef([]);
+  const labelMarkersRef = useRef([]);
   const gradientElsRef = useRef([]);
   const rafIdRef = useRef(null);
   const revealTimeoutRef = useRef(null);
+  const labelRafIdRef = useRef(null);
   const completedRevealKeyRef = useRef("");
   const isAnimatingRef = useRef(false);
   const pendingTraceRef = useRef(null);
   const reducedMotion = useReducedMotion();
-  const aircraftHex = aircraft ? getAircraftIdentity(aircraft) || null : null;
 
-  // Local "committed" trace points decouple render from prop. While the
-  // growth animation is running, live poll appends are held in
-  // pendingTraceRef and applied once the animation settles. Keeping the
-  // aircraft id on the committed payload prevents a one-frame stale trace
-  // flash when the user switches selections quickly.
+  // Local "committed" trace points decouple render from context. While the
+  // growth fade is running, live poll appends are held in pendingTraceRef
+  // and applied once the animation settles. The aircraft id rides along on
+  // the payload so a fast selection change can't flush the previous
+  // aircraft's data into the new selection.
   const [committedTrace, setCommittedTrace] = useState({
     aircraftHex: aircraftHex || "",
     tracePoints: [],
   });
 
-  // Sync prop → committed when not animating. When animating, stash the
-  // aircraft id with the points so a later selection change can't flush
-  // the previous aircraft's trace into the new selection.
   useEffect(() => {
     const nextTrace = {
       aircraftHex: aircraftHex || "",
       tracePoints,
     };
-
     if (!aircraftHex) {
       pendingTraceRef.current = null;
       setCommittedTrace(nextTrace);
       return;
     }
-
     if (isAnimatingRef.current) {
       pendingTraceRef.current = nextTrace;
       return;
@@ -171,7 +177,6 @@ export default function SelectedAircraftTrace({
     setCommittedTrace(nextTrace);
   }, [aircraftHex, tracePoints]);
 
-  // Pre-computed render geometry. Pure function of committed trace points.
   const geometry = useMemo(() => {
     if (
       !shouldRenderCommittedTrace({
@@ -182,12 +187,12 @@ export default function SelectedAircraftTrace({
     ) {
       return null;
     }
-
     return computeTraceGeometry({
       tracePoints: committedTrace.tracePoints,
       maxRenderPoints: SELECTED_AIRCRAFT_TRACE_STYLE.maxRenderPoints,
     });
   }, [aircraftHex, committedTrace.aircraftHex, committedTrace.tracePoints]);
+
   const traceRevealKey = useMemo(
     () =>
       getTraceRevealKey({
@@ -197,6 +202,20 @@ export default function SelectedAircraftTrace({
     [aircraftHex, committedTrace.tracePoints],
   );
 
+  // labelKey is a string derived from labelPoints. As long as the historic
+  // sample set is stable (same timestamps + altitudes), the key is the
+  // same string and the label-effect dep doesn't change — labels stay
+  // mounted across polls instead of re-rendering every 3 seconds.
+  const labelKey = useMemo(
+    () => (geometry ? makeLabelKey(geometry.labelPoints) : ""),
+    [geometry],
+  );
+
+  // -------------------------------------------------------------------
+  // Effect 1: line + glow + sample dots. Re-runs on every geometry change
+  // (poll-driven head extensions are visible here as the curve extends).
+  // Handles the opacity-fade reveal animation when the aircraft is fresh.
+  // -------------------------------------------------------------------
   useEffect(() => {
     if (rafIdRef.current) {
       cancelAnimationFrame(rafIdRef.current);
@@ -206,8 +225,8 @@ export default function SelectedAircraftTrace({
       clearTimeout(revealTimeoutRef.current);
       revealTimeoutRef.current = null;
     }
-    removeLayers(layersRef.current, map);
-    layersRef.current = [];
+    removeLayers(lineLayersRef.current, map);
+    lineLayersRef.current = [];
     removeElements(gradientElsRef.current);
     gradientElsRef.current = [];
 
@@ -290,8 +309,115 @@ export default function SelectedAircraftTrace({
       );
     });
 
-    // Time / altitude labels for historic sample points. Built head→tail so
-    // the head label can fade in first when we cascade the visibility flip.
+    lineLayersRef.current = layers;
+    gradientElsRef.current = gradientEls.filter(Boolean);
+
+    const flushPendingTrace = () => {
+      if (pendingTraceRef.current?.aircraftHex !== aircraftHex) return;
+      const pending = pendingTraceRef.current;
+      pendingTraceRef.current = null;
+      setCommittedTrace(pending);
+    };
+    const finishReveal = (paths = []) => {
+      rafIdRef.current = null;
+      revealTimeoutRef.current = null;
+      isAnimatingRef.current = false;
+      paths.forEach((path) => {
+        path.style.transition = "";
+        path.style.opacity = "";
+      });
+      completedRevealKeyRef.current = traceRevealKey;
+      flushPendingTrace();
+    };
+
+    if (!shouldAnimateReveal || reducedMotion) {
+      if (traceRevealKey) completedRevealKeyRef.current = traceRevealKey;
+      return () => {
+        if (rafIdRef.current) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        removeLayers(lineLayersRef.current, map);
+        lineLayersRef.current = [];
+        removeElements(gradientElsRef.current);
+        gradientElsRef.current = [];
+      };
+    }
+
+    const revealPaths = revealPolylines
+      .map((polyline) => polyline.getElement?.())
+      .filter(Boolean);
+
+    if (revealPaths.length === 0) {
+      completedRevealKeyRef.current = traceRevealKey;
+      flushPendingTrace();
+      return () => {
+        if (rafIdRef.current) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        removeLayers(lineLayersRef.current, map);
+        lineLayersRef.current = [];
+        removeElements(gradientElsRef.current);
+        gradientElsRef.current = [];
+      };
+    }
+
+    isAnimatingRef.current = true;
+    revealPaths.forEach((path) => {
+      path.style.transition = "none";
+      path.style.opacity = "0";
+    });
+
+    rafIdRef.current = requestAnimationFrame(() => {
+      revealPaths.forEach((path) => {
+        path.style.transition = `opacity ${TRACE_GROWTH_DURATION_MS}ms ${TRACE_REVEAL_EASING}`;
+        path.style.opacity = "1";
+      });
+      revealTimeoutRef.current = setTimeout(
+        () => finishReveal(revealPaths),
+        TRACE_GROWTH_DURATION_MS + TRACE_REVEAL_SETTLE_MS,
+      );
+    });
+
+    return () => {
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      if (revealTimeoutRef.current) {
+        clearTimeout(revealTimeoutRef.current);
+        revealTimeoutRef.current = null;
+      }
+      revealPaths.forEach((path) => {
+        path.style.transition = "";
+        path.style.opacity = "";
+      });
+      isAnimatingRef.current = false;
+      removeLayers(lineLayersRef.current, map);
+      lineLayersRef.current = [];
+      removeElements(gradientElsRef.current);
+      gradientElsRef.current = [];
+    };
+  }, [map, theme, geometry, aircraftHex, reducedMotion, traceRevealKey]);
+
+  // -------------------------------------------------------------------
+  // Effect 2: historic time/altitude labels. Keyed by labelKey so it only
+  // re-runs when the sample SET changes (sampling stride shifts, aircraft
+  // changes). Same-aircraft polls leave the label markers mounted —
+  // they stay at full opacity without a re-fade.
+  // -------------------------------------------------------------------
+  useEffect(() => {
+    if (labelRafIdRef.current) {
+      cancelAnimationFrame(labelRafIdRef.current);
+      labelRafIdRef.current = null;
+    }
+    removeLayers(labelMarkersRef.current, map);
+    labelMarkersRef.current = [];
+
+    if (!map || !geometry || !labelKey) return undefined;
+
+    const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.trace);
     const labelMarkers = [];
     [...geometry.labelPoints].reverse().forEach((point, index) => {
       const time = formatTraceLabelTime(point.timestampMs);
@@ -316,8 +442,6 @@ export default function SelectedAircraftTrace({
         }),
         interactive: false,
         keyboard: false,
-        // Head-first iteration means index 0 is the freshest sample; give it
-        // the highest stacking offset so overlapping older cards sit beneath.
         zIndexOffset: (geometry.labelPoints.length - index) * 10,
       }).addTo(map);
       const el = marker.getElement?.();
@@ -325,6 +449,7 @@ export default function SelectedAircraftTrace({
         el.style.transitionDuration = reducedMotion
           ? "0ms"
           : `${TRACE_LABEL_FADE_DURATION_MS}ms`;
+        // Stagger only meaningful for the fresh reveal; recomputed below.
         el.style.transitionDelay = `${getTraceLabelRevealDelay({
           index,
           growthDurationMs: TRACE_GROWTH_DURATION_MS,
@@ -333,157 +458,55 @@ export default function SelectedAircraftTrace({
         })}ms`;
       }
       labelMarkers.push(marker);
-      layers.push(marker);
     });
+    labelMarkersRef.current = labelMarkers;
 
-    layersRef.current = layers;
-    gradientElsRef.current = gradientEls.filter(Boolean);
-
-    // Helper: flip all label markers to visible.
-    // - mode "instant": no transition (reduced-motion).
-    // - mode "staggered": keep the per-marker transitionDelay set at marker
-    //   creation so labels cascade in head-first during a fresh reveal.
-    // - mode "uniform": override delay to 0 so poll-driven re-renders fade
-    //   in together quickly instead of inheriting the long fresh-reveal
-    //   stagger.
-    const revealLabels = (mode = "uniform") => {
-      if (mode === "instant") {
-        labelMarkers.forEach((m) => {
-          const el = m.getElement?.();
-          if (!el) return;
-          el.style.transition = "none";
-          el.style.opacity = "1";
-        });
-        return;
-      }
-
-      if (mode === "uniform") {
-        labelMarkers.forEach((m) => {
-          const el = m.getElement?.();
-          if (el) el.style.transitionDelay = "0ms";
-        });
-      }
-
-      // Defer one frame so the browser sees the CSS opacity:0 baseline
-      // before the inline opacity:1 lands. Without this, freshly-mounted
-      // labels can skip the transition because the browser hasn't
-      // computed a baseline opacity to interpolate from.
-      requestAnimationFrame(() => {
-        labelMarkers.forEach((m) => {
-          const el = m.getElement?.();
-          if (!el) return;
-          el.style.opacity = "1";
-        });
+    if (reducedMotion) {
+      labelMarkers.forEach((m) => {
+        const el = m.getElement?.();
+        if (!el) return;
+        el.style.transition = "none";
+        el.style.opacity = "1";
       });
-    };
-    const flushPendingTrace = () => {
-      if (pendingTraceRef.current?.aircraftHex !== aircraftHex) return;
-      const pending = pendingTraceRef.current;
-      pendingTraceRef.current = null;
-      setCommittedTrace(pending);
-    };
-    const finishReveal = (paths = []) => {
-      rafIdRef.current = null;
-      revealTimeoutRef.current = null;
-      isAnimatingRef.current = false;
-      paths.forEach((path) => {
-        path.style.transition = "";
-        path.style.opacity = "";
-      });
-      completedRevealKeyRef.current = traceRevealKey;
-      flushPendingTrace();
-    };
-
-    if (!shouldAnimateReveal || reducedMotion) {
-      // Poll-driven re-renders (same aircraft) still fade the labels in so
-      // they don't pop every 3s. reducedMotion users get the instant flip.
-      revealLabels(reducedMotion ? "instant" : "uniform");
-      if (traceRevealKey) completedRevealKeyRef.current = traceRevealKey;
       return () => {
-        if (rafIdRef.current) {
-          cancelAnimationFrame(rafIdRef.current);
-          rafIdRef.current = null;
+        if (labelRafIdRef.current) {
+          cancelAnimationFrame(labelRafIdRef.current);
+          labelRafIdRef.current = null;
         }
-        removeLayers(layersRef.current, map);
-        layersRef.current = [];
-        removeElements(gradientElsRef.current);
-        gradientElsRef.current = [];
+        removeLayers(labelMarkersRef.current, map);
+        labelMarkersRef.current = [];
       };
     }
 
-    // Resolve the SVG <path> elements for the core + glow polylines. Any
-    // path that isn't ready (canvas renderer, unmounted) just renders at
-    // full state — same fallback as before, no animation.
-    const revealPaths = revealPolylines
-      .map((polyline) => polyline.getElement?.())
-      .filter(Boolean);
-
-    if (revealPaths.length === 0) {
-      revealLabels("instant");
-      completedRevealKeyRef.current = traceRevealKey;
-      flushPendingTrace();
-      return () => {
-        if (rafIdRef.current) {
-          cancelAnimationFrame(rafIdRef.current);
-          rafIdRef.current = null;
-        }
-        removeLayers(layersRef.current, map);
-        layersRef.current = [];
-        removeElements(gradientElsRef.current);
-        gradientElsRef.current = [];
-      };
+    // If the line is currently animating, this is a fresh reveal — keep
+    // the staggered per-marker delays so labels cascade in head-first
+    // mid-line-fade. Otherwise (label set just shifted while line is
+    // settled), override delays to 0 so the new labels fade in together.
+    const fresh = isAnimatingRef.current;
+    if (!fresh) {
+      labelMarkers.forEach((m) => {
+        const el = m.getElement?.();
+        if (el) el.style.transitionDelay = "0ms";
+      });
     }
 
-    isAnimatingRef.current = true;
-
-    // Stage: paths at opacity 0 with transitions off so the next paint
-    // commits the hidden state without interpolating from the implicit
-    // default of 1.
-    revealPaths.forEach((path) => {
-      path.style.transition = "none";
-      path.style.opacity = "0";
-    });
-
-    // One rAF later, flip transition on and opacity to 1 — the browser
-    // sees the committed 0 state, schedules the GPU transition, and runs
-    // the fade natively. No per-frame JS, no stroke-dasharray gymnastics.
-    rafIdRef.current = requestAnimationFrame(() => {
-      revealPaths.forEach((path) => {
-        path.style.transition = `opacity ${TRACE_GROWTH_DURATION_MS}ms ${TRACE_REVEAL_EASING}`;
-        path.style.opacity = "1";
+    labelRafIdRef.current = requestAnimationFrame(() => {
+      labelMarkers.forEach((m) => {
+        const el = m.getElement?.();
+        if (!el) return;
+        el.style.opacity = "1";
       });
-      // Labels fade in mid-trace-fade so the text reads as attached to
-      // the same reveal instead of arriving as a separate overlay.
-      revealLabels("staggered");
-
-      revealTimeoutRef.current = setTimeout(
-        () => finishReveal(revealPaths),
-        TRACE_GROWTH_DURATION_MS + TRACE_REVEAL_SETTLE_MS,
-      );
     });
 
     return () => {
-      if (rafIdRef.current) {
-        cancelAnimationFrame(rafIdRef.current);
-        rafIdRef.current = null;
+      if (labelRafIdRef.current) {
+        cancelAnimationFrame(labelRafIdRef.current);
+        labelRafIdRef.current = null;
       }
-      if (revealTimeoutRef.current) {
-        clearTimeout(revealTimeoutRef.current);
-        revealTimeoutRef.current = null;
-      }
-      // Restore inline styles if we tore down mid-fade — otherwise stale
-      // opacity:0 / transition values can carry over to the next render.
-      revealPaths.forEach((path) => {
-        path.style.transition = "";
-        path.style.opacity = "";
-      });
-      isAnimatingRef.current = false;
-      removeLayers(layersRef.current, map);
-      layersRef.current = [];
-      removeElements(gradientElsRef.current);
-      gradientElsRef.current = [];
+      removeLayers(labelMarkersRef.current, map);
+      labelMarkersRef.current = [];
     };
-  }, [map, theme, geometry, aircraftHex, reducedMotion, traceRevealKey]);
+  }, [map, labelKey, reducedMotion, geometry]);
 
   return null;
 }

--- a/src/components/map/SelectedAircraftTrace.jsx
+++ b/src/components/map/SelectedAircraftTrace.jsx
@@ -311,11 +311,14 @@ export default function SelectedAircraftTrace({
             <span class="aircraft-trace-label__time">${time}</span>
             ${altRow}
           `,
-          iconSize: [76, 30],
-          iconAnchor: [38, 38],
+          iconSize: [56, 24],
+          iconAnchor: [-4, 28],
         }),
         interactive: false,
         keyboard: false,
+        // Head-first iteration means index 0 is the freshest sample; give it
+        // the highest stacking offset so overlapping older cards sit beneath.
+        zIndexOffset: (geometry.labelPoints.length - index) * 10,
       }).addTo(map);
       const el = marker.getElement?.();
       if (el) {
@@ -336,19 +339,41 @@ export default function SelectedAircraftTrace({
     layersRef.current = layers;
     gradientElsRef.current = gradientEls.filter(Boolean);
 
-    // Helper: flip all label markers to visible. Used for both the
-    // immediate (non-fresh / reduced-motion) path and the deferred
-    // post-animation cascade.
-    const revealLabels = (instant) => {
-      labelMarkers.forEach((m) => {
-        const el = m.getElement?.();
-        if (!el) return;
-        if (instant) {
+    // Helper: flip all label markers to visible.
+    // - mode "instant": no transition (reduced-motion).
+    // - mode "staggered": keep the per-marker transitionDelay set at marker
+    //   creation so labels cascade in head-first during a fresh reveal.
+    // - mode "uniform": override delay to 0 so poll-driven re-renders fade
+    //   in together quickly instead of inheriting the long fresh-reveal
+    //   stagger.
+    const revealLabels = (mode = "uniform") => {
+      if (mode === "instant") {
+        labelMarkers.forEach((m) => {
+          const el = m.getElement?.();
+          if (!el) return;
           el.style.transition = "none";
           el.style.opacity = "1";
-        } else {
+        });
+        return;
+      }
+
+      if (mode === "uniform") {
+        labelMarkers.forEach((m) => {
+          const el = m.getElement?.();
+          if (el) el.style.transitionDelay = "0ms";
+        });
+      }
+
+      // Defer one frame so the browser sees the CSS opacity:0 baseline
+      // before the inline opacity:1 lands. Without this, freshly-mounted
+      // labels can skip the transition because the browser hasn't
+      // computed a baseline opacity to interpolate from.
+      requestAnimationFrame(() => {
+        labelMarkers.forEach((m) => {
+          const el = m.getElement?.();
+          if (!el) return;
           el.style.opacity = "1";
-        }
+        });
       });
     };
     const flushPendingTrace = () => {
@@ -370,7 +395,9 @@ export default function SelectedAircraftTrace({
     };
 
     if (!shouldAnimateReveal || reducedMotion) {
-      revealLabels(true);
+      // Poll-driven re-renders (same aircraft) still fade the labels in so
+      // they don't pop every 3s. reducedMotion users get the instant flip.
+      revealLabels(reducedMotion ? "instant" : "uniform");
       if (traceRevealKey) completedRevealKeyRef.current = traceRevealKey;
       return () => {
         if (rafIdRef.current) {
@@ -392,7 +419,7 @@ export default function SelectedAircraftTrace({
       .filter(Boolean);
 
     if (revealPaths.length === 0) {
-      revealLabels(true);
+      revealLabels("instant");
       completedRevealKeyRef.current = traceRevealKey;
       flushPendingTrace();
       return () => {
@@ -427,7 +454,7 @@ export default function SelectedAircraftTrace({
       });
       // Labels fade in mid-trace-fade so the text reads as attached to
       // the same reveal instead of arriving as a separate overlay.
-      revealLabels(false);
+      revealLabels("staggered");
 
       revealTimeoutRef.current = setTimeout(
         () => finishReveal(revealPaths),

--- a/src/config/about.js
+++ b/src/config/about.js
@@ -1,5 +1,5 @@
 export const ABOUT_BUILD_META = [
-  { label: "Version", value: "0.10.0" },
+  { label: "Version", value: "0.11.0" },
   { label: "Release", value: "Next.js Web" },
   { label: "Stack", value: "React 19 · Next 16 · Leaflet" },
   { label: "Scope", value: "Maps · Weather · Traffic" },

--- a/src/config/airportMap.js
+++ b/src/config/airportMap.js
@@ -26,10 +26,7 @@ export const AIRPORT_MAP_PANES = {
 };
 
 export const SELECTED_AIRCRAFT_TRACE_STYLE = {
-  maxHistoryPoints: 36,
-  maxRenderPoints: 220,
-  bandCount: 7,
-  sweepTailRatio: 0.22,
+  maxRenderPoints: 140,
   dark: {
     glowColor: "#8ec5ff",
     glowOpacity: 0.18,
@@ -37,15 +34,9 @@ export const SELECTED_AIRCRAFT_TRACE_STYLE = {
     lineColor: "#d5ecff",
     lineOpacity: 0.94,
     lineWeight: 3.2,
-    sweepColor: "#f6fbff",
-    sweepOpacity: 0.9,
-    sweepWeight: 2.2,
     pointColor: "#d5ecff",
     pointFillOpacity: 0.42,
     pointRadius: 2,
-    headColor: "#f6fbff",
-    headOpacity: 0.95,
-    headRadius: 3.6,
   },
   light: {
     glowColor: "#9ab7d6",
@@ -54,15 +45,9 @@ export const SELECTED_AIRCRAFT_TRACE_STYLE = {
     lineColor: "#234a73",
     lineOpacity: 0.86,
     lineWeight: 3,
-    sweepColor: "#2e5a86",
-    sweepOpacity: 0.72,
-    sweepWeight: 2,
     pointColor: "#234a73",
     pointFillOpacity: 0.28,
     pointRadius: 1.8,
-    headColor: "#234a73",
-    headOpacity: 0.82,
-    headRadius: 3.2,
   },
 };
 

--- a/src/features/aircraft-trace/SelectedAircraftTraceContext.jsx
+++ b/src/features/aircraft-trace/SelectedAircraftTraceContext.jsx
@@ -12,6 +12,7 @@ import { getAircraftIdentity } from "../airport-context/airportContextUiModel.js
 
 const SelectedAircraftTraceContext = createContext({
   aircraftHex: null,
+  movement: null,
   tracePoints: [],
   loading: false,
 });
@@ -23,11 +24,15 @@ export function SelectedAircraftTraceProvider({
   const aircraftHex = selectedAircraft
     ? getAircraftIdentity(selectedAircraft) || null
     : null;
+  const movement =
+    typeof selectedAircraft?.movement === "string"
+      ? selectedAircraft.movement
+      : null;
   const { tracePoints, loading } = useAircraftTrace(selectedAircraft);
 
   const value = useMemo(
-    () => ({ aircraftHex, tracePoints, loading }),
-    [aircraftHex, tracePoints, loading],
+    () => ({ aircraftHex, movement, tracePoints, loading }),
+    [aircraftHex, movement, tracePoints, loading],
   );
 
   return (

--- a/src/features/aircraft-trace/SelectedAircraftTraceContext.jsx
+++ b/src/features/aircraft-trace/SelectedAircraftTraceContext.jsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext, useMemo } from "react";
+import { useAircraftTrace } from "../../hooks/useAircraftTrace.js";
+import { getAircraftIdentity } from "../airport-context/airportContextUiModel.js";
+
+// Single source of truth for the currently-focused aircraft's trace.
+// Provider runs the fetch + live-append machinery once, near the top of
+// the explorer tree, and consumers (currently only SelectedAircraftTrace)
+// read aircraftHex / tracePoints / loading from this context instead of
+// drilling them through props.
+
+const SelectedAircraftTraceContext = createContext({
+  aircraftHex: null,
+  tracePoints: [],
+  loading: false,
+});
+
+export function SelectedAircraftTraceProvider({
+  selectedAircraft = null,
+  children,
+}) {
+  const aircraftHex = selectedAircraft
+    ? getAircraftIdentity(selectedAircraft) || null
+    : null;
+  const { tracePoints, loading } = useAircraftTrace(selectedAircraft);
+
+  const value = useMemo(
+    () => ({ aircraftHex, tracePoints, loading }),
+    [aircraftHex, tracePoints, loading],
+  );
+
+  return (
+    <SelectedAircraftTraceContext.Provider value={value}>
+      {children}
+    </SelectedAircraftTraceContext.Provider>
+  );
+}
+
+export function useSelectedAircraftTrace() {
+  return useContext(SelectedAircraftTraceContext);
+}

--- a/src/features/aircraft-trace/traceGeometry.js
+++ b/src/features/aircraft-trace/traceGeometry.js
@@ -1,35 +1,11 @@
 // Pure trace-geometry computation. Takes raw trace points and produces the
-// final render geometry (curve + bands + sample points + sweep coords) that
-// SelectedAircraftTrace draws. Kept side-effect-free so the render component
-// can memoize / defer / batch it however it likes — calculation is decoupled
-// from rendering.
+// single curved trail plus sparse points/labels that SelectedAircraftTrace
+// draws. Kept side-effect-free so render can memoize / defer / batch it.
 
 import {
   buildAircraftTraceCurve,
   downsampleTracePoints,
 } from "./aircraftTraceModel.js";
-
-function sliceCurve(coords, startIndex, endIndex) {
-  if (endIndex - startIndex < 1) return [];
-  return coords.slice(startIndex, endIndex + 1);
-}
-
-function buildTraceBands(coords, bandCount) {
-  const segmentCount = Math.max(0, coords.length - 1);
-  if (segmentCount < 1) return [];
-
-  return Array.from({ length: bandCount }, (_, bandIndex) => {
-    const startIndex = Math.floor((segmentCount * bandIndex) / bandCount);
-    const endIndex = Math.floor((segmentCount * (bandIndex + 1)) / bandCount);
-    return {
-      index: bandIndex,
-      startIndex,
-      endIndex,
-      coords: sliceCurve(coords, startIndex, endIndex),
-      emphasis: bandIndex / Math.max(1, bandCount - 1),
-    };
-  }).filter((band) => band.coords.length >= 2);
-}
 
 function buildTraceSamplePoints(points) {
   const usable = points.slice(0, -1);
@@ -49,19 +25,9 @@ function buildTraceLabelPoints(points, maxLabels = 5) {
   return usable.filter((_, index) => index % stride === 0);
 }
 
-function buildHeadSweepCoords(coords, tailRatio) {
-  const startIndex = Math.max(
-    0,
-    Math.floor(coords.length - Math.max(8, coords.length * tailRatio)),
-  );
-  return coords.slice(startIndex);
-}
-
 export function computeTraceGeometry({
   tracePoints = [],
   maxRenderPoints,
-  bandCount,
-  sweepTailRatio,
   curveSteps = 5,
 }) {
   if (!Array.isArray(tracePoints) || tracePoints.length < 2) return null;
@@ -72,10 +38,7 @@ export function computeTraceGeometry({
 
   return {
     curve,
-    bands: buildTraceBands(curve, bandCount),
     samplePoints: buildTraceSamplePoints(sampled),
     labelPoints: buildTraceLabelPoints(sampled),
-    sweepCoords: buildHeadSweepCoords(curve, sweepTailRatio),
-    headIndex: Math.max(1, curve.length - 1),
   };
 }

--- a/src/features/aircraft-trace/traceRevealModel.js
+++ b/src/features/aircraft-trace/traceRevealModel.js
@@ -1,0 +1,38 @@
+const TRACE_LABEL_REVEAL_START_RATIO = 0.55;
+
+function normalizeAircraftHex(value) {
+  return String(value || "").trim();
+}
+
+export function shouldRenderCommittedTrace({
+  aircraftHex,
+  committedAircraftHex,
+  tracePoints = [],
+} = {}) {
+  return (
+    normalizeAircraftHex(aircraftHex) !== "" &&
+    normalizeAircraftHex(aircraftHex) ===
+      normalizeAircraftHex(committedAircraftHex) &&
+    Array.isArray(tracePoints) &&
+    tracePoints.length >= 2
+  );
+}
+
+export function getTraceLabelRevealDelay({
+  index = 0,
+  growthDurationMs,
+  staggerMs,
+  reducedMotion = false,
+} = {}) {
+  if (reducedMotion) return 0;
+  return (
+    Math.round(Number(growthDurationMs || 0) * TRACE_LABEL_REVEAL_START_RATIO) +
+    Math.max(0, Number(index) || 0) * Math.max(0, Number(staggerMs) || 0)
+  );
+}
+
+export function getTraceRevealKey({ aircraftHex, tracePoints = [] } = {}) {
+  const hex = normalizeAircraftHex(aircraftHex);
+  if (!hex || !Array.isArray(tracePoints) || tracePoints.length < 2) return "";
+  return hex;
+}

--- a/src/features/aircraft-trace/traceRevealModel.test.js
+++ b/src/features/aircraft-trace/traceRevealModel.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getTraceRevealKey,
+  getTraceLabelRevealDelay,
+  shouldRenderCommittedTrace,
+} from "./traceRevealModel.js";
+
+test("does not render committed trace geometry for a previous aircraft", () => {
+  assert.equal(
+    shouldRenderCommittedTrace({
+      aircraftHex: "A7BBE9",
+      committedAircraftHex: "A12345",
+      tracePoints: [{ lat: 42, lon: -71 }, { lat: 43, lon: -72 }],
+    }),
+    false,
+  );
+});
+
+test("renders committed trace geometry when the aircraft still matches", () => {
+  assert.equal(
+    shouldRenderCommittedTrace({
+      aircraftHex: "A7BBE9",
+      committedAircraftHex: "A7BBE9",
+      tracePoints: [{ lat: 42, lon: -71 }, { lat: 43, lon: -72 }],
+    }),
+    true,
+  );
+});
+
+test("staggered trace labels start during the line reveal", () => {
+  const first = getTraceLabelRevealDelay({
+    index: 0,
+    growthDurationMs: 900,
+    staggerMs: 70,
+  });
+  const second = getTraceLabelRevealDelay({
+    index: 1,
+    growthDurationMs: 900,
+    staggerMs: 70,
+  });
+
+  assert.equal(first, 495);
+  assert.equal(second, 565);
+});
+
+test("trace reveal key is stable across live updates for the same aircraft", () => {
+  const first = getTraceRevealKey({
+    aircraftHex: "A7BBE9",
+    tracePoints: [
+      { timestampMs: 1_000, lat: 42, lon: -71 },
+      { timestampMs: 2_000, lat: 43, lon: -72 },
+    ],
+  });
+  const second = getTraceRevealKey({
+    aircraftHex: "A7BBE9",
+    tracePoints: [
+      { timestampMs: 1_000, lat: 42, lon: -71 },
+      { timestampMs: 3_000, lat: 44, lon: -73 },
+    ],
+  });
+
+  assert.equal(first, second);
+});

--- a/src/features/airport-explorer/AirportExplorer.jsx
+++ b/src/features/airport-explorer/AirportExplorer.jsx
@@ -13,7 +13,7 @@ import { resolveAirportProfile } from "./airportExplorerModel.js";
 import { useAirportExplorerData } from "./useAirportExplorerData.js";
 import { useAirportProcedures } from "../../hooks/useAirportProcedures.js";
 import { useNearbyAirports } from "../../hooks/useNearbyAirports.js";
-import { useAircraftTrace } from "../../hooks/useAircraftTrace.js";
+import { SelectedAircraftTraceProvider } from "../aircraft-trace/SelectedAircraftTraceContext.jsx";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -66,9 +66,6 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
         (item) => (item.icao24 || item.callsign) === selectedAircraftId,
       ) || null,
     [selectedAircraftId, traffic.aircraft],
-  );
-  const { tracePoints: selectedAircraftTrace } = useAircraftTrace(
-    selectedAircraft,
   );
 
   useEffect(() => {
@@ -123,58 +120,59 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   };
 
   return (
-    <div
-      className={`font-sans text-atc-text ${
-        isMobile
-          ? "fixed inset-0 z-0 flex overflow-hidden overscroll-none"
-          : "flex h-dvh overflow-hidden"
-      }`}
-    >
-      {!isMobile && (
-        <div
-          className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
-          style={{ width: sidebarOpen ? desktopSidebarWidth : "0" }}
-        >
-          <div className="h-full" style={{ width: desktopSidebarWidth }}>
-            <AirportSidebar {...sidebarProps} />
-          </div>
-        </div>
-      )}
-
-      <div className="relative min-w-0 flex-1 overflow-hidden bg-atc-bg">
-        {!(isMobile && sidebarOpen) && <AirportExplorerMapMenu />}
-
-        <AirportMap
-          icao={airportProfile.icao}
-          lat={airportProfile.lat}
-          lon={airportProfile.lon}
-          zoom={mapZoom}
-          accent="var(--atc-accent)"
-          aircraft={traffic.aircraft}
-          nearbyAirports={nearbyAirports.airports}
-          airport={airport}
-          showMapLabels={showMapLabels}
-          showRunwayBeams={showRunwayBeams}
-          showRoutingPointBadges={showRoutingPointBadges}
-          trafficFilter={trafficFilter}
-          typeFilter={typeFilter}
-          altitudeLevel={altitudeLevel}
-          selectedAircraftId={selectedAircraftId}
-          selectedAircraftTrace={selectedAircraftTrace}
-          onSelectAircraft={selectAircraft}
-          runwayMap={procedures.runwayMap}
-          runwayProcedures={null}
-          procedureFixLabelRunwayProcedures={procedures.runwayProcedures}
-          showProcedureFixLabels
-        />
-        <AircraftDataLoadingOverlay active={traffic.aircraftInitialLoading} />
-
-        {isMobile && sidebarOpen && (
-          <div className="absolute inset-0 z-[1100]">
-            <AirportSidebar {...sidebarProps} onClose={closeSidebar} />
+    <SelectedAircraftTraceProvider selectedAircraft={selectedAircraft}>
+      <div
+        className={`font-sans text-atc-text ${
+          isMobile
+            ? "fixed inset-0 z-0 flex overflow-hidden overscroll-none"
+            : "flex h-dvh overflow-hidden"
+        }`}
+      >
+        {!isMobile && (
+          <div
+            className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+            style={{ width: sidebarOpen ? desktopSidebarWidth : "0" }}
+          >
+            <div className="h-full" style={{ width: desktopSidebarWidth }}>
+              <AirportSidebar {...sidebarProps} />
+            </div>
           </div>
         )}
+
+        <div className="relative min-w-0 flex-1 overflow-hidden bg-atc-bg">
+          {!(isMobile && sidebarOpen) && <AirportExplorerMapMenu />}
+
+          <AirportMap
+            icao={airportProfile.icao}
+            lat={airportProfile.lat}
+            lon={airportProfile.lon}
+            zoom={mapZoom}
+            accent="var(--atc-accent)"
+            aircraft={traffic.aircraft}
+            nearbyAirports={nearbyAirports.airports}
+            airport={airport}
+            showMapLabels={showMapLabels}
+            showRunwayBeams={showRunwayBeams}
+            showRoutingPointBadges={showRoutingPointBadges}
+            trafficFilter={trafficFilter}
+            typeFilter={typeFilter}
+            altitudeLevel={altitudeLevel}
+            selectedAircraftId={selectedAircraftId}
+            onSelectAircraft={selectAircraft}
+            runwayMap={procedures.runwayMap}
+            runwayProcedures={null}
+            procedureFixLabelRunwayProcedures={procedures.runwayProcedures}
+            showProcedureFixLabels
+          />
+          <AircraftDataLoadingOverlay active={traffic.aircraftInitialLoading} />
+
+          {isMobile && sidebarOpen && (
+            <div className="absolute inset-0 z-[1100]">
+              <AirportSidebar {...sidebarProps} onClose={closeSidebar} />
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </SelectedAircraftTraceProvider>
   );
 }

--- a/src/features/airport-explorer/AirportExplorer.jsx
+++ b/src/features/airport-explorer/AirportExplorer.jsx
@@ -158,6 +158,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             altitudeLevel={altitudeLevel}
             selectedAircraftId={selectedAircraftId}
             onSelectAircraft={selectAircraft}
+            onRevalidateRoute={traffic.revalidateFlightRoute}
             runwayMap={procedures.runwayMap}
             runwayProcedures={null}
             procedureFixLabelRunwayProcedures={procedures.runwayProcedures}

--- a/src/features/airport-explorer/AirportExplorer.jsx
+++ b/src/features/airport-explorer/AirportExplorer.jsx
@@ -147,7 +147,6 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             lat={airportProfile.lat}
             lon={airportProfile.lon}
             zoom={mapZoom}
-            accent="var(--atc-accent)"
             aircraft={traffic.aircraft}
             nearbyAirports={nearbyAirports.airports}
             airport={airport}

--- a/src/features/airport-explorer/airportExplorerModel.js
+++ b/src/features/airport-explorer/airportExplorerModel.js
@@ -1,6 +1,6 @@
 import { AIRPORT_FALLBACKS, COORDS } from "../../data/airportFallbacks.js";
 import { enrichAircraftWithAirportContext } from "../airport-context/airportContextModel.js";
-import { resolveMovement } from "../../utils/aircraftMovement.js";
+import { resolveMovement, UNKNOWN } from "../../utils/aircraftMovement.js";
 import { normalizeCallsign } from "../../utils/callsign.js";
 import { formatFlightRouteLabel } from "../../utils/flightRouteDisplay.js";
 
@@ -30,13 +30,21 @@ export function enrichAircraftWithRoutes({
   const aircraftWithRoutes = aircraft.map((item) => {
     const key = normalizeCallsign(item.callsign);
     const route = routesByCallsign[key] || null;
-    const movement = resolveMovement(route, airportProfile?.icao, airportProfile?.iata);
+    const flightRouteLabel = formatFlightRouteLabel(route);
+    // Tie movement to a renderable label so the marker color and the
+    // sidebar row text never disagree. A partial route (origin known,
+    // destination missing — common in AeroDataBox responses for flights
+    // mid-departure) would otherwise color the marker DEPARTURE while
+    // leaving the route text empty.
+    const movement = flightRouteLabel
+      ? resolveMovement(route, airportProfile?.icao, airportProfile?.iata)
+      : UNKNOWN;
 
     return {
       ...item,
       flightRoute: route,
       movement,
-      flightRouteLabel: formatFlightRouteLabel(route),
+      flightRouteLabel,
     };
   });
 

--- a/src/features/airport-explorer/useAirportExplorerData.js
+++ b/src/features/airport-explorer/useAirportExplorerData.js
@@ -24,8 +24,11 @@ export function useAirportExplorerData(airportProfile) {
     airportProfile.lat,
     airportProfile.lon,
   );
-  const { routesByCallsign, loadingCount: routeLoadingCount } =
-    useFlightRoutes(aircraft, airportProfile);
+  const {
+    routesByCallsign,
+    loadingCount: routeLoadingCount,
+    revalidate: revalidateFlightRoute,
+  } = useFlightRoutes(aircraft, airportProfile);
 
   const aircraftWithRoutes = useMemo(
     () =>
@@ -51,6 +54,7 @@ export function useAirportExplorerData(airportProfile) {
       feedStatus,
       feedSource,
       routeLoadingCount,
+      revalidateFlightRoute,
     },
   };
 }

--- a/src/hooks/useAircraftTrace.js
+++ b/src/hooks/useAircraftTrace.js
@@ -33,7 +33,10 @@ function liveAircraftToTracePoint(aircraft) {
 
 export function useAircraftTrace(selectedAircraft = null) {
   const hex = selectedAircraft?.icao24 || "";
-  const [tracePoints, setTracePoints] = useState([]);
+  const [traceState, setTraceState] = useState({
+    hex: "",
+    tracePoints: [],
+  });
   const [loading, setLoading] = useState(false);
 
   // Fetch the recent trace once when the selection changes. Merge into
@@ -41,13 +44,13 @@ export function useAircraftTrace(selectedAircraft = null) {
   // positions that polled in between selection and fetch resolution.
   useEffect(() => {
     if (!hex) {
-      setTracePoints([]);
+      setTraceState({ hex: "", tracePoints: [] });
       setLoading(false);
       return undefined;
     }
 
     let disposed = false;
-    setTracePoints([]);
+    setTraceState({ hex, tracePoints: [] });
     setLoading(true);
 
     aircraftTraceClient
@@ -55,12 +58,13 @@ export function useAircraftTrace(selectedAircraft = null) {
       .then((payload) => {
         if (disposed) return;
         const recent = normalizeAdsbTracePayload(payload?.recent);
-        setTracePoints((current) =>
-          mergeTraceHistory({
+        setTraceState((current) => ({
+          hex,
+          tracePoints: mergeTraceHistory({
             recentTrace: recent,
-            fallbackHistory: current,
+            fallbackHistory: current.hex === hex ? current.tracePoints : [],
           }),
-        );
+        }));
       })
       .catch((error) => {
         if (!disposed) {
@@ -88,16 +92,20 @@ export function useAircraftTrace(selectedAircraft = null) {
     if (!hex || loading) return;
     const point = liveAircraftToTracePoint(selectedAircraft);
     if (!point) return;
-    setTracePoints((current) =>
-      mergeTraceHistory({
-        recentTrace: [point],
-        fallbackHistory: current,
-      }),
-    );
+    setTraceState((current) => {
+      if (current.hex !== hex) return current;
+      return {
+        hex,
+        tracePoints: mergeTraceHistory({
+          recentTrace: [point],
+          fallbackHistory: current.tracePoints,
+        }),
+      };
+    });
   }, [hex, loading, selectedAircraft]);
 
   return {
-    tracePoints,
+    tracePoints: traceState.hex === hex ? traceState.tracePoints : [],
     loading,
   };
 }

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -214,17 +214,19 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
     });
   }, [aircraft, routeContext, version]);
 
-  // Bypass the cache + the VRS standing-data step and force a fresh
-  // AeroDataBox lookup. Used when the user explicitly asks to revalidate
-  // a focused aircraft's route (e.g., clicking on the already-selected
-  // plane). The new result overwrites the cached entry.
+  // Force a fresh AeroDataBox lookup for a focused aircraft. When the
+  // upstream returns a route we overwrite the cached entry — the aircraft
+  // gets re-enriched on the next render and downstream (marker color,
+  // sidebar row, trail accent color) repaints with the new data. When
+  // AeroDataBox returns nothing OR the call fails, we deliberately
+  // leave the cached entry alone so a perfectly good VRS route doesn't
+  // get erased by an inconclusive revalidation.
   const revalidate = useCallback(
     async (callsign) => {
       const normalized = normalizeCallsign(callsign);
       if (!normalized) return null;
 
       const cacheKey = buildRouteCacheKey(normalized, routeContext);
-      routeCache.delete(cacheKey);
       inFlight.add(normalized);
       if (mountedRef.current) {
         setLoadingCount(inFlight.size + queued.size);
@@ -235,14 +237,15 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
           routeContext,
           { forceAerodatabox: true },
         );
-        routeCache.set(cacheKey, { route, time: Date.now() });
+        if (route) {
+          routeCache.set(cacheKey, { route, time: Date.now() });
+        }
         return route;
       } catch (error) {
         console.warn(
           `Flight route revalidation failed for ${normalized}:`,
           error.message,
         );
-        routeCache.set(cacheKey, { route: null, time: Date.now() });
         return null;
       } finally {
         inFlight.delete(normalized);

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   buildRouteCacheKey,
   buildRoutesByCallsign,
@@ -9,6 +9,7 @@ import {
 } from "../features/flight-routes/flightRouteLookupModel.js";
 import { flightRouteClient } from "../services/aviationData.js";
 import { FLIGHT_ROUTE_LOOKUP_CONFIG } from "../config/aviation.js";
+import { normalizeCallsign } from "../utils/callsign.js";
 
 const routeCache = new Map();
 const inFlight = new Set();
@@ -213,5 +214,46 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
     });
   }, [aircraft, routeContext, version]);
 
-  return { routesByCallsign, loadingCount };
+  // Bypass the cache + the VRS standing-data step and force a fresh
+  // AeroDataBox lookup. Used when the user explicitly asks to revalidate
+  // a focused aircraft's route (e.g., clicking on the already-selected
+  // plane). The new result overwrites the cached entry.
+  const revalidate = useCallback(
+    async (callsign) => {
+      const normalized = normalizeCallsign(callsign);
+      if (!normalized) return null;
+
+      const cacheKey = buildRouteCacheKey(normalized, routeContext);
+      routeCache.delete(cacheKey);
+      inFlight.add(normalized);
+      if (mountedRef.current) {
+        setLoadingCount(inFlight.size + queued.size);
+      }
+      try {
+        const route = await flightRouteClient.fetchFlightRoute(
+          normalized,
+          routeContext,
+          { forceAerodatabox: true },
+        );
+        routeCache.set(cacheKey, { route, time: Date.now() });
+        return route;
+      } catch (error) {
+        console.warn(
+          `Flight route revalidation failed for ${normalized}:`,
+          error.message,
+        );
+        routeCache.set(cacheKey, { route: null, time: Date.now() });
+        return null;
+      } finally {
+        inFlight.delete(normalized);
+        if (mountedRef.current) {
+          setVersion((v) => v + 1);
+          setLoadingCount(inFlight.size + queued.size);
+        }
+      }
+    },
+    [routeContext],
+  );
+
+  return { routesByCallsign, loadingCount, revalidate };
 }

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -237,7 +237,15 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
           routeContext,
           { forceAerodatabox: true },
         );
-        if (route) {
+        // Only overwrite the cache when AeroDataBox returns a *complete*
+        // route. A partial response (origin known, destination missing)
+        // would clobber a perfectly good complete VRS entry, leaving the
+        // user worse off after asking us to "revalidate".
+        const hasOrigin = Boolean(route?.origin?.icao || route?.origin?.iata);
+        const hasDestination = Boolean(
+          route?.destination?.icao || route?.destination?.iata,
+        );
+        if (route && hasOrigin && hasDestination) {
           routeCache.set(cacheKey, { route, time: Date.now() });
         }
         return route;

--- a/src/services/aviation/flightRouteClient.js
+++ b/src/services/aviation/flightRouteClient.js
@@ -29,24 +29,25 @@ export const createFlightRouteClient = ({
 
   let consecutiveBackoffMs = 0;
 
-  const routeUrl = (callsign, targetAirport = {}) => {
+  const routeUrl = (callsign, targetAirport = {}, options = {}) => {
     const params = new URLSearchParams();
     const airportIcao = normalizeCallsign(targetAirport.icao || "");
     const airportIata = normalizeCallsign(targetAirport.iata || "");
     if (airportIcao) params.set("airportIcao", airportIcao);
     if (airportIata) params.set("airportIata", airportIata);
+    if (options.forceAerodatabox) params.set("force", "aerodatabox");
     const query = params.toString();
     return `${baseUrl}/${encodeURIComponent(callsign)}${query ? `?${query}` : ""}`;
   };
 
   return {
-    async fetchFlightRoute(callsign, targetAirport = {}) {
+    async fetchFlightRoute(callsign, targetAirport = {}, options = {}) {
       const normalized = normalizeCallsign(callsign);
       if (!normalized) return null;
 
       await limiter.acquire();
 
-      const url = routeUrl(normalized, targetAirport);
+      const url = routeUrl(normalized, targetAirport, options);
       const response = await auditedFetch(
         url,
         {

--- a/src/services/aviation/vrsRouteProxyModel.js
+++ b/src/services/aviation/vrsRouteProxyModel.js
@@ -2,7 +2,7 @@ export const VRS_STANDING_DATA_BASE =
   "https://vrs-standing-data.adsb.lol/routes";
 
 export const VRS_ROUTE_USER_AGENT =
-  "ADSBao/0.10.0 (+https://github.com/orriduck/ADSBao) VRS-standing-data/1.0";
+  "ADSBao/0.11.0 (+https://github.com/orriduck/ADSBao) VRS-standing-data/1.0";
 
 export const VRS_ROUTE_MISS_STATUS = 200;
 

--- a/src/style.css
+++ b/src/style.css
@@ -2418,52 +2418,54 @@ body {
     );
 }
 
-/* Two-row pill-style marker pinned above a trace sample point. Card
- * surface tone keeps it readable over either basemap; the thin
- * subpixel border + outer shadow lift it just enough off the trail. */
+/* Compact left-aligned card pinned just off a trace sample point. The
+ * container hugs its content (inline-flex, auto width) so the card never
+ * stretches to the divIcon's bounding box. Subpixel border + soft outer
+ * shadow lift it off the trail; surface tone keeps it readable on either
+ * basemap. */
 .aircraft-trace-label {
-    align-items: center;
+    align-items: flex-start;
     background: color-mix(in oklab, var(--atc-card) 86%, transparent);
     border: 1px solid color-mix(in oklab, var(--atc-line-strong) 55%, transparent);
-    border-radius: 3px;
+    border-radius: 2px;
     box-shadow:
-        0 1px 6px color-mix(in oklab, var(--atc-bg) 60%, transparent),
+        0 1px 4px color-mix(in oklab, var(--atc-bg) 60%, transparent),
         inset 0 0 0 1px color-mix(in oklab, var(--atc-line) 22%, transparent);
-    display: flex;
+    display: inline-flex;
     flex-direction: column;
     font-family: "JetBrains Mono", monospace;
-    gap: 1px;
-    height: 100%;
-    justify-content: center;
+    /* !important is needed to beat Leaflet's iconSize inline width/height. */
+    height: max-content !important;
     line-height: 1;
     opacity: 0;
-    padding: 3px 6px 2px;
+    padding: 2px 5px;
     pointer-events: none;
-    text-align: center;
+    text-align: left;
     transition: opacity 360ms ease-out;
     white-space: nowrap;
-    width: 100%;
+    width: max-content !important;
 }
 
 .aircraft-trace-label__time {
     color: var(--atc-text);
-    font-size: 9.5px;
+    font-size: 9px;
     font-weight: 700;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.4px;
 }
 
 .aircraft-trace-label__alt {
     color: var(--atc-dim);
-    font-size: 8px;
+    font-size: 7.5px;
     font-weight: 600;
-    letter-spacing: 0.4px;
+    letter-spacing: 0.3px;
+    margin-top: 1px;
 }
 
 .aircraft-trace-label__alt-unit {
     color: var(--atc-faint);
-    font-size: 6.5px;
+    font-size: 6px;
     font-weight: 700;
-    letter-spacing: 0.6px;
+    letter-spacing: 0.5px;
     margin-left: 2px;
     text-transform: uppercase;
 }
@@ -2471,7 +2473,7 @@ body {
 .aircraft-trace-label__alt--ground {
     color: var(--atc-faint);
     font-weight: 700;
-    letter-spacing: 0.8px;
+    letter-spacing: 0.6px;
     text-transform: uppercase;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -2407,22 +2407,9 @@ body {
     pointer-events: none;
 }
 
-.aircraft-trace--band {
-    transition:
-        opacity 220ms ease,
-        stroke-width 220ms ease;
-}
-
 .aircraft-trace--glow {
     filter: blur(4px);
     mix-blend-mode: screen;
-}
-
-.aircraft-trace--sweep {
-    animation: aircraft-trace-flow 2s linear infinite;
-    filter: drop-shadow(
-        0 0 8px color-mix(in oklab, var(--atc-accent) 26%, transparent)
-    );
 }
 
 .aircraft-trace-point {
@@ -2488,47 +2475,15 @@ body {
     text-transform: uppercase;
 }
 
-.aircraft-trace-head {
-    animation: aircraft-trace-pulse 1.9s ease-in-out infinite;
-    filter: drop-shadow(
-        0 0 12px color-mix(in oklab, var(--atc-accent) 34%, transparent)
-    );
-}
-
 :root[data-theme="light"] .aircraft-trace--glow {
     filter: blur(2.5px);
     mix-blend-mode: multiply;
 }
 
-:root[data-theme="light"] .aircraft-trace--sweep,
-:root[data-theme="light"] .aircraft-trace-point,
-:root[data-theme="light"] .aircraft-trace-head {
+:root[data-theme="light"] .aircraft-trace-point {
     filter: drop-shadow(
         0 0 4px color-mix(in oklab, var(--atc-accent) 12%, transparent)
     );
-}
-
-@keyframes aircraft-trace-flow {
-    from {
-        stroke-dashoffset: 30;
-    }
-
-    to {
-        stroke-dashoffset: 0;
-    }
-}
-
-@keyframes aircraft-trace-pulse {
-    0%,
-    100% {
-        opacity: 0.82;
-        transform: scale(0.94);
-    }
-
-    45% {
-        opacity: 1;
-        transform: scale(1.18);
-    }
 }
 
 .aircraft-label-title {
@@ -2946,7 +2901,8 @@ body {
 @media (prefers-reduced-motion: reduce) {
     .map-ctrl-bar,
     .map-action-drawer,
-    .ctrl-btn {
+    .ctrl-btn,
+    .aircraft-trace-label {
         transition: none;
     }
 


### PR DESCRIPTION
## Summary

- Selected-aircraft trace renders the focused plane's recent path as a Leaflet polyline with an SVG `linearGradient` core (tail 20% → head 95% opacity) plus fade-in timestamped label cards. State lives in `SelectedAircraftTraceProvider` so the trail and labels survive the 3-second ADS-B poll without re-flashing, and pick up the marker's movement color (orange for DEPARTURE, blue for ARRIVAL).
- Clicking an already-focused marker triggers an AeroDataBox revalidation of its route (`?force=aerodatabox` + `Cache-Control: no-store`). The revalidate path only overwrites the cache when AeroDataBox returns both origin and destination, so a partial response can't clobber a complete VRS entry.
- `enrichAircraftWithRoutes` now ties `movement` to a renderable `flightRouteLabel`. Partial routes (origin known, destination missing) become `UNKNOWN` instead of orange "DEPARTURE" markers with empty sidebar text — the ENY3573 / GJS4391 case.
- Map overlays removed: top-left ICAO + coordinates label and right-edge DEP/UNKN/ARR legend (both redundant with the existing marker color encoding).
- ADS-B provider failover: proxy retries `airplanes.live` whenever `adsb.lol` returns 5xx, 429, or times out, with per-process cool-down and per-request audit logging.
- Trail re-render polish: label cards hug their content (`width: max-content`), latest stacks on top via `zIndexOffset`, and unchanged labels stay mounted across polls thanks to a stable label signature. Switching focus no longer briefly shows the previous aircraft's path.
- Version bumped 0.10.0 → 0.11.0 (`package.json`, about page, VRS User-Agent, README, CHANGELOG, CLAUDE.md / architecture.md tables).

## Test plan
- [ ] `pnpm test` — 51 test files pass ✓
- [ ] `pnpm build` — production build green ✓
- [ ] Focus a flight on the Vercel preview; trail renders with gradient + labels; trail picks up DEPARTURE/ARRIVAL color when the route is complete
- [ ] Click the focused marker — verify a fresh AeroDataBox call in Network panel and the existing route survives if AeroDataBox returns a partial response
- [ ] Find a partial-route aircraft (e.g., ENY3573 / GJS4391 at KORD) — marker should now stay neutral instead of orange-with-no-text
- [ ] Switch focus rapidly between two planes — no stale-aircraft trail flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)