### PR TITLE
fix: correct Wuling focus-mode YouTube video ID

### DIFF
--- a/src/config/mapControls.js
+++ b/src/config/mapControls.js
@@ -9,7 +9,7 @@ import {
 // accent palette also swaps the focus-mode audio.
 export const MAP_FOCUS_VIDEO_BY_PRIMARY = {
   yellow: "i4PuYS2Yy2A",
-  teal: "VmTfpAgX2",
+  teal: "VmTfpAgX2AU",
 };
 export const MAP_FOCUS_VIDEO_DEFAULT = MAP_FOCUS_VIDEO_BY_PRIMARY.yellow;
 // Backwards-compat re-export — left for any caller still expecting the


### PR DESCRIPTION
## Summary
Patches the Wuling/teal focus-mode track ID from `VmTfpAgX2` (9 chars, truncated) to `VmTfpAgX2AU` (full 11-char YouTube ID).

## Test plan
- [ ] Switch accent to **Wuling**, click focus-mode — track loads + plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)