### PR TITLE
feat: move FlightAware allowlist to Clerk publicMetadata

### DIFF
--- a/src/features/app-shell/auth/clerkRouteProviderAccess.js
+++ b/src/features/app-shell/auth/clerkRouteProviderAccess.js
@@ -1,36 +1,22 @@
-// Emails allowed to use the FlightAware route provider. All other
-// signed-in (or anonymous) users fall back to adsbdb.
-export const FLIGHTAWARE_OWNER_EMAILS = [
-  "ruyyi0323@gmail.com",
-];
-
-// Legacy single-owner export — kept so any caller still importing the
-// scalar form continues to resolve. Always points at the first entry
-// of the list.
-export const FLIGHTAWARE_OWNER_EMAIL = FLIGHTAWARE_OWNER_EMAILS[0];
-
-const OWNER_EMAIL_SET = new Set(
-  FLIGHTAWARE_OWNER_EMAILS.map((email) => normalizeEmail(email)),
-);
+// Gate for the FlightAware route provider. The previous version
+// hardcoded an email allowlist in source; this reads a per-user flag
+// from Clerk publicMetadata so the list lives in Clerk, not the repo.
+//
+// Setting the flag (Clerk dashboard → user → Public metadata):
+//   { "flightAwareEnabled": true }
+//
+// Only strict `=== true` unlocks the gate so a stray "true" string or
+// truthy non-boolean can't accidentally enable the provider.
+const FLAG_KEY = "flightAwareEnabled";
 
 export function buildClerkUserAccessEntity(user) {
   if (!user?.id) return undefined;
-  const email =
-    user.primaryEmailAddress?.emailAddress ||
-    user.emailAddresses?.find((item) => item?.emailAddress)?.emailAddress ||
-    "";
-
   return {
     id: String(user.id),
-    email: normalizeEmail(email),
-    name: String(user.fullName || "").trim(),
+    flightAwareEnabled: user.publicMetadata?.[FLAG_KEY] === true,
   };
 }
 
 export function isFlightAwareOwnerEntity(userEntity) {
-  return OWNER_EMAIL_SET.has(normalizeEmail(userEntity?.email));
-}
-
-function normalizeEmail(value) {
-  return String(value || "").trim().toLowerCase();
+  return userEntity?.flightAwareEnabled === true;
 }

--- a/src/features/app-shell/auth/clerkRouteProviderAccess.test.js
+++ b/src/features/app-shell/auth/clerkRouteProviderAccess.test.js
@@ -6,49 +6,46 @@ import {
 } from "./clerkRouteProviderAccess.js";
 
 assert.equal(buildClerkUserAccessEntity(null), undefined);
-assert.deepEqual(
-  buildClerkUserAccessEntity({
-    id: "user_123",
-    primaryEmailAddress: { emailAddress: "owner@example.com" },
-    fullName: "Owner Pilot",
-  }),
-  {
-    id: "user_123",
-    email: "owner@example.com",
-    name: "Owner Pilot",
-  },
-);
-assert.deepEqual(
-  buildClerkUserAccessEntity({
-    id: "user_456",
-    emailAddresses: [{ emailAddress: "fallback@example.com" }],
-  }),
-  {
-    id: "user_456",
-    email: "fallback@example.com",
-    name: "",
-  },
-);
+assert.equal(buildClerkUserAccessEntity({}), undefined);
+
 assert.deepEqual(
   buildClerkUserAccessEntity({
     id: "user_owner",
-    primaryEmailAddress: { emailAddress: " Ruyyi0323@Gmail.com " },
+    publicMetadata: { flightAwareEnabled: true },
   }),
-  {
-    id: "user_owner",
-    email: "ruyyi0323@gmail.com",
-    name: "",
-  },
+  { id: "user_owner", flightAwareEnabled: true },
 );
-assert.equal(
-  isFlightAwareOwnerEntity({ email: "ruyyi0323@gmail.com" }),
-  true,
+
+assert.deepEqual(
+  buildClerkUserAccessEntity({
+    id: "user_other",
+    publicMetadata: { flightAwareEnabled: false },
+  }),
+  { id: "user_other", flightAwareEnabled: false },
 );
-assert.equal(
-  isFlightAwareOwnerEntity({ email: " Ruyyi0323@Gmail.com " }),
-  true,
+
+assert.deepEqual(
+  buildClerkUserAccessEntity({ id: "user_blank" }),
+  { id: "user_blank", flightAwareEnabled: false },
 );
+
+// Only strict `=== true` unlocks the flag — string "true" or 1 stays off.
 assert.equal(
-  isFlightAwareOwnerEntity({ email: "owner@example.com" }),
+  buildClerkUserAccessEntity({
+    id: "u",
+    publicMetadata: { flightAwareEnabled: "true" },
+  }).flightAwareEnabled,
   false,
 );
+assert.equal(
+  buildClerkUserAccessEntity({
+    id: "u",
+    publicMetadata: { flightAwareEnabled: 1 },
+  }).flightAwareEnabled,
+  false,
+);
+
+assert.equal(isFlightAwareOwnerEntity({ flightAwareEnabled: true }), true);
+assert.equal(isFlightAwareOwnerEntity({ flightAwareEnabled: false }), false);
+assert.equal(isFlightAwareOwnerEntity({}), false);
+assert.equal(isFlightAwareOwnerEntity(undefined), false);

--- a/src/style.css
+++ b/src/style.css
@@ -5625,7 +5625,8 @@ body {
 }
 
 .endf-row-active .text-atc-dim,
-.endf-row-active .text-atc-faint {
+.endf-row-active .text-atc-faint,
+.endf-row-active .aircraft-table-route-cycle {
     color: color-mix(in oklab, var(--endf-yellow) 72%, transparent);
 }
 


### PR DESCRIPTION
## Summary

The FlightAware route-provider gate previously hardcoded \`ruyyi0323@gmail.com\` in a checked-in array (\`FLIGHTAWARE_OWNER_EMAILS\` in \`clerkRouteProviderAccess.js\`). Anyone reading the repo could see who has the elevated provider. Move the gate to a per-user Clerk \`publicMetadata\` flag so the allowlist lives in Clerk, not in source.

### How to grant access

1. Clerk dashboard → Users → select user → **Public metadata**.
2. Set:
   ```json
   { "flightAwareEnabled": true }
   ```
3. Save. Effective on the user's next request — no deploy.

Revoke by flipping the flag to \`false\` (or removing the key). Adding multiple users is just doing this for each.

### Why \`publicMetadata\` and not \`privateMetadata\`?

\`publicMetadata\` ships to the browser as part of the session, so it's only suitable for non-sensitive flags. "Does this user get the better route provider" qualifies. If you ever want to gate UI on the same flag (e.g., a "Pro" badge) it's already accessible client-side via \`useUser().user.publicMetadata\`. If you'd rather it stay server-only, swap one line — same shape, just \`privateMetadata\` instead. I'd default to public for this one.

### Safety

Only strict \`=== true\` unlocks the gate. Tests cover \`"true"\` (string) and \`1\` (number) — both stay off. Defensive against future-you fat-fingering the metadata.

### Call-site untouched

\`flightRoutes.mechanism.js\` still composes \`isFlightAwareOwnerEntity(buildClerkUserAccessEntity(user))\` — the entity shape just gained \`flightAwareEnabled\` and lost \`email\`/\`name\` (neither were used outside the test).

## Test plan

- [ ] Set \`{ "flightAwareEnabled": true }\` on your Clerk user → \`/aircraft/<callsign>\` resolves routes via FlightAware (network tab → \`flightaware.com\` request, or route response includes the FlightAware-only fields).
- [ ] Remove the flag → next request falls back to adsbdb.
- [ ] Anonymous user → still falls back to adsbdb (no Clerk session, no flag, gate stays closed).
- [ ] \`pnpm test\` green (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)