### PR TITLE
v0.12.0 — Aircraft tracking page + polymorphic explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,43 @@
 # Changelog
 
 
+## v0.12.0 — Aircraft tracking page, airport-prefixed routes, polymorphic sidebar/preview
+
+### Added
+- `/aircraft/[callsign]` route renders the same layout as the airport detail page: same sidebar shell, same nav row, same map controls, same aircraft list. The page centers the map on the focal aircraft, fetches its trace, and follows it as it moves. The focal aircraft renders as a silhouette + callsign on the map regardless of speed/altitude (no slow-traffic dot collapse).
+- Adaptive ADS-B callsign provider chain: `/api/proxy/aircraft/callsign/[callsign]` races `adsb.lol` + `airplanes.live`, with race-then-stick failover.
+- Hover/click on a sidebar row pops a unified preview card. The card is polymorphic — it renders an aircraft variant (callsign hero, photo, telemetry, Track → `/aircraft/[callsign]`) or an airport variant (`IATA · ICAO` hero, flag + place, distance + elevation, Track → `/airport/[icao]`). Clicking an airport marker on the map opens the same preview.
+- Airport markers on the map are now clickable on both pages, sharing the same selection state as aircraft.
+- Sidebar list is now polymorphic: aircraft entries appear first (with identity-flipping animations), nearby airports follow. The "Show" filter (All / Aircraft / Airports) gates which entity types render. Column rhythm switched to `Name / Route · Dist · Alt`.
+- Map control bar gains a "Fit to trace" button that zooms the map to the bounds of the currently-rendered trace and stops auto-following the focal until the user clicks back to a preset zoom.
+- Secondary trace (clicked aircraft that isn't the focal) renders at 40% opacity so the URL-tracked focal stays visually dominant. Trace points cache by `(mode, hex)` so flipping between aircraft doesn't re-pay the recent-trace fetch.
+- Flight detail telemetry strip renders GS / ALT / V/S / HEADING / ICAO24 / STATUS as the same stat-card style the airport sidebar uses for WEATHER / FLIGHTS; cards are individually selectable (radio-group style).
+- Map-label tiles default to ON on the flight detail page so place names give the moving map useful context.
+
+### Changed
+- **Route rename**: airport detail page moved from `/[icao]` to `/airport/[icao]`. The flight detail page is `/aircraft/[callsign]`. Old `/KBOS`-style URLs are not preserved (no automatic redirects).
+- Selection-mode mask (when an aircraft or airport is "selected") is lighter than before — non-selected aircraft go from 28% opacity to 55%, and the base map tile dim drops from 0.72/0.78 to 0.88/0.92 so context stays readable.
+- Theme detection moved from a client-side boot script to a server-rendered `data-theme` attribute driven by a `theme` cookie. The cookie is set in lockstep with `localStorage` by `useThemePreference`, and the cookie value is read server-side via `next/headers#cookies()` on every render. Eliminates the React 19 "script inside React component" console warning and any flash of unstyled content for users with an explicit preference.
+
+### Refactored
+- Extracted shared explorer primitives:
+  - `SidebarShell` — outer panel + sticky nav row, used by both `AirportSidebar` and `FlightSidebar`.
+  - `SidebarIdentityHero` — label + mono-extrabold code + horizontal rule pattern.
+  - `SidebarMetric` (`SidebarMetricGrid` + `SidebarMetricCard`) — two-column stat-card grid, used by both the airport tab strip and the flight telemetry grid.
+  - `ExplorerUiContext` / `ExplorerUiProvider` / `useExplorerUi` — moved from `components/airport/explorer/` to `components/explorer/` since both pages consume it. Renamed exports to drop the misleading "airport" prefix.
+  - `ExplorerMapMenu` — same move + rename for the sidebar toggle + map control bar wrapper.
+- `AirportMap` accepts arbitrary `children` rendered inside `MapContext.Provider`, so per-page concerns (e.g. `MapFitToTraceController` on the flight page) can be composed without touching the map shell.
+- `SelectedAircraftTraceContext` now exposes a deduplicated `traces[]` array; `SelectedAircraftTrace` was split into a thin context-reader + a `SingleAircraftTrace` renderer that takes trace data as props, allowing N coexistent traces with independent animation state.
+- Aircraft + airport preview cards share the same outer `AircraftPreviewCard` shell — the inner `AircraftPreviewMetadataCard` / `AirportPreviewMetadataCard` swap based on which entity is selected.
+
+### Fixed
+- `MapFitToTraceController`'s `leaflet` import crashed SSR with `window is not defined`; the component is now dynamic-imported with `ssr: false`.
+- `getVisibleAircraft` was silently filtering out the focal aircraft on the flight page (the focal sits at "the airport's ground area" because the map's airport-center IS the focal). The ground filter is now skipped when there's no actual airport in focus.
+- Sidebar list rows were collapsing to zero horizontal padding inside the flight sidebar because `--airport-sidebar-inset` was only declared on `.airport-sidebar-panel`. The token now lives on `.sidebar-shell` so both pages get it.
+- React 19 "Encountered a script tag while rendering React component" console warning eliminated (see Changed — cookie-driven theme).
+- Stat cards' big numbers were selectable on text-click, which the focus highlight made look like a click-state. Cards now have `user-select: none` and `cursor: default` by default; the interactive variant overrides.
+
+
 ## v0.11.0 — Selected-aircraft trace, focused revalidation, route consistency
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Use the current ADSBao web release line:
 | `v0.9.0` | Navy tracking console redesign |
 | `v0.10.0` | Global airport data layer (OurAirports + Supabase) and richer aircraft silhouettes |
 | `v0.11.0` | Selected-aircraft trace + multi-provider failover + AeroDataBox revalidation |
+| `v0.12.0` | Aircraft tracking page + airport-prefixed routes + polymorphic sidebar/preview |
 
 `v0.3.x` and earlier are legacy desktop-app history. Do not use those releases as the current ADSBao web product line.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A modern airport-monitoring HUD with dynamic airport search, METAR context, and 
 ## Overview
 ADSBao provides a search-first airport operations view with weather context and aircraft position overlays. Airport search is backed by public airport directory data.
 
-Current web app version: **0.11.0**. See `CHANGELOG.md` for product version history and the legacy desktop release split.
+Current web app version: **0.12.0**. See `CHANGELOG.md` for product version history and the legacy desktop release split.
 
 ## Tech Stack
 - **Frontend**: React on Next.js App Router, Tailwind CSS v4, DaisyUI, Lucide Icons.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,5 +91,6 @@ The current ADSBao web line starts at `v0.4.0`.
 | `v0.9.0` | Navy tracking console redesign |
 | `v0.10.0` | Global airport data layer (OurAirports + Supabase) and richer aircraft silhouettes |
 | `v0.11.0` | Selected-aircraft trace + multi-provider failover + AeroDataBox revalidation |
+| `v0.12.0` | Aircraft tracking page + airport-prefixed routes + polymorphic sidebar/preview |
 
 `v0.3.x` and earlier are legacy desktop-app history and should not be used as the current ADSBao web product line.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/src/app/[icao]/[channel]/page.js
+++ b/src/app/[icao]/[channel]/page.js
@@ -1,6 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default async function LegacyChannelPage({ params }) {
-  const { icao } = await params;
-  redirect(`/${String(icao || "").toUpperCase()}`);
-}

--- a/src/app/aircraft/[callsign]/page.js
+++ b/src/app/aircraft/[callsign]/page.js
@@ -1,0 +1,42 @@
+import FlightScreen from "@/components/screens/FlightScreen";
+import { SITE_DESCRIPTION, SITE_NAME } from "@/config/site";
+
+const normalizeCallsign = (value) =>
+  String(value || "").trim().toUpperCase();
+
+export async function generateMetadata({ params }) {
+  const { callsign } = await params;
+  const normalized = normalizeCallsign(callsign);
+  const path = normalized ? `/aircraft/${normalized}` : "/";
+  const title = normalized
+    ? `${normalized} - Flight Tracking`
+    : SITE_NAME;
+  const description = normalized
+    ? `${SITE_NAME} live flight tracking for ${normalized}: position, telemetry, route, and aircraft metadata.`
+    : SITE_DESCRIPTION;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      type: "website",
+      url: path,
+      siteName: SITE_NAME,
+      title: `${title} | ${SITE_NAME}`,
+      description,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${title} | ${SITE_NAME}`,
+      description,
+    },
+  };
+}
+
+export default async function FlightPage({ params }) {
+  const { callsign } = await params;
+  return <FlightScreen callsign={normalizeCallsign(callsign)} />;
+}

--- a/src/app/airport/[icao]/page.js
+++ b/src/app/airport/[icao]/page.js
@@ -27,7 +27,7 @@ const getAirportSeo = (icao) => {
 export async function generateMetadata({ params }) {
   const { icao } = await params;
   const seo = getAirportSeo(icao);
-  const path = seo.normalizedIcao ? `/${seo.normalizedIcao}` : "/";
+  const path = seo.normalizedIcao ? `/airport/${seo.normalizedIcao}` : "/";
 
   return {
     title: seo.title,

--- a/src/app/api/proxy/aircraft/callsign/[callsign]/route.js
+++ b/src/app/api/proxy/aircraft/callsign/[callsign]/route.js
@@ -1,0 +1,67 @@
+import {
+  buildProxyHeaders,
+  createCorsPreflightResponse,
+  enforceProxyRequest,
+  jsonProxyResponse,
+} from "@/app/api/_shared/apiProxySecurity.js";
+import {
+  fetchAircraftByCallsign,
+} from "@/features/aircraft/callsign/aircraftCallsign.mechanism.js";
+import {
+  AircraftCallsignProviderError,
+} from "@/features/aircraft/callsign/aircraftCallsign.models.js";
+import {
+  normalizeRouteCallsign,
+} from "@/features/aviation/flight-routes/vrsRouteProxyModel.js";
+
+const rateLimit = {
+  key: "proxy:aircraft-callsign",
+  maxRequests: 120,
+  windowMs: 60_000,
+};
+
+export function OPTIONS(request) {
+  return createCorsPreflightResponse(request);
+}
+
+export async function GET(request, { params }) {
+  const securityResponse = enforceProxyRequest(request, { rateLimit });
+  if (securityResponse) return securityResponse;
+
+  const { callsign: rawCallsign } = await params;
+  const callsign = normalizeRouteCallsign(rawCallsign);
+
+  if (!callsign) {
+    return jsonProxyResponse(
+      request,
+      { error: "Invalid aircraft callsign" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await fetchAircraftByCallsign({ callsign });
+    return Response.json(result.payload, {
+      headers: buildProxyHeaders(request, {
+        "Cache-Control": "no-store",
+        "X-Data-Source": result.source,
+        "X-Provider-Attempts": result.attempts.join(";"),
+      }),
+    });
+  } catch (error) {
+    if (error instanceof AircraftCallsignProviderError) {
+      return jsonProxyResponse(
+        request,
+        { error: error.message },
+        {
+          status: Number(error.status) || 502,
+          headers: {
+            "X-Data-Source": "failed",
+            "X-Provider-Attempts": error.attempts?.join(";") || "none",
+          },
+        },
+      );
+    }
+    throw error;
+  }
+}

--- a/src/app/api/proxy/aircraft/trace/[hex]/route.js
+++ b/src/app/api/proxy/aircraft/trace/[hex]/route.js
@@ -36,8 +36,13 @@ export async function GET(request, { params }) {
     );
   }
 
+  // ?full=1 switches the upstream from trace_recent_*.json (rolling
+  // tail) to trace_full_*.json (whole flight). Used on aircraft-detail
+  // page init so the user sees the entire path on load.
+  const full = new URL(request.url).searchParams.get("full") === "1";
+
   try {
-    const result = await getAircraftTrace({ hex });
+    const result = await getAircraftTrace({ hex, full });
     if (!result.found) {
       return jsonProxyResponse(
         request,

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-page-custom-font */
+import { cookies } from "next/headers";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import Script from "next/script";
 import { Toaster } from "sonner";
 import "leaflet/dist/leaflet.css";
 import {
@@ -63,9 +63,24 @@ export const viewport = {
   viewportFit: "cover",
 };
 
-export default function RootLayout({ children }) {
+// Resolve the theme preference from the request cookie so the server
+// can render <html data-theme="..."> directly — no client-side boot
+// script, no React 19 "script inside component" warning. For users
+// without a cookie or with "system" preference, we default to dark
+// (matches the previous behavior when matchMedia wasn't yet readable).
+// useThemePreference syncs the cookie whenever the user toggles, so
+// subsequent navigations always see their explicit choice.
+async function resolveInitialTheme() {
+  const store = await cookies();
+  const raw = store.get("theme")?.value;
+  if (raw === "light" || raw === "dark") return raw;
+  return "dark";
+}
+
+export default async function RootLayout({ children }) {
+  const initialTheme = await resolveInitialTheme();
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" data-theme={initialTheme} suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
@@ -79,7 +94,6 @@ export default function RootLayout({ children }) {
         />
       </head>
       <body>
-        <ThemeBootScript />
         <div className="min-h-dvh bg-atc-bg text-atc-text">{children}</div>
         <Toaster
           theme="system"
@@ -93,21 +107,3 @@ export default function RootLayout({ children }) {
   );
 }
 
-function ThemeBootScript() {
-  return (
-    <Script id="theme-boot" strategy="beforeInteractive">
-      {`
-        (() => {
-          const themes = new Set(["light", "dark", "system"]);
-          const stored = window.localStorage.getItem("theme");
-          const preference = themes.has(stored) ? stored : "system";
-          const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-          document.documentElement.setAttribute(
-            "data-theme",
-            preference === "system" ? (systemDark ? "dark" : "light") : preference
-          );
-        })();
-      `}
-    </Script>
-  );
-}

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -24,7 +24,7 @@ export default function sitemap() {
       priority: route.priority,
     })),
     ...FEATURED_AIRPORT_CODES.map((icao) => ({
-      url: getAbsoluteUrl(`/${icao}`),
+      url: getAbsoluteUrl(`/airport/${icao}`),
       lastModified: now,
       changeFrequency: "daily",
       priority: 0.8,

--- a/src/components/aircraft/preview/AircraftPreviewCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.jsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import AircraftPreviewMediaCard from "./AircraftPreviewMediaCard.jsx";
 import AircraftPreviewMetadataCard from "./AircraftPreviewMetadataCard.jsx";
 import AircraftPreviewMobileCard from "./AircraftPreviewMobileCard.jsx";
+import AirportPreviewMetadataCard from "./AirportPreviewMetadataCard.jsx";
 import { useAircraftPhoto } from "@/features/aircraft/preview/useAircraftPhoto.js";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel.js";
 
@@ -27,25 +28,34 @@ const MEDIA_MOTION = {
 const PHOTO_TONE_DARK = "dark";
 const PHOTO_TONE_LIGHT = "light";
 
-export default function AircraftPreviewCard({ aircraft = null, isMobile = false, sidebarOpen = false }) {
+export default function AircraftPreviewCard({
+  aircraft = null,
+  airport = null,
+  isMobile = false,
+  sidebarOpen = false,
+}) {
   const reducedMotion = useReducedMotion();
   const photoState = useAircraftPhoto(aircraft);
   const photo = photoState.photo;
   const hasPhoto = Boolean(photo?.src);
   const photoTone = usePhotoTone(photo?.src);
 
-  const identityKey = (aircraft && getAircraftIdentity(aircraft)) || "preview-card";
-  const showMobile = isMobile && !sidebarOpen;
+  const entity = aircraft || airport;
+  const isAirport = !aircraft && Boolean(airport);
+  const identityKey = isAirport
+    ? `airport:${airport?.icao || "preview"}`
+    : (aircraft && getAircraftIdentity(aircraft)) || "preview-card";
+  const showMobile = isMobile && !sidebarOpen && Boolean(aircraft);
 
   return (
     <AnimatePresence>
-      {aircraft && !isMobile && (
+      {entity && !isMobile && (
         <motion.aside
           key={identityKey}
           className={`aircraft-preview-card ${
-            hasPhoto ? "aircraft-preview-card--has-photo" : ""
+            !isAirport && hasPhoto ? "aircraft-preview-card--has-photo" : ""
           } aircraft-preview-card--photo-${photoTone}`}
-          aria-label="Aircraft preview"
+          aria-label={isAirport ? "Airport preview" : "Aircraft preview"}
           {...(reducedMotion
             ? {
                 initial: false,
@@ -54,20 +64,26 @@ export default function AircraftPreviewCard({ aircraft = null, isMobile = false,
               }
             : STACK_MOTION)}
         >
-          <AnimatePresence>
-            {hasPhoto && (
-              <motion.div
-                className="aircraft-preview-card__media-slot"
-                key={`photo-${photo.src}`}
-                {...(reducedMotion
-                  ? { initial: false, animate: { opacity: 1 }, exit: { opacity: 0 } }
-                  : MEDIA_MOTION)}
-              >
-                <AircraftPreviewMediaCard photo={photo} />
-              </motion.div>
-            )}
-          </AnimatePresence>
-          <AircraftPreviewMetadataCard aircraft={aircraft} photo={photo} />
+          {!isAirport && (
+            <AnimatePresence>
+              {hasPhoto && (
+                <motion.div
+                  className="aircraft-preview-card__media-slot"
+                  key={`photo-${photo.src}`}
+                  {...(reducedMotion
+                    ? { initial: false, animate: { opacity: 1 }, exit: { opacity: 0 } }
+                    : MEDIA_MOTION)}
+                >
+                  <AircraftPreviewMediaCard photo={photo} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          )}
+          {isAirport ? (
+            <AirportPreviewMetadataCard airport={airport} />
+          ) : (
+            <AircraftPreviewMetadataCard aircraft={aircraft} photo={photo} />
+          )}
         </motion.aside>
       )}
       {aircraft && showMobile && (

--- a/src/components/aircraft/preview/AircraftPreviewMetadataCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewMetadataCard.jsx
@@ -1,11 +1,25 @@
 "use client";
 
+import { usePathname, useRouter } from "next/navigation";
 import AircraftPreviewIdentity from "./AircraftPreviewIdentity.jsx";
 import AircraftPreviewMetadata from "./AircraftPreviewMetadata.jsx";
 import AircraftPreviewTelemetry from "./AircraftPreviewTelemetry.jsx";
 
 export default function AircraftPreviewMetadataCard({ aircraft, photo }) {
+  const router = useRouter();
+  const pathname = usePathname();
   const credit = photo?.photographer || null;
+  const trackCallsign = (aircraft?.callsign || "").trim().toUpperCase();
+  // When the previewed aircraft is the page we're already on (i.e. the
+  // user clicked the focal plane on the aircraft detail page), there's
+  // nothing to track — surface that as a disabled "Tracking" label.
+  const alreadyTracking =
+    Boolean(trackCallsign) && pathname === `/aircraft/${trackCallsign}`;
+
+  const handleTrack = () => {
+    if (!trackCallsign || alreadyTracking) return;
+    router.push(`/aircraft/${trackCallsign}`);
+  };
 
   return (
     <div className="aircraft-preview-metadata-card">
@@ -16,6 +30,14 @@ export default function AircraftPreviewMetadataCard({ aircraft, photo }) {
       <AircraftPreviewTelemetry aircraft={aircraft} />
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
       <AircraftPreviewMetadata aircraft={aircraft} />
+      <button
+        type="button"
+        className="aircraft-preview-card__track-btn"
+        onClick={handleTrack}
+        disabled={!trackCallsign || alreadyTracking}
+      >
+        {alreadyTracking ? "Tracking" : "Track"}
+      </button>
     </div>
   );
 }

--- a/src/components/aircraft/preview/AirportPreviewMetadataCard.jsx
+++ b/src/components/aircraft/preview/AirportPreviewMetadataCard.jsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import NumberFlow from "@number-flow/react";
+import { countryName, flagEmoji } from "@/utils/flag.js";
+import { toFiniteNumber } from "@/utils/math.js";
+
+// Airport variant of the bottom-right preview card. Mirrors the aircraft
+// card's chrome (same container class so the slide-in / blur / sizing
+// match) and exposes a Track button that lands on /airport/[icao].
+export default function AirportPreviewMetadataCard({ airport }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const icao = (airport?.icao || "").trim().toUpperCase();
+  const iata = (airport?.iata || "").trim().toUpperCase();
+  const codeLine = iata && iata !== icao ? `${iata} · ${icao}` : icao || "—";
+  const name = airport?.name || "Unknown airport";
+  const flag = flagEmoji(airport?.country);
+  const country = countryName(airport?.country) || airport?.country || "";
+  const placeText = [airport?.city, country].filter(Boolean).join(", ");
+  const placeLine = flag && placeText ? `${flag} ${placeText}` : placeText;
+  const distance = toFiniteNumber(airport?.distanceNm);
+  const elevation = toFiniteNumber(airport?.elevationFt);
+
+  const alreadyTracking = icao && pathname === `/airport/${icao}`;
+
+  const handleTrack = () => {
+    if (!icao || alreadyTracking) return;
+    router.push(`/airport/${icao}`);
+  };
+
+  return (
+    <div className="aircraft-preview-metadata-card">
+      <div className="flex flex-col gap-1">
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-atc-faint">
+          Airport
+        </span>
+        <span className="airport-sidebar-display-mono airport-sidebar-display-mono--hero text-[24px] font-extrabold text-atc-text">
+          {codeLine}
+        </span>
+        <h2 className="text-[15px] font-semibold leading-tight text-atc-text">
+          {name}
+        </h2>
+        {placeLine ? (
+          <span className="text-[12px] text-atc-dim">{placeLine}</span>
+        ) : null}
+      </div>
+
+      <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
+
+      <dl className="grid grid-cols-2 gap-y-1.5 gap-x-3 font-mono text-[11px]">
+        <dt className="text-atc-faint uppercase tracking-[0.12em]">Dist</dt>
+        <dd className="text-right text-atc-text">
+          {distance == null ? (
+            "—"
+          ) : (
+            <>
+              <NumberFlow
+                value={distance}
+                format={{
+                  maximumFractionDigits: 1,
+                  minimumFractionDigits: 1,
+                }}
+              />
+              <span className="ml-1 text-atc-dim">NM</span>
+            </>
+          )}
+        </dd>
+        <dt className="text-atc-faint uppercase tracking-[0.12em]">Elev</dt>
+        <dd className="text-right text-atc-text">
+          {elevation == null ? (
+            "—"
+          ) : (
+            <>
+              <NumberFlow value={Math.round(elevation)} />
+              <span className="ml-1 text-atc-dim">FT</span>
+            </>
+          )}
+        </dd>
+      </dl>
+
+      <button
+        type="button"
+        className="aircraft-preview-card__track-btn"
+        onClick={handleTrack}
+        disabled={!icao || alreadyTracking}
+      >
+        {alreadyTracking ? "Tracking" : "Track"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
+++ b/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
@@ -4,35 +4,90 @@ import { createContext, useContext, useMemo } from "react";
 import { useAircraftTrace } from "@/hooks/useAircraftTrace.js";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel.js";
 
-// Single source of truth for the currently-focused aircraft's trace.
-// Provider runs the fetch + live-append machinery once, near the top of
-// the explorer tree, and consumers (currently only SelectedAircraftTrace)
-// read aircraftHex / tracePoints / loading from this context instead of
-// drilling them through props.
+// Source of truth for trace data to render on the map.
+//
+//   - selectedAircraft → the "primary" trace tied to the user-clicked
+//     aircraft (preview card target). Used on both airport and flight
+//     pages.
+//   - focalAircraft → optional second trace, used on the flight detail
+//     page so the URL-tracked aircraft's path is always visible even
+//     when the user clicks a different plane.
+//
+// Exposes a `traces[]` array (1 or 2 entries, deduplicated by hex) for
+// SelectedAircraftTrace to iterate over. Top-level fields mirror the
+// primary trace so existing consumers (TraceLoadingToast) keep working
+// without changes.
 
-const SelectedAircraftTraceContext = createContext({
+const EMPTY_TRACE = {
   aircraftHex: null,
   movement: null,
   tracePoints: [],
   loading: false,
+};
+
+const SelectedAircraftTraceContext = createContext({
+  ...EMPTY_TRACE,
+  traces: [],
 });
+
+function deriveTrace(aircraft, hookResult) {
+  return {
+    aircraftHex: aircraft ? getAircraftIdentity(aircraft) || null : null,
+    movement:
+      typeof aircraft?.movement === "string" ? aircraft.movement : null,
+    tracePoints: hookResult.tracePoints,
+    loading: hookResult.loading,
+  };
+}
 
 export function SelectedAircraftTraceProvider({
   selectedAircraft = null,
+  focalAircraft = null,
+  fullTraceForFocal = false,
   children,
 }) {
-  const aircraftHex = selectedAircraft
-    ? getAircraftIdentity(selectedAircraft) || null
-    : null;
-  const movement =
-    typeof selectedAircraft?.movement === "string"
-      ? selectedAircraft.movement
-      : null;
-  const { tracePoints, loading } = useAircraftTrace(selectedAircraft);
+  const primaryHook = useAircraftTrace(selectedAircraft);
+  // Focal trace uses adsb.lol's trace_full endpoint on the aircraft
+  // detail page so the user sees the whole flight on load — not just
+  // the rolling tail. Secondary (clicked) traces stick with recent.
+  const focalHook = useAircraftTrace(focalAircraft, {
+    fullTrace: fullTraceForFocal,
+  });
+
+  const primary = useMemo(
+    () => deriveTrace(selectedAircraft, primaryHook),
+    [selectedAircraft, primaryHook],
+  );
+  const focal = useMemo(
+    () => deriveTrace(focalAircraft, focalHook),
+    [focalAircraft, focalHook],
+  );
+
+  const traces = useMemo(() => {
+    const out = [];
+    const seen = new Set();
+    // The URL-tracked focal renders at full opacity. A "secondary" trace
+    // — the aircraft the user clicked when it's NOT the focal — renders
+    // at 40% so the eye still privileges the page's anchor flight.
+    const focalKey = focal.aircraftHex;
+    if (primary.aircraftHex) {
+      const isPrimaryFocal =
+        !focalKey || primary.aircraftHex === focalKey;
+      out.push({ ...primary, opacity: isPrimaryFocal ? 1 : 0.4 });
+      seen.add(primary.aircraftHex);
+    }
+    if (focal.aircraftHex && !seen.has(focal.aircraftHex)) {
+      out.push({ ...focal, opacity: 1 });
+    }
+    return out;
+  }, [primary, focal]);
 
   const value = useMemo(
-    () => ({ aircraftHex, movement, tracePoints, loading }),
-    [aircraftHex, movement, tracePoints, loading],
+    () => ({
+      ...primary,
+      traces,
+    }),
+    [primary, traces],
   );
 
   return (

--- a/src/components/airport/explorer/AirportExplorer.jsx
+++ b/src/components/airport/explorer/AirportExplorer.jsx
@@ -4,11 +4,11 @@ import dynamic from "next/dynamic";
 import { useEffect, useMemo } from "react";
 import AirportSidebar from "@/components/sidebar/AirportSidebar";
 import {
-  AirportExplorerUiProvider,
-  useAirportExplorerUi,
-} from "./AirportExplorerUiContext.jsx";
+  ExplorerUiProvider,
+  useExplorerUi,
+} from "@/components/explorer/ExplorerUiContext.jsx";
 import AircraftDataLoadingOverlay from "./AircraftDataLoadingOverlay.jsx";
-import AirportExplorerMapMenu from "./AirportExplorerMapMenu.jsx";
+import ExplorerMapMenu from "@/components/explorer/ExplorerMapMenu.jsx";
 import { resolveAirportProfile } from "@/features/airport/explorer/airportExplorerModel.js";
 import { useAirportExplorerData } from "@/features/airport/explorer/useAirportExplorerData.js";
 import { useAirportProcedures } from "@/hooks/useAirportProcedures.js";
@@ -28,9 +28,9 @@ const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
 
 export default function AirportExplorer(props) {
   return (
-    <AirportExplorerUiProvider>
+    <ExplorerUiProvider>
       <AirportExplorerContent {...props} />
-    </AirportExplorerUiProvider>
+    </ExplorerUiProvider>
   );
 }
 
@@ -47,10 +47,13 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     typeFilter,
     altitudeLevel,
     selectedAircraftId,
+    selectedAirportIcao,
     closeSidebar,
     selectAircraft,
     setSelectedAircraftId,
-  } = useAirportExplorerUi();
+    selectAirport,
+    mapFollowsAircraft,
+  } = useExplorerUi();
   const airportProfile = useMemo(
     () => resolveAirportProfile({ icao, airport }),
     [icao, airport],
@@ -100,6 +103,14 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     };
   }, [isMobile]);
 
+  const selectedAirport = useMemo(
+    () =>
+      nearbyAirports.airports.find(
+        (airport) => airport?.icao === selectedAirportIcao,
+      ) || null,
+    [nearbyAirports.airports, selectedAirportIcao],
+  );
+
   const sidebarProps = {
     icao: airportProfile.icao,
     iata: airportProfile.iata,
@@ -113,18 +124,28 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     metarLoading: weather.metarLoading,
     metarError: weather.metarError,
     aircraft: traffic.aircraft,
+    airports: nearbyAirports.airports,
+    focusLat: airportProfile.lat,
+    focusLon: airportProfile.lon,
     selectedAircraftId,
+    selectedAirportIcao,
     lastUpdated: traffic.lastUpdated,
     feedStatus: traffic.feedStatus,
     feedSource: traffic.feedSource,
     onSelectAircraft: selectAircraft,
+    onSelectAirport: selectAirport,
     onBack,
   };
 
   return (
     <SelectedAircraftTraceProvider selectedAircraft={selectedAircraft}>
       <TraceLoadingToast />
-      <AircraftPreviewCard aircraft={selectedAircraft} isMobile={isMobile} sidebarOpen={sidebarOpen} />
+      <AircraftPreviewCard
+        aircraft={selectedAircraft}
+        airport={selectedAirport}
+        isMobile={isMobile}
+        sidebarOpen={sidebarOpen}
+      />
       <div
         className={`font-sans text-atc-text ${
           isMobile
@@ -144,7 +165,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
         )}
 
         <div className="relative min-w-0 flex-1 overflow-hidden bg-atc-bg">
-          {!(isMobile && sidebarOpen) && <AirportExplorerMapMenu />}
+          {!(isMobile && sidebarOpen) && <ExplorerMapMenu />}
 
           <AirportMap
             icao={airportProfile.icao}
@@ -161,7 +182,10 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             typeFilter={typeFilter}
             altitudeLevel={altitudeLevel}
             selectedAircraftId={selectedAircraftId}
+            selectedAirportIcao={selectedAirportIcao}
+            followsCenter={mapFollowsAircraft}
             onSelectAircraft={selectAircraft}
+            onSelectAirport={selectAirport}
             onRevalidateRoute={traffic.revalidateFlightRoute}
             runwayMap={procedures.runwayMap}
             runwayProcedures={null}

--- a/src/components/explorer/ExplorerMapMenu.jsx
+++ b/src/components/explorer/ExplorerMapMenu.jsx
@@ -2,12 +2,13 @@
 
 import { PanelLeft } from "lucide-react";
 import MapControlBar from "@/components/ui/MapControlBar";
-import { useAirportExplorerUi } from "./AirportExplorerUiContext.jsx";
+import { useExplorerUi } from "./ExplorerUiContext.jsx";
 
-export default function AirportExplorerMapMenu() {
+export default function ExplorerMapMenu({ onFitToTrace = null } = {}) {
   const {
     isMobile,
     mapZoom,
+    mapFollowsAircraft,
     showMapLabels,
     showRunwayBeams,
     showRoutingPointBadges,
@@ -16,7 +17,7 @@ export default function AirportExplorerMapMenu() {
     toggleMapLabels,
     toggleRunwayBeams,
     toggleRoutingPointBadges,
-  } = useAirportExplorerUi();
+  } = useExplorerUi();
 
   return (
     <div
@@ -35,6 +36,7 @@ export default function AirportExplorerMapMenu() {
 
       <MapControlBar
         activeZoom={mapZoom}
+        zoomActive={mapFollowsAircraft}
         showMapLabels={showMapLabels}
         showRunwayBeams={showRunwayBeams}
         showRoutingPointBadges={showRoutingPointBadges}
@@ -42,6 +44,7 @@ export default function AirportExplorerMapMenu() {
         onToggleMapLabels={toggleMapLabels}
         onToggleRunwayBeams={toggleRunwayBeams}
         onToggleRoutingPointBadges={toggleRoutingPointBadges}
+        onFitToTrace={onFitToTrace}
       />
     </div>
   );

--- a/src/components/explorer/ExplorerUiContext.jsx
+++ b/src/components/explorer/ExplorerUiContext.jsx
@@ -15,13 +15,24 @@ import {
   getAirportSidebarOpenForMode,
 } from "@/utils/sidebarDisplay.js";
 
-const AirportExplorerUiContext = createContext(null);
+const ExplorerUiContext = createContext(null);
 
 const initialUiState = {
   ...DEFAULT_AIRPORT_EXPLORER_UI_STATE,
   sidebarMode: "desktop",
   sidebarOpen: true,
   selectedAircraftId: "",
+  selectedAirportIcao: "",
+  // Monotonic counter. Incremented by the UI when the user wants the map
+  // to fit its viewport to the currently-rendered aircraft trace; a
+  // child of AirportMap listens for changes and runs fitBounds against
+  // the trace points.
+  fitToTraceSignal: 0,
+  // When true (default), the map re-centers on every aircraft position
+  // poll. The user opts out by clicking "fit to trace" — the map then
+  // stays anchored on the trace bounds. Clicking any preset zoom
+  // re-enables auto-follow.
+  mapFollowsAircraft: true,
 };
 
 function toggleValue(value) {
@@ -44,7 +55,14 @@ function airportExplorerUiReducer(state, action) {
     case "closeSidebar":
       return { ...state, sidebarOpen: false };
     case "setMapZoom":
-      return { ...state, mapZoom: action.mapZoom };
+      // Any user-initiated zoom cycle re-engages auto-follow — the user
+      // is asking for one of the named perspectives again, so the map
+      // should resume tracking the focal aircraft from that zoom.
+      return {
+        ...state,
+        mapZoom: action.mapZoom,
+        mapFollowsAircraft: true,
+      };
     case "toggleMapLabels":
       return { ...state, showMapLabels: toggleValue(state.showMapLabels) };
     case "toggleRunwayBeams":
@@ -60,6 +78,8 @@ function airportExplorerUiReducer(state, action) {
       return { ...state, typeFilter: action.typeFilter };
     case "setAltitudeLevel":
       return { ...state, altitudeLevel: action.altitudeLevel };
+    case "setEntityFilter":
+      return { ...state, entityFilter: action.entityFilter };
     case "selectAircraft":
       return {
         ...state,
@@ -67,15 +87,35 @@ function airportExplorerUiReducer(state, action) {
           state.selectedAircraftId === action.aircraftId
             ? ""
             : action.aircraftId,
+        // Selecting an aircraft clears any airport selection so only one
+        // preview card is up at a time.
+        selectedAirportIcao: "",
       };
     case "setSelectedAircraftId":
-      return { ...state, selectedAircraftId: action.aircraftId };
+      return {
+        ...state,
+        selectedAircraftId: action.aircraftId,
+        selectedAirportIcao: "",
+      };
+    case "selectAirport":
+      return {
+        ...state,
+        selectedAirportIcao:
+          state.selectedAirportIcao === action.icao ? "" : action.icao,
+        selectedAircraftId: "",
+      };
+    case "fitToTrace":
+      return {
+        ...state,
+        fitToTraceSignal: state.fitToTraceSignal + 1,
+        mapFollowsAircraft: false,
+      };
     default:
       return state;
   }
 }
 
-export function AirportExplorerUiProvider({ children }) {
+export function ExplorerUiProvider({ children }) {
   const [state, dispatch] = useReducer(
     airportExplorerUiReducer,
     initialUiState,
@@ -90,7 +130,9 @@ export function AirportExplorerUiProvider({ children }) {
     trafficFilter,
     typeFilter,
     altitudeLevel,
+    entityFilter,
     selectedAircraftId,
+    selectedAirportIcao,
   } = state;
   const isMobile = sidebarMode === "mobile";
 
@@ -144,6 +186,10 @@ export function AirportExplorerUiProvider({ children }) {
     dispatch({ type: "setAltitudeLevel", altitudeLevel });
   }, []);
 
+  const setEntityFilter = useCallback((entityFilter) => {
+    dispatch({ type: "setEntityFilter", entityFilter });
+  }, []);
+
   const selectAircraft = useCallback((aircraftId) => {
     dispatch({ type: "selectAircraft", aircraftId });
   }, []);
@@ -152,6 +198,17 @@ export function AirportExplorerUiProvider({ children }) {
     dispatch({ type: "setSelectedAircraftId", aircraftId });
   }, []);
 
+  const selectAirport = useCallback((icao) => {
+    dispatch({ type: "selectAirport", icao });
+  }, []);
+
+  const fitToTrace = useCallback(() => {
+    dispatch({ type: "fitToTrace" });
+  }, []);
+
+  const fitToTraceSignal = state.fitToTraceSignal;
+  const mapFollowsAircraft = state.mapFollowsAircraft;
+
   const value = useMemo(
     () => ({
       desktopSidebarWidth: AIRPORT_EXPLORER_UI_CONFIG.desktopSidebarWidth,
@@ -159,17 +216,22 @@ export function AirportExplorerUiProvider({ children }) {
       sidebarOpen,
       isMobile,
       mapZoom,
+      mapFollowsAircraft,
       showMapLabels,
       showRunwayBeams,
       showRoutingPointBadges,
       trafficFilter,
       typeFilter,
       altitudeLevel,
+      entityFilter,
       selectedAircraftId,
+      selectedAirportIcao,
+      fitToTraceSignal,
       setMapZoom,
       setTrafficFilter,
       setTypeFilter,
       setAltitudeLevel,
+      setEntityFilter,
       toggleSidebar,
       closeSidebar,
       toggleMapLabels,
@@ -177,23 +239,30 @@ export function AirportExplorerUiProvider({ children }) {
       toggleRoutingPointBadges,
       selectAircraft,
       setSelectedAircraftId,
+      selectAirport,
+      fitToTrace,
     }),
     [
       sidebarMode,
       sidebarOpen,
       isMobile,
       mapZoom,
+      mapFollowsAircraft,
       showMapLabels,
       showRunwayBeams,
       showRoutingPointBadges,
       trafficFilter,
       typeFilter,
       altitudeLevel,
+      entityFilter,
       selectedAircraftId,
+      selectedAirportIcao,
+      fitToTraceSignal,
       setMapZoom,
       setTrafficFilter,
       setTypeFilter,
       setAltitudeLevel,
+      setEntityFilter,
       toggleSidebar,
       closeSidebar,
       toggleMapLabels,
@@ -201,21 +270,23 @@ export function AirportExplorerUiProvider({ children }) {
       toggleRoutingPointBadges,
       selectAircraft,
       setSelectedAircraftId,
+      selectAirport,
+      fitToTrace,
     ],
   );
 
   return (
-    <AirportExplorerUiContext.Provider value={value}>
+    <ExplorerUiContext.Provider value={value}>
       {children}
-    </AirportExplorerUiContext.Provider>
+    </ExplorerUiContext.Provider>
   );
 }
 
-export function useAirportExplorerUi() {
-  const context = useContext(AirportExplorerUiContext);
+export function useExplorerUi() {
+  const context = useContext(ExplorerUiContext);
   if (!context) {
     throw new Error(
-      "useAirportExplorerUi must be used within AirportExplorerUiProvider",
+      "useExplorerUi must be used within ExplorerUiProvider",
     );
   }
   return context;

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -1,0 +1,258 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useMemo, useRef } from "react";
+import { useRouter } from "next/navigation";
+import FlightSidebar from "@/components/sidebar/FlightSidebar";
+import ExplorerMapMenu from "@/components/explorer/ExplorerMapMenu.jsx";
+
+// MapFitToTraceController imports leaflet, which evaluates `window` at
+// module top — SSR-incompatible. Dynamic-import keeps the controller
+// out of the server bundle, same pattern AirportMap uses.
+const MapFitToTraceController = dynamic(
+  () => import("@/components/map/MapFitToTraceController.jsx"),
+  { ssr: false },
+);
+import {
+  ExplorerUiProvider,
+  useExplorerUi,
+} from "@/components/explorer/ExplorerUiContext.jsx";
+import { useAircraftPositions } from "@/hooks/useAircraftPositions.js";
+import { useNearbyAirports } from "@/hooks/useNearbyAirports.js";
+import { useTrackedAircraft } from "@/hooks/useTrackedAircraft.js";
+import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel.js";
+import { SelectedAircraftTraceProvider } from "@/components/aircraft/trace/SelectedAircraftTraceContext.jsx";
+import TraceLoadingToast from "@/components/aircraft/trace/TraceLoadingToast.jsx";
+import AircraftPreviewCard from "@/components/aircraft/preview/AircraftPreviewCard.jsx";
+
+const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full w-full items-center justify-center bg-atc-bg font-mono text-[11px] uppercase tracking-[0.2em] text-atc-faint">
+      Loading map...
+    </div>
+  ),
+});
+
+export default function FlightExplorer({ callsign = "" }) {
+  return (
+    <ExplorerUiProvider>
+      <FlightExplorerContent callsign={callsign} />
+    </ExplorerUiProvider>
+  );
+}
+
+function FlightExplorerContent({ callsign }) {
+  const router = useRouter();
+  const {
+    desktopSidebarWidth,
+    sidebarOpen,
+    isMobile,
+    mapZoom,
+    showMapLabels,
+    trafficFilter,
+    typeFilter,
+    altitudeLevel,
+    selectedAircraftId,
+    selectedAirportIcao,
+    closeSidebar,
+    selectAircraft,
+    setSelectedAircraftId,
+    selectAirport,
+    toggleMapLabels,
+    fitToTrace,
+    mapFollowsAircraft,
+  } = useExplorerUi();
+
+  // Default-on location labels for the flight page: when tracking a
+  // specific aircraft cross-country the place names give the moving map
+  // useful context, so the labels start visible (user can still toggle
+  // off via the map control). Effect fires once via the ref guard so
+  // subsequent toggles aren't clobbered.
+  const labelsInitializedRef = useRef(false);
+  useEffect(() => {
+    if (labelsInitializedRef.current) return;
+    labelsInitializedRef.current = true;
+    if (!showMapLabels) toggleMapLabels();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const {
+    aircraft: trackedAircraft,
+    feedSource,
+    lastUpdated,
+  } = useTrackedAircraft(callsign);
+
+  // Keep the last known position around so the map doesn't snap back when
+  // the tracked aircraft is briefly absent from the feed.
+  const lastKnownRef = useRef({ lat: null, lon: null });
+  if (
+    trackedAircraft?.lat != null &&
+    Number.isFinite(Number(trackedAircraft.lat)) &&
+    trackedAircraft?.lon != null &&
+    Number.isFinite(Number(trackedAircraft.lon))
+  ) {
+    lastKnownRef.current = {
+      lat: Number(trackedAircraft.lat),
+      lon: Number(trackedAircraft.lon),
+    };
+  }
+  const focalLat = lastKnownRef.current.lat;
+  const focalLon = lastKnownRef.current.lon;
+
+  const { aircraft: nearbyAircraft } = useAircraftPositions(
+    callsign || "",
+    focalLat,
+    focalLon,
+  );
+
+  // Pull airports around the focal so the sidebar list and the map's
+  // airport layer both show context relative to the moving flight.
+  const { airports: nearbyAirports } = useNearbyAirports({
+    lat: focalLat || 0,
+    lon: focalLon || 0,
+    radiusNm: 80,
+    limit: 12,
+  });
+
+  const selectedAirport = useMemo(
+    () =>
+      nearbyAirports.find(
+        (airport) => airport?.icao === selectedAirportIcao,
+      ) || null,
+    [nearbyAirports, selectedAirportIcao],
+  );
+
+  // Merge tracked aircraft into the nearby list so the map always renders
+  // it (the radius poll can lag a beat behind the callsign poll).
+  const aircraft = useMemo(() => {
+    if (!trackedAircraft) return nearbyAircraft;
+    const trackedKey = getAircraftIdentity(trackedAircraft);
+    const alreadyIn = nearbyAircraft.some(
+      (entry) => getAircraftIdentity(entry) === trackedKey,
+    );
+    return alreadyIn ? nearbyAircraft : [trackedAircraft, ...nearbyAircraft];
+  }, [trackedAircraft, nearbyAircraft]);
+
+  // Default the selection to the focal aircraft so its trace appears on
+  // load. Once the user clicks around it's their choice.
+  const focalKey = trackedAircraft
+    ? getAircraftIdentity(trackedAircraft)
+    : "";
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || !focalKey) return;
+    seededRef.current = true;
+    setSelectedAircraftId(focalKey);
+  }, [focalKey, setSelectedAircraftId]);
+
+  const selectedAircraft = useMemo(
+    () =>
+      aircraft.find(
+        (item) => getAircraftIdentity(item) === selectedAircraftId,
+      ) || null,
+    [aircraft, selectedAircraftId],
+  );
+
+  useEffect(() => {
+    if (!isMobile) return undefined;
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalHtmlOverflow = document.documentElement.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.documentElement.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.documentElement.style.overflow = originalHtmlOverflow;
+    };
+  }, [isMobile]);
+
+  const handleBack = () => router.push("/");
+
+  const sidebarProps = {
+    callsign,
+    aircraft: trackedAircraft,
+    nearbyAircraft: aircraft,
+    nearbyAirports,
+    focusLat: focalLat,
+    focusLon: focalLon,
+    selectedAircraftId,
+    selectedAirportIcao,
+    onSelectAircraft: selectAircraft,
+    onSelectAirport: selectAirport,
+    feedSource,
+    lastUpdated,
+    onBack: handleBack,
+  };
+
+  return (
+    <SelectedAircraftTraceProvider
+      selectedAircraft={selectedAircraft}
+      focalAircraft={trackedAircraft}
+    >
+      <TraceLoadingToast />
+      <AircraftPreviewCard
+        aircraft={selectedAircraft}
+        airport={selectedAirport}
+        isMobile={isMobile}
+        sidebarOpen={sidebarOpen}
+      />
+      <div
+        className={`font-sans text-atc-text ${
+          isMobile
+            ? "fixed inset-0 z-0 flex overflow-hidden overscroll-none"
+            : "flex h-dvh overflow-hidden"
+        }`}
+      >
+        {!isMobile && (
+          <div
+            className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+            style={{ width: sidebarOpen ? desktopSidebarWidth : "0" }}
+          >
+            <div className="h-full" style={{ width: desktopSidebarWidth }}>
+              <FlightSidebar {...sidebarProps} />
+            </div>
+          </div>
+        )}
+
+        <div className="relative min-w-0 flex-1 overflow-hidden bg-atc-bg">
+          {!(isMobile && sidebarOpen) && (
+            <ExplorerMapMenu onFitToTrace={fitToTrace} />
+          )}
+          <AirportMap
+            icao=""
+            lat={focalLat || 0}
+            lon={focalLon || 0}
+            zoom={mapZoom}
+            aircraft={aircraft}
+            nearbyAirports={nearbyAirports}
+            airport={null}
+            showMapLabels={showMapLabels}
+            showRunwayBeams={false}
+            showRoutingPointBadges={false}
+            trafficFilter={trafficFilter}
+            typeFilter={typeFilter}
+            altitudeLevel={altitudeLevel}
+            selectedAircraftId={selectedAircraftId}
+            selectedAirportIcao={selectedAirportIcao}
+            focalAircraftId={focalKey}
+            followsCenter={mapFollowsAircraft}
+            onSelectAircraft={selectAircraft}
+            onSelectAirport={selectAirport}
+            runwayMap={null}
+            runwayProcedures={null}
+            procedureFixLabelRunwayProcedures={null}
+            showProcedureFixLabels={false}
+          >
+            <MapFitToTraceController />
+          </AirportMap>
+
+          {isMobile && sidebarOpen && (
+            <div className="absolute inset-0 z-[1100]">
+              <FlightSidebar {...sidebarProps} onClose={closeSidebar} />
+            </div>
+          )}
+        </div>
+      </div>
+    </SelectedAircraftTraceProvider>
+  );
+}

--- a/src/components/map/AircraftPosition.jsx
+++ b/src/components/map/AircraftPosition.jsx
@@ -41,6 +41,7 @@ export default function AircraftPosition({
   selected = false,
   selectionActive = false,
   traceActive = false,
+  forceSilhouette = false,
   onSelectAircraft,
   onRevalidateRoute,
 }) {
@@ -132,10 +133,15 @@ export default function AircraftPosition({
   if (!container) return null;
 
   const speedKt = Number(aircraft.velocity ?? 0);
-  const showArrow = speedKt >= SLOW_AIRCRAFT_THRESHOLD_KT;
+  // forceSilhouette is used on the flight tracking page so the focal
+  // aircraft never collapses to the slow-traffic dot — the "what we're
+  // tracking" plane should always read as a recognizable shape.
+  const showArrow = forceSilhouette || speedKt >= SLOW_AIRCRAFT_THRESHOLD_KT;
   const color = getAircraftColor(aircraft, showArrow);
   const silhouette =
-    showArrow && !aircraft.onGround ? resolveAircraftIcon(aircraft) : null;
+    forceSilhouette || (showArrow && !aircraft.onGround)
+      ? resolveAircraftIcon(aircraft)
+      : null;
   // Wake-class scale (A1–0.90 → A5–1.10). Applied to the moving marker
   // glyphs so heavies read larger than light traffic; falls back to 1× for
   // unknown / out-of-range categories. The slow-traffic dot stays unscaled
@@ -162,7 +168,9 @@ export default function AircraftPosition({
         silhouette={silhouette}
         sizeScale={sizeScale}
       />
-      {(selected || (!traceActive && emphasis.showLabel)) && (
+      {(selected ||
+        forceSilhouette ||
+        (!traceActive && emphasis.showLabel)) && (
         <Label
           color={color}
           label={label}

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -43,12 +43,17 @@ export default function AirportMap({
   typeFilter = "all",
   altitudeLevel = "all",
   selectedAircraftId = "",
+  selectedAirportIcao = "",
+  focalAircraftId = "",
+  followsCenter = true,
   onSelectAircraft,
+  onSelectAirport,
   onRevalidateRoute,
   runwayMap = null,
   runwayProcedures = null,
   procedureFixLabelRunwayProcedures = runwayProcedures,
   showProcedureFixLabels = false,
+  children = null,
 }) {
   const mapEl = useRef(null);
   const mapRef = useRef(null);
@@ -105,36 +110,55 @@ export default function AirportMap({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // followsCenter controls whether the map re-centers on every poll.
+  // After "fit to trace" the caller flips this to false so the map
+  // stays anchored to the trace bounds even though the aircraft keeps
+  // moving; clicking a preset zoom flips it back to true upstream.
   useEffect(() => {
-    if (mapRef.current && lat && lon) {
+    if (mapRef.current && lat && lon && followsCenter) {
       mapRef.current.setView([lat, lon], zoom);
     }
-  }, [lat, lon, zoom]);
+  }, [lat, lon, zoom, followsCenter]);
 
   // Clicks on the map background (not on an aircraft marker) clear the
   // selection so the user can drop "trace mode" without targeting an
   // explicit element. Aircraft markers stop event propagation in their own
   // container click handler, so this listener only fires on bare tiles.
   useEffect(() => {
-    if (!mapInstance || typeof onSelectAircraft !== "function") return undefined;
+    if (!mapInstance) return undefined;
     const handleMapClick = () => {
-      if (selectedAircraftId) onSelectAircraft("");
+      if (selectedAircraftId && typeof onSelectAircraft === "function") {
+        onSelectAircraft("");
+      }
+      if (selectedAirportIcao && typeof onSelectAirport === "function") {
+        onSelectAirport("");
+      }
     };
     mapInstance.on("click", handleMapClick);
     return () => {
       mapInstance.off("click", handleMapClick);
     };
-  }, [mapInstance, onSelectAircraft, selectedAircraftId]);
+  }, [
+    mapInstance,
+    onSelectAircraft,
+    onSelectAirport,
+    selectedAircraftId,
+    selectedAirportIcao,
+  ]);
 
   const visibleAircraft = useMemo(() => {
     return getVisibleAircraft({
       aircraft,
-      airportLat: lat,
-      airportLon: lon,
+      // Only apply the airport-ground filter when there's actually an
+      // airport in focus. On the flight page (no icao) the map center is
+      // the focal aircraft's own position — applying the filter there
+      // would silently hide the focal because it's "at the airport".
+      airportLat: icao ? lat : null,
+      airportLon: icao ? lon : null,
       nearbyAirports,
       zoom,
     });
-  }, [aircraft, lat, lon, nearbyAirports, zoom]);
+  }, [aircraft, icao, lat, lon, nearbyAirports, zoom]);
   const selectedAircraft = useMemo(
     () =>
       visibleAircraft.find(
@@ -165,16 +189,20 @@ export default function AirportMap({
             zoom={zoom}
             theme={currentTheme}
           />
-          <AirportMarker
-            lat={lat}
-            lon={lon}
-            icao={icao}
-            airport={airport}
-          />
+          {icao && (
+            <AirportMarker
+              lat={lat}
+              lon={lon}
+              icao={icao}
+              airport={airport}
+            />
+          )}
           <NearbyAirportLayer
             airports={nearbyAirports}
             theme={currentTheme}
             zoom={zoom}
+            selectedIcao={selectedAirportIcao}
+            onSelectAirport={onSelectAirport}
           />
           <ProcedureSegmentLayer
             runwayProcedures={runwayProcedures}
@@ -189,14 +217,17 @@ export default function AirportMap({
             showBeams={showRunwayBeams}
             showBadges={showRoutingPointBadges}
           />
-          <GroundStatsCounter
-            lat={lat}
-            lon={lon}
-            zoom={zoom}
-            icao={icao}
-            aircraft={aircraft}
-          />
+          {icao && (
+            <GroundStatsCounter
+              lat={lat}
+              lon={lon}
+              zoom={zoom}
+              icao={icao}
+              aircraft={aircraft}
+            />
+          )}
           <SelectedAircraftTrace theme={currentTheme} />
+          {children}
           {visibleAircraft.map((ac) => (
             <AircraftPosition
               key={getAircraftIdentity(ac)}
@@ -210,6 +241,10 @@ export default function AirportMap({
               selected={getAircraftIdentity(ac) === selectedAircraftId}
               selectionActive={selectionActive}
               traceActive={selectionActive}
+              forceSilhouette={
+                Boolean(focalAircraftId) &&
+                getAircraftIdentity(ac) === focalAircraftId
+              }
               onSelectAircraft={onSelectAircraft}
               onRevalidateRoute={onRevalidateRoute}
             />

--- a/src/components/map/MapFitToTraceController.jsx
+++ b/src/components/map/MapFitToTraceController.jsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import { useMapInstance } from "./MapContext.js";
+import { useExplorerUi } from "@/components/explorer/ExplorerUiContext.jsx";
+import { useSelectedAircraftTrace } from "@/components/aircraft/trace/SelectedAircraftTraceContext.jsx";
+
+// Listens for the `fitToTrace` signal from the UI reducer and pans/zooms
+// the map so the full trace of every currently-visible aircraft fits in
+// the viewport. After fitting we push the resolved Leaflet zoom level
+// back into React state so the map control's zoom-level button no longer
+// reports as "active" — the next zoom click takes the user back to the
+// preset cycle from a clean slate.
+export default function MapFitToTraceController() {
+  const map = useMapInstance();
+  const { fitToTraceSignal } = useExplorerUi();
+  const { traces } = useSelectedAircraftTrace();
+  const lastSignalRef = useRef(0);
+
+  useEffect(() => {
+    if (!map || fitToTraceSignal === lastSignalRef.current) return;
+    lastSignalRef.current = fitToTraceSignal;
+    if (fitToTraceSignal === 0) return;
+
+    const points = [];
+    for (const trace of traces || []) {
+      for (const point of trace.tracePoints || []) {
+        const lat = Number(point?.lat);
+        const lon = Number(point?.lon);
+        if (Number.isFinite(lat) && Number.isFinite(lon)) {
+          points.push([lat, lon]);
+        }
+      }
+    }
+    if (points.length === 0) return;
+
+    const bounds = L.latLngBounds(points);
+    map.fitBounds(bounds, { padding: [60, 60], maxZoom: 14 });
+    // We deliberately don't sync React's mapZoom here: the auto-follow
+    // is gated by mapFollowsAircraft (set to false by the fitToTrace
+    // action), so even if the Leaflet zoom happens to land on a preset
+    // value, the map stays anchored on the trace bounds.
+  }, [fitToTraceSignal, map, traces]);
+
+  return null;
+}

--- a/src/components/map/MapTileLayers.jsx
+++ b/src/components/map/MapTileLayers.jsx
@@ -65,9 +65,12 @@ export default function MapTileLayers({
     if (!baseLayer) return;
 
     if (selectionActive) {
-      baseLayer.setOpacity(theme === "light" ? 0.78 : 0.72);
+      // Lighter selection-mode dim than before (0.72/0.78) — enough to
+      // signal focus mode but not so heavy that other aircraft / map
+      // context vanish under the mask.
+      baseLayer.setOpacity(theme === "light" ? 0.92 : 0.88);
       if (labelLayer) {
-        labelLayer.setOpacity(theme === "light" ? 0.38 : 0.28);
+        labelLayer.setOpacity(theme === "light" ? 0.55 : 0.5);
       }
       return;
     }

--- a/src/components/map/NearbyAirportLayer.jsx
+++ b/src/components/map/NearbyAirportLayer.jsx
@@ -88,9 +88,20 @@ const runwayLayers = ({ airport, map, theme, zoom }) => {
   ];
 };
 
-export default function NearbyAirportLayer({ airports = [], theme = "dark", zoom }) {
+export default function NearbyAirportLayer({
+  airports = [],
+  theme = "dark",
+  zoom,
+  selectedIcao = "",
+  onSelectAirport = null,
+}) {
   const map = useMapInstance();
   const layerRef = useRef(null);
+  // Keep the click handler in a ref so re-rendering the layer doesn't
+  // require tearing down + re-adding the markers each time the callback
+  // identity changes.
+  const onSelectRef = useRef(onSelectAirport);
+  onSelectRef.current = onSelectAirport;
 
   useEffect(() => {
     if (!map || !map.getContainer) return undefined;
@@ -103,15 +114,25 @@ export default function NearbyAirportLayer({ airports = [], theme = "dark", zoom
       runwayLayers({ airport, map, theme, zoom }).forEach((runwayLayer) =>
         runwayLayer.addTo(layer),
       );
-      L.marker([airport.lat, airport.lon], {
-        interactive: false,
+      const interactive = Boolean(onSelectRef.current);
+      const isSelected = selectedIcao && airport.icao === selectedIcao;
+      const marker = L.marker([airport.lat, airport.lon], {
+        interactive,
+        keyboard: interactive,
         icon: L.divIcon({
-          className: "",
+          className: isSelected ? "nearby-airport-marker--selected" : "",
           html: markerHtml(airport),
           iconSize: [96, 24],
           iconAnchor: [12, 12],
         }),
-      }).addTo(layer);
+      });
+      if (interactive) {
+        marker.on("click", (event) => {
+          event?.originalEvent?.stopPropagation?.();
+          onSelectRef.current?.(airport.icao);
+        });
+      }
+      marker.addTo(layer);
     }
 
     layer.addTo(map);
@@ -121,7 +142,7 @@ export default function NearbyAirportLayer({ airports = [], theme = "dark", zoom
       layer.removeFrom(map);
       layerRef.current = null;
     };
-  }, [map, airports, theme, zoom]);
+  }, [map, airports, theme, zoom, selectedIcao]);
 
   return null;
 }

--- a/src/components/map/SelectedAircraftTrace.jsx
+++ b/src/components/map/SelectedAircraftTrace.jsx
@@ -140,8 +140,47 @@ function makeLabelKey(labelPoints) {
     .join("·");
 }
 
+// Default export reads the trace context and renders one or two trace
+// instances (e.g. focal + selected on the flight detail page). Each
+// SingleAircraftTrace manages its own animation/layer state, so two
+// instances coexist cleanly without sharing refs.
 export default function SelectedAircraftTrace({ theme = "dark" }) {
-  const { aircraftHex, movement, tracePoints } = useSelectedAircraftTrace();
+  const ctx = useSelectedAircraftTrace();
+  const traces = Array.isArray(ctx?.traces) && ctx.traces.length > 0
+    ? ctx.traces
+    : [
+        {
+          aircraftHex: ctx?.aircraftHex,
+          movement: ctx?.movement,
+          tracePoints: ctx?.tracePoints || [],
+        },
+      ];
+
+  return (
+    <>
+      {traces.map((trace) =>
+        trace?.aircraftHex ? (
+          <SingleAircraftTrace
+            key={trace.aircraftHex}
+            theme={theme}
+            aircraftHex={trace.aircraftHex}
+            movement={trace.movement}
+            tracePoints={trace.tracePoints}
+            opacity={typeof trace.opacity === "number" ? trace.opacity : 1}
+          />
+        ) : null,
+      )}
+    </>
+  );
+}
+
+function SingleAircraftTrace({
+  theme = "dark",
+  aircraftHex,
+  movement,
+  tracePoints,
+  opacity = 1,
+}) {
   const map = useMapInstance();
   const lineLayersRef = useRef([]);
   const labelMarkersRef = useRef([]);
@@ -287,9 +326,9 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
         curve: geometry.curve,
         gradientId: `aircraft-trace-core-${gradientBase}`,
         color: lineColor,
-        tailOpacity: TRACE_CORE_TAIL_OPACITY,
-        midOpacity: TRACE_CORE_MID_OPACITY,
-        headOpacity: TRACE_CORE_HEAD_OPACITY,
+        tailOpacity: TRACE_CORE_TAIL_OPACITY * opacity,
+        midOpacity: TRACE_CORE_MID_OPACITY * opacity,
+        headOpacity: TRACE_CORE_HEAD_OPACITY * opacity,
       }),
     );
 
@@ -312,8 +351,8 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
         gradientId: `aircraft-trace-glow-${gradientBase}`,
         color: glowColor,
         tailOpacity: 0,
-        midOpacity: traceStyle.glowOpacity * 0.38,
-        headOpacity: traceStyle.glowOpacity,
+        midOpacity: traceStyle.glowOpacity * 0.38 * opacity,
+        headOpacity: traceStyle.glowOpacity * opacity,
       }),
     );
     const revealPolylines = [corePolyline, glowPolyline];
@@ -326,7 +365,8 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
           radius: traceStyle.pointRadius,
           stroke: false,
           fillColor: dotColor,
-          fillOpacity: traceStyle.pointFillOpacity * (0.3 + emphasis * 0.7),
+          fillOpacity:
+            traceStyle.pointFillOpacity * (0.3 + emphasis * 0.7) * opacity,
           interactive: false,
           className: "aircraft-trace-point",
         }).addTo(map),
@@ -431,6 +471,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
     accentColor,
     reducedMotion,
     traceRevealKey,
+    opacity,
   ]);
 
   // -------------------------------------------------------------------
@@ -502,7 +543,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
         const el = m.getElement?.();
         if (!el) return;
         el.style.transition = "none";
-        el.style.opacity = "1";
+        el.style.opacity = String(opacity);
       });
       return () => {
         if (labelRafIdRef.current) {
@@ -530,7 +571,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
       labelMarkers.forEach((m) => {
         const el = m.getElement?.();
         if (!el) return;
-        el.style.opacity = "1";
+        el.style.opacity = String(opacity);
       });
     });
 
@@ -546,7 +587,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
     // to geometry's per-poll reference churn. labelKey changes iff the
     // sample set actually shifts, at which point the ref's value is the
     // new set.
-  }, [map, labelKey, reducedMotion]);
+  }, [map, labelKey, reducedMotion, opacity]);
 
   return null;
 }

--- a/src/components/map/controls/MapControlRail.jsx
+++ b/src/components/map/controls/MapControlRail.jsx
@@ -9,6 +9,7 @@ const LAYERS_ICON_KEY = "layers";
 
 export default function MapControlRail({
   currentZoomOption,
+  zoomActive = true,
   currentTheme,
   themeTitle,
   layerDrawerOpen,
@@ -16,16 +17,30 @@ export default function MapControlRail({
   audioReady,
   layerDrawerId,
   onCycleZoom,
+  onFitToTrace = null,
   onToggleAudio,
   onCycleTheme,
   onToggleLayerDrawer,
 }) {
   return (
     <div className="map-ctrl-bar">
+      {onFitToTrace && (
+        <Button
+          variant="atcIcon"
+          size="icon"
+          className="ctrl-btn ctrl-fit-trace"
+          title="Fit map to trace"
+          onClick={onFitToTrace}
+          type="button"
+        >
+          <MapControlIcon iconKey="route" />
+        </Button>
+      )}
+
       <Button
         variant="atcIcon"
         size="icon"
-        className="ctrl-btn ctrl-view active"
+        className={`ctrl-btn ctrl-view ${zoomActive ? "active" : ""}`}
         title={`${currentZoomOption.title} (click to cycle)`}
         onClick={onCycleZoom}
         type="button"

--- a/src/components/screens/FlightScreen.jsx
+++ b/src/components/screens/FlightScreen.jsx
@@ -1,0 +1,11 @@
+"use client";
+
+import FlightExplorer from "@/components/flight/explorer/FlightExplorer";
+
+// Entry point for the per-aircraft tracking page. Shares the airport
+// detail layout (left sidebar + full-height map) but the sidebar shows
+// the focal aircraft's metadata and the map centers on / tracks that
+// aircraft as it moves.
+export default function FlightScreen({ callsign = "" }) {
+  return <FlightExplorer callsign={callsign} />;
+}

--- a/src/components/screens/HomeScreen.jsx
+++ b/src/components/screens/HomeScreen.jsx
@@ -61,7 +61,7 @@ export default function HomeScreen({ initialIcao = "" }) {
     if (!nextIcao) return;
     setAirport(selectedAirport);
     setCurrentIcao(nextIcao);
-    window.history.pushState({ icao: nextIcao }, "", `/${nextIcao}`);
+    window.history.pushState({ icao: nextIcao }, "", `/airport/${nextIcao}`);
   };
 
   const handleBack = () => {
@@ -84,9 +84,13 @@ export default function HomeScreen({ initialIcao = "" }) {
 }
 
 function normalizePathIcao(pathname) {
-  const segment = String(pathname || "")
+  // Airport pages live under /airport/[icao]; pull the segment that follows
+  // /airport/ rather than the first path segment.
+  const segments = String(pathname || "")
     .split("/")
-    .filter(Boolean)[0];
-  const normalized = String(segment || "").trim().toUpperCase();
+    .filter(Boolean);
+  const airportIndex = segments.indexOf("airport");
+  const candidate = airportIndex >= 0 ? segments[airportIndex + 1] : "";
+  const normalized = String(candidate || "").trim().toUpperCase();
   return /^[A-Z0-9]{3,4}$/.test(normalized) ? normalized : "";
 }

--- a/src/components/sidebar/AircraftRow.jsx
+++ b/src/components/sidebar/AircraftRow.jsx
@@ -18,7 +18,7 @@ export default function AircraftRow({
   const hasRouteMunicipalities = Boolean(
     routeMunicipalities && routeMunicipalities !== route,
   );
-  const gsValue = toNumber(aircraft.velocity);
+  const distValue = toNumber(aircraft.distanceNm);
   const altValue = toNumber(aircraft.altitude);
 
   return (
@@ -37,10 +37,14 @@ export default function AircraftRow({
         hasRouteMunicipalities={hasRouteMunicipalities}
       />
       <div className="text-right font-mono text-[12px] font-semibold text-atc-text">
-        {gsValue == null ? (
+        {distValue == null ? (
           <span>-</span>
         ) : (
-          <NumberWithUnit value={Math.round(gsValue)} unit="KT" />
+          <NumberWithUnit
+            value={distValue}
+            unit="NM"
+            format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
+          />
         )}
       </div>
       <div className="text-right font-mono text-[12px] font-semibold text-atc-text">
@@ -120,13 +124,13 @@ function AircraftIdentityCell({
   );
 }
 
-function NumberWithUnit({ value, unit }) {
+function NumberWithUnit({ value, unit, format }) {
   return (
     <span
       className="inline-flex items-baseline justify-end gap-0.5 tabular-nums"
       style={{ isolation: "isolate", willChange: "contents" }}
     >
-      <NumberFlow value={value} />
+      <NumberFlow value={value} format={format} />
       <sub className="relative top-[0.22em] text-[7px] font-semibold leading-none text-atc-dim">
         {unit}
       </sub>

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -20,9 +20,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { useAirportExplorerUi } from "@/components/airport/explorer/AirportExplorerUiContext.jsx";
+import { useExplorerUi } from "@/components/explorer/ExplorerUiContext.jsx";
 import {
   ALTITUDE_LEVEL_OPTIONS,
+  ENTITY_FILTER_OPTIONS,
   aircraftMatchesFilters,
   aircraftTypeLabel,
   getAircraftTypeGroups,
@@ -33,23 +34,32 @@ import {
   getContextTagLabel,
 } from "../../features/airport/context/airportContextUiModel.js";
 import { formatFlightRouteMunicipalityLabel } from "../../utils/flightRouteDisplay.js";
+import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
 import AircraftList from "./AircraftList.jsx";
 import AircraftSlot from "./AircraftSlot.jsx";
+import AirportRow from "./AirportRow.jsx";
 
 export default function AircraftTable({
   aircraft = [],
+  airports = [],
+  focusLat = null,
+  focusLon = null,
   selectedAircraftId = "",
+  selectedAirportIcao = "",
   onSelectAircraft,
+  onSelectAirport,
   fill = true,
 }) {
   const {
     trafficFilter,
     typeFilter,
     altitudeLevel,
+    entityFilter,
     setTrafficFilter,
     setTypeFilter,
     setAltitudeLevel,
-  } = useAirportExplorerUi();
+    setEntityFilter,
+  } = useExplorerUi();
   const [query, setQuery] = useState("");
   const selectedTypes = useMemo(
     () => (Array.isArray(typeFilter) ? typeFilter : []),
@@ -59,17 +69,49 @@ export default function AircraftTable({
     () => getAircraftTypeGroups(aircraft, selectedTypes),
     [aircraft, selectedTypes],
   );
+  // Aircraft entries enriched with a distanceNm relative to the focus
+  // point (focal aircraft or airport). The airport-explorer enrichment
+  // already provides distanceNm in airport-page context; for the flight
+  // page we compute it on the fly here.
+  const aircraftWithDist = useMemo(() => {
+    if (focusLat == null || focusLon == null) return aircraft;
+    return aircraft.map((item) => {
+      const computed = getDistanceNm(focusLat, focusLon, item?.lat, item?.lon);
+      if (computed == null) return item;
+      return { ...item, distanceNm: computed };
+    });
+  }, [aircraft, focusLat, focusLon]);
+
   const rows = useMemo(
     () =>
       filterAndSortAircraft({
-        aircraft,
+        aircraft: aircraftWithDist,
         altitudeLevel,
         query,
         trafficFilter,
         typeFilter,
       }),
-    [aircraft, altitudeLevel, query, trafficFilter, typeFilter],
+    [aircraftWithDist, altitudeLevel, query, trafficFilter, typeFilter],
   );
+
+  const filteredAirports = useMemo(() => {
+    if (entityFilter === "aircraft") return [];
+    const normalizedQuery = query.trim().toLowerCase();
+    return airports
+      .filter((airport) =>
+        normalizedQuery
+          ? airportSearchText(airport).includes(normalizedQuery)
+          : true,
+      )
+      .toSorted(
+        (left, right) => (left.distanceNm || 0) - (right.distanceNm || 0),
+      );
+  }, [airports, entityFilter, query]);
+
+  const filteredAircraft = useMemo(() => {
+    if (entityFilter === "airports") return [];
+    return rows;
+  }, [rows, entityFilter]);
   // Pinned aircraft sits above the scrolling list and stays visible even
   // when filters would otherwise exclude it. Look in the full nearby set,
   // not the filtered rows, so a user can keep watching a selection without
@@ -83,23 +125,26 @@ export default function AircraftTable({
   }, [aircraft, selectedAircraftId]);
   // Don't duplicate the pinned aircraft inside the scroll list.
   const listRows = useMemo(() => {
-    if (!pinnedAircraft) return rows;
-    return rows.filter(
+    if (!pinnedAircraft) return filteredAircraft;
+    return filteredAircraft.filter(
       (item) => getAircraftIdentity(item) !== selectedAircraftId,
     );
-  }, [pinnedAircraft, rows, selectedAircraftId]);
+  }, [pinnedAircraft, filteredAircraft, selectedAircraftId]);
 
   return (
     <div className={`flex flex-col ${fill ? "h-full" : ""}`}>
       <div className="flex-none">
         <div className="flex items-baseline justify-between px-[var(--airport-sidebar-inset)] pt-4 pb-2.5">
           <div className="text-[10px] font-semibold uppercase tracking-normal text-atc-faint">
-            Aircraft
+            {entityFilter === "airports" ? "Airports" : "Traffic"}
           </div>
           <div className="whitespace-nowrap text-[10px] font-semibold uppercase tracking-normal text-atc-dim tabular-nums">
-            <NumberFlow value={rows.length} />
+            <NumberFlow value={filteredAircraft.length + filteredAirports.length} />
             <span> / </span>
-            <NumberFlow value={aircraft.length} suffix=" nearby" />
+            <NumberFlow
+              value={aircraft.length + airports.length}
+              suffix=" nearby"
+            />
           </div>
         </div>
 
@@ -117,10 +162,19 @@ export default function AircraftTable({
         </div>
 
         <div
-          className="aircraft-filter-cards"
+          className="aircraft-filter-cards aircraft-filter-cards--grid"
           role="group"
-          aria-label="Aircraft filters"
+          aria-label="Sidebar list filters"
         >
+          <AircraftFilterCardSelect
+            label="Show"
+            value={entityFilter}
+            onValueChange={setEntityFilter}
+            options={ENTITY_FILTER_OPTIONS}
+            ariaLabel="Filter what to show in the list"
+            contentClassName="min-w-[220px]"
+          />
+
           <TooltipProvider delayDuration={250}>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -170,9 +224,9 @@ export default function AircraftTable({
         </div>
 
         <div className="grid grid-cols-[minmax(0,1fr)_54px_70px] items-center gap-3 border-b border-[var(--atc-line)] px-[var(--airport-sidebar-inset)] py-1.5 font-mono text-[9px] uppercase text-atc-faint">
-          <span>Callsign / Route</span>
-          <span className="text-right">GS</span>
-          <span className="text-right">ALT</span>
+          <span>Name / Route</span>
+          <span className="text-right">Dist</span>
+          <span className="text-right">Alt</span>
         </div>
 
         <AnimatePresence initial={false}>
@@ -201,16 +255,41 @@ export default function AircraftTable({
         layoutScroll
         className={fill ? "flex-1 overflow-y-auto" : "overflow-visible"}
       >
-        {listRows.length === 0 && !pinnedAircraft ? (
+        {listRows.length === 0 &&
+        filteredAirports.length === 0 &&
+        !pinnedAircraft ? (
           <div className="px-[var(--airport-sidebar-inset)] py-8 text-center text-[11px] font-semibold uppercase tracking-normal text-atc-faint">
-            {aircraft.length ? "No aircraft match" : "No aircraft in range"}
+            {aircraft.length + airports.length
+              ? "No matches"
+              : "Nothing in range"}
           </div>
         ) : (
-          <AircraftList
-            aircraft={listRows}
-            selectedAircraftId={selectedAircraftId}
-            onSelectAircraft={onSelectAircraft}
-          />
+          <>
+            {listRows.length > 0 && (
+              <AircraftList
+                aircraft={listRows}
+                selectedAircraftId={selectedAircraftId}
+                onSelectAircraft={onSelectAircraft}
+              />
+            )}
+            {filteredAirports.length > 0 && (
+              <ul className="aircraft-table-list">
+                {filteredAirports.map((airport) => (
+                  <li
+                    key={`airport:${airport.icao}`}
+                    className="aircraft-table-list__item"
+                  >
+                    <AirportRow
+                      airport={airport}
+                      airportId={airport.icao}
+                      selected={airport.icao === selectedAirportIcao}
+                      onSelectAirport={onSelectAirport}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
         )}
       </motion.div>
     </div>
@@ -454,6 +533,19 @@ function filterAndSortAircraft({
       normalizedQuery ? aircraftSearchText(item).includes(normalizedQuery) : true,
     )
     .sort(sortAircraftByAltitude);
+}
+
+function airportSearchText(airport = {}) {
+  return [
+    airport.icao,
+    airport.iata,
+    airport.name,
+    airport.city,
+    airport.country,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
 }
 
 function aircraftSearchText(aircraft = {}) {

--- a/src/components/sidebar/AirportIdentity.jsx
+++ b/src/components/sidebar/AirportIdentity.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 
+import SidebarIdentityHero from "./SidebarIdentityHero";
 import { countryName, flagEmoji } from "../../utils/flag.js";
 import { resolveTimezone } from "../../utils/timezone.js";
 
@@ -24,19 +25,7 @@ export default function AirportIdentity({
   const localTimeLine = useLocalTime(country);
 
   return (
-    <div className="airport-sidebar-identity">
-      <div className="text-[10px] font-semibold uppercase tracking-normal text-atc-faint">
-        Airport
-      </div>
-      <div className="mt-3 flex items-baseline gap-3">
-        <span className="airport-sidebar-display-mono airport-sidebar-display-mono--hero text-[28px] font-extrabold text-atc-text">
-          {codeLine}
-        </span>
-        <span
-          aria-hidden="true"
-          className="h-px flex-1 bg-[var(--atc-line-strong)]"
-        />
-      </div>
+    <SidebarIdentityHero label="Airport" code={codeLine}>
       <h1 className="mt-4 text-[26px] font-semibold leading-[1.1] tracking-[-0.01em] text-atc-text">
         {name || "Unknown airport"}
       </h1>
@@ -53,7 +42,7 @@ export default function AirportIdentity({
           {localTimeLine}
         </div>
       ) : null}
-    </div>
+    </SidebarIdentityHero>
   );
 }
 

--- a/src/components/sidebar/AirportRow.jsx
+++ b/src/components/sidebar/AirportRow.jsx
@@ -1,0 +1,80 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
+
+// Airport equivalent of AircraftRow — same column rhythm so an
+// "airports & aircraft" mixed list reads as one coherent table.
+// Left: ICAO · IATA / city + country. Right: DIST and ELEV (in place of
+// the aircraft row's GS / ALT).
+export default function AirportRow({
+  airport,
+  airportId,
+  selected,
+  onSelectAirport,
+}) {
+  const icao = airport?.icao || "";
+  const iata = airport?.iata || "";
+  const code = iata && iata !== icao ? `${iata} · ${icao}` : icao || "—";
+  const city = airport?.city || "";
+  const country = airport?.country || "";
+  const placeText = [city, country].filter(Boolean).join(", ") || airport?.name;
+  const dist = toFiniteNumber(airport?.distanceNm);
+  const elevation = toFiniteNumber(airport?.elevationFt);
+
+  return (
+    <button
+      type="button"
+      className={`aircraft-table-card grid w-full grid-cols-[minmax(0,1fr)_54px_70px] items-center gap-3 px-[var(--airport-sidebar-inset)] text-left transition-[background,color,opacity] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] ${
+        selected ? "bg-[color-mix(in_oklab,var(--atc-accent)_11%,transparent)]" : ""
+      }`}
+      aria-pressed={selected}
+      onClick={() => airportId && onSelectAirport?.(airportId)}
+    >
+      <div className="aircraft-table-identity aircraft-table-identity--solo min-w-0">
+        <span className="aircraft-table-callsign airport-sidebar-display-mono truncate text-[12px] font-semibold text-atc-text">
+          {code}
+        </span>
+        {placeText ? (
+          <span className="truncate text-[9.5px] text-atc-dim">{placeText}</span>
+        ) : null}
+      </div>
+      <div className="text-right font-mono text-[12px] font-semibold text-atc-text">
+        {dist == null ? (
+          <span>—</span>
+        ) : (
+          <NumberWithUnit
+            value={dist}
+            unit="NM"
+            format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
+          />
+        )}
+      </div>
+      <div className="text-right font-mono text-[12px] font-semibold text-atc-text">
+        {elevation == null ? (
+          <span>—</span>
+        ) : (
+          <NumberWithUnit value={Math.round(elevation)} unit="FT" />
+        )}
+      </div>
+    </button>
+  );
+}
+
+function NumberWithUnit({ value, unit, format }) {
+  return (
+    <span
+      className="inline-flex items-baseline justify-end gap-0.5 tabular-nums"
+      style={{ isolation: "isolate", willChange: "contents" }}
+    >
+      <NumberFlow value={value} format={format} />
+      <sub className="relative top-[0.22em] text-[7px] font-semibold leading-none text-atc-dim">
+        {unit}
+      </sub>
+    </span>
+  );
+}
+
+function toFiniteNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/components/sidebar/AirportSidebar.jsx
+++ b/src/components/sidebar/AirportSidebar.jsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowLeft, ArrowRight } from "lucide-react";
 import AircraftTable from "./AircraftTable";
 import AirportIdentity from "./AirportIdentity";
+import SidebarShell from "./SidebarShell";
 import SidebarViewSwitch from "./SidebarViewSwitch";
 import WeatherBriefingStack from "./WeatherBriefingStack";
-import RequestPulseDots from "@/components/ui/RequestPulseDots";
 
 export default function AirportSidebar({
   icao = "",
@@ -21,121 +20,80 @@ export default function AirportSidebar({
   metarLoading = false,
   metarError = null,
   aircraft = [],
+  airports = [],
+  focusLat = null,
+  focusLon = null,
   selectedAircraftId = "",
+  selectedAirportIcao = "",
   lastUpdated = null,
   feedStatus = "live",
   feedSource = "",
   onSelectAircraft,
+  onSelectAirport,
   onBack,
   onClose = null,
 }) {
   const isMobileOverlay = Boolean(onClose);
-  const updatedLabel = formatUpdated(lastUpdated);
   const [activeView, setActiveView] = useState("traffic");
 
-  return (
-    <div
-      className={`airport-sidebar-panel flex h-full flex-col border-r border-atc-line-strong bg-atc-bg ${
-        isMobileOverlay ? "airport-sidebar-panel--mobile" : ""
-      }`}
-    >
-      <div className="sticky top-0 z-20 flex h-11 flex-none items-center justify-between gap-4 border-b border-atc-line-strong bg-atc-bg px-6">
-        <button
-          type="button"
-          onClick={onBack}
-          className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-normal text-atc-faint transition-colors hover:text-atc-text"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
-          <span>ADSBao</span>
-        </button>
-        {onClose ? (
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-normal text-atc-faint transition-colors hover:text-atc-text"
-          >
-            <span>Map</span>
-            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        ) : (
-          <span
-            className={`airport-feed-status airport-feed-status--${feedStatus} inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-normal text-atc-dim tabular-nums`}
-          >
-            {feedSource ? (
-              <span className="airport-feed-status__source">{feedSource}</span>
-            ) : null}
-            <RequestPulseDots ariaLabel="Live feed" />
-            {updatedLabel ? <span key={updatedLabel}>{updatedLabel}</span> : null}
-          </span>
-        )}
-      </div>
-
-      <div
-        className={
-          isMobileOverlay
-            ? "flex flex-none flex-col overflow-visible"
-            : "flex flex-1 flex-col overflow-hidden"
-        }
-      >
-        <div className="flex-none">
-          <AirportIdentity
-            icao={icao}
-            iata={iata}
-            name={name}
-            city={city}
-            country={country}
-            lat={lat}
-            lon={lon}
-          />
-          <SidebarViewSwitch
-            activeView={activeView}
-            onViewChange={setActiveView}
-            metar={metar}
-            aircraftCount={aircraft.length}
-          />
-        </div>
-        <div
-          className={
-            isMobileOverlay
-              ? "flex-none overflow-visible"
-              : "flex-1 overflow-y-auto"
-          }
-        >
-          {activeView === "briefing" ? (
-            <WeatherBriefingStack
-              icao={icao}
-              iata={iata}
-              name={name}
-              city={city}
-              country={country}
-              metar={metar}
-              metarRaw={metarRaw}
-              metarLoading={metarLoading}
-              metarError={metarError}
-              airportCode={iata || icao}
-              airportLat={lat}
-              airportLon={lon}
-            />
-          ) : (
-            <AircraftTable
-              aircraft={aircraft}
-              selectedAircraftId={selectedAircraftId}
-              onSelectAircraft={onSelectAircraft}
-              fill={!isMobileOverlay}
-            />
-          )}
-        </div>
-      </div>
-    </div>
+  const header = (
+    <>
+      <AirportIdentity
+        icao={icao}
+        iata={iata}
+        name={name}
+        city={city}
+        country={country}
+        lat={lat}
+        lon={lon}
+      />
+      <SidebarViewSwitch
+        activeView={activeView}
+        onViewChange={setActiveView}
+        metar={metar}
+        aircraftCount={aircraft.length}
+      />
+    </>
   );
-}
 
-function formatUpdated(date) {
-  if (!date) return "";
-  return date.toLocaleTimeString([], {
-    hour12: false,
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
+  return (
+    <SidebarShell
+      variant="airport"
+      feedStatus={feedStatus}
+      feedSource={feedSource}
+      lastUpdated={lastUpdated}
+      onBack={onBack}
+      onClose={onClose}
+      header={header}
+    >
+      {activeView === "briefing" ? (
+        <WeatherBriefingStack
+          icao={icao}
+          iata={iata}
+          name={name}
+          city={city}
+          country={country}
+          metar={metar}
+          metarRaw={metarRaw}
+          metarLoading={metarLoading}
+          metarError={metarError}
+          airportCode={iata || icao}
+          airportLat={lat}
+          airportLon={lon}
+        />
+      ) : (
+        <AircraftTable
+          aircraft={aircraft}
+          airports={airports}
+          focusLat={focusLat}
+          focusLon={focusLon}
+          selectedAircraftId={selectedAircraftId}
+          selectedAirportIcao={selectedAirportIcao}
+          onSelectAircraft={onSelectAircraft}
+          onSelectAirport={onSelectAirport}
+          fill={!isMobileOverlay}
+        />
+      )}
+    </SidebarShell>
+  );
 }

--- a/src/components/sidebar/FlightSidebar.jsx
+++ b/src/components/sidebar/FlightSidebar.jsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+import NumberFlow from "@number-flow/react";
+import AircraftTable from "./AircraftTable";
+import SidebarIdentityHero from "./SidebarIdentityHero";
+import { SidebarMetricCard, SidebarMetricGrid } from "./SidebarMetric";
+import SidebarShell from "./SidebarShell";
+import { formatFlightRouteLabel } from "@/utils/flightRouteDisplay.js";
+import { toFiniteNumber } from "@/utils/math.js";
+
+// Sidebar for /aircraft/[callsign]. Shares chrome (SidebarShell), identity
+// hero (SidebarIdentityHero), and the stat-card layout (SidebarMetricGrid)
+// with the airport sidebar. The only flight-specific piece is the
+// FlightIdentity content slot.
+export default function FlightSidebar({
+  callsign = "",
+  aircraft = null,
+  nearbyAircraft = [],
+  nearbyAirports = [],
+  focusLat = null,
+  focusLon = null,
+  selectedAircraftId = "",
+  selectedAirportIcao = "",
+  onSelectAircraft,
+  onSelectAirport,
+  feedSource = "",
+  lastUpdated = null,
+  onBack,
+  onClose = null,
+}) {
+  const isMobileOverlay = Boolean(onClose);
+  const displayCallsign =
+    (aircraft?.callsign || callsign || "").trim() || "—";
+  const hex = aircraft?.icao24 ? aircraft.icao24.toUpperCase() : "";
+  const type = (aircraft?.type || "").trim().toUpperCase();
+  const category = (aircraft?.category || "").trim().toUpperCase();
+  const route = formatFlightRouteLabel(aircraft?.flightRoute) || "";
+  const speed = toFiniteNumber(aircraft?.velocity);
+  const altitude = toFiniteNumber(aircraft?.altitude);
+  const vs = toFiniteNumber(aircraft?.baroRate);
+  const track = toFiniteNumber(aircraft?.track);
+  const onGround = Boolean(aircraft?.onGround);
+
+  const header = (
+    <>
+      <FlightIdentity
+        callsign={displayCallsign}
+        type={type}
+        category={category}
+        route={route}
+      />
+      <FlightTelemetryGrid
+        speed={speed}
+        altitude={altitude}
+        vs={vs}
+        track={track}
+        onGround={onGround}
+        hex={hex}
+      />
+    </>
+  );
+
+  return (
+    <SidebarShell
+      variant="flight"
+      feedSource={feedSource}
+      lastUpdated={lastUpdated}
+      onBack={onBack}
+      onClose={onClose}
+      header={header}
+    >
+      <AircraftTable
+        aircraft={nearbyAircraft}
+        airports={nearbyAirports}
+        focusLat={focusLat}
+        focusLon={focusLon}
+        selectedAircraftId={selectedAircraftId}
+        selectedAirportIcao={selectedAirportIcao}
+        onSelectAircraft={onSelectAircraft}
+        onSelectAirport={onSelectAirport}
+        fill={!isMobileOverlay}
+      />
+    </SidebarShell>
+  );
+}
+
+function FlightIdentity({ callsign, type, category, route }) {
+  return (
+    <SidebarIdentityHero label="Tracking" code={callsign} codeClassName="italic">
+      {(type || category) && (
+        <div className="mt-2 flex items-baseline gap-2">
+          {type && (
+            <span className="font-mono text-[13px] font-semibold italic text-atc-text">
+              {type}
+            </span>
+          )}
+          {category && (
+            <span className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-atc-faint">
+              {category}
+            </span>
+          )}
+        </div>
+      )}
+      {route ? (
+        <div className="mt-2 font-mono text-[12px] tracking-[0.04em] text-atc-dim">
+          {route}
+        </div>
+      ) : (
+        <div className="mt-2 font-mono text-[12px] italic text-atc-faint">
+          No route
+        </div>
+      )}
+    </SidebarIdentityHero>
+  );
+}
+
+function FlightTelemetryGrid({ speed, altitude, vs, track, onGround, hex }) {
+  // Local "highlighted metric" state — clicking any card toggles its
+  // active state so the user can pin a metric the same way the airport
+  // page pins WEATHER vs FLIGHTS. Click an already-active card to
+  // deselect.
+  const [activeMetric, setActiveMetric] = useState(null);
+  const toggle = (id) =>
+    setActiveMetric((current) => (current === id ? null : id));
+
+  return (
+    <SidebarMetricGrid label="Flight telemetry">
+      <SidebarMetricCard
+        label="Speed"
+        value={
+          speed != null ? (
+            <NumberFlow value={Math.round(speed)} />
+          ) : (
+            "—"
+          )
+        }
+        unit={speed != null ? "kt" : ""}
+        active={activeMetric === "speed"}
+        onClick={() => toggle("speed")}
+      />
+      <SidebarMetricCard
+        label="Altitude"
+        value={
+          onGround
+            ? "GND"
+            : altitude != null
+              ? <NumberFlow value={Math.round(altitude)} />
+              : "—"
+        }
+        unit={onGround ? "" : altitude != null ? "ft" : ""}
+        active={activeMetric === "altitude"}
+        onClick={() => toggle("altitude")}
+      />
+      <SidebarMetricCard
+        label="V/S"
+        value={
+          vs != null ? (
+            <NumberFlow
+              value={Math.round(vs)}
+              format={{ signDisplay: "exceptZero" }}
+            />
+          ) : (
+            "—"
+          )
+        }
+        unit={vs != null ? "fpm" : ""}
+        active={activeMetric === "vs"}
+        onClick={() => toggle("vs")}
+      />
+      <SidebarMetricCard
+        label="Heading"
+        value={track != null ? <NumberFlow value={Math.round(track)} /> : "—"}
+        unit={track != null ? "deg" : ""}
+        active={activeMetric === "track"}
+        onClick={() => toggle("track")}
+      />
+      {hex && (
+        <>
+          <SidebarMetricCard
+            label="ICAO24"
+            value={hex}
+            active={activeMetric === "hex"}
+            onClick={() => toggle("hex")}
+          />
+          <SidebarMetricCard
+            label="Status"
+            value={onGround ? "GND" : "AIR"}
+            active={activeMetric === "status"}
+            onClick={() => toggle("status")}
+          />
+        </>
+      )}
+    </SidebarMetricGrid>
+  );
+}

--- a/src/components/sidebar/SidebarIdentityHero.jsx
+++ b/src/components/sidebar/SidebarIdentityHero.jsx
@@ -1,0 +1,38 @@
+"use client";
+
+// Shared identity-hero pattern used at the top of every sidebar (airport
+// and flight). Renders:
+//   - A small uppercase label (e.g. "Airport", "Tracking").
+//   - A large mono-extrabold "code" line (e.g. "BOS · KBOS", "DAL2043")
+//     with a horizontal rule trailing off to the right.
+//   - Whatever else the caller passes as children below the hero.
+//
+// Spacing, padding, and typography are unified across both pages by going
+// through this primitive instead of letting each page hand-roll its own
+// label/hero/ruler trio.
+export default function SidebarIdentityHero({
+  label,
+  code,
+  codeClassName = "",
+  children,
+}) {
+  return (
+    <div className="airport-sidebar-identity">
+      <div className="text-[10px] font-semibold uppercase tracking-normal text-atc-faint">
+        {label}
+      </div>
+      <div className="mt-3 flex items-baseline gap-3">
+        <span
+          className={`airport-sidebar-display-mono airport-sidebar-display-mono--hero text-[28px] font-extrabold text-atc-text ${codeClassName}`}
+        >
+          {code}
+        </span>
+        <span
+          aria-hidden="true"
+          className="h-px flex-1 bg-[var(--atc-line-strong)]"
+        />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/sidebar/SidebarMetric.jsx
+++ b/src/components/sidebar/SidebarMetric.jsx
@@ -1,0 +1,68 @@
+"use client";
+
+// Two-column metric grid used at the top of every sidebar. Renders rows
+// of stat-card cells (label, value, unit). The airport sidebar uses it
+// as a tab strip (WEATHER / FLIGHTS, interactive); the flight sidebar
+// uses it to display the focal aircraft's telemetry as static cells.
+//
+// Divider lines are applied automatically:
+//   - Every "even" cell (the right column) gets a left border so the
+//     vertical seam between the two columns is consistent.
+//   - Cells past the first row get a top border so multi-row grids
+//     still read as a panel of cards.
+
+export function SidebarMetricGrid({ children, label = "Metrics" }) {
+  return (
+    <div className="sidebar-metric-grid" role="group" aria-label={label}>
+      {children}
+    </div>
+  );
+}
+
+export function SidebarMetricCard({
+  label,
+  value,
+  unit = "",
+  active = false,
+  onClick,
+}) {
+  const className = [
+    "sidebar-metric-card",
+    active ? "sidebar-metric-card--active" : "",
+    onClick ? "sidebar-metric-card--interactive" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const body = (
+    <>
+      <span className="sidebar-metric-card__label">{label}</span>
+      <strong className="sidebar-metric-card__value airport-sidebar-display-mono airport-sidebar-display-mono--metric">
+        {value}
+      </strong>
+      {unit ? (
+        <small className="sidebar-metric-card__unit">{unit}</small>
+      ) : (
+        <small className="sidebar-metric-card__unit" aria-hidden="true">
+          &nbsp;
+        </small>
+      )}
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active}
+        className={className}
+        onClick={onClick}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return <div className={className}>{body}</div>;
+}

--- a/src/components/sidebar/SidebarShell.jsx
+++ b/src/components/sidebar/SidebarShell.jsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import RequestPulseDots from "@/components/ui/RequestPulseDots";
+
+// Shared chrome for the airport + flight sidebars. Handles:
+//   - The outer panel container + responsive overlay variant.
+//   - The sticky nav row (back to ADSBao + feed status / mobile close).
+//   - The "fixed top section / scrolling list" body split.
+//
+// Pages provide their identity content via `header` and the scrollable
+// content (typically the AircraftTable) via `children`.
+export default function SidebarShell({
+  feedStatus = "live",
+  feedSource = "",
+  lastUpdated = null,
+  onBack,
+  onClose = null,
+  header,
+  children,
+  variant = "airport",
+}) {
+  const isMobileOverlay = Boolean(onClose);
+  const updatedLabel = formatUpdated(lastUpdated);
+
+  const panelClasses = [
+    "sidebar-shell flex h-full flex-col border-r border-atc-line-strong bg-atc-bg",
+    variant === "airport" ? "airport-sidebar-panel" : "flight-sidebar-panel",
+    isMobileOverlay
+      ? variant === "airport"
+        ? "airport-sidebar-panel--mobile"
+        : "flight-sidebar-panel--mobile"
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={panelClasses}>
+      <div className="sticky top-0 z-20 flex h-11 flex-none items-center justify-between gap-4 border-b border-atc-line-strong bg-atc-bg px-6">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-normal text-atc-faint transition-colors hover:text-atc-text"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>ADSBao</span>
+        </button>
+        {onClose ? (
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-normal text-atc-faint transition-colors hover:text-atc-text"
+          >
+            <span>Map</span>
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        ) : (
+          <span
+            className={`airport-feed-status airport-feed-status--${feedStatus} inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-normal text-atc-dim tabular-nums`}
+          >
+            {feedSource ? (
+              <span className="airport-feed-status__source">{feedSource}</span>
+            ) : null}
+            <RequestPulseDots ariaLabel="Live feed" />
+            {updatedLabel ? <span key={updatedLabel}>{updatedLabel}</span> : null}
+          </span>
+        )}
+      </div>
+
+      <div
+        className={
+          isMobileOverlay
+            ? "flex flex-none flex-col overflow-visible"
+            : "flex flex-1 flex-col overflow-hidden"
+        }
+      >
+        {header ? <div className="flex-none">{header}</div> : null}
+        <div
+          className={
+            isMobileOverlay
+              ? "flex-none overflow-visible"
+              : "flex-1 overflow-y-auto"
+          }
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatUpdated(date) {
+  if (!date) return "";
+  return date.toLocaleTimeString([], {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}

--- a/src/components/sidebar/SidebarViewSwitch.jsx
+++ b/src/components/sidebar/SidebarViewSwitch.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import NumberFlow from "@number-flow/react";
+import { SidebarMetricCard, SidebarMetricGrid } from "./SidebarMetric";
 
 export default function SidebarViewSwitch({
   activeView = "briefing",
@@ -12,50 +13,22 @@ export default function SidebarViewSwitch({
   const rule = metar?.flightCategory?.toUpperCase() || "WX";
 
   return (
-    <div className="airport-sidebar-view-switch" role="tablist" aria-label="Airport sidebar views">
-      <SwitchButton
-        active={activeView === "briefing"}
+    <SidebarMetricGrid label="Airport sidebar views">
+      <SidebarMetricCard
         label="Weather"
         value={temperature.value}
         unit={temperature.unit}
+        active={activeView === "briefing"}
         onClick={() => onViewChange?.("briefing")}
       />
-      <SwitchButton
-        active={activeView === "traffic"}
+      <SidebarMetricCard
         label="Flights"
         value={<NumberFlow value={aircraftCount} />}
         unit={`${rule} / ADS-B`}
-        divided
+        active={activeView === "traffic"}
         onClick={() => onViewChange?.("traffic")}
       />
-    </div>
-  );
-}
-
-function SwitchButton({
-  active = false,
-  label,
-  value,
-  unit = "",
-  divided = false,
-  onClick,
-}) {
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      className={`airport-sidebar-view-switch__button ${
-        active ? "airport-sidebar-view-switch__button--active" : ""
-      } ${divided ? "airport-sidebar-view-switch__button--divided" : ""}`}
-      onClick={onClick}
-    >
-      <span>{label}</span>
-      <strong className="airport-sidebar-display-mono airport-sidebar-display-mono--metric">
-        {value}
-      </strong>
-      {unit ? <small>{unit}</small> : null}
-    </button>
+    </SidebarMetricGrid>
   );
 }
 

--- a/src/components/ui/MapControlBar.jsx
+++ b/src/components/ui/MapControlBar.jsx
@@ -17,6 +17,7 @@ const LAYER_DRAWER_ID = "map-layer-drawer";
 
 export default function MapControlBar({
   activeZoom = ZOOM_AIRPORT,
+  zoomActive = true,
   showMapLabels = false,
   showRunwayBeams = true,
   showRoutingPointBadges = true,
@@ -24,6 +25,7 @@ export default function MapControlBar({
   onToggleMapLabels,
   onToggleRunwayBeams,
   onToggleRoutingPointBadges,
+  onFitToTrace = null,
 }) {
   const controlZone = useRef(null);
   const [layerDrawerOpen, setLayerDrawerOpen] = useState(false);
@@ -70,6 +72,7 @@ export default function MapControlBar({
 
         <MapControlRail
           currentZoomOption={currentZoomOption}
+          zoomActive={zoomActive}
           currentTheme={themePreference}
           themeTitle={themeTitle}
           layerDrawerOpen={layerDrawerOpen}
@@ -77,6 +80,7 @@ export default function MapControlBar({
           audioReady={audioReady}
           layerDrawerId={LAYER_DRAWER_ID}
           onCycleZoom={cycleZoom}
+          onFitToTrace={onFitToTrace}
           onToggleAudio={toggleAudio}
           onCycleTheme={cycleTheme}
           onToggleLayerDrawer={toggleLayerDrawer}

--- a/src/config/about.js
+++ b/src/config/about.js
@@ -1,5 +1,5 @@
 export const ABOUT_BUILD_META = [
-  { label: "Version", value: "0.11.0" },
+  { label: "Version", value: "0.12.0" },
   { label: "Release", value: "Next.js Web" },
   { label: "Stack", value: "React 19 · Next 16 · Leaflet" },
   { label: "Scope", value: "Maps · Weather · Traffic" },

--- a/src/config/aviation.js
+++ b/src/config/aviation.js
@@ -19,6 +19,7 @@ export const AIRCRAFT_TRAFFIC_CONFIG = {
 export const AVIATION_PROXY_BASES = {
   metar: "/api/proxy/metar",
   aircraftPositions: "/api/proxy/aircraft/positions",
+  aircraftCallsign: "/api/proxy/aircraft/callsign",
   aircraftPhotos: "/api/proxy/aircraft/photos",
   aircraftTrace: "/api/proxy/aircraft/trace",
   flightRoute: "/api/proxy/flight-routes/callsign",
@@ -30,6 +31,7 @@ export const AVIATION_REQUEST_TIMEOUT_MS = {
   metar: 10_000,
   localWeather: 10_000,
   aircraftPositions: AIRCRAFT_TRAFFIC_CONFIG.pollMs,
+  aircraftCallsign: 6_000,
   aircraftPhoto: 8_000,
   aircraftTrace: 12_000,
   flightRoute: 10_000,

--- a/src/features/aircraft/callsign/aircraftCallsign.mechanism.js
+++ b/src/features/aircraft/callsign/aircraftCallsign.mechanism.js
@@ -1,0 +1,125 @@
+import { readResponseJson } from "../../../app/api/_shared/apiProxySecurity.js";
+import { CALLSIGN_PROVIDER_CHAIN } from "../../aviation/aircraftDataProviders.js";
+import {
+  createAdaptiveProviderSelector,
+  raceProviders,
+} from "../../aviation/providerHealth.js";
+
+import {
+  AIRCRAFT_CALLSIGN_MAX_BYTES,
+  AIRCRAFT_CALLSIGN_USER_AGENT,
+  AircraftCallsignProviderError,
+} from "./aircraftCallsign.models.js";
+
+const selector = createAdaptiveProviderSelector();
+
+const formatAttempt = (providerId, error) => {
+  if (!error) return `${providerId}:200`;
+  return `${providerId}:${error.status || "ERR"}`;
+};
+
+async function fetchProviderPayload(provider, { callsign }) {
+  const url = provider.buildCallsignUrl({ callsign });
+
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": AIRCRAFT_CALLSIGN_USER_AGENT,
+      },
+      next: { revalidate: 0 },
+    });
+  } catch (networkError) {
+    throw new AircraftCallsignProviderError(
+      `network: ${networkError.message}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new AircraftCallsignProviderError(
+      `HTTP ${response.status}`,
+      response.status,
+    );
+  }
+
+  let payload;
+  try {
+    payload = await readResponseJson(response, {
+      label: `${provider.id} callsign response`,
+      maxBytes: AIRCRAFT_CALLSIGN_MAX_BYTES,
+    });
+  } catch (parseError) {
+    throw new AircraftCallsignProviderError(`parse: ${parseError.message}`);
+  }
+
+  if (!payload || typeof payload !== "object" || !Array.isArray(payload.ac)) {
+    throw new AircraftCallsignProviderError("Invalid callsign payload");
+  }
+
+  return payload;
+}
+
+const successResult = (provider, payload, attempts) => ({
+  payload: { ...payload, source: provider.id },
+  source: provider.id,
+  attempts,
+});
+
+export const fetchAircraftByCallsign = async ({ callsign } = {}) => {
+  if (!callsign) {
+    throw new AircraftCallsignProviderError("Callsign required", 400);
+  }
+
+  const fetcher = (provider) => fetchProviderPayload(provider, { callsign });
+  const attempts = [];
+
+  const preferredId = selector.getPreferredId();
+  const preferred = preferredId
+    ? CALLSIGN_PROVIDER_CHAIN.find((provider) => provider.id === preferredId)
+    : null;
+
+  if (preferred) {
+    try {
+      const payload = await fetcher(preferred);
+      attempts.push(formatAttempt(preferred.id));
+      return successResult(preferred, payload, attempts);
+    } catch (error) {
+      attempts.push(formatAttempt(preferred.id, error));
+      console.warn(
+        `[aircraft-callsign] preferred ${preferred.id} failed, racing`,
+        error.status ? `status=${error.status}` : error.message,
+      );
+      selector.clear();
+    }
+  }
+
+  try {
+    const { provider, payload } = await raceProviders(
+      CALLSIGN_PROVIDER_CHAIN,
+      fetcher,
+    );
+    selector.setPreferredId(provider.id);
+    attempts.push(formatAttempt(provider.id));
+    return successResult(provider, payload, attempts);
+  } catch (aggregate) {
+    const errors = aggregate?.errors || [aggregate];
+    for (let index = 0; index < CALLSIGN_PROVIDER_CHAIN.length; index += 1) {
+      const provider = CALLSIGN_PROVIDER_CHAIN[index];
+      const error = errors[index];
+      attempts.push(formatAttempt(provider.id, error));
+      console.warn(
+        `[aircraft-callsign] race: ${provider.id} failed`,
+        error?.status ? `status=${error.status}` : error?.message,
+      );
+    }
+
+    const lastError = errors[errors.length - 1];
+    const error = new AircraftCallsignProviderError(
+      "Failed to load aircraft by callsign",
+      Number(lastError?.status) || 502,
+    );
+    error.attempts = attempts;
+    throw error;
+  }
+};

--- a/src/features/aircraft/callsign/aircraftCallsign.models.js
+++ b/src/features/aircraft/callsign/aircraftCallsign.models.js
@@ -1,0 +1,12 @@
+export const AIRCRAFT_CALLSIGN_USER_AGENT =
+  "ADSBao/0.12.0 (https://github.com/orriduck/ADSBao)";
+
+export const AIRCRAFT_CALLSIGN_MAX_BYTES = 1 * 1024 * 1024;
+
+export class AircraftCallsignProviderError extends Error {
+  constructor(message, status = null) {
+    super(message);
+    this.name = "AircraftCallsignProviderError";
+    this.status = status;
+  }
+}

--- a/src/features/aircraft/callsign/aircraftCallsignClient.js
+++ b/src/features/aircraft/callsign/aircraftCallsignClient.js
@@ -1,0 +1,36 @@
+import {
+  AVIATION_PROXY_BASES,
+  AVIATION_REQUEST_TIMEOUT_MS,
+} from "../../../config/aviation.js";
+import { withAuditLogging } from "../../../utils/apiLogger.js";
+import { fetchJson } from "../../aviation/httpClient.js";
+
+const env = typeof process !== "undefined" ? process.env : {};
+
+export const createAircraftCallsignClient = ({
+  fetchImpl = globalThis.fetch?.bind(globalThis),
+  baseUrl =
+    env.NEXT_PUBLIC_AIRCRAFT_CALLSIGN_BASE ||
+    AVIATION_PROXY_BASES.aircraftCallsign,
+} = {}) => {
+  if (!fetchImpl)
+    throw new Error("Aircraft callsign client requires fetch support");
+
+  const auditedFetch = withAuditLogging(fetchImpl, {
+    service: "adsb.lol/Callsign",
+  });
+
+  return {
+    fetchByCallsign({ callsign }) {
+      const normalized = String(callsign || "").trim().toUpperCase();
+      if (!normalized) {
+        throw new Error("Aircraft callsign required");
+      }
+      return fetchJson(
+        auditedFetch,
+        `${baseUrl}/${encodeURIComponent(normalized)}`,
+        { timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.aircraftCallsign },
+      );
+    },
+  };
+};

--- a/src/features/aircraft/filters/aircraftFilters.js
+++ b/src/features/aircraft/filters/aircraftFilters.js
@@ -14,7 +14,18 @@ export const DEFAULT_AIRCRAFT_FILTERS = Object.freeze({
   trafficFilter: "all",
   typeFilter: "all",
   altitudeLevel: "all",
+  // What kind of entities to show in the list:
+  //   "all"      — aircraft + nearby airports
+  //   "airports" — nearby airports only
+  //   "aircraft" — aircraft only
+  entityFilter: "all",
 });
+
+export const ENTITY_FILTER_OPTIONS = [
+  { value: "all", label: "All" },
+  { value: "aircraft", label: "Aircraft" },
+  { value: "airports", label: "Airports" },
+];
 
 // ADS-B emitter / wake-class categories. A1–A7 map to specific labels; anything
 // outside (B*, C*, A0, blank) collapses into a single "Other" bucket so the

--- a/src/features/aircraft/photos/aircraftPhotos.models.js
+++ b/src/features/aircraft/photos/aircraftPhotos.models.js
@@ -1,5 +1,5 @@
 export const AIRCRAFT_PHOTOS_USER_AGENT =
-  "ADSBao/0.11.0 (+https://github.com/orriduck/ADSBao)";
+  "ADSBao/0.12.0 (+https://github.com/orriduck/ADSBao)";
 
 export const AIRCRAFT_PHOTO_MAX_BYTES = 256 * 1024;
 export const AIRCRAFT_PHOTO_IMAGE_MAX_BYTES = 2 * 1024 * 1024;

--- a/src/features/aircraft/positions/aircraftPositions.models.js
+++ b/src/features/aircraft/positions/aircraftPositions.models.js
@@ -1,5 +1,5 @@
 export const AIRCRAFT_POSITIONS_USER_AGENT =
-  "ADSBao/0.11.0 (https://github.com/orriduck/ADSBao)";
+  "ADSBao/0.12.0 (https://github.com/orriduck/ADSBao)";
 
 export const AIRCRAFT_POSITIONS_MAX_BYTES = 2 * 1024 * 1024;
 

--- a/src/features/aircraft/trace/aircraftTrace.mechanism.js
+++ b/src/features/aircraft/trace/aircraftTrace.mechanism.js
@@ -10,8 +10,10 @@ import { formatAircraftTraceAttempt } from "./aircraftTrace.utils.js";
 
 const [TRACE_PROVIDER] = TRACE_PROVIDER_CHAIN;
 
-async function fetchTrace({ hex }) {
-  const url = TRACE_PROVIDER.buildTraceUrl({ hex });
+async function fetchTrace({ hex, full = false }) {
+  const url = full
+    ? TRACE_PROVIDER.buildFullTraceUrl({ hex })
+    : TRACE_PROVIDER.buildTraceUrl({ hex });
 
   let response;
   try {
@@ -41,9 +43,9 @@ async function fetchTrace({ hex }) {
   }
 }
 
-export const getAircraftTrace = async ({ hex } = {}) => {
+export const getAircraftTrace = async ({ hex, full = false } = {}) => {
   try {
-    const recent = await fetchTrace({ hex });
+    const recent = await fetchTrace({ hex, full });
     if (!recent) {
       return {
         found: false,

--- a/src/features/aircraft/trace/aircraftTrace.models.js
+++ b/src/features/aircraft/trace/aircraftTrace.models.js
@@ -1,7 +1,9 @@
 export const AIRCRAFT_TRACE_USER_AGENT =
-  "ADSBao/0.11.0 (https://github.com/orriduck/ADSBao)";
+  "ADSBao/0.12.0 (https://github.com/orriduck/ADSBao)";
 
-export const AIRCRAFT_TRACE_MAX_BYTES = 6 * 1024 * 1024;
+// Full traces for long-haul flights can run several MB — bump the
+// upstream-response cap accordingly. Recent traces are still small.
+export const AIRCRAFT_TRACE_MAX_BYTES = 24 * 1024 * 1024;
 
 export class AircraftTraceProviderError extends Error {
   constructor(message, status = null) {

--- a/src/features/aircraft/trace/aircraftTraceClient.js
+++ b/src/features/aircraft/trace/aircraftTraceClient.js
@@ -20,13 +20,18 @@ export const createAircraftTraceClient = ({
   });
 
   return {
-    fetchAircraftTrace({ hex }) {
+    fetchAircraftTrace({ hex, full = false }) {
       const normalizedHex = normalizeAircraftHex(hex);
       if (!normalizedHex) throw new Error("Invalid aircraft trace query");
 
-      return fetchJson(auditedFetch, `${baseUrl}/${encodeURIComponent(normalizedHex)}`, {
+      const path = `${baseUrl}/${encodeURIComponent(normalizedHex)}${
+        full ? "?full=1" : ""
+      }`;
+      return fetchJson(auditedFetch, path, {
         timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.aircraftTrace,
-        maxBytes: 6 * 1024 * 1024,
+        // Full traces for long-haul flights can run multi-MB — give the
+        // client buffer some headroom too.
+        maxBytes: 24 * 1024 * 1024,
       });
     },
   };

--- a/src/features/airport/context/airportContextUiModel.js
+++ b/src/features/airport/context/airportContextUiModel.js
@@ -1,5 +1,8 @@
 const PRIMARY_OPACITY = 1;
-const DIMMED_OPACITY = 0.28;
+// Lighter dim than the original 0.28 — selecting an aircraft should
+// privilege the focal/clicked plane but the rest of the traffic still
+// needs to read clearly enough to scan the scene.
+const DIMMED_OPACITY = 0.55;
 
 export function getAircraftIdentity(aircraft = {}) {
   return aircraft.icao24 || aircraft.callsign || "";

--- a/src/features/airport/context/airportContextUiModel.test.js
+++ b/src/features/airport/context/airportContextUiModel.test.js
@@ -37,7 +37,7 @@ assert.deepEqual(resolveAircraftContextEmphasis({ matchesFilters: true }), {
   showLabel: true,
 });
 assert.deepEqual(resolveAircraftContextEmphasis({ matchesFilters: false }), {
-  opacity: 0.28,
+  opacity: 0.55,
   showLabel: false,
 });
 assert.deepEqual(

--- a/src/features/app-shell/useThemePreference.js
+++ b/src/features/app-shell/useThemePreference.js
@@ -26,6 +26,10 @@ export function useThemePreference() {
     });
     setThemePreference(initialized.preference);
     themePreferenceRef.current = initialized.preference;
+    // Mirror localStorage into the cookie so the server-rendered
+    // <html data-theme> matches the user's stored choice on the next
+    // request. One-shot migration for users who pre-date the cookie.
+    writeStoredTheme(initialized.preference);
 
     const listener = () => {
       if (themePreferenceRef.current === THEME_SYSTEM) {

--- a/src/features/aviation/aircraftDataProviders.js
+++ b/src/features/aviation/aircraftDataProviders.js
@@ -12,10 +12,23 @@ export const ADSB_LOL = Object.freeze({
     )}/lon/${encodeURIComponent(String(lon))}/dist/${encodeURIComponent(
       String(distanceNm),
     )}`,
+  buildCallsignUrl: ({ callsign }) =>
+    `https://api.adsb.lol/v2/callsign/${encodeURIComponent(
+      String(callsign || "").toUpperCase(),
+    )}`,
   buildTraceUrl: ({ hex }) => {
     const lower = String(hex || "").toLowerCase();
     const suffix = lower.slice(-2);
     return `https://adsb.lol/data/traces/${suffix}/trace_recent_${lower}.json`;
+  },
+  // Full trace = the entire flight from gate to gate. Larger payload
+  // than trace_recent (which is just the rolling tail), used when the
+  // aircraft tracking page first initializes so the user sees the
+  // complete path on load.
+  buildFullTraceUrl: ({ hex }) => {
+    const lower = String(hex || "").toLowerCase();
+    const suffix = lower.slice(-2);
+    return `https://adsb.lol/data/traces/${suffix}/trace_full_${lower}.json`;
   },
 });
 
@@ -28,10 +41,18 @@ export const AIRPLANES_LIVE = Object.freeze({
     )}/${encodeURIComponent(String(lon))}/${encodeURIComponent(
       String(distanceNm),
     )}`,
+  buildCallsignUrl: ({ callsign }) =>
+    `https://api.airplanes.live/v2/callsign/${encodeURIComponent(
+      String(callsign || "").toUpperCase(),
+    )}`,
   buildTraceUrl: null,
 });
 
 export const POSITION_PROVIDER_CHAIN = Object.freeze([
+  ADSB_LOL,
+  AIRPLANES_LIVE,
+]);
+export const CALLSIGN_PROVIDER_CHAIN = Object.freeze([
   ADSB_LOL,
   AIRPLANES_LIVE,
 ]);

--- a/src/features/aviation/aviationData.js
+++ b/src/features/aviation/aviationData.js
@@ -1,4 +1,5 @@
 import { AIRCRAFT_TRAFFIC_CONFIG } from "../../config/aviation.js";
+import { createAircraftCallsignClient } from "../aircraft/callsign/aircraftCallsignClient.js";
 import { createAircraftPhotoClient } from "../aircraft/photos/aircraftPhotoClient.js";
 import { createAircraftPositionClient } from "../aircraft/positions/aircraftPositionClient.js";
 import { createAircraftTraceClient } from "../aircraft/trace/aircraftTraceClient.js";
@@ -6,6 +7,7 @@ import { createFlightRouteClient } from "./flight-routes/flightRouteClient.js";
 import { createLocalWeatherClient } from "../weather/localWeatherClient.js";
 import { createMetarClient } from "../weather/metar/metarClient.js";
 
+export { createAircraftCallsignClient } from "../aircraft/callsign/aircraftCallsignClient.js";
 export { createAircraftPhotoClient } from "../aircraft/photos/aircraftPhotoClient.js";
 export { createAircraftPositionClient } from "../aircraft/positions/aircraftPositionClient.js";
 export { createAircraftTraceClient } from "../aircraft/trace/aircraftTraceClient.js";
@@ -20,6 +22,7 @@ export const DEFAULT_AIRCRAFT_POLL_MS = AIRCRAFT_TRAFFIC_CONFIG.pollMs;
 export const DEFAULT_AIRCRAFT_RANGE_NM = AIRCRAFT_TRAFFIC_CONFIG.rangeNm;
 
 export const metarClient = createMetarClient();
+export const aircraftCallsignClient = createAircraftCallsignClient();
 export const aircraftPhotoClient = createAircraftPhotoClient();
 export const aircraftPositionClient = createAircraftPositionClient();
 export const aircraftTraceClient = createAircraftTraceClient();

--- a/src/features/aviation/flight-routes/vrsRouteProxyModel.js
+++ b/src/features/aviation/flight-routes/vrsRouteProxyModel.js
@@ -2,7 +2,7 @@ export const VRS_STANDING_DATA_BASE =
   "https://vrs-standing-data.adsb.lol/routes";
 
 export const VRS_ROUTE_USER_AGENT =
-  "ADSBao/0.11.0 (+https://github.com/orriduck/ADSBao) VRS-standing-data/1.0";
+  "ADSBao/0.12.0 (+https://github.com/orriduck/ADSBao) VRS-standing-data/1.0";
 
 export const VRS_ROUTE_MISS_STATUS = 200;
 

--- a/src/hooks/useAircraftTrace.js
+++ b/src/hooks/useAircraftTrace.js
@@ -7,6 +7,39 @@ import {
   normalizeAdsbTracePayload,
 } from "../features/aircraft/trace/aircraftTraceModel.js";
 
+// Session-level cache of trace points keyed by ICAO24 hex + trace mode
+// (recent vs full). Lets the user flip between aircraft without re-paying
+// the fetch each time: warm-start from any prior render, then a background
+// refresh. Module scope, not persisted across reloads.
+const traceCache = new Map();
+const TRACE_CACHE_TTL_MS = 90_000;
+// Full traces are heavier and update less often; cache them longer so the
+// user can flip away and back without re-paying the multi-MB fetch.
+const TRACE_FULL_CACHE_TTL_MS = 10 * 60 * 1000;
+
+function cacheKey(hex, fullTrace) {
+  return `${fullTrace ? "full" : "recent"}:${hex}`;
+}
+
+function readTraceCache(hex, fullTrace) {
+  const entry = traceCache.get(cacheKey(hex, fullTrace));
+  if (!entry) return null;
+  const ttl = fullTrace ? TRACE_FULL_CACHE_TTL_MS : TRACE_CACHE_TTL_MS;
+  if (Date.now() - entry.fetchedAt > ttl) {
+    traceCache.delete(cacheKey(hex, fullTrace));
+    return null;
+  }
+  return entry;
+}
+
+function writeTraceCache(hex, fullTrace, tracePoints) {
+  if (!hex) return;
+  traceCache.set(cacheKey(hex, fullTrace), {
+    tracePoints,
+    fetchedAt: Date.now(),
+  });
+}
+
 function liveAircraftToTracePoint(aircraft) {
   if (!aircraft) return null;
   const lat = Number(aircraft.lat);
@@ -31,17 +64,20 @@ function liveAircraftToTracePoint(aircraft) {
   };
 }
 
-export function useAircraftTrace(selectedAircraft = null) {
+export function useAircraftTrace(selectedAircraft = null, options = {}) {
   const hex = selectedAircraft?.icao24 || "";
+  const fullTrace = Boolean(options?.fullTrace);
   const [traceState, setTraceState] = useState({
     hex: "",
     tracePoints: [],
   });
   const [loading, setLoading] = useState(false);
 
-  // Fetch the recent trace once when the selection changes. Merge into
-  // whatever live points have already accumulated so we don't trample
-  // positions that polled in between selection and fetch resolution.
+  // Fetch the recent trace once when the selection changes. Warm-start
+  // from the session cache so re-selecting the same aircraft doesn't
+  // black out the trail mid-render; merge into whatever live points have
+  // already accumulated so we don't trample positions that polled in
+  // between selection and fetch resolution.
   useEffect(() => {
     if (!hex) {
       setTraceState({ hex: "", tracePoints: [] });
@@ -50,21 +86,26 @@ export function useAircraftTrace(selectedAircraft = null) {
     }
 
     let disposed = false;
-    setTraceState({ hex, tracePoints: [] });
-    setLoading(true);
+    const cached = readTraceCache(hex, fullTrace);
+    setTraceState({
+      hex,
+      tracePoints: cached?.tracePoints || [],
+    });
+    setLoading(!cached);
 
     aircraftTraceClient
-      .fetchAircraftTrace({ hex })
+      .fetchAircraftTrace({ hex, full: fullTrace })
       .then((payload) => {
         if (disposed) return;
         const recent = normalizeAdsbTracePayload(payload?.recent);
-        setTraceState((current) => ({
-          hex,
-          tracePoints: mergeTraceHistory({
+        setTraceState((current) => {
+          const merged = mergeTraceHistory({
             recentTrace: recent,
             fallbackHistory: current.hex === hex ? current.tracePoints : [],
-          }),
-        }));
+          });
+          writeTraceCache(hex, fullTrace, merged);
+          return { hex, tracePoints: merged };
+        });
       })
       .catch((error) => {
         if (!disposed) {
@@ -78,7 +119,7 @@ export function useAircraftTrace(selectedAircraft = null) {
     return () => {
       disposed = true;
     };
-  }, [hex]);
+  }, [hex, fullTrace]);
 
   // Append the latest polled position to the trace so the trail extends
   // forward in real time. Wait until the recent-trace fetch has resolved
@@ -94,15 +135,14 @@ export function useAircraftTrace(selectedAircraft = null) {
     if (!point) return;
     setTraceState((current) => {
       if (current.hex !== hex) return current;
-      return {
-        hex,
-        tracePoints: mergeTraceHistory({
-          recentTrace: [point],
-          fallbackHistory: current.tracePoints,
-        }),
-      };
+      const merged = mergeTraceHistory({
+        recentTrace: [point],
+        fallbackHistory: current.tracePoints,
+      });
+      writeTraceCache(hex, fullTrace, merged);
+      return { hex, tracePoints: merged };
     });
-  }, [hex, loading, selectedAircraft]);
+  }, [hex, loading, selectedAircraft, fullTrace]);
 
   return {
     tracePoints: traceState.hex === hex ? traceState.tracePoints : [],

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { aircraftCallsignClient } from "../features/aviation/aviationData.js";
+import { AIRCRAFT_TRAFFIC_CONFIG } from "../config/aviation.js";
+import {
+  normalizeAdsbAircraft,
+} from "../features/aircraft/positions/aircraftPositionsModel.js";
+
+// Polls the upstream ADS-B feed for the focal callsign so the flight
+// tracking page knows where the aircraft is right now and where to center
+// the map. The hook returns the latest normalized snapshot for that
+// aircraft (or null while we wait / when it's no longer reporting).
+export function useTrackedAircraft(callsign) {
+  const [aircraft, setAircraft] = useState(null);
+  const [feedSource, setFeedSource] = useState("");
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [error, setError] = useState(null);
+  const [initialLoading, setInitialLoading] = useState(false);
+  const timerRef = useRef(null);
+  const disposedRef = useRef(false);
+
+  useEffect(() => {
+    disposedRef.current = false;
+
+    if (!callsign) {
+      setAircraft(null);
+      setInitialLoading(false);
+      setLastUpdated(null);
+      setError(null);
+      return undefined;
+    }
+
+    setInitialLoading(true);
+    setError(null);
+
+    const poll = async () => {
+      try {
+        const payload = await aircraftCallsignClient.fetchByCallsign({
+          callsign,
+        });
+        if (disposedRef.current) return;
+        const matches = Array.isArray(payload?.ac) ? payload.ac : [];
+        const receiveTime = Date.now();
+        if (matches.length === 0) {
+          setAircraft(null);
+        } else {
+          // Pick the freshest entry — multiple aircraft can share a
+          // callsign across operators; the one currently broadcasting is
+          // what we want.
+          const best = pickFreshest(matches);
+          const normalized = normalizeAdsbAircraft(best, {
+            responseNow: payload?.now,
+            receiveTime,
+          });
+          setAircraft(normalized);
+        }
+        setFeedSource(
+          typeof payload?.source === "string" ? payload.source : "",
+        );
+        setLastUpdated(new Date(receiveTime));
+        setError(null);
+      } catch (err) {
+        if (disposedRef.current) return;
+        console.warn(`[tracked-aircraft] ${callsign} fetch failed`, err);
+        setError(err);
+      } finally {
+        if (!disposedRef.current) setInitialLoading(false);
+      }
+    };
+
+    poll();
+    timerRef.current = setInterval(poll, AIRCRAFT_TRAFFIC_CONFIG.pollMs);
+
+    return () => {
+      disposedRef.current = true;
+      if (timerRef.current) clearInterval(timerRef.current);
+      timerRef.current = null;
+    };
+  }, [callsign]);
+
+  return { aircraft, feedSource, lastUpdated, initialLoading, error };
+}
+
+function pickFreshest(entries) {
+  let best = entries[0];
+  for (const entry of entries) {
+    const a = Number(entry?.seen ?? Number.POSITIVE_INFINITY);
+    const b = Number(best?.seen ?? Number.POSITIVE_INFINITY);
+    if (a < b) best = entry;
+  }
+  return best;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -3027,6 +3027,16 @@ body {
     color: var(--atc-faint);
 }
 
+.sidebar-shell {
+    /* Shared baseline tokens for every sidebar variant: padding inset and
+       the typography stack. Defined on the shell so AircraftTable rows
+       (which read --airport-sidebar-inset for horizontal padding) align
+       identically on the airport and flight pages. */
+    --airport-sidebar-inset: 28px;
+    --airport-sidebar-sans: "Inter", var(--font-sans);
+    font-family: var(--airport-sidebar-sans);
+}
+
 .airport-sidebar-panel {
     --airport-sidebar-inset: 28px;
     --airport-sidebar-sans: "Inter", var(--font-sans);
@@ -3047,13 +3057,13 @@ body {
 
 .airport-sidebar-display-mono--hero {
     font-weight: 800;
-    letter-spacing: 0.105em;
+    letter-spacing: -0.025em;
     line-height: 0.95;
 }
 
 .airport-sidebar-display-mono--metric {
     font-weight: 800;
-    letter-spacing: 0.06em;
+    letter-spacing: -0.025em;
     line-height: 0.9;
 }
 
@@ -3064,6 +3074,137 @@ body {
 
 .airport-sidebar-identity {
     padding: 28px var(--airport-sidebar-inset) 24px;
+}
+
+/* Two-column metric grid shared between the airport sidebar (interactive
+   WEATHER/FLIGHTS tabs) and the flight sidebar (focal aircraft telemetry
+   cards). Auto-divides between columns and across rows so any number of
+   cards reads as a coherent panel. */
+.sidebar-metric-grid {
+    border-bottom: 1px solid var(--atc-line);
+    border-top: 1px solid var(--atc-line);
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.sidebar-metric-card {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: var(--atc-text);
+    align-content: center;
+    display: grid;
+    gap: 8px;
+    grid-template-rows: 16px 44px 14px;
+    isolation: isolate;
+    min-height: 116px;
+    min-width: 0;
+    overflow: hidden;
+    padding: 22px var(--airport-sidebar-inset) 20px;
+    position: relative;
+    text-align: left;
+    /* Static stat cards on the flight page shouldn't behave like
+       clickable surfaces — disable text selection + the user-agent's
+       text caret so clicking just feels inert. The button variant
+       (interactive) overrides cursor below. */
+    cursor: default;
+    user-select: none;
+    -webkit-user-select: none;
+    transition:
+        background 0.18s ease,
+        box-shadow 0.18s ease,
+        color 0.18s ease;
+}
+
+.sidebar-metric-card--interactive {
+    cursor: pointer;
+}
+
+/* Active-state glow — same "light rising from the bottom" treatment the
+   aircraft filter cards use. Fades in over ~360ms when the metric becomes
+   active. */
+.sidebar-metric-card::after {
+    background: var(--atc-tab-glow);
+    content: "";
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    transition: opacity 360ms ease;
+    z-index: 0;
+}
+
+.sidebar-metric-card--active::after {
+    opacity: 1;
+}
+
+.sidebar-metric-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+/* Vertical seam between the two columns. */
+.sidebar-metric-card:nth-child(2n) {
+    border-left: 1px solid var(--atc-line);
+}
+
+/* Horizontal seam between rows (anything past the first row). */
+.sidebar-metric-card:nth-child(n + 3) {
+    border-top: 1px solid var(--atc-line);
+}
+
+.sidebar-metric-card__label,
+.sidebar-metric-card__unit {
+    color: var(--atc-faint);
+    font-family: var(--airport-sidebar-sans);
+    text-transform: uppercase;
+}
+
+.sidebar-metric-card__label {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+.sidebar-metric-card__value {
+    align-items: center;
+    color: var(--atc-text);
+    display: flex;
+    font-size: 34px;
+    font-weight: 800;
+    line-height: 1;
+    min-height: 44px;
+}
+
+.sidebar-metric-card__unit {
+    display: block;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0;
+    line-height: 14px;
+    min-height: 14px;
+}
+
+.sidebar-metric-card--interactive:hover,
+.sidebar-metric-card--active {
+    background: color-mix(in oklab, var(--atc-card) 58%, transparent);
+}
+
+/* Active-tab bottom indicator (the accent-colored line) — preserved from
+   the original view-switch design. Painted via inset box-shadow so it
+   doesn't push content / disturb the grid layout. */
+.sidebar-metric-card--active {
+    box-shadow: inset 0 -2px 0 var(--atc-accent);
+}
+
+.sidebar-metric-card--interactive:focus {
+    outline: none;
+}
+
+.sidebar-metric-card--interactive:focus-visible {
+    box-shadow:
+        inset 0 0 0 2px var(--atc-accent),
+        inset 0 -2px 0 var(--atc-accent);
 }
 
 .airport-sidebar-view-switch {
@@ -3364,6 +3505,19 @@ body {
     border-top: 1px solid var(--atc-line);
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* 2 × 2 layout for the four-filter variant (Show / Traffic / Type / Alt).
+   Adds a horizontal seam between rows so the grid reads as a panel of
+   cards rather than a single dense strip. */
+.aircraft-filter-cards--grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.aircraft-filter-cards--grid > .aircraft-filter-card:nth-child(n + 3),
+.aircraft-filter-cards--grid > .aircraft-filter-type > .aircraft-filter-card:nth-child(n + 3),
+.aircraft-filter-cards--grid > *:nth-child(n + 3) {
+    border-top: 1px solid var(--atc-line);
 }
 
 .aircraft-filter-card {
@@ -3904,7 +4058,7 @@ body {
     font-size: 22px;
     font-weight: 800;
     font-style: italic;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.05em;
     line-height: 1;
     color: var(--atc-text);
     white-space: nowrap;
@@ -4017,7 +4171,7 @@ body {
     font-size: 22px;
     font-weight: 800;
     font-style: italic;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.05em;
     line-height: 1;
     color: var(--atc-text);
     min-width: 0;
@@ -4178,6 +4332,42 @@ body {
     backdrop-filter: blur(12px) saturate(1.08);
 }
 
+/* Primary CTA inside the preview card — italic-bold Inter that reads
+   as a confident action ("Track this aircraft"). Card itself has
+   pointer-events:none, so the button restores its own pointer-events. */
+.aircraft-preview-card__track-btn {
+    width: 100%;
+    margin-top: 14px;
+    padding: 10px 14px;
+    border: none;
+    border-radius: 6px;
+    background: var(--atc-accent);
+    color: var(--atc-bg);
+    font-family: 'Inter', system-ui, sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    font-style: italic;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    text-transform: uppercase;
+    cursor: pointer;
+    pointer-events: auto;
+    transition: opacity 0.15s ease-out, transform 0.15s ease-out;
+}
+
+.aircraft-preview-card__track-btn:hover {
+    opacity: 0.92;
+}
+
+.aircraft-preview-card__track-btn:active {
+    transform: scale(0.98);
+}
+
+.aircraft-preview-card__track-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+}
+
 .aircraft-preview-metadata-card__credit {
     display: block;
     margin-bottom: 8px;
@@ -4334,3 +4524,7 @@ body {
     display: block;
     pointer-events: none;
 }
+
+/* Flight tracking sidebar — chrome, identity block, and metric grid are
+   all reused from the airport sidebar via SidebarShell, SidebarIdentityHero,
+   and SidebarMetric. No flight-specific layout CSS remains. */

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -26,8 +26,17 @@ const applyThemePreference = ({
   return { preference: safeTheme, resolvedTheme }
 }
 
+const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
+
 const writeStoredTheme = (theme, storage = window.localStorage) => {
-  storage.setItem(THEME_KEY, sanitizeTheme(theme))
+  const safe = sanitizeTheme(theme)
+  storage.setItem(THEME_KEY, safe)
+  // Mirror the preference into a cookie so the Next.js server layout
+  // can read it on the next request and render the right data-theme
+  // attribute directly — no client-side boot script needed.
+  if (typeof document !== 'undefined') {
+    document.cookie = `${THEME_KEY}=${safe}; Path=/; Max-Age=${THEME_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`
+  }
 }
 
 const initThemePreference = ({


### PR DESCRIPTION
## Summary

Major minor release. New `/aircraft/[callsign]` route shares the same sidebar/map shell as the airport detail page (now at `/airport/[icao]`); preview card + sidebar list are polymorphic over aircraft and airports; theme detection moved to a server-rendered cookie so the React 19 inline-script warning is gone.

### Highlights
- **`/aircraft/[callsign]`** — full layout parity with `/airport/[icao]`: sidebar shell, nav row, map controls. Map centers on the focal aircraft, fetches its trace, and follows it as it moves. Adaptive callsign-by-icao proxy chains `adsb.lol` + `airplanes.live`.
- **Airport route prefix** — `/[icao]` → `/airport/[icao]`. Aircraft route is `/aircraft/[callsign]`. Old URLs not preserved.
- **Polymorphic preview card** — same outer card, swaps aircraft vs airport inner. Aircraft → Track to `/aircraft/[callsign]`; airport → Track to `/airport/[icao]`. Map-marker click + sidebar-row click open the same preview.
- **Polymorphic sidebar list** — aircraft + nearby airports in one table, gated by a new \"Show\" filter (All / Aircraft / Airports). Column rhythm switched to Name / Route · Dist · Alt.
- **Fit-to-trace** map control — zooms to the rendered trace bounds and stops auto-following the focal until the user clicks back to a preset zoom.
- **Cookie-driven SSR theme** — `theme` cookie read via `next/headers#cookies()` and rendered as `<html data-theme>` server-side. No client boot script, no React 19 \"script inside React component\" warning, no flash for users with an explicit preference.

### Shared primitives extracted
- `SidebarShell`, `SidebarIdentityHero`, `SidebarMetric{Grid,Card}` — same chrome on both pages.
- `ExplorerUiContext` / `ExplorerUiProvider` / `useExplorerUi` — moved from `components/airport/explorer/` to `components/explorer/` since both pages consume it; airport-prefix dropped from the names.
- `ExplorerMapMenu` — same move + rename.
- `AircraftPreviewCard` is polymorphic (aircraft or airport variant).
- `AirportMap` accepts `children` rendered inside `MapContext.Provider` for per-page composition.

### Notable fixes
- `MapFitToTraceController` was crashing SSR via its top-level `leaflet` import — now dynamic-imported with `ssr: false`.
- Focal aircraft was being silently filtered out of the flight-page map because `getVisibleAircraft` applied airport-ground filtering against the map's center (which on the flight page IS the focal). Ground filter is now skipped when there's no actual airport.
- Sidebar list rows on the flight page had collapsed-to-zero horizontal padding — `--airport-sidebar-inset` was only declared on `.airport-sidebar-panel`; moved to `.sidebar-shell`.
- Stat-card big numbers were selectable on click, which created a text-selection highlight that read as a click-state. Cards now have `user-select: none` + `cursor: default` by default; the interactive button variant overrides.

See `CHANGELOG.md` for the full set.

## Test plan
- [ ] `pnpm test` — 51 files pass ✓
- [ ] `pnpm build` — green ✓
- [ ] On Vercel preview, navigate to `/airport/KBOS` and confirm: 2×2 filter row, list shows aircraft + nearby airports, click an airport row → preview card with Track button → `/airport/[icao]`
- [ ] Click an aircraft row → preview with Track button → `/aircraft/[callsign]`
- [ ] On `/aircraft/[callsign]`, confirm: focal silhouette + callsign always visible on map, trace renders, map follows the aircraft, fit-to-trace button works
- [ ] Click another aircraft on the flight map → preview opens, focal trace stays + secondary trace at 40% opacity
- [ ] Toggle theme — verify the `theme` cookie is set and subsequent loads SSR with the right `data-theme`
- [ ] No React 19 console warnings about script tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)