### PR TITLE
Adaptive race-then-stick failover for ADS-B feeds

### DIFF
--- a/src/app/api/proxy/aircraft/positions/[lat]/[lon]/[dist]/route.js
+++ b/src/app/api/proxy/aircraft/positions/[lat]/[lon]/[dist]/route.js
@@ -10,9 +10,8 @@ import {
 } from "@/services/apiProxySecurity.js";
 import { POSITION_PROVIDER_CHAIN } from "@/services/aviation/aircraftDataProviders.js";
 import {
-  createProviderHealthTracker,
-  isRetriableStatus,
-  selectProviderOrder,
+  createAdaptiveProviderSelector,
+  raceProviders,
 } from "@/services/aviation/providerHealth.js";
 
 const rateLimit = {
@@ -21,9 +20,12 @@ const rateLimit = {
   windowMs: 60_000,
 };
 
-const USER_AGENT = "ADSBao/0.10.0 (https://github.com/orriduck/ADSBao)";
+const USER_AGENT = "ADSBao/0.11.0 (https://github.com/orriduck/ADSBao)";
 const POSITION_MAX_BYTES = 2 * 1024 * 1024;
-const healthTracker = createProviderHealthTracker();
+
+// Module-level selector — survives between warm-instance invocations on
+// Vercel so the "preferred provider" sticks until it errors out.
+const selector = createAdaptiveProviderSelector();
 
 export function OPTIONS(request) {
   return createCorsPreflightResponse(request);
@@ -46,16 +48,11 @@ async function fetchProviderPayload(provider, { latitude, longitude, distanceNm 
       next: { revalidate: 0 },
     });
   } catch (networkError) {
-    const error = new Error(`network: ${networkError.message}`);
-    error.retriable = true;
-    throw error;
+    throw new ProviderError(`network: ${networkError.message}`);
   }
 
   if (!response.ok) {
-    const error = new Error(`HTTP ${response.status}`);
-    error.status = response.status;
-    error.retriable = isRetriableStatus(response.status);
-    throw error;
+    throw new ProviderError(`HTTP ${response.status}`, response.status);
   }
 
   let payload;
@@ -65,18 +62,26 @@ async function fetchProviderPayload(provider, { latitude, longitude, distanceNm 
       maxBytes: POSITION_MAX_BYTES,
     });
   } catch (parseError) {
-    const error = new Error(`parse: ${parseError.message}`);
-    error.retriable = true;
-    throw error;
+    throw new ProviderError(`parse: ${parseError.message}`);
   }
 
   if (!payload || typeof payload !== "object" || !Array.isArray(payload.ac)) {
-    const error = new Error("Invalid aircraft payload");
-    error.retriable = true;
-    throw error;
+    throw new ProviderError("Invalid aircraft payload");
   }
 
   return payload;
+}
+
+class ProviderError extends Error {
+  constructor(message, status = null) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function formatAttempt(providerId, error) {
+  if (!error) return `${providerId}:200`;
+  return `${providerId}:${error.status || "ERR"}`;
 }
 
 export async function GET(request, { params }) {
@@ -96,52 +101,77 @@ export async function GET(request, { params }) {
     );
   }
 
-  const providers = selectProviderOrder(POSITION_PROVIDER_CHAIN, healthTracker);
+  const fetcher = (provider) =>
+    fetchProviderPayload(provider, { latitude, longitude, distanceNm });
   const attempts = [];
-  let lastError = null;
 
-  for (const provider of providers) {
+  // Phase 1: if we have a sticky winner from a prior request, try it alone.
+  const preferredId = selector.getPreferredId();
+  const preferred = preferredId
+    ? POSITION_PROVIDER_CHAIN.find((p) => p.id === preferredId)
+    : null;
+
+  if (preferred) {
     try {
-      const payload = await fetchProviderPayload(provider, {
-        latitude,
-        longitude,
-        distanceNm,
-      });
-      attempts.push(`${provider.id}:200`);
-      return Response.json(
-        { ...payload, source: provider.id },
-        {
-          headers: buildProxyHeaders(request, {
-            "Cache-Control": "no-store",
-            "X-Data-Source": provider.id,
-            "X-Provider-Attempts": attempts.join(";"),
-          }),
-        },
-      );
+      const payload = await fetcher(preferred);
+      attempts.push(formatAttempt(preferred.id));
+      return successResponse(request, preferred, payload, attempts);
     } catch (error) {
-      lastError = error;
-      attempts.push(`${provider.id}:${error.status || "ERR"}`);
+      attempts.push(formatAttempt(preferred.id, error));
       console.warn(
-        `[aircraft-positions] ${provider.id} failed`,
+        `[aircraft-positions] preferred ${preferred.id} failed, racing`,
         error.status ? `status=${error.status}` : error.message,
       );
-      if (error.retriable) {
-        healthTracker.markUnhealthy(provider.id);
-        continue;
-      }
-      break;
+      selector.clear();
+      // Fall through to the race.
     }
   }
 
-  return jsonProxyResponse(
-    request,
-    { error: "Failed to load aircraft positions" },
-    {
-      status: Number(lastError?.status) || 502,
-      headers: {
-        "X-Data-Source": "failed",
-        "X-Provider-Attempts": attempts.join(";") || "none",
+  // Phase 2: no winner (or preferred just failed) → race all providers,
+  // first non-error response wins and becomes the new sticky winner.
+  let raceResult;
+  try {
+    raceResult = await raceProviders(POSITION_PROVIDER_CHAIN, fetcher);
+  } catch (aggregate) {
+    const errors = aggregate?.errors || [aggregate];
+    for (let i = 0; i < POSITION_PROVIDER_CHAIN.length; i += 1) {
+      const provider = POSITION_PROVIDER_CHAIN[i];
+      const error = errors[i];
+      attempts.push(formatAttempt(provider.id, error));
+      console.warn(
+        `[aircraft-positions] race: ${provider.id} failed`,
+        error?.status ? `status=${error.status}` : error?.message,
+      );
+    }
+    const lastError = errors[errors.length - 1];
+    return jsonProxyResponse(
+      request,
+      { error: "Failed to load aircraft positions" },
+      {
+        status: Number(lastError?.status) || 502,
+        headers: {
+          "X-Data-Source": "failed",
+          "X-Provider-Attempts": attempts.join(";") || "none",
+        },
       },
+    );
+  }
+
+  const { provider, payload } = raceResult;
+  selector.setPreferredId(provider.id);
+  attempts.push(formatAttempt(provider.id));
+  return successResponse(request, provider, payload, attempts);
+}
+
+function successResponse(request, provider, payload, attempts) {
+  return Response.json(
+    { ...payload, source: provider.id },
+    {
+      headers: buildProxyHeaders(request, {
+        "Cache-Control": "no-store",
+        "X-Data-Source": provider.id,
+        "X-Provider-Attempts": attempts.join(";"),
+      }),
     },
   );
 }

--- a/src/app/api/proxy/aircraft/trace/[hex]/route.js
+++ b/src/app/api/proxy/aircraft/trace/[hex]/route.js
@@ -7,11 +7,6 @@ import {
   readResponseJson,
 } from "@/services/apiProxySecurity.js";
 import { TRACE_PROVIDER_CHAIN } from "@/services/aviation/aircraftDataProviders.js";
-import {
-  createProviderHealthTracker,
-  isRetriableStatus,
-  selectProviderOrder,
-} from "@/services/aviation/providerHealth.js";
 
 const rateLimit = {
   key: "proxy:aircraft-trace",
@@ -19,22 +14,20 @@ const rateLimit = {
   windowMs: 60_000,
 };
 
-const USER_AGENT = "ADSBao/0.10.0 (https://github.com/orriduck/ADSBao)";
+const USER_AGENT = "ADSBao/0.11.0 (https://github.com/orriduck/ADSBao)";
 const TRACE_MAX_BYTES = 6 * 1024 * 1024;
-const healthTracker = createProviderHealthTracker();
+
+// Trace data is only published by adsb.lol; airplanes.live exposes no
+// equivalent endpoint. There's nothing to fail over to, so this route
+// just calls the single provider and returns whatever it gets.
+const [TRACE_PROVIDER] = TRACE_PROVIDER_CHAIN;
 
 export function OPTIONS(request) {
   return createCorsPreflightResponse(request);
 }
 
-async function fetchTraceFromProvider(provider, { hex }) {
-  if (!provider.buildTraceUrl) {
-    const error = new Error(`${provider.id} has no trace endpoint`);
-    error.retriable = true;
-    throw error;
-  }
-
-  const url = provider.buildTraceUrl({ hex });
+async function fetchTrace({ hex }) {
+  const url = TRACE_PROVIDER.buildTraceUrl({ hex });
 
   let response;
   try {
@@ -47,7 +40,6 @@ async function fetchTraceFromProvider(provider, { hex }) {
     });
   } catch (networkError) {
     const error = new Error(`network: ${networkError.message}`);
-    error.retriable = true;
     throw error;
   }
 
@@ -55,19 +47,16 @@ async function fetchTraceFromProvider(provider, { hex }) {
   if (!response.ok) {
     const error = new Error(`HTTP ${response.status}`);
     error.status = response.status;
-    error.retriable = isRetriableStatus(response.status);
     throw error;
   }
 
   try {
     return await readResponseJson(response, {
-      label: `${provider.id} aircraft trace response`,
+      label: `${TRACE_PROVIDER.id} aircraft trace response`,
       maxBytes: TRACE_MAX_BYTES,
     });
   } catch (parseError) {
-    const error = new Error(`parse: ${parseError.message}`);
-    error.retriable = true;
-    throw error;
+    throw new Error(`parse: ${parseError.message}`);
   }
 }
 
@@ -85,62 +74,50 @@ export async function GET(request, { params }) {
     );
   }
 
-  const providers = selectProviderOrder(TRACE_PROVIDER_CHAIN, healthTracker);
   const attempts = [];
-  let lastError = null;
-
-  for (const provider of providers) {
-    try {
-      const recent = await fetchTraceFromProvider(provider, { hex });
-      if (!recent) {
-        attempts.push(`${provider.id}:404`);
-        return jsonProxyResponse(
-          request,
-          { error: "Aircraft trace not found" },
-          {
-            status: 404,
-            headers: {
-              "X-Data-Source": provider.id,
-              "X-Provider-Attempts": attempts.join(";"),
-            },
-          },
-        );
-      }
-      attempts.push(`${provider.id}:200`);
-      return Response.json(
-        { hex, recent, source: provider.id },
+  try {
+    const recent = await fetchTrace({ hex });
+    if (!recent) {
+      attempts.push(`${TRACE_PROVIDER.id}:404`);
+      return jsonProxyResponse(
+        request,
+        { error: "Aircraft trace not found" },
         {
-          headers: buildProxyHeaders(request, {
-            "Cache-Control": "no-store",
-            "X-Data-Source": provider.id,
+          status: 404,
+          headers: {
+            "X-Data-Source": TRACE_PROVIDER.id,
             "X-Provider-Attempts": attempts.join(";"),
-          }),
+          },
         },
       );
-    } catch (error) {
-      lastError = error;
-      attempts.push(`${provider.id}:${error.status || "ERR"}`);
-      console.warn(
-        `[aircraft-trace] ${provider.id} failed`,
-        error.status ? `status=${error.status}` : error.message,
-      );
-      if (error.retriable) {
-        healthTracker.markUnhealthy(provider.id);
-        continue;
-      }
-      break;
     }
-  }
-
-  return jsonProxyResponse(
-    request,
-    { error: "Failed to load aircraft trace" },
-    {
-      status: Number(lastError?.status) || 502,
-      headers: {
-        "X-Data-Source": "failed",
-        "X-Provider-Attempts": attempts.join(";") || "none",
+    attempts.push(`${TRACE_PROVIDER.id}:200`);
+    return Response.json(
+      { hex, recent, source: TRACE_PROVIDER.id },
+      {
+        headers: buildProxyHeaders(request, {
+          "Cache-Control": "no-store",
+          "X-Data-Source": TRACE_PROVIDER.id,
+          "X-Provider-Attempts": attempts.join(";"),
+        }),
       },
-    },
-  );
+    );
+  } catch (error) {
+    attempts.push(`${TRACE_PROVIDER.id}:${error.status || "ERR"}`);
+    console.warn(
+      `[aircraft-trace] ${TRACE_PROVIDER.id} failed`,
+      error.status ? `status=${error.status}` : error.message,
+    );
+    return jsonProxyResponse(
+      request,
+      { error: "Failed to load aircraft trace" },
+      {
+        status: Number(error.status) || 502,
+        headers: {
+          "X-Data-Source": "failed",
+          "X-Provider-Attempts": attempts.join(";") || "none",
+        },
+      },
+    );
+  }
 }

--- a/src/config/about.js
+++ b/src/config/about.js
@@ -26,7 +26,7 @@ export const ABOUT_DATA_SOURCES = [
     glyph: "ADS-B",
     title: "airplanes.live Aircraft Feed",
     description:
-      "Backup ADS-B positions feed. The proxy fails over to airplanes.live whenever adsb.lol returns 5xx, 429, or times out.",
+      "Peer ADS-B positions feed. On cold start the proxy races both feeds and sticks with whichever responds first; on error it re-races to pick a fresh winner.",
     host: "api.airplanes.live",
     href: "https://airplanes.live/api-guide/",
   },

--- a/src/services/aviation/providerHealth.js
+++ b/src/services/aviation/providerHealth.js
@@ -11,12 +11,6 @@
 // re-race on cold start" — the cost is one extra race per cold start,
 // and the happy path is single-provider load.
 
-const RETRIABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
-
-export function isRetriableStatus(status) {
-  return RETRIABLE_STATUSES.has(Number(status));
-}
-
 export function createAdaptiveProviderSelector() {
   let preferredId = null;
   return {

--- a/src/services/aviation/providerHealth.js
+++ b/src/services/aviation/providerHealth.js
@@ -1,65 +1,46 @@
-// Per-process cool-down tracker for upstream provider health. When a
-// provider fails with a retriable status (5xx / 429 / network / timeout),
-// the proxy marks it unhealthy for a short window — subsequent requests
-// from the same instance skip straight to the next provider in the chain
-// until the cool-down lapses, then re-probe the primary automatically.
+// Adaptive provider selector for upstream ADS-B feeds.
 //
-// Vercel's serverless model gives each instance its own memory, so this
-// state is per-instance. That's fine for the "lots of 503s in a row from
-// adsb.lol" case: each instance learns independently and recovers
-// independently when adsb.lol comes back.
+// Cold start: no preferred provider → race all providers, stick with the
+// winner. Steady state: use the preferred provider only (single outbound
+// call per request). Failure: clear preferred → next request re-races
+// to pick a fresh winner, including the just-failed provider in case the
+// error was transient.
+//
+// State is per-process. Vercel serverless reuses warm container memory
+// across invocations, so this gives us "sticky on the same instance,
+// re-race on cold start" — the cost is one extra race per cold start,
+// and the happy path is single-provider load.
 
-const DEFAULT_COOL_DOWN_MS = 90_000;
 const RETRIABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
 export function isRetriableStatus(status) {
   return RETRIABLE_STATUSES.has(Number(status));
 }
 
-export function createProviderHealthTracker({
-  coolDownMs = DEFAULT_COOL_DOWN_MS,
-  now = () => Date.now(),
-} = {}) {
-  const unhealthyUntil = new Map();
-
-  const isUnhealthy = (providerId) => {
-    const until = unhealthyUntil.get(providerId);
-    if (until == null) return false;
-    if (now() >= until) {
-      unhealthyUntil.delete(providerId);
-      return false;
-    }
-    return true;
-  };
-
+export function createAdaptiveProviderSelector() {
+  let preferredId = null;
   return {
-    markUnhealthy(providerId) {
-      unhealthyUntil.set(providerId, now() + coolDownMs);
+    getPreferredId: () => preferredId,
+    setPreferredId: (id) => {
+      preferredId = id || null;
     },
-    isUnhealthy,
-    snapshot() {
-      const result = {};
-      const currentTime = now();
-      for (const [id, until] of unhealthyUntil.entries()) {
-        if (until > currentTime) result[id] = until - currentTime;
-      }
-      return result;
-    },
-    clear() {
-      unhealthyUntil.clear();
+    clear: () => {
+      preferredId = null;
     },
   };
 }
 
-// Order a provider chain so healthy providers come first, preserving
-// their declared order; unhealthy providers stay in the chain as last-resort
-// fallbacks (the cool-down might be stale). Pure function — no side effects.
-export function selectProviderOrder(chain, healthTracker) {
-  const healthy = [];
-  const unhealthy = [];
-  for (const provider of chain) {
-    if (healthTracker.isUnhealthy(provider.id)) unhealthy.push(provider);
-    else healthy.push(provider);
+// Race providers in parallel; resolve with the first to succeed along with
+// the provider that produced the payload. If every provider rejects, throw
+// the AggregateError raised by Promise.any — its .errors[] mirrors the
+// input order so callers can pair rejections back to providers for logging.
+export async function raceProviders(providers, fetcher) {
+  if (!providers || providers.length === 0) {
+    throw new Error("raceProviders: empty provider list");
   }
-  return [...healthy, ...unhealthy];
+  const attempts = providers.map(async (provider) => {
+    const payload = await fetcher(provider);
+    return { provider, payload };
+  });
+  return Promise.any(attempts);
 }

--- a/src/services/aviation/providerHealth.test.js
+++ b/src/services/aviation/providerHealth.test.js
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 
 import {
-  createProviderHealthTracker,
+  createAdaptiveProviderSelector,
   isRetriableStatus,
-  selectProviderOrder,
+  raceProviders,
 } from "./providerHealth.js";
 
 // isRetriableStatus
@@ -13,60 +13,70 @@ assert.equal(isRetriableStatus(500), true);
 assert.equal(isRetriableStatus(404), false);
 assert.equal(isRetriableStatus(200), false);
 
-// cool-down lifecycle
+// Selector lifecycle
 {
-  let currentTime = 1_000;
-  const tracker = createProviderHealthTracker({
-    coolDownMs: 5_000,
-    now: () => currentTime,
-  });
-
-  assert.equal(tracker.isUnhealthy("adsb.lol"), false);
-  tracker.markUnhealthy("adsb.lol");
-  assert.equal(tracker.isUnhealthy("adsb.lol"), true);
-  assert.deepEqual(tracker.snapshot(), { "adsb.lol": 5_000 });
-
-  // Halfway through the window — still unhealthy.
-  currentTime = 3_500;
-  assert.equal(tracker.isUnhealthy("adsb.lol"), true);
-
-  // Past the window — auto-recovers and snapshot drops it.
-  currentTime = 7_000;
-  assert.equal(tracker.isUnhealthy("adsb.lol"), false);
-  assert.deepEqual(tracker.snapshot(), {});
+  const selector = createAdaptiveProviderSelector();
+  assert.equal(selector.getPreferredId(), null);
+  selector.setPreferredId("adsb.lol");
+  assert.equal(selector.getPreferredId(), "adsb.lol");
+  selector.clear();
+  assert.equal(selector.getPreferredId(), null);
 }
 
-// selectProviderOrder: healthy first, unhealthy as last-resort fallback
+// raceProviders: first fulfilled wins, carries the provider reference
 {
-  let currentTime = 1_000;
-  const tracker = createProviderHealthTracker({
-    coolDownMs: 5_000,
-    now: () => currentTime,
-  });
-  const chain = [
-    { id: "adsb.lol" },
-    { id: "adsb.fi" },
-  ];
+  const providers = [{ id: "slow" }, { id: "fast" }];
+  const fetcher = (provider) =>
+    new Promise((resolve) => {
+      const delay = provider.id === "fast" ? 1 : 30;
+      setTimeout(() => resolve({ ok: provider.id }), delay);
+    });
 
-  // All healthy: declared order.
-  assert.deepEqual(
-    selectProviderOrder(chain, tracker).map((p) => p.id),
-    ["adsb.lol", "adsb.fi"],
-  );
+  const { provider, payload } = await raceProviders(providers, fetcher);
+  assert.equal(provider.id, "fast");
+  assert.deepEqual(payload, { ok: "fast" });
+}
 
-  // Primary unhealthy: secondary moves to front, primary tails as fallback.
-  tracker.markUnhealthy("adsb.lol");
-  assert.deepEqual(
-    selectProviderOrder(chain, tracker).map((p) => p.id),
-    ["adsb.fi", "adsb.lol"],
-  );
+// raceProviders: AggregateError when every provider rejects
+{
+  const providers = [{ id: "a" }, { id: "b" }];
+  const fetcher = (provider) =>
+    Promise.reject(new Error(`${provider.id} down`));
 
-  // After cool-down: primary is back at the top.
-  currentTime = 7_000;
-  assert.deepEqual(
-    selectProviderOrder(chain, tracker).map((p) => p.id),
-    ["adsb.lol", "adsb.fi"],
-  );
+  let caught = null;
+  try {
+    await raceProviders(providers, fetcher);
+  } catch (error) {
+    caught = error;
+  }
+  assert.ok(caught, "expected raceProviders to reject");
+  assert.equal(caught.name, "AggregateError");
+  assert.equal(caught.errors.length, 2);
+  assert.equal(caught.errors[0].message, "a down");
+  assert.equal(caught.errors[1].message, "b down");
+}
+
+// raceProviders: a single fulfillment is enough even when one rejects
+{
+  const providers = [{ id: "broken" }, { id: "ok" }];
+  const fetcher = (provider) =>
+    provider.id === "broken"
+      ? Promise.reject(new Error("nope"))
+      : Promise.resolve({ ok: true });
+
+  const { provider } = await raceProviders(providers, fetcher);
+  assert.equal(provider.id, "ok");
+}
+
+// raceProviders: empty list is a programmer error
+{
+  let caught = null;
+  try {
+    await raceProviders([], () => Promise.resolve());
+  } catch (error) {
+    caught = error;
+  }
+  assert.ok(caught, "expected raceProviders([]) to throw");
 }
 
 console.log("providerHealth.test.js: ok");

--- a/src/services/aviation/providerHealth.test.js
+++ b/src/services/aviation/providerHealth.test.js
@@ -2,16 +2,8 @@ import assert from "node:assert/strict";
 
 import {
   createAdaptiveProviderSelector,
-  isRetriableStatus,
   raceProviders,
 } from "./providerHealth.js";
-
-// isRetriableStatus
-assert.equal(isRetriableStatus(503), true);
-assert.equal(isRetriableStatus(429), true);
-assert.equal(isRetriableStatus(500), true);
-assert.equal(isRetriableStatus(404), false);
-assert.equal(isRetriableStatus(200), false);
 
 // Selector lifecycle
 {


### PR DESCRIPTION
## Summary

Replaces the cool-down-based primary+fallback model with a simpler adaptive selector.

- **Cold start** (no preferred provider): race `adsb.lol` and `airplanes.live` in parallel via `Promise.any`. The first non-error response wins, returns to the client, and becomes the sticky preferred for this warm instance.
- **Steady state**: only the preferred provider is called per request — one outbound request per inbound request, no second-provider load on the happy path.
- **On error**: clear preferred and re-race on the next request (including the just-failed provider, in case the error was transient). Whoever wins the re-race becomes the new sticky.

The state lives in module-level memory, so it persists across warm Vercel invocations but resets on cold start — meaning the worst-case extra cost is one race per cold start, not per request.

Audit headers (`X-Data-Source`, `X-Provider-Attempts`) are preserved so the sidebar audit log keeps working unchanged.

The trace handler also simplifies: adsb.lol is the only provider that publishes a public trace endpoint, so the loop+health-tracker machinery was never doing anything there. Reduced to a single try/catch.

## Test plan
- [ ] `pnpm test` — 51 test files pass ✓ (new race/selector coverage in `providerHealth.test.js`)
- [ ] `pnpm build` — production build green ✓
- [ ] On preview, hit an airport page from cold and confirm the first response logs a race in `[aircraft-positions]` then subsequent requests log only the winner
- [ ] Simulate a provider outage (e.g., block one host) and confirm the next request re-races and recovers, with `X-Provider-Attempts` showing the failed-then-succeeded chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)