### PR TITLE
Toast when trace fetch takes >400ms

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -84,12 +84,7 @@ export default function RootLayout({ children }) {
         <Toaster
           theme="system"
           position="bottom-right"
-          toastOptions={{
-            style: {
-              fontFamily: "'Manrope', system-ui, sans-serif",
-              fontSize: "14px",
-            },
-          }}
+          toastOptions={{ className: "atc-toast" }}
         />
         <Analytics />
         <SpeedInsights />

--- a/src/features/aircraft-trace/TraceLoadingToast.jsx
+++ b/src/features/aircraft-trace/TraceLoadingToast.jsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { useSelectedAircraftTrace } from "./SelectedAircraftTraceContext.jsx";
+
+const TOAST_ID = "selected-aircraft-trace-loading";
+const SHOW_DELAY_MS = 400;
+const TOAST_MESSAGE = "Working on getting the recent trace…";
+
+// Shows a sonner toast when the recent-trace fetch for the focused aircraft
+// is still pending past SHOW_DELAY_MS. Dismisses the toast as soon as the
+// fetch resolves (or the user switches selection / deselects), so a fast
+// response stays silent.
+export default function TraceLoadingToast() {
+  const { aircraftHex, loading } = useSelectedAircraftTrace();
+
+  useEffect(() => {
+    if (!aircraftHex || !loading) {
+      toast.dismiss(TOAST_ID);
+      return undefined;
+    }
+
+    const timer = setTimeout(() => {
+      toast.loading(TOAST_MESSAGE, { id: TOAST_ID });
+    }, SHOW_DELAY_MS);
+
+    return () => {
+      clearTimeout(timer);
+      toast.dismiss(TOAST_ID);
+    };
+  }, [aircraftHex, loading]);
+
+  return null;
+}

--- a/src/features/airport-explorer/AirportExplorer.jsx
+++ b/src/features/airport-explorer/AirportExplorer.jsx
@@ -14,6 +14,7 @@ import { useAirportExplorerData } from "./useAirportExplorerData.js";
 import { useAirportProcedures } from "../../hooks/useAirportProcedures.js";
 import { useNearbyAirports } from "../../hooks/useNearbyAirports.js";
 import { SelectedAircraftTraceProvider } from "../aircraft-trace/SelectedAircraftTraceContext.jsx";
+import TraceLoadingToast from "../aircraft-trace/TraceLoadingToast.jsx";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -121,6 +122,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
 
   return (
     <SelectedAircraftTraceProvider selectedAircraft={selectedAircraft}>
+      <TraceLoadingToast />
       <div
         className={`font-sans text-atc-text ${
           isMobile

--- a/src/style.css
+++ b/src/style.css
@@ -3644,3 +3644,66 @@ body {
     --sidebar-border: hsl(240 3.7% 15.9%);
     --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
+
+/* Sonner toast — match the console-panel idiom used throughout the app:
+   dense padding, sharp 4px corners, design-token surface + border that
+   flip automatically with [data-theme]. Sonner's defaults live on
+   :where() selectors so a single-class override wins without !important. */
+.atc-toast[data-sonner-toast] {
+    font-family: 'Manrope', system-ui, sans-serif;
+    font-size: 12px;
+    line-height: 1.35;
+    letter-spacing: 0.005em;
+    padding: 8px 12px;
+    gap: 8px;
+    width: auto;
+    min-height: 0;
+    max-width: min(360px, calc(100vw - 32px));
+    background: var(--tone-card-strong);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid var(--tone-border-firm);
+    border-radius: var(--atc-radius-panel);
+    box-shadow: 0 6px 20px color-mix(in oklab, var(--atc-bg) 60%, transparent);
+    color: var(--atc-text);
+}
+
+.atc-toast[data-sonner-toast] [data-icon] {
+    width: 14px;
+    height: 14px;
+    margin: 0;
+}
+
+.atc-toast[data-sonner-toast] [data-icon] > * {
+    width: 14px;
+    height: 14px;
+    color: var(--atc-accent);
+}
+
+.atc-toast[data-sonner-toast] [data-content] {
+    gap: 2px;
+}
+
+.atc-toast[data-sonner-toast] [data-title] {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--atc-text);
+}
+
+.atc-toast[data-sonner-toast] [data-description] {
+    font-size: 11px;
+    color: var(--atc-faint);
+}
+
+.atc-toast[data-sonner-toast] [data-close-button] {
+    width: 16px;
+    height: 16px;
+    background: transparent;
+    border: none;
+    color: var(--atc-faint);
+}
+
+.atc-toast[data-sonner-toast] [data-close-button]:hover {
+    color: var(--atc-text);
+}
+


### PR DESCRIPTION
## Summary

When the user focuses an aircraft, the trace endpoint sometimes takes a beat to respond — long enough to be confusing, short enough that any progress UI sitting in the map area would feel like clutter. This adds a quiet sonner toast that only appears if the recent-trace fetch is still pending after 400ms, then dismisses as soon as it resolves.

- New `TraceLoadingToast` component lives inside `SelectedAircraftTraceProvider` and reads `aircraftHex` + `loading` from the existing trace context.
- 400ms grace window so fast fetches stay silent (the common case).
- Toast uses a fixed id, so switching focus between aircraft replaces (or restarts the delay window for) the same toast — no stacking.
- Cleanup dismisses the toast on selection change, deselect, and unmount.

Message text: "Working on getting the recent trace…"

## Test plan
- [ ] `pnpm test` — 51 files pass ✓
- [ ] `pnpm build` — green ✓
- [ ] On Vercel preview, focus an aircraft with throttled network — toast appears after 400ms, dismisses on trace arrival
- [ ] Focus a fast-responding aircraft — no toast appears
- [ ] Click map to deselect while toast is up — toast disappears
- [ ] Switch focus between two aircraft mid-toast — toast text persists or restarts cleanly, no stacked toasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)