### PR TITLE
fix: keep selected sidebar row's route line readable in light theme

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -5625,7 +5625,8 @@ body {
 }
 
 .endf-row-active .text-atc-dim,
-.endf-row-active .text-atc-faint {
+.endf-row-active .text-atc-faint,
+.endf-row-active .aircraft-table-route-cycle {
     color: color-mix(in oklab, var(--endf-yellow) 72%, transparent);
 }
 


### PR DESCRIPTION
## Summary

The selected sidebar row (\`.endf-row-active\`) paints its background ink-black and flips every text color to yellow — but only for elements whose color comes from a Tailwind utility (\`text-atc-text\`, \`text-atc-dim\`, \`text-atc-faint\`). The route line under the callsign is colored by the plain CSS rule \`.aircraft-table-route-cycle { color: var(--atc-dim); }\`, so the active-row override misses it.

In dark theme \`--atc-dim\` is translucent light gray → still readable on ink. In light theme \`--atc-dim\` is translucent near-black → black on ink. Result: the selected row's "Boston ⇆ San Juan" / "KBOS → TJSJ" disappears under light theme.

One-line fix: append \`.endf-row-active .aircraft-table-route-cycle\` to the existing dim/faint override so the route gets the same 72%-yellow muted color the rest of the row's secondary text already uses.

## Test plan

- [ ] Light theme + sidebar open: select a flight row that has a route. Route line should be readable yellow, not invisible.
- [ ] Dark theme: same row should still look identical to before (the rule resolves to the same muted-yellow mix that already worked there).
- [ ] Unselected rows in both themes: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)