### PR TITLE
feat: per-primary focus-mode audio (Wuling swaps the track)

### DIFF
--- a/src/components/ui/MapControlBar.jsx
+++ b/src/components/ui/MapControlBar.jsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
-import { MAP_ZOOM_OPTIONS } from "../../config/mapControls.js";
+import {
+  MAP_FOCUS_VIDEO_BY_PRIMARY,
+  MAP_FOCUS_VIDEO_DEFAULT,
+  MAP_ZOOM_OPTIONS,
+} from "../../config/mapControls.js";
 import { useThemePreference } from "../../features/app-shell/useThemePreference.js";
+import { usePrimaryColor } from "../../features/app-shell/usePrimaryColor.js";
 import MapControlRail from "@/components/map/controls/MapControlRail.jsx";
 import MapLayerDrawer from "@/components/map/controls/MapLayerDrawer.jsx";
 import {
@@ -30,7 +35,11 @@ export default function MapControlBar({
   const controlZone = useRef(null);
   const [layerDrawerOpen, setLayerDrawerOpen] = useState(false);
   const { themePreference, themeTitle, cycleTheme } = useThemePreference();
-  const { playerHost, playing, audioReady, toggleAudio } = useFocusAudio();
+  const { primary } = usePrimaryColor();
+  const focusVideoId =
+    MAP_FOCUS_VIDEO_BY_PRIMARY[primary] ?? MAP_FOCUS_VIDEO_DEFAULT;
+  const { playerHost, playing, audioReady, toggleAudio } =
+    useFocusAudio(focusVideoId);
 
   const currentZoomOption = useMemo(
     () => resolveZoomOption(activeZoom, MAP_ZOOM_OPTIONS),

--- a/src/config/mapControls.js
+++ b/src/config/mapControls.js
@@ -4,7 +4,17 @@ import {
   ZOOM_DETAIL,
 } from "../utils/airportMapDisplay.js";
 
-export const MAP_FOCUS_VIDEO_ID = "i4PuYS2Yy2A";
+// Per-primary focus-mode YouTube video. The map is keyed by the same
+// values the primary-color hook uses (yellow / teal) so switching the
+// accent palette also swaps the focus-mode audio.
+export const MAP_FOCUS_VIDEO_BY_PRIMARY = {
+  yellow: "i4PuYS2Yy2A",
+  teal: "VmTfpAgX2",
+};
+export const MAP_FOCUS_VIDEO_DEFAULT = MAP_FOCUS_VIDEO_BY_PRIMARY.yellow;
+// Backwards-compat re-export — left for any caller still expecting the
+// single-ID form.
+export const MAP_FOCUS_VIDEO_ID = MAP_FOCUS_VIDEO_DEFAULT;
 
 export const MAP_ZOOM_OPTIONS = [
   { value: ZOOM_APPROACH, title: "Approaching view", iconKey: "planeLanding" },

--- a/src/features/airport/map-controls/useFocusAudio.js
+++ b/src/features/airport/map-controls/useFocusAudio.js
@@ -1,13 +1,14 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { MAP_FOCUS_VIDEO_ID } from "../../../config/mapControls.js";
+import { MAP_FOCUS_VIDEO_DEFAULT } from "../../../config/mapControls.js";
 
-export function useFocusAudio() {
+export function useFocusAudio(videoId = MAP_FOCUS_VIDEO_DEFAULT) {
   const playerHost = useRef(null);
   const player = useRef(null);
   const [playing, setPlaying] = useState(false);
   const [audioReady, setAudioReady] = useState(false);
+  const currentVideoIdRef = useRef(videoId);
 
   useEffect(() => {
     const playerHostEl = playerHost.current;
@@ -25,11 +26,11 @@ export function useFocusAudio() {
       player.current = new window.YT.Player(playerTarget, {
         height: 1,
         width: 1,
-        videoId: MAP_FOCUS_VIDEO_ID,
+        videoId: currentVideoIdRef.current,
         playerVars: {
           autoplay: 0,
           loop: 1,
-          playlist: MAP_FOCUS_VIDEO_ID,
+          playlist: currentVideoIdRef.current,
           controls: 0,
           playsinline: 1,
           rel: 0,
@@ -53,6 +54,26 @@ export function useFocusAudio() {
       playerHostEl.replaceChildren();
     };
   }, []);
+
+  // Swap to a new video without tearing down the player. Calling
+  // loadVideoById preserves the iframe + listeners, keeps the
+  // playing/paused state visible to the UI, and starts the new track
+  // immediately if the user was already in focus mode (which is the
+  // right UX — selecting a new accent means selecting its track).
+  useEffect(() => {
+    if (videoId === currentVideoIdRef.current) return;
+    currentVideoIdRef.current = videoId;
+    if (!audioReady || !player.current) return;
+    const wasPlaying = playing;
+    // cueVideoById buffers without auto-play; loadVideoById plays
+    // immediately. Match the previous play state so a paused user
+    // doesn't suddenly hear audio after a primary-color switch.
+    if (wasPlaying) {
+      player.current.loadVideoById({ videoId, suggestedQuality: "small" });
+    } else {
+      player.current.cueVideoById({ videoId, suggestedQuality: "small" });
+    }
+  }, [videoId, audioReady, playing]);
 
   const toggleAudio = () => {
     if (!player.current || !audioReady) return;


### PR DESCRIPTION
## Summary
Focus-mode audio now follows the selected primary color preset:

- **Valley IV** (yellow): existing track `i4PuYS2Yy2A`.
- **Wuling** (teal): `VmTfpAgX2`.

> ⚠️ **Heads-up on the Wuling video ID** — the URL pasted in the request had only **9 characters** in the `v=` parameter (`VmTfpAgX2`). Standard YouTube IDs are **11 characters**. Saved exactly as given; if the focus-mode button loads but can't play, paste the full 11-char ID and I'll patch it.

## Changes
- `config/mapControls.js` — new `MAP_FOCUS_VIDEO_BY_PRIMARY` map keyed by primary preset. `MAP_FOCUS_VIDEO_DEFAULT` and the legacy `MAP_FOCUS_VIDEO_ID` re-export the yellow track for any caller still using the single-ID form.
- `useFocusAudio(videoId)` — now takes a video ID as a parameter (defaults to the yellow track). When the value changes it swaps the video via `player.loadVideoById` / `cueVideoById` instead of tearing down the iframe, so listeners + play state survive the swap. If the user was already in focus mode, the new track starts immediately; if they were paused, it cues silently.
- `MapControlBar` reads the current primary via `usePrimaryColor` and resolves the right track from the map before calling the hook.

## Test plan
- [ ] `pnpm build` clean
- [ ] `pnpm test` — 56/56 pass
- [ ] Open an airport, click focus-mode → yellow track plays
- [ ] Swap accent to **Wuling** in the nav menu while playing → track changes to the teal-paired video without stopping
- [ ] Pause focus-mode, swap accent → track changes silently, next click plays the new one
- [ ] Verify Wuling video ID actually loads (see heads-up above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)