### PR TITLE
feat: rename primary color presets to Valley IV / Wuling

### DIFF
--- a/src/config/i18n/en.js
+++ b/src/config/i18n/en.js
@@ -234,8 +234,8 @@ const en = {
   },
   primary: {
     menuLabel: "Accent",
-    yellow: "Yellow",
-    teal: "Teal",
+    yellow: "Valley IV",
+    teal: "Wuling",
   },
   ui: {
     close: "Close",

--- a/src/config/i18n/zh-CN.js
+++ b/src/config/i18n/zh-CN.js
@@ -230,8 +230,8 @@ const zhCN = {
   },
   primary: {
     menuLabel: "主色调",
-    yellow: "黄色",
-    teal: "青色",
+    yellow: "四号谷地",
+    teal: "武陵",
   },
   ui: {
     close: "关闭",


### PR DESCRIPTION
## Summary
Renames the two accent presets in the nav menu's Accent picker:

- `yellow` → **Valley IV** (en) / **四号谷地** (zh-CN)
- `teal` → **Wuling** (en) / **武陵** (zh-CN)

Internal keys (`yellow`, `teal`) are unchanged — `data-primary`, the cookie value, localStorage value, and the CSS override block all continue to use the old identifiers. Only the labels rendered in the menu and the i18n strings change.

## Test plan
- [ ] `pnpm test` — 56/56 pass
- [ ] Pop the nav menu, Accent section shows **Valley IV** + **Wuling**
- [ ] Switch zh-CN, Accent section shows **四号谷地** + **武陵**
- [ ] Existing users with a saved primary preference (`yellow` / `teal` in localStorage + cookie) still resolve correctly — the storage layer didn't change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)