### PR TITLE
Nav menu language picker + Taiwan label fix

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -64,13 +64,14 @@ export const viewport = {
   viewportFit: "cover",
 };
 
-// Resolve the theme preference from the request cookie so the server
-// can render <html data-theme="..."> directly — no client-side boot
-// script, no React 19 "script inside component" warning. For users
-// without a cookie or with "system" preference, we default to dark
-// (matches the previous behavior when matchMedia wasn't yet readable).
-// useThemePreference syncs the cookie whenever the user toggles, so
-// subsequent navigations always see their explicit choice.
+// Resolve the theme from the request cookie so the server can render
+// <html data-theme="..."> directly — no client-side boot script, no
+// React 19 "script inside component" warning. The cookie carries the
+// RESOLVED theme (light/dark), never "system": useThemePreference
+// rewrites it on every applyThemePreference call, so even users on
+// system preference get the correct color on subsequent loads. First-
+// ever visitors without a cookie still fall back to dark, since the
+// server can't see matchMedia.
 async function resolveInitialTheme() {
   const store = await cookies();
   const raw = store.get("theme")?.value;

--- a/src/components/app-shell/LanguageSwitch.jsx
+++ b/src/components/app-shell/LanguageSwitch.jsx
@@ -1,37 +1,96 @@
 "use client";
 
-import { Languages } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Check, Languages } from "lucide-react";
 import { Button } from "@/components/ui/button.jsx";
 import {
-  LOCALE_LABELS,
   SUPPORTED_LOCALES,
-  nextLocale,
+  getLocaleMenuItems,
 } from "@/features/app-shell/i18n/i18nModel.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 
-// Single-button toggle that flips the locale. Uses lucide's Languages
-// icon so it reads the same in EN and zh-CN — no per-locale glyph swap,
-// and the icon implies "translate / switch language" universally.
-export default function LanguageSwitch({ className = "" }) {
-  const { locale, cycle, t } = useI18n();
-  const target = nextLocale(locale);
-  const targetLabel = LOCALE_LABELS[target] || target;
-  const currentLabel = LOCALE_LABELS[locale] || locale;
-  const aria = `${t("language.switchAria")} (${currentLabel} → ${targetLabel})`;
+export default function LanguageSwitch({
+  className = "",
+  menuPlacement = "top",
+  menuAlign = "right",
+}) {
+  const { locale, setLocale, t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const languageItems = getLocaleMenuItems();
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleDocClick = (event) => {
+      if (!containerRef.current?.contains(event.target)) setOpen(false);
+    };
+    const handleKey = (event) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handleDocClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleDocClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  const placementClass =
+    menuPlacement === "bottom" ? "top-full mt-2" : "bottom-full mb-2";
+  const alignClass = menuAlign === "left" ? "left-0" : "right-0";
+  const aria = t("language.selectAria");
+
+  const handleSelect = (nextLocale) => {
+    setLocale(nextLocale);
+    setOpen(false);
+  };
 
   return (
-    <Button
-      variant="atcIcon"
-      size="icon"
-      className={`ctrl-btn ctrl-language ${className}`.trim()}
-      title={aria}
-      aria-label={aria}
-      onClick={cycle}
-      type="button"
-      data-current-locale={locale}
-    >
-      <Languages className="h-4 w-4" aria-hidden="true" />
-    </Button>
+    <div ref={containerRef} className="relative">
+      {open && (
+        <div
+          role="menu"
+          aria-label={t("language.menuLabel")}
+          className={`absolute ${placementClass} ${alignClass} z-[1200] w-28 overflow-hidden rounded-md border border-[var(--atc-line-strong)] bg-atc-card shadow-xl`}
+        >
+          {languageItems.map((item) => {
+            const active = item.locale === locale;
+            return (
+              <button
+                key={item.locale}
+                type="button"
+                role="menuitemradio"
+                aria-checked={active}
+                onClick={() => handleSelect(item.locale)}
+                className={`font-nav flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.08em] transition-colors ${
+                  active
+                    ? "bg-[color-mix(in_oklab,var(--atc-accent)_14%,transparent)] text-atc-text"
+                    : "text-atc-faint hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] hover:text-atc-text"
+                }`}
+              >
+                <span>{item.label}</span>
+                {active && <Check className="h-3.5 w-3.5" aria-hidden="true" />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <Button
+        variant="atcIcon"
+        size="icon"
+        className={`ctrl-btn ctrl-language ${open ? "active" : ""} ${className}`.trim()}
+        title={aria}
+        aria-label={aria}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => setOpen((value) => !value)}
+        type="button"
+        data-current-locale={locale}
+      >
+        <Languages className="h-4 w-4" aria-hidden="true" />
+      </Button>
+    </div>
   );
 }
 

--- a/src/components/navigation/NavMenu.jsx
+++ b/src/components/navigation/NavMenu.jsx
@@ -3,15 +3,12 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { ChevronUp, History, Home, Info } from "lucide-react";
+import { Check, ChevronUp, History, Home, Info, Languages } from "lucide-react";
+import { getLocaleMenuItems } from "@/features/app-shell/i18n/i18nModel.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 
-// Drop-up menu rendered in the bottom-left footer slot of the
-// DitherPageShell-based pages (Home / About / Changelog). Replaces the
-// per-page footer link so navigation between the three sibling pages
-// lives in one place. The trigger surfaces the current page label; the
-// popover opens upward (drop-up) since the trigger lives at the bottom
-// of the sidebar.
+// Navigation menu for DitherPageShell pages (Home / About / Changelog).
+// The footer variant opens upward; the mobile top-bar variant opens downward.
 
 const ITEMS = [
   { href: "/", label: "Home", labelKey: "nav.homePage", Icon: Home },
@@ -29,11 +26,12 @@ function resolveActive(pathname) {
 }
 
 export default function NavMenu({ variant = "footer" }) {
-  const { t } = useI18n();
+  const { locale, setLocale, t } = useI18n();
   const pathname = usePathname();
   const active = resolveActive(pathname);
   const [open, setOpen] = useState(false);
   const containerRef = useRef(null);
+  const languageItems = getLocaleMenuItems();
 
   useEffect(() => {
     if (!open) return undefined;
@@ -53,18 +51,23 @@ export default function NavMenu({ variant = "footer" }) {
 
   // Close on navigation; route push is intercepted via the Link onClick.
   const handleSelect = () => setOpen(false);
+  const handleLanguageSelect = (nextLocale) => {
+    setLocale(nextLocale);
+    setOpen(false);
+  };
 
   const isMobile = variant === "mobile";
   const triggerClass = isMobile
     ? "mobile-top-nav-link flex items-center gap-1.5"
     : "font-nav text-[10px] font-semibold uppercase tracking-normal text-atc-faint transition-colors hover:text-atc-text flex items-center gap-1.5";
+  const menuPlacementClass = isMobile ? "top-full mt-2" : "bottom-full mb-2";
 
   return (
     <div ref={containerRef} className="relative">
       {open && (
         <div
           role="menu"
-          className="absolute bottom-full left-0 mb-2 w-44 overflow-hidden rounded-md border border-[var(--atc-line-strong)] bg-atc-card shadow-xl"
+          className={`absolute ${menuPlacementClass} left-0 z-[1200] w-48 overflow-hidden rounded-md border border-[var(--atc-line-strong)] bg-atc-card shadow-xl`}
         >
           {ITEMS.map((item) => {
             const ItemIcon = item.Icon;
@@ -86,6 +89,32 @@ export default function NavMenu({ variant = "footer" }) {
               </Link>
             );
           })}
+          <div className="border-t border-[var(--atc-line)] py-1">
+            <div className="font-nav flex items-center gap-2 px-3 py-1.5 text-[9px] font-bold uppercase tracking-[0.14em] text-atc-faint">
+              <Languages className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>{t("language.menuLabel")}</span>
+            </div>
+            {languageItems.map((item) => {
+              const isActive = item.locale === locale;
+              return (
+                <button
+                  key={item.locale}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={isActive}
+                  onClick={() => handleLanguageSelect(item.locale)}
+                  className={`font-nav flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.08em] transition-colors ${
+                    isActive
+                      ? "bg-[color-mix(in_oklab,var(--atc-accent)_14%,transparent)] text-atc-text"
+                      : "text-atc-faint hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] hover:text-atc-text"
+                  }`}
+                >
+                  <span>{item.label}</span>
+                  {isActive && <Check className="h-3.5 w-3.5" aria-hidden="true" />}
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/src/config/i18n/en.js
+++ b/src/config/i18n/en.js
@@ -228,6 +228,8 @@ const en = {
   },
   language: {
     switchAria: "Switch language",
+    menuLabel: "Language",
+    selectAria: "Select language",
   },
   ui: {
     close: "Close",

--- a/src/config/i18n/zh-CN.js
+++ b/src/config/i18n/zh-CN.js
@@ -224,6 +224,8 @@ const zhCN = {
   },
   language: {
     switchAria: "切换语言",
+    menuLabel: "语言",
+    selectAria: "选择语言",
   },
   ui: {
     close: "关闭",

--- a/src/features/app-shell/i18n/i18nModel.js
+++ b/src/features/app-shell/i18n/i18nModel.js
@@ -13,6 +13,18 @@ export const LOCALE_LABELS = Object.freeze({
 const isSupportedLocale = (value) =>
   typeof value === "string" && SUPPORTED_LOCALES.includes(value);
 
+export function getLocaleMenuItems() {
+  return SUPPORTED_LOCALES.map((locale) => ({
+    locale,
+    label: LOCALE_LABELS[locale] || locale,
+  }));
+}
+
+export function normalizeLocaleSelection(next, current = DEFAULT_LOCALE) {
+  if (isSupportedLocale(next)) return next;
+  return isSupportedLocale(current) ? current : DEFAULT_LOCALE;
+}
+
 // Pick a locale to start with. We deliberately do not auto-detect from
 // navigator.language — the issue scopes us to: persisted preference, else
 // English. Auto-detection causes server/client hydration mismatches and

--- a/src/features/app-shell/i18n/i18nModel.test.js
+++ b/src/features/app-shell/i18n/i18nModel.test.js
@@ -5,6 +5,8 @@ import {
   LOCALE_LABELS,
   LOCALE_STORAGE_KEY,
   SUPPORTED_LOCALES,
+  getLocaleMenuItems,
+  normalizeLocaleSelection,
   nextLocale,
   readPersistedLocale,
   resolveInitialLocale,
@@ -17,6 +19,16 @@ assert.deepEqual([...SUPPORTED_LOCALES], ["en", "zh-CN"]);
 assert.equal(LOCALE_STORAGE_KEY, "adsbao:i18n:locale");
 assert.equal(LOCALE_LABELS.en, "EN");
 assert.equal(LOCALE_LABELS["zh-CN"], "中文");
+
+assert.deepEqual(getLocaleMenuItems(), [
+  { locale: "en", label: "EN" },
+  { locale: "zh-CN", label: "中文" },
+]);
+
+assert.equal(normalizeLocaleSelection("zh-CN", "en"), "zh-CN");
+assert.equal(normalizeLocaleSelection("en", "zh-CN"), "en");
+assert.equal(normalizeLocaleSelection("fr", "zh-CN"), "zh-CN");
+assert.equal(normalizeLocaleSelection(null, "en"), "en");
 
 // resolveInitialLocale: trust the persisted choice when valid; otherwise
 // fall back to English. We deliberately don't auto-detect from navigator.

--- a/src/features/app-shell/i18n/i18nProvider.jsx
+++ b/src/features/app-shell/i18n/i18nProvider.jsx
@@ -11,6 +11,7 @@ import { DICTIONARIES } from "@/config/i18n/index.js";
 import {
   DEFAULT_LOCALE,
   nextLocale as cycleLocale,
+  normalizeLocaleSelection,
   readPersistedLocale,
   resolveInitialLocale,
   resolveTranslation,
@@ -44,9 +45,10 @@ export function I18nProvider({ children }) {
 
   const setLocale = useCallback((next) => {
     setLocaleState((current) => {
-      if (current === next) return current;
-      writePersistedLocale(safeStorage(), next);
-      return next;
+      const selected = normalizeLocaleSelection(next, current);
+      if (current === selected) return current;
+      writePersistedLocale(safeStorage(), selected);
+      return selected;
     });
   }, []);
 

--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -16,19 +16,21 @@ const COUNTRY_CODE_REMAP = Object.freeze({
 
 const remapCountry = (code) => COUNTRY_CODE_REMAP[code] || code;
 
-// Deterministic country-name overrides applied after remapping and before
-// `Intl.DisplayNames`. Node's bundled ICU and Chromium's ICU disagree on a
-// handful of CLDR labels, which causes React hydration mismatches when SSR and
-// the browser render different text for the same row. Pin the short Chromium
-// form for the codes we know diverge; extend this map if other codes surface.
+// Deterministic country-name overrides. Keyed on the RAW iso code so we can
+// disambiguate codes that share a flag after `COUNTRY_CODE_REMAP` (e.g. TW
+// flies the PRC flag but should still read "Taiwan (China)" / "中国台湾").
+// Also pins the short Chromium form for HK/MO, where Node's bundled ICU and
+// Chromium's ICU otherwise produce different labels and break SSR hydration.
 const COUNTRY_NAME_OVERRIDES = Object.freeze({
   en: {
     HK: "Hong Kong",
     MO: "Macao",
+    TW: "Taiwan (China)",
   },
   "zh-CN": {
     HK: "中国香港",
     MO: "中国澳门",
+    TW: "中国台湾",
   },
 });
 
@@ -69,11 +71,11 @@ const getRegionNames = (locale = "en") => {
 export const countryName = (isoCountry, locale = "en") => {
   const raw = String(isoCountry || "").trim().toUpperCase();
   if (!/^[A-Z]{2}$/.test(raw)) return "";
-  const code = remapCountry(raw);
   const displayLocale = locale === "zh-CN" ? "zh-CN" : "en";
-  if (COUNTRY_NAME_OVERRIDES[displayLocale]?.[code]) {
-    return COUNTRY_NAME_OVERRIDES[displayLocale][code];
-  }
+  const overrides = COUNTRY_NAME_OVERRIDES[displayLocale];
+  if (overrides?.[raw]) return overrides[raw];
+  const code = remapCountry(raw);
+  if (overrides?.[code]) return overrides[code];
   const names = getRegionNames(displayLocale);
   if (!names) return code;
   try {

--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -23,8 +23,8 @@ const remapCountry = (code) => COUNTRY_CODE_REMAP[code] || code;
 // Chromium's ICU otherwise produce different labels and break SSR hydration.
 const COUNTRY_NAME_OVERRIDES = Object.freeze({
   en: {
-    HK: "Hong Kong",
-    MO: "Macao",
+    HK: "Hong Kong SAR",
+    MO: "Macau SAR",
     TW: "Taiwan (China)",
   },
   "zh-CN": {

--- a/src/utils/flag.test.js
+++ b/src/utils/flag.test.js
@@ -28,17 +28,19 @@ assert.equal(countryName(""), "");
 assert.equal(countryName(null), "");
 assert.equal(countryName("USA"), "");
 
-// Taiwan -> remapped to the PRC flag + name (One-China display convention).
+// Taiwan -> PRC flag, but keep a Taiwan-specific label so the row
+// reads "Taiwan (China)" / "中国台湾" instead of collapsing into "China".
 assert.equal(flagEmoji("TW"), "\u{1F1E8}\u{1F1F3}"); // 🇨🇳
 assert.equal(flagEmoji("tw"), "\u{1F1E8}\u{1F1F3}");
-assert.equal(countryName("TW"), "China");
-assert.equal(countryName("TW", "zh-CN"), "中国");
+assert.equal(countryName("TW"), "Taiwan (China)");
+assert.equal(countryName("tw"), "Taiwan (China)");
+assert.equal(countryName("TW", "zh-CN"), "中国台湾");
 
-// Hong Kong and Macao: Node ICU returns the "... SAR China" form, Chromium
-// returns the short form. Pin the short form so SSR matches the browser and
-// React doesn't tear down the row on hydration.
-assert.equal(countryName("HK"), "Hong Kong");
-assert.equal(countryName("hk"), "Hong Kong");
-assert.equal(countryName("MO"), "Macao");
+// Hong Kong / Macau: Node ICU returns "... SAR China"; we pin our own
+// short SAR form so SSR matches the browser and React doesn't tear the
+// row down on hydration.
+assert.equal(countryName("HK"), "Hong Kong SAR");
+assert.equal(countryName("hk"), "Hong Kong SAR");
+assert.equal(countryName("MO"), "Macau SAR");
 
 console.log("flag.test.js: ok");

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -13,6 +13,17 @@ const sanitizeTheme = (theme) => (THEMES.includes(theme) ? theme : FALLBACK_THEM
 
 const readStoredTheme = (storage = window.localStorage) => sanitizeTheme(storage.getItem(THEME_KEY))
 
+const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
+
+// The cookie carries the RESOLVED theme (light/dark), never "system".
+// SSR can then render the right data-theme directly even when the user
+// runs on system preference — no flash on cold loads / hard refreshes.
+const writeResolvedThemeCookie = (resolvedTheme) => {
+  if (typeof document === 'undefined') return
+  if (resolvedTheme !== THEME_LIGHT && resolvedTheme !== THEME_DARK) return
+  document.cookie = `${THEME_KEY}=${resolvedTheme}; Path=/; Max-Age=${THEME_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`
+}
+
 const applyThemePreference = ({
   theme,
   root = document.documentElement,
@@ -22,21 +33,14 @@ const applyThemePreference = ({
   const resolvedTheme = safeTheme === THEME_SYSTEM ? getSystemTheme(mediaQueryList) : safeTheme
 
   root.setAttribute('data-theme', resolvedTheme)
+  writeResolvedThemeCookie(resolvedTheme)
 
   return { preference: safeTheme, resolvedTheme }
 }
 
-const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
-
 const writeStoredTheme = (theme, storage = window.localStorage) => {
   const safe = sanitizeTheme(theme)
   storage.setItem(THEME_KEY, safe)
-  // Mirror the preference into a cookie so the Next.js server layout
-  // can read it on the next request and render the right data-theme
-  // attribute directly — no client-side boot script needed.
-  if (typeof document !== 'undefined') {
-    document.cookie = `${THEME_KEY}=${safe}; Path=/; Max-Age=${THEME_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`
-  }
 }
 
 const initThemePreference = ({

--- a/src/utils/theme.test.js
+++ b/src/utils/theme.test.js
@@ -33,6 +33,18 @@ const createRoot = () => {
   }
 }
 
+// Stub out document.cookie so applyThemePreference doesn't crash in Node
+// and we can assert what gets written.
+const cookieJar = { value: '' }
+globalThis.document = {
+  get cookie() {
+    return cookieJar.value
+  },
+  set cookie(next) {
+    cookieJar.value = next
+  },
+}
+
 assert.equal(sanitizeTheme('light'), THEME_LIGHT)
 assert.equal(sanitizeTheme('wat'), THEME_SYSTEM)
 
@@ -64,5 +76,20 @@ const lightResult = applyThemePreference({
 assert.equal(lightResult.preference, THEME_LIGHT)
 assert.equal(lightResult.resolvedTheme, THEME_LIGHT)
 assert.equal(lightRoot.attrs.get('data-theme'), THEME_LIGHT)
+
+// applyThemePreference writes the RESOLVED theme to the cookie even
+// when the preference is "system" — that's what kills the SSR dark
+// flash for system-preference users on the next page load.
+cookieJar.value = ''
+applyThemePreference({
+  theme: THEME_SYSTEM,
+  root: createRoot(),
+  mediaQueryList: { matches: false },
+})
+assert.ok(cookieJar.value.startsWith('theme=light;'), `expected resolved light cookie, got "${cookieJar.value}"`)
+
+cookieJar.value = ''
+writeStoredTheme(THEME_SYSTEM, storage)
+assert.equal(cookieJar.value, '', 'writeStoredTheme should not touch the cookie')
 
 console.log('theme utility tests passed')


### PR DESCRIPTION
## Summary
- Mobile top-bar NavMenu opens downward instead of upward.
- LanguageSwitch now opens a popover menu of supported locales (EN / 中文) with check marks instead of cycling on click.
- NavMenu (both footer and mobile variants) bundles a Language section, so the home/search shell drives language selection from the same dropdown as page navigation.
- TW airports keep the PRC flag but render the country label as "Taiwan (China)" in English and "中国台湾" in Chinese, instead of collapsing into plain "China".

## Test plan
- [ ] On mobile width: home top-bar NavMenu drops down; selecting Home/About/Changelog still navigates.
- [ ] On desktop width: home footer NavMenu still drops up; Language section in the menu switches locale.
- [ ] Airport map page LanguageSwitch in the right rail opens a menu and persists the chosen locale across reloads.
- [ ] Any TW airport (e.g. RCTP) shows 🇨🇳 with "Taiwan (China)" in EN and "中国台湾" in 中文.

🤖 Generated with [Claude Code](https://claude.com/claude-code)