### PR TITLE
[codex] Decouple route loading from rendering

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewIdentity.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewIdentity.jsx
@@ -1,25 +1,9 @@
-/* eslint-disable @next/next/no-img-element */
 "use client";
 
-import { useState } from "react";
+import AirlineLogo from "./AirlineLogo.jsx";
 import AircraftPreviewType from "./AircraftPreviewType.jsx";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay.js";
-
-function AirlineLogo({ src, className }) {
-  const [hidden, setHidden] = useState(false);
-  if (!src || hidden) return null;
-  return (
-    <img
-      src={src}
-      alt=""
-      className={className}
-      loading="lazy"
-      decoding="async"
-      onError={() => setHidden(true)}
-    />
-  );
-}
 
 // Callsign + parsed route. Mirrors the sidebar row's identity cell so the
 // hover state feels like a richer continuation rather than new data.

--- a/src/components/aircraft/preview/AirlineLogo.jsx
+++ b/src/components/aircraft/preview/AirlineLogo.jsx
@@ -1,0 +1,32 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  isAirlineLogoUnavailable,
+  markAirlineLogoUnavailable,
+} from "@/features/aviation/airlineLogoModel.js";
+
+export default function AirlineLogo({ src, className }) {
+  const [hidden, setHidden] = useState(() => !src || isAirlineLogoUnavailable(src));
+
+  useEffect(() => {
+    setHidden(!src || isAirlineLogoUnavailable(src));
+  }, [src]);
+
+  if (!src || hidden) return null;
+
+  return (
+    <img
+      src={src}
+      alt=""
+      className={className}
+      loading="lazy"
+      decoding="async"
+      onError={() => {
+        markAirlineLogoUnavailable(src);
+        setHidden(true);
+      }}
+    />
+  );
+}

--- a/src/components/airport/explorer/AirportExplorer.jsx
+++ b/src/components/airport/explorer/AirportExplorer.jsx
@@ -3,13 +3,17 @@
 import dynamic from "next/dynamic";
 import { useEffect, useMemo } from "react";
 import AirportSidebar from "@/components/sidebar/AirportSidebar";
+import AirportExplorerDesktopSidebar from "./AirportExplorerDesktopSidebar.jsx";
 import {
   ExplorerUiProvider,
   useExplorerUi,
 } from "@/components/explorer/ExplorerUiContext.jsx";
 import AircraftDataLoadingOverlay from "./AircraftDataLoadingOverlay.jsx";
 import ExplorerMapMenu from "@/components/explorer/ExplorerMapMenu.jsx";
-import { resolveAirportProfile } from "@/features/airport/explorer/airportExplorerModel.js";
+import {
+  resolveAirportExplorerSelection,
+  resolveAirportProfile,
+} from "@/features/airport/explorer/airportExplorerModel.js";
 import { useAirportExplorerData } from "@/features/airport/explorer/useAirportExplorerData.js";
 import { useAirportProcedures } from "@/hooks/useAirportProcedures.js";
 import { useNearbyAirports } from "@/hooks/useNearbyAirports.js";
@@ -64,21 +68,30 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     lat: airportProfile.lat,
     lon: airportProfile.lon,
   });
-  const selectedAircraft = useMemo(
+  const selection = useMemo(
     () =>
-      traffic.aircraft.find(
-        (item) => (item.icao24 || item.callsign) === selectedAircraftId,
-      ) || null,
-    [selectedAircraftId, traffic.aircraft],
+      resolveAirportExplorerSelection({
+        aircraft: traffic.aircraft,
+        selectedAircraftId,
+        airports: nearbyAirports.airports,
+        selectedAirportIcao,
+      }),
+    [
+      nearbyAirports.airports,
+      selectedAircraftId,
+      selectedAirportIcao,
+      traffic.aircraft,
+    ],
   );
 
   useEffect(() => {
     if (!selectedAircraftId) return;
-    const stillVisible = traffic.aircraft.some(
-      (item) => (item.icao24 || item.callsign) === selectedAircraftId,
-    );
-    if (!stillVisible) setSelectedAircraftId("");
-  }, [selectedAircraftId, setSelectedAircraftId, traffic.aircraft]);
+    if (!selection.selectedAircraftStillVisible) setSelectedAircraftId("");
+  }, [
+    selectedAircraftId,
+    selection.selectedAircraftStillVisible,
+    setSelectedAircraftId,
+  ]);
 
   useEffect(() => {
     if (!isMobile) return undefined;
@@ -101,14 +114,6 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
       document.documentElement.style.overscrollBehavior = originalHtmlOverscroll;
     };
   }, [isMobile]);
-
-  const selectedAirport = useMemo(
-    () =>
-      nearbyAirports.airports.find(
-        (airport) => airport?.icao === selectedAirportIcao,
-      ) || null,
-    [nearbyAirports.airports, selectedAirportIcao],
-  );
 
   const sidebarProps = {
     icao: airportProfile.icao,
@@ -137,10 +142,10 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   };
 
   return (
-    <SelectedAircraftTraceProvider selectedAircraft={selectedAircraft}>
+    <SelectedAircraftTraceProvider selectedAircraft={selection.selectedAircraft}>
       <AircraftPreviewCard
-        aircraft={selectedAircraft}
-        airport={selectedAirport}
+        aircraft={selection.selectedAircraft}
+        airport={selection.selectedAirport}
         isMobile={isMobile}
         sidebarOpen={sidebarOpen}
         airportProfile={airportProfile}
@@ -154,14 +159,11 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
         }`}
       >
         {!isMobile && (
-          <div
-            className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
-            style={{ width: sidebarOpen ? desktopSidebarWidth : "0" }}
-          >
-            <div className="h-full" style={{ width: desktopSidebarWidth }}>
-              <AirportSidebar {...sidebarProps} />
-            </div>
-          </div>
+          <AirportExplorerDesktopSidebar
+            open={sidebarOpen}
+            width={desktopSidebarWidth}
+            sidebarProps={sidebarProps}
+          />
         )}
 
         <div className="relative min-w-0 flex-1 overflow-hidden bg-atc-bg">

--- a/src/components/airport/explorer/AirportExplorerDesktopSidebar.jsx
+++ b/src/components/airport/explorer/AirportExplorerDesktopSidebar.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+import AirportSidebar from "@/components/sidebar/AirportSidebar";
+
+export default function AirportExplorerDesktopSidebar({
+  open,
+  width,
+  sidebarProps,
+}) {
+  return (
+    <div
+      className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+      style={{ width: open ? width : "0" }}
+    >
+      <div className="h-full" style={{ width }}>
+        <AirportSidebar {...sidebarProps} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/AirportMarker.jsx
+++ b/src/components/map/AirportMarker.jsx
@@ -5,6 +5,10 @@ import { createPortal } from "react-dom";
 import L from "leaflet";
 import NumberFlow from "@number-flow/react";
 import { useMapInstance } from "./MapContext.js";
+import {
+  safeAddToMap,
+  safeRemoveFromMap,
+} from "../../features/airport/map/leafletLayerSafety.js";
 import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
 import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
 
@@ -38,18 +42,23 @@ export default function AirportMarker({
   useEffect(() => {
     if (!map || !map.getContainer || !lat || !lon || !container)
       return undefined;
-    const marker = L.marker([lat, lon], {
-      interactive: false,
-      icon: L.divIcon({
-        className: "",
-        html: container,
-        iconSize: [120, 34],
-        iconAnchor: [0, -8],
+    const marker = safeAddToMap(
+      L.marker([lat, lon], {
+        interactive: false,
+        icon: L.divIcon({
+          className: "",
+          html: container,
+          iconSize: [120, 34],
+          iconAnchor: [0, -8],
+        }),
       }),
-    }).addTo(map);
+      map,
+      { label: "AirportMarker" },
+    );
+    if (!marker) return undefined;
     markerRef.current = marker;
     return () => {
-      marker.remove();
+      safeRemoveFromMap(marker, map);
       markerRef.current = null;
     };
   }, [map, lat, lon, container]);

--- a/src/components/map/AreaMarker.jsx
+++ b/src/components/map/AreaMarker.jsx
@@ -7,6 +7,10 @@ import {
   buildAirportRangeRingLabels,
   buildAirportRangeRings,
 } from "../../features/airport/map/airportRangeRings.js";
+import {
+  safeAddToMap,
+  safeRemoveFromMap,
+} from "../../features/airport/map/leafletLayerSafety.js";
 import { ZOOM_AIRPORT } from "../../utils/airportMapDisplay.js";
 
 const DEFAULT_RING_INTERVAL_NM = 3;
@@ -15,28 +19,6 @@ const DEFAULT_RING_MAX_NM = 30;
 // Per-ring labels show at the airport preset and closer; below that
 // the MapRangeLegend scale bar carries distance context.
 const RING_LABEL_MIN_ZOOM = ZOOM_AIRPORT;
-
-// HMR + rapid airport switching can land children on a map whose SVG
-// renderer is mid-rebuild — addTo throws "Cannot read properties of
-// undefined (reading 'appendChild')". Swallow it so the next render
-// can succeed.
-const safeAddTo = (layer, map) => {
-  try {
-    return layer.addTo(map);
-  } catch (error) {
-    console.warn("[AreaMarker] addTo skipped (map not ready)", error.message);
-    return null;
-  }
-};
-
-const safeRemoveFrom = (layer, map) => {
-  if (!layer || !map) return;
-  try {
-    layer.removeFrom(map);
-  } catch {
-    /* layer or pane already torn down — nothing to clean up */
-  }
-};
 
 export default function AreaMarker({
   lat,
@@ -55,7 +37,7 @@ export default function AreaMarker({
       return undefined;
     if (!lat || !lon) return undefined;
 
-    safeRemoveFrom(ringsRef.current, map);
+    safeRemoveFromMap(ringsRef.current, map);
     const rings = buildAirportRangeRings(L, {
       lat,
       lon,
@@ -64,9 +46,11 @@ export default function AreaMarker({
       theme,
     });
     ringsRef.current =
-      rings.length > 0 ? safeAddTo(L.layerGroup(rings), map) : null;
+      rings.length > 0
+        ? safeAddToMap(L.layerGroup(rings), map, { label: "AreaMarker" })
+        : null;
 
-    safeRemoveFrom(ringLabelsRef.current, map);
+    safeRemoveFromMap(ringLabelsRef.current, map);
     ringLabelsRef.current = null;
     if (Number(zoom) >= RING_LABEL_MIN_ZOOM) {
       const labels = buildAirportRangeRingLabels(L, {
@@ -77,13 +61,15 @@ export default function AreaMarker({
         theme,
       });
       if (labels.length > 0) {
-        ringLabelsRef.current = safeAddTo(L.layerGroup(labels), map);
+        ringLabelsRef.current = safeAddToMap(L.layerGroup(labels), map, {
+          label: "AreaMarker",
+        });
       }
     }
 
     return () => {
-      safeRemoveFrom(ringsRef.current, map);
-      safeRemoveFrom(ringLabelsRef.current, map);
+      safeRemoveFromMap(ringsRef.current, map);
+      safeRemoveFromMap(ringLabelsRef.current, map);
       ringsRef.current = null;
       ringLabelsRef.current = null;
     };

--- a/src/features/airport/explorer/airportExplorerModel.js
+++ b/src/features/airport/explorer/airportExplorerModel.js
@@ -54,3 +54,24 @@ export function enrichAircraftWithRoutes({
     airspaceVolumes,
   });
 }
+
+const aircraftSelectionId = (aircraft) => aircraft?.icao24 || aircraft?.callsign || "";
+
+export function resolveAirportExplorerSelection({
+  aircraft = [],
+  selectedAircraftId = "",
+  airports = [],
+  selectedAirportIcao = "",
+} = {}) {
+  const selectedAircraft =
+    aircraft.find((item) => aircraftSelectionId(item) === selectedAircraftId) ||
+    null;
+  const selectedAirport =
+    airports.find((airport) => airport?.icao === selectedAirportIcao) || null;
+
+  return {
+    selectedAircraft,
+    selectedAircraftStillVisible: !selectedAircraftId || Boolean(selectedAircraft),
+    selectedAirport,
+  };
+}

--- a/src/features/airport/explorer/airportExplorerModel.test.js
+++ b/src/features/airport/explorer/airportExplorerModel.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   enrichAircraftWithRoutes,
   resolveAirportProfile,
+  resolveAirportExplorerSelection,
 } from "./airportExplorerModel.js";
 import { ARRIVAL, DEPARTURE, UNKNOWN } from "../../../utils/aircraftMovement.js";
 
@@ -62,3 +63,28 @@ assert.equal(enriched[1].airportContext.movement, "arrival");
 assert.equal(enriched[2].movement, UNKNOWN);
 assert.equal(enriched[2].flightRouteLabel, "JFK -> ORD");
 assert.equal(enriched[2].airportContext.movement, "unknown");
+
+const selection = resolveAirportExplorerSelection({
+  aircraft: [
+    { icao24: "a1", callsign: "DAL123" },
+    { icao24: "", callsign: "JBU456" },
+  ],
+  selectedAircraftId: "JBU456",
+  airports: [{ icao: "KBOS" }, { icao: "KJFK" }],
+  selectedAirportIcao: "KJFK",
+});
+
+assert.equal(selection.selectedAircraft.callsign, "JBU456");
+assert.equal(selection.selectedAircraftStillVisible, true);
+assert.equal(selection.selectedAirport.icao, "KJFK");
+
+const missingSelection = resolveAirportExplorerSelection({
+  aircraft: [{ icao24: "a1", callsign: "DAL123" }],
+  selectedAircraftId: "gone",
+  airports: [{ icao: "KBOS" }],
+  selectedAirportIcao: "KJFK",
+});
+
+assert.equal(missingSelection.selectedAircraft, null);
+assert.equal(missingSelection.selectedAircraftStillVisible, false);
+assert.equal(missingSelection.selectedAirport, null);

--- a/src/features/airport/map/leafletLayerSafety.js
+++ b/src/features/airport/map/leafletLayerSafety.js
@@ -1,0 +1,22 @@
+export function safeAddToMap(
+  layer,
+  map,
+  { label = "LeafletLayer", logger = console } = {},
+) {
+  if (!layer || !map) return null;
+  try {
+    return layer.addTo(map);
+  } catch (error) {
+    logger.warn?.(`[${label}] addTo skipped (map not ready)`, error.message);
+    return null;
+  }
+}
+
+export function safeRemoveFromMap(layer, map) {
+  if (!layer || !map) return;
+  try {
+    layer.removeFrom(map);
+  } catch {
+    /* layer or pane already torn down; nothing to clean up */
+  }
+}

--- a/src/features/airport/map/leafletLayerSafety.test.js
+++ b/src/features/airport/map/leafletLayerSafety.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+
+import { safeAddToMap, safeRemoveFromMap } from "./leafletLayerSafety.js";
+
+{
+  const layer = {
+    addedTo: null,
+    addTo(map) {
+      this.addedTo = map;
+      return this;
+    },
+  };
+  const map = { id: "map" };
+
+  assert.equal(safeAddToMap(layer, map, { label: "test-layer" }), layer);
+  assert.equal(layer.addedTo, map);
+}
+
+{
+  const warnings = [];
+  const layer = {
+    addTo() {
+      throw new Error("Cannot read properties of undefined (reading 'appendChild')");
+    },
+  };
+
+  assert.equal(
+    safeAddToMap(layer, {}, {
+      label: "test-layer",
+      logger: { warn: (...args) => warnings.push(args) },
+    }),
+    null,
+  );
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0][0], "[test-layer] addTo skipped (map not ready)");
+}
+
+{
+  let removedFrom = null;
+  const layer = {
+    removeFrom(map) {
+      removedFrom = map;
+    },
+  };
+  const map = { id: "map" };
+
+  safeRemoveFromMap(layer, map);
+  assert.equal(removedFrom, map);
+  assert.doesNotThrow(() => safeRemoveFromMap(null, map));
+}

--- a/src/features/aviation/airlineLogoModel.js
+++ b/src/features/aviation/airlineLogoModel.js
@@ -1,0 +1,24 @@
+const unavailableAirlineLogoUrls = new Set();
+
+export function getFlightRouteAirlineIconUrl(route) {
+  const code = String(route?.airlineIcao || route?.airline?.icao || "")
+    .trim()
+    .toUpperCase();
+  if (!/^[A-Z]{2,3}$/.test(code)) return "";
+
+  const url = `/api/proxy/airlines/${code}`;
+  return unavailableAirlineLogoUrls.has(url) ? "" : url;
+}
+
+export function markAirlineLogoUnavailable(src) {
+  const url = String(src || "").trim();
+  if (url) unavailableAirlineLogoUrls.add(url);
+}
+
+export function isAirlineLogoUnavailable(src) {
+  return unavailableAirlineLogoUrls.has(String(src || "").trim());
+}
+
+export function clearAirlineLogoCacheForTest() {
+  unavailableAirlineLogoUrls.clear();
+}

--- a/src/features/aviation/airlineLogoModel.test.js
+++ b/src/features/aviation/airlineLogoModel.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+
+import {
+  clearAirlineLogoCacheForTest,
+  getFlightRouteAirlineIconUrl,
+  isAirlineLogoUnavailable,
+  markAirlineLogoUnavailable,
+} from "./airlineLogoModel.js";
+
+clearAirlineLogoCacheForTest();
+
+assert.equal(
+  getFlightRouteAirlineIconUrl({
+    airlineIcao: " dal ",
+  }),
+  "/api/proxy/airlines/DAL",
+);
+
+assert.equal(
+  getFlightRouteAirlineIconUrl({
+    airline: { icao: "BAW" },
+  }),
+  "/api/proxy/airlines/BAW",
+);
+
+assert.equal(getFlightRouteAirlineIconUrl({ airlineIcao: "N12" }), "");
+assert.equal(getFlightRouteAirlineIconUrl({ airlineIcao: "TOOLONG" }), "");
+
+markAirlineLogoUnavailable("/api/proxy/airlines/DAL");
+assert.equal(isAirlineLogoUnavailable("/api/proxy/airlines/DAL"), true);
+assert.equal(
+  getFlightRouteAirlineIconUrl({
+    airlineIcao: "DAL",
+  }),
+  "",
+);
+
+clearAirlineLogoCacheForTest();
+assert.equal(isAirlineLogoUnavailable("/api/proxy/airlines/DAL"), false);
+assert.equal(
+  getFlightRouteAirlineIconUrl({
+    airlineIcao: "DAL",
+  }),
+  "/api/proxy/airlines/DAL",
+);

--- a/src/features/aviation/flight-routes/flightRouteScheduler.js
+++ b/src/features/aviation/flight-routes/flightRouteScheduler.js
@@ -1,0 +1,219 @@
+import { FLIGHT_ROUTE_LOOKUP_CONFIG } from "../../../config/aviation.js";
+import { normalizeCallsign } from "../../../utils/callsign.js";
+import { flightRouteClient } from "../aviationData.js";
+import {
+  buildRouteCacheKey,
+  buildRoutesByCallsign,
+  getRouteLookupStats,
+  resolvePendingRouteLookups,
+} from "./flightRouteLookupModel.js";
+
+function callsignSetForRouteContext(keys, routeContext) {
+  const callsigns = new Set();
+  for (const key of keys) {
+    const callsign = String(key).split("|")[0] || "";
+    if (buildRouteCacheKey(callsign, routeContext) === key) {
+      callsigns.add(callsign);
+    }
+  }
+  return callsigns;
+}
+
+function defaultLogger() {
+  return console;
+}
+
+export function formatFlightRouteQueueAudit(stats) {
+  return `[audit:flight-route-queue]: done=${stats.done},in_queue=${stats.in_queue},inflight=${stats.inflight},not_do=${stats.not_do}`;
+}
+
+export function createFlightRouteScheduler({
+  client = flightRouteClient,
+  config = FLIGHT_ROUTE_LOOKUP_CONFIG,
+  cache = new Map(),
+  logger = defaultLogger(),
+  now = Date.now,
+  schedule = setTimeout,
+  clearSchedule = clearTimeout,
+} = {}) {
+  const listeners = new Set();
+  const inFlightKeys = new Set();
+  const queuedKeys = new Set();
+  const routeQueue = [];
+
+  let routeQueueTimer = null;
+  let lastLookupStartedAt = 0;
+  let lastAuditLoggedAt = 0;
+  let lastAuditSnapshot = "";
+  let latestAircraft = [];
+  let latestRouteContext = {};
+
+  const notify = () => {
+    const state = { loadingCount: inFlightKeys.size + queuedKeys.size };
+    for (const listener of listeners) listener(state);
+  };
+
+  const getStatsForLatestInput = () =>
+    getRouteLookupStats({
+      aircraft: latestAircraft,
+      cache,
+      queued: callsignSetForRouteContext(queuedKeys, latestRouteContext),
+      inFlight: callsignSetForRouteContext(inFlightKeys, latestRouteContext),
+      routeContext: latestRouteContext,
+      now: now(),
+    });
+
+  const auditRouteQueue = () => {
+    const payload = getStatsForLatestInput();
+    const snapshot = JSON.stringify(payload);
+    const timestamp = now();
+    const queueDrained =
+      payload.in_queue === 0 && payload.inflight === 0 && payload.not_do === 0;
+
+    if (
+      snapshot === lastAuditSnapshot &&
+      timestamp - lastAuditLoggedAt < config.auditLogIntervalMs
+    ) {
+      return;
+    }
+
+    if (!queueDrained && timestamp - lastAuditLoggedAt < config.auditLogIntervalMs) {
+      return;
+    }
+
+    lastAuditSnapshot = snapshot;
+    lastAuditLoggedAt = timestamp;
+    logger.info(formatFlightRouteQueueAudit(payload));
+  };
+
+  const scheduleNextLookup = (delayMs = 0) => {
+    if (routeQueueTimer || routeQueue.length === 0) return;
+    routeQueueTimer = schedule(() => {
+      routeQueueTimer = null;
+      drainRouteQueue();
+    }, delayMs);
+  };
+
+  const lookup = async ({ callsign, routeContext, cacheKey }) => {
+    inFlightKeys.add(cacheKey);
+    notify();
+    auditRouteQueue();
+    try {
+      const route = await client.fetchFlightRoute(callsign, routeContext);
+      cache.set(cacheKey, { route, time: now() });
+      auditRouteQueue();
+    } catch (error) {
+      logger.warn?.(
+        `Flight route lookup failed for ${callsign}:`,
+        error?.message || error,
+      );
+      cache.set(cacheKey, { route: null, time: now() });
+      auditRouteQueue();
+    } finally {
+      inFlightKeys.delete(cacheKey);
+      notify();
+      scheduleNextLookup(config.queueIntervalMs);
+    }
+  };
+
+  function drainRouteQueue() {
+    if (
+      inFlightKeys.size >= config.maxConcurrentLookups ||
+      routeQueue.length === 0
+    ) {
+      return;
+    }
+
+    const elapsed = now() - lastLookupStartedAt;
+    const waitMs = Math.max(0, config.queueIntervalMs - elapsed);
+    if (waitMs > 0) {
+      scheduleNextLookup(waitMs);
+      return;
+    }
+
+    while (
+      routeQueue.length > 0 &&
+      inFlightKeys.size < config.maxConcurrentLookups
+    ) {
+      const entry = routeQueue.shift();
+      queuedKeys.delete(entry.cacheKey);
+      lastLookupStartedAt = now();
+      lookup(entry);
+    }
+  }
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      listener({ loadingCount: inFlightKeys.size + queuedKeys.size });
+      return () => listeners.delete(listener);
+    },
+
+    syncAircraft({ aircraft = [], routeContext = {} }) {
+      latestAircraft = aircraft;
+      latestRouteContext = routeContext;
+
+      const pending = resolvePendingRouteLookups({
+        aircraft,
+        cache,
+        inFlight: callsignSetForRouteContext(inFlightKeys, routeContext),
+        queued: callsignSetForRouteContext(queuedKeys, routeContext),
+        routeContext,
+        now: now(),
+        maxLookups: Math.min(
+          config.maxLookupsPerPass,
+          Math.max(0, config.maxQueueSize - queuedKeys.size),
+        ),
+      });
+
+      for (const callsign of pending) {
+        const normalized = normalizeCallsign(callsign);
+        const cacheKey = buildRouteCacheKey(normalized, routeContext);
+        if (!cacheKey || queuedKeys.has(cacheKey) || inFlightKeys.has(cacheKey)) {
+          continue;
+        }
+        queuedKeys.add(cacheKey);
+        routeQueue.push({ callsign: normalized, routeContext, cacheKey });
+      }
+
+      if (pending.length > 0) {
+        auditRouteQueue();
+        scheduleNextLookup();
+      }
+      notify();
+    },
+
+    getRoutesByCallsign({ aircraft = [], routeContext = {} } = {}) {
+      return buildRoutesByCallsign({
+        aircraft,
+        cache,
+        routeContext,
+        now: now(),
+      });
+    },
+
+    getLoadingCount() {
+      return inFlightKeys.size + queuedKeys.size;
+    },
+
+    applyTemporaryRoute(callsign, route, routeContext = {}) {
+      const normalized = normalizeCallsign(callsign);
+      if (!normalized || !route) return;
+      cache.set(buildRouteCacheKey(normalized, routeContext), {
+        route,
+        time: now(),
+      });
+      notify();
+    },
+
+    dispose() {
+      if (routeQueueTimer) {
+        clearSchedule(routeQueueTimer);
+        routeQueueTimer = null;
+      }
+      listeners.clear();
+    },
+  };
+}
+
+export const flightRouteScheduler = createFlightRouteScheduler();

--- a/src/features/aviation/flight-routes/flightRouteScheduler.test.js
+++ b/src/features/aviation/flight-routes/flightRouteScheduler.test.js
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+
+import { createFlightRouteScheduler } from "./flightRouteScheduler.js";
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function createManualTimer() {
+  const callbacks = [];
+  return {
+    callbacks,
+    schedule(callback) {
+      callbacks.push(callback);
+      return callback;
+    },
+    clear(callback) {
+      const index = callbacks.indexOf(callback);
+      if (index >= 0) callbacks.splice(index, 1);
+    },
+    runNext() {
+      const callback = callbacks.shift();
+      if (callback) callback();
+    },
+  };
+}
+
+{
+  const timer = createManualTimer();
+  const fetched = [];
+  const route = {
+    callsign: "DAL123",
+    origin: { icao: "KATL" },
+    destination: { icao: "KBOS" },
+  };
+  const scheduler = createFlightRouteScheduler({
+    client: {
+      async fetchFlightRoute(callsign, routeContext) {
+        fetched.push({ callsign, routeContext });
+        return route;
+      },
+    },
+    config: {
+      maxConcurrentLookups: 1,
+      maxLookupsPerPass: 2,
+      maxQueueSize: 10,
+      queueIntervalMs: 0,
+      auditLogIntervalMs: 0,
+      hitCacheMs: 60_000,
+      missCacheMs: 10_000,
+    },
+    logger: { info() {}, warn() {} },
+    schedule: timer.schedule,
+    clearSchedule: timer.clear,
+    now: () => 1_700_000_000_000,
+  });
+
+  let notificationCount = 0;
+  scheduler.subscribe(() => {
+    notificationCount += 1;
+  });
+
+  const routeContext = {
+    icao: "KBOS",
+    iata: "BOS",
+    lat: 42.3656,
+    lon: -71.0096,
+    routeProvider: "flightaware",
+  };
+
+  scheduler.syncAircraft({
+    aircraft: [{ callsign: "DAL123", lat: 40.64, lon: -73.78 }],
+    routeContext,
+  });
+
+  assert.equal(scheduler.getLoadingCount(), 1);
+  timer.runNext();
+  await flushPromises();
+
+  assert.deepEqual(fetched, [{ callsign: "DAL123", routeContext }]);
+  assert.equal(scheduler.getLoadingCount(), 0);
+  assert.deepEqual(
+    scheduler.getRoutesByCallsign({
+      aircraft: [{ callsign: "dal123" }],
+      routeContext,
+    }),
+    { DAL123: route },
+  );
+  assert.ok(notificationCount >= 2);
+
+  scheduler.syncAircraft({
+    aircraft: [{ callsign: "DAL123", lat: 40.64, lon: -73.78 }],
+    routeContext,
+  });
+  assert.equal(timer.callbacks.length, 0);
+  await flushPromises();
+  assert.equal(fetched.length, 1);
+  scheduler.dispose();
+}
+
+{
+  const timer = createManualTimer();
+  const scheduler = createFlightRouteScheduler({
+    client: {
+      async fetchFlightRoute() {
+        throw new Error("network should not run");
+      },
+    },
+    config: {
+      maxConcurrentLookups: 1,
+      maxLookupsPerPass: 2,
+      maxQueueSize: 10,
+      queueIntervalMs: 0,
+      auditLogIntervalMs: 0,
+      hitCacheMs: 60_000,
+      missCacheMs: 10_000,
+    },
+    logger: { info() {}, warn() {} },
+    schedule: timer.schedule,
+    clearSchedule: timer.clear,
+    now: () => 1_700_000_000_000,
+  });
+
+  const routeContext = { icao: "KJFK", iata: "JFK" };
+  const temporaryRoute = {
+    callsign: "AAL456",
+    origin: { icao: "KLAX" },
+    destination: { icao: "KJFK" },
+  };
+
+  scheduler.applyTemporaryRoute(" aal456 ", temporaryRoute, routeContext);
+
+  assert.deepEqual(
+    scheduler.getRoutesByCallsign({
+      aircraft: [{ callsign: "AAL456" }],
+      routeContext,
+    }),
+    { AAL456: temporaryRoute },
+  );
+  assert.equal(timer.callbacks.length, 0);
+  scheduler.dispose();
+}

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -1,69 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  buildRouteCacheKey,
-  buildRoutesByCallsign,
-  getRouteLookupStats,
-  resolvePendingRouteLookups,
-} from "../features/aviation/flight-routes/flightRouteLookupModel.js";
-import { flightRouteClient } from "../features/aviation/aviationData.js";
-import { FLIGHT_ROUTE_LOOKUP_CONFIG } from "../config/aviation.js";
 import { normalizeCallsign } from "../utils/callsign.js";
+import { flightRouteScheduler } from "../features/aviation/flight-routes/flightRouteScheduler.js";
 
-const routeCache = new Map();
-const inFlight = new Set();
-const queued = new Set();
-const routeQueue = [];
-
-let routeQueueTimer = null;
-let lastLookupStartedAt = 0;
-let lastAuditLoggedAt = 0;
-let lastAuditSnapshot = "";
-let latestAircraft = [];
-let latestRouteContext = {};
-
-function getAuditPayload() {
-  const stats = getRouteLookupStats({
-    aircraft: latestAircraft,
-    cache: routeCache,
-    queued,
-    inFlight,
-    routeContext: latestRouteContext,
-    now: Date.now(),
-  });
-  return stats;
-}
-
-export function formatFlightRouteQueueAudit(stats) {
-  return `[audit:flight-route-queue]: done=${stats.done},in_queue=${stats.in_queue},inflight=${stats.inflight},not_do=${stats.not_do}`;
-}
-
-function auditRouteQueue() {
-  const payload = getAuditPayload();
-  const snapshot = JSON.stringify(payload);
-  const now = Date.now();
-  const queueDrained =
-    payload.in_queue === 0 && payload.inflight === 0 && payload.not_do === 0;
-
-  if (
-    snapshot === lastAuditSnapshot &&
-    now - lastAuditLoggedAt < FLIGHT_ROUTE_LOOKUP_CONFIG.auditLogIntervalMs
-  ) {
-    return;
-  }
-
-  if (
-    !queueDrained &&
-    now - lastAuditLoggedAt < FLIGHT_ROUTE_LOOKUP_CONFIG.auditLogIntervalMs
-  ) {
-    return;
-  }
-
-  lastAuditSnapshot = snapshot;
-  lastAuditLoggedAt = now;
-  console.info(formatFlightRouteQueueAudit(payload));
-}
+export { formatFlightRouteQueueAudit } from "../features/aviation/flight-routes/flightRouteScheduler.js";
 
 export function useFlightRoutes(aircraft, routeContextInput = {}) {
   const [version, setVersion] = useState(0);
@@ -96,123 +37,29 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
   }, []);
 
   useEffect(() => {
-    latestAircraft = aircraft;
-    latestRouteContext = routeContext;
+    flightRouteScheduler.syncAircraft({
+      aircraft,
+      routeContext,
+    });
+  }, [aircraft, routeContext]);
 
-    const bump = () => {
-      if (mountedRef.current) setVersion((value) => value + 1);
-    };
-
-    const updateLoadingCount = () => {
-      if (mountedRef.current) setLoadingCount(inFlight.size + queued.size);
-    };
-
-    const scheduleNextLookup = (delayMs = 0) => {
-      if (routeQueueTimer || routeQueue.length === 0) return;
-      routeQueueTimer = setTimeout(() => {
-        routeQueueTimer = null;
-        drainRouteQueue();
-      }, delayMs);
-    };
-
-    const lookup = async (callsign) => {
-      inFlight.add(callsign);
-      updateLoadingCount();
-      auditRouteQueue();
-      try {
-        const route = await flightRouteClient.fetchFlightRoute(
-          callsign,
-          routeContext,
-        );
-        routeCache.set(buildRouteCacheKey(callsign, routeContext), {
-          route,
-          time: Date.now(),
-        });
-        auditRouteQueue();
-      } catch (error) {
-        console.warn(`Flight route lookup failed for ${callsign}:`, error.message);
-        routeCache.set(buildRouteCacheKey(callsign, routeContext), {
-          route: null,
-          time: Date.now(),
-        });
-        auditRouteQueue();
-      } finally {
-        inFlight.delete(callsign);
+  useEffect(
+    () =>
+      flightRouteScheduler.subscribe(({ loadingCount: nextLoadingCount }) => {
+        if (!mountedRef.current) return;
+        setLoadingCount(nextLoadingCount);
         // Always bump so the color updates the moment the route lands,
         // even if the aircraft list has refreshed since this fetch started.
-        bump();
-        updateLoadingCount();
-        scheduleNextLookup(FLIGHT_ROUTE_LOOKUP_CONFIG.queueIntervalMs);
-      }
-    };
-
-    const drainRouteQueue = () => {
-      if (
-        inFlight.size >= FLIGHT_ROUTE_LOOKUP_CONFIG.maxConcurrentLookups ||
-        routeQueue.length === 0
-      ) {
-        return;
-      }
-
-      const elapsed = Date.now() - lastLookupStartedAt;
-      const waitMs = Math.max(
-        0,
-        FLIGHT_ROUTE_LOOKUP_CONFIG.queueIntervalMs - elapsed,
-      );
-      if (waitMs > 0) {
-        scheduleNextLookup(waitMs);
-        return;
-      }
-
-      while (
-        routeQueue.length > 0 &&
-        inFlight.size < FLIGHT_ROUTE_LOOKUP_CONFIG.maxConcurrentLookups
-      ) {
-        const callsign = routeQueue.shift();
-        queued.delete(callsign);
-        lastLookupStartedAt = Date.now();
-        lookup(callsign);
-      }
-    };
-
-    const queueSlots = Math.max(
-      0,
-      FLIGHT_ROUTE_LOOKUP_CONFIG.maxQueueSize - queued.size,
-    );
-    const pending = resolvePendingRouteLookups({
-      aircraft,
-      cache: routeCache,
-      inFlight,
-      queued,
-      routeContext,
-      now: Date.now(),
-      maxLookups: Math.min(
-        FLIGHT_ROUTE_LOOKUP_CONFIG.maxLookupsPerPass,
-        queueSlots,
-      ),
-    });
-
-    for (const callsign of pending) {
-      queued.add(callsign);
-      routeQueue.push(callsign);
-    }
-
-    if (pending.length > 0) {
-      auditRouteQueue();
-      updateLoadingCount();
-      scheduleNextLookup();
-    }
-
-    bump();
-  }, [aircraft, routeContext]);
+        setVersion((value) => value + 1);
+      }),
+    [],
+  );
 
   const routesByCallsign = useMemo(() => {
     version;
-    return buildRoutesByCallsign({
+    return flightRouteScheduler.getRoutesByCallsign({
       aircraft,
-      cache: routeCache,
       routeContext,
-      now: Date.now(),
     });
   }, [aircraft, routeContext, version]);
 
@@ -225,11 +72,7 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
     (callsign, route) => {
       const normalized = normalizeCallsign(callsign);
       if (!normalized || !route) return;
-      routeCache.set(buildRouteCacheKey(normalized, routeContext), {
-        route,
-        time: Date.now(),
-      });
-      if (mountedRef.current) setVersion((v) => v + 1);
+      flightRouteScheduler.applyTemporaryRoute(normalized, route, routeContext);
     },
     [routeContext],
   );

--- a/src/utils/flightRouteDisplay.js
+++ b/src/utils/flightRouteDisplay.js
@@ -1,4 +1,5 @@
 import { ARRIVAL, DEPARTURE } from './aircraftMovement.js'
+export { getFlightRouteAirlineIconUrl } from '../features/aviation/airlineLogoModel.js'
 
 const airportCode = (airport) =>
   String(airport?.iata || airport?.icao || '').trim().toUpperCase()
@@ -57,26 +58,6 @@ export const formatFlightRouteMunicipalityLabel = (route) => {
   if (!origin || !destination) return ''
   if (sameAirport(route.origin, route.destination)) return ''
   return `${origin} -> ${destination}${routeDisplaySuffix(route)}`
-}
-
-// Build the airline logo URL from the airline ICAO (e.g. "JBU" → JetBlue).
-// We always route through /api/proxy/airlines/[icao] instead of using the
-// raw url that some providers attach — direct hot-links to the upstream
-// CDN get blocked / 403'd in the browser, and the proxy lets both
-// FlightAware and adsbdb routes share the same URL shape so adsbdb users
-// see logos too.
-//
-// Strictly 2-3 alphabetic chars. The FlightAware parser falls back to
-// the first 3 chars of the callsign when no airline meta is in the page,
-// so for US general-aviation tail numbers (callsign like N123AB) we'd
-// otherwise request /api/proxy/airlines/N12 which 404s upstream. The
-// alphabetic-only guard short-circuits those before they hit the network.
-export const getFlightRouteAirlineIconUrl = (route) => {
-  const code = String(route?.airlineIcao || route?.airline?.icao || '')
-    .trim()
-    .toUpperCase()
-  if (!/^[A-Z]{2,3}$/.test(code)) return ''
-  return `/api/proxy/airlines/${code}`
 }
 
 export const formatLocalFlightRouteLabel = (route, airport, movement) => {


### PR DESCRIPTION
## Summary
- Move flight route queue/cache/network scheduling into a feature-level scheduler so `useFlightRoutes` only syncs React inputs and subscribes to route state.
- Add an aviation airline logo model plus reusable preview `AirlineLogo` component with client-side unavailable-logo caching.
- Extract airport explorer selection/sidebar pieces and add shared Leaflet layer safety for map marker lifecycle races.
- Remove stale untracked FIDS POC test leftovers that referenced non-existent implementation modules before staging this PR scope.

## Validation
- `pnpm lint`
- `pnpm test` (67 test files)
- `pnpm build`
- Dev smoke: `curl -I http://localhost:3000/airport/KBOS` returned 200 on the current dev server.

## Notes
- During smoke verification, Clerk/dev external loading and ADS-B timeout warnings appeared in the local browser log; route SSR and build checks were successful.
- The Leaflet marker guard follows the existing AreaMarker pattern and now shares it through `leafletLayerSafety.js`.
