### PR TITLE
[codex] Use webpack for Next runtime stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "1.2.1",
   "type": "module",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "next dev --webpack",
+    "build": "next build --webpack",
     "lint": "eslint .",
     "test": "node scripts/run-tests.js",
     "test:all": "pnpm test",


### PR DESCRIPTION
## Summary
- Switch pnpm dev and pnpm build to next with the --webpack flag.
- Avoid the Next 16 Turbopack app-ssr/module-factory runtime error seen after the translation PR.

## Validation
- Not run per request; this is a one-line script fallback PR.

## Notes
- Next 16 defaults to Turbopack for dev and build. Official docs say --webpack opts back into webpack when Turbopack compatibility/runtime issues appear.