### PR TITLE
[codex] show mobile map source status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A modern airport-monitoring HUD with dynamic airport search, METAR context, and 
 ## Overview
 ADSBao provides a search-first airport operations view with weather context and aircraft position overlays. Airport search is backed by public airport directory data.
 
-Current web app version: **1.4.0**. See `src/config/changelog.js` (rendered at `/changelog`) for product version history.
+Current web app version: **1.4.0**. Runtime version strings and ADSBao User-Agent values share `src/config/siteMeta.js`; see `src/config/changelog.js` (rendered at `/changelog`) for product version history.
 
 ## Tech Stack
 - **Frontend**: React on Next.js App Router, Tailwind CSS v4, DaisyUI, Lucide Icons.

--- a/src/app/api/proxy/airlines/[icao]/route.js
+++ b/src/app/api/proxy/airlines/[icao]/route.js
@@ -5,6 +5,7 @@ import {
   jsonProxyResponse,
   readResponseArrayBuffer,
 } from "@/app/api/_shared/apiProxySecurity.js";
+import { ADSBAO_SITE_VERSION } from "@/config/siteMeta.js";
 
 // Pass-through proxy for airline logo PNGs. Direct hot-links to
 // flightaware.com get blocked or rate-limited in the browser, so we
@@ -80,7 +81,7 @@ export async function GET(request, { params }) {
         // Identify as a regular browser so the CDN serves the image
         // rather than a hot-link block page.
         "User-Agent":
-          "Mozilla/5.0 (compatible; ADSBao/1.0; +https://adsbao.com)",
+          `Mozilla/5.0 (compatible; ADSBao/${ADSBAO_SITE_VERSION}; +https://adsbao.com)`,
         Accept: "image/png,image/*",
       },
       // Next.js fetch dedupe + cache so we don't hammer the CDN.

--- a/src/components/airport/explorer/AirportExplorer.jsx
+++ b/src/components/airport/explorer/AirportExplorer.jsx
@@ -167,7 +167,14 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
         )}
 
         <div className="relative min-w-0 flex-1 overflow-hidden bg-atc-bg">
-          {!(isMobile && sidebarOpen) && <ExplorerMapMenu />}
+          {!(isMobile && sidebarOpen) && (
+            <ExplorerMapMenu
+              feedSource={traffic.feedSource}
+              feedStatus={traffic.feedStatus}
+              lastUpdated={traffic.lastUpdated}
+              routeProvider={traffic.routeProvider}
+            />
+          )}
 
           <AirportMap
             icao={airportProfile.icao}

--- a/src/components/explorer/ExplorerMapMenu.jsx
+++ b/src/components/explorer/ExplorerMapMenu.jsx
@@ -2,10 +2,17 @@
 
 import { PanelLeft } from "lucide-react";
 import MapControlBar from "@/components/ui/MapControlBar";
+import MobileMapSourceStatus from "./MobileMapSourceStatus.jsx";
 import { useExplorerUi } from "./ExplorerUiContext.jsx";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 
-export default function ExplorerMapMenu({ onFitToTrace = null } = {}) {
+export default function ExplorerMapMenu({
+  feedSource = "",
+  feedStatus = "live",
+  lastUpdated = null,
+  routeProvider = "",
+  onFitToTrace = null,
+} = {}) {
   const { t } = useI18n();
   const {
     isMobile,
@@ -48,6 +55,15 @@ export default function ExplorerMapMenu({ onFitToTrace = null } = {}) {
         onToggleRoutingPointBadges={toggleRoutingPointBadges}
         onFitToTrace={onFitToTrace}
       />
+
+      {isMobile ? (
+        <MobileMapSourceStatus
+          feedSource={feedSource}
+          feedStatus={feedStatus}
+          lastUpdated={lastUpdated}
+          routeProvider={routeProvider}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/explorer/MobileMapSourceStatus.jsx
+++ b/src/components/explorer/MobileMapSourceStatus.jsx
@@ -1,0 +1,60 @@
+"use client";
+
+import RequestPulseDots from "@/components/ui/RequestPulseDots";
+import {
+  ROUTE_PROVIDER,
+  buildMobileMapSourceStatus,
+} from "@/features/aviation/sourceDisplayModel.js";
+
+export default function MobileMapSourceStatus({
+  feedSource = "",
+  feedStatus = "live",
+  lastUpdated = null,
+  routeProvider = ROUTE_PROVIDER.ADSBDB,
+}) {
+  const status = buildMobileMapSourceStatus({ feedSource, routeProvider });
+  const updatedLabel = formatUpdated(lastUpdated);
+  if (!status.feedSource && !updatedLabel && !status.routeProvider) return null;
+
+  return (
+    <div
+      className={`airport-map-source-status airport-map-source-status--${feedStatus}`}
+      aria-label="Map data sources"
+    >
+      {status.feedSource || updatedLabel ? (
+        <span className="airport-map-source-status__line">
+          {status.feedSource ? (
+            <span className="airport-map-source-status__source notranslate" translate="no">
+              {status.feedSource}
+            </span>
+          ) : null}
+          {status.feedSource ? <RequestPulseDots ariaLabel="ADS-B feed live" /> : null}
+          {updatedLabel ? (
+            <span className="airport-map-source-status__time">{updatedLabel}</span>
+          ) : null}
+        </span>
+      ) : null}
+      {status.routeProvider ? (
+        <span className="airport-map-source-status__route">
+          <span
+            aria-hidden="true"
+            className="airport-map-source-status__diamond"
+          />
+          <span className="notranslate" translate="no">
+            {status.routeProvider}
+          </span>
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function formatUpdated(date) {
+  if (!date) return "";
+  return date.toLocaleTimeString([], {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}

--- a/src/components/sidebar/SidebarShell.jsx
+++ b/src/components/sidebar/SidebarShell.jsx
@@ -4,6 +4,10 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 import RequestPulseDots from "@/components/ui/RequestPulseDots";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
+import {
+  getRouteProviderDisplayName,
+  resolveRouteProvider,
+} from "@/features/aviation/sourceDisplayModel.js";
 
 // Shared chrome for the airport + flight sidebars. Handles:
 //   - The outer panel container + responsive overlay variant.
@@ -24,7 +28,9 @@ export default function SidebarShell({
 }) {
   const { t } = useI18n();
   const flightAwareEnabled = useFlightAwareEnabled();
-  const routeProviderLabel = flightAwareEnabled ? "FlightAware" : "adsbdb";
+  const routeProviderLabel = getRouteProviderDisplayName(
+    resolveRouteProvider({ flightAwareEnabled }),
+  );
   const isMobileOverlay = Boolean(onClose);
   const updatedLabel = formatUpdated(lastUpdated);
 

--- a/src/config/about.js
+++ b/src/config/about.js
@@ -1,12 +1,22 @@
+import { ADSBAO_SITE_VERSION } from "./siteMeta.js";
+
 export const ABOUT_BUILD_META = [
-  { label: "Version", labelKey: "about.meta.version", value: "1.3.0" },
+  {
+    label: "Version",
+    labelKey: "about.meta.version",
+    value: ADSBAO_SITE_VERSION,
+  },
   {
     label: "Release",
     labelKey: "about.meta.release",
     value: "Next.js Web",
     valueKey: "about.meta.nextWeb",
   },
-  { label: "Stack", labelKey: "about.meta.stack", value: "React 19 · Next 16 · Leaflet" },
+  {
+    label: "Stack",
+    labelKey: "about.meta.stack",
+    value: "React 19 · Next 16 · Leaflet",
+  },
   {
     label: "Scope",
     labelKey: "about.meta.scope",

--- a/src/config/aviation.js
+++ b/src/config/aviation.js
@@ -1,3 +1,5 @@
+import { buildAdsbaoUserAgent } from "./siteMeta.js";
+
 export const AIRPORT_MAP_ZOOM = {
   approach: 10,
   airport: 11,
@@ -49,7 +51,7 @@ export const FLIGHT_ROUTE_LOOKUP_CONFIG = {
   rateLimitRefillMs: 1000,
   backoffInitialMs: 2000,
   backoffMaxMs: 60_000,
-  userAgent: "ADSBao/0.10.0 (https://github.com/orriduck/ADSBao)",
+  userAgent: buildAdsbaoUserAgent(),
 };
 
 export const PROCEDURE_DATA_CONFIG = {
@@ -59,5 +61,5 @@ export const PROCEDURE_DATA_CONFIG = {
   maxProceduresPerAirport: 12,
   maxZipBytes: 50 * 1024 * 1024,
   maxCifpBytes: 120 * 1024 * 1024,
-  userAgent: "ADSBao/0.10.0 (https://github.com/orriduck/ADSBao)",
+  userAgent: buildAdsbaoUserAgent(),
 };

--- a/src/config/siteMeta.js
+++ b/src/config/siteMeta.js
@@ -1,0 +1,9 @@
+export const ADSBAO_PRODUCT_NAME = "ADSBao";
+export const ADSBAO_SITE_VERSION = "1.4.0";
+export const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
+
+export function buildAdsbaoUserAgent(suffix = "") {
+  const base = `${ADSBAO_PRODUCT_NAME}/${ADSBAO_SITE_VERSION} (+${ADSBAO_REPOSITORY_URL})`;
+  const cleanSuffix = String(suffix || "").trim();
+  return cleanSuffix ? `${base} ${cleanSuffix}` : base;
+}

--- a/src/config/siteMeta.test.js
+++ b/src/config/siteMeta.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+
+import {
+  ADSBAO_PRODUCT_NAME,
+  ADSBAO_SITE_VERSION,
+  buildAdsbaoUserAgent,
+} from "./siteMeta.js";
+
+assert.equal(ADSBAO_PRODUCT_NAME, "ADSBao");
+assert.equal(ADSBAO_SITE_VERSION, "1.4.0");
+assert.equal(
+  buildAdsbaoUserAgent("adsbdb/v0"),
+  "ADSBao/1.4.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+);
+assert.equal(
+  buildAdsbaoUserAgent(),
+  "ADSBao/1.4.0 (+https://github.com/orriduck/ADSBao)",
+);
+
+console.log("siteMeta.test.js ok");

--- a/src/features/aircraft/callsign/aircraftCallsign.models.js
+++ b/src/features/aircraft/callsign/aircraftCallsign.models.js
@@ -1,5 +1,6 @@
-export const AIRCRAFT_CALLSIGN_USER_AGENT =
-  "ADSBao/1.2.1 (https://github.com/orriduck/ADSBao)";
+import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
+
+export const AIRCRAFT_CALLSIGN_USER_AGENT = buildAdsbaoUserAgent();
 
 export const AIRCRAFT_CALLSIGN_MAX_BYTES = 1 * 1024 * 1024;
 

--- a/src/features/aircraft/photos/aircraftPhotos.models.js
+++ b/src/features/aircraft/photos/aircraftPhotos.models.js
@@ -1,5 +1,6 @@
-export const AIRCRAFT_PHOTOS_USER_AGENT =
-  "ADSBao/1.2.1 (+https://github.com/orriduck/ADSBao)";
+import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
+
+export const AIRCRAFT_PHOTOS_USER_AGENT = buildAdsbaoUserAgent();
 
 export const AIRCRAFT_PHOTO_MAX_BYTES = 256 * 1024;
 export const AIRCRAFT_PHOTO_IMAGE_MAX_BYTES = 2 * 1024 * 1024;

--- a/src/features/aircraft/positions/aircraftPositions.models.js
+++ b/src/features/aircraft/positions/aircraftPositions.models.js
@@ -1,5 +1,6 @@
-export const AIRCRAFT_POSITIONS_USER_AGENT =
-  "ADSBao/1.2.1 (https://github.com/orriduck/ADSBao)";
+import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
+
+export const AIRCRAFT_POSITIONS_USER_AGENT = buildAdsbaoUserAgent();
 
 export const AIRCRAFT_POSITIONS_MAX_BYTES = 2 * 1024 * 1024;
 

--- a/src/features/aircraft/trace/aircraftTrace.models.js
+++ b/src/features/aircraft/trace/aircraftTrace.models.js
@@ -1,5 +1,6 @@
-export const AIRCRAFT_TRACE_USER_AGENT =
-  "ADSBao/1.2.1 (https://github.com/orriduck/ADSBao)";
+import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
+
+export const AIRCRAFT_TRACE_USER_AGENT = buildAdsbaoUserAgent();
 
 // Full traces for long-haul flights can run several MB — bump the
 // upstream-response cap accordingly. Recent traces are still small.

--- a/src/features/airport/explorer/useAirportExplorerData.js
+++ b/src/features/airport/explorer/useAirportExplorerData.js
@@ -5,10 +5,15 @@ import { useAircraftPositions } from "@/hooks/useAircraftPositions.js";
 import { useFlightRoutes } from "@/hooks/useFlightRoutes.js";
 import { useMetar } from "@/hooks/useMetar.js";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled.js";
+import {
+  ROUTE_PROVIDER,
+  resolveRouteProvider,
+} from "@/features/aviation/sourceDisplayModel.js";
 import { enrichAircraftWithRoutes } from "./airportExplorerModel.js";
 
 export function useAirportExplorerData(airportProfile) {
   const flightAwareEnabled = useFlightAwareEnabled();
+  const routeProvider = resolveRouteProvider({ flightAwareEnabled });
   const {
     raw: metarRaw,
     parsed: metar,
@@ -32,7 +37,8 @@ export function useAirportExplorerData(airportProfile) {
     applyTemporaryRoute,
   } = useFlightRoutes(aircraft, {
     ...airportProfile,
-    routeProvider: flightAwareEnabled ? "flightaware" : "",
+    routeProvider:
+      routeProvider === ROUTE_PROVIDER.FLIGHTAWARE ? routeProvider : "",
   });
 
   const aircraftWithRoutes = useMemo(
@@ -58,6 +64,7 @@ export function useAirportExplorerData(airportProfile) {
       lastUpdated,
       feedStatus,
       feedSource,
+      routeProvider,
       routeLoadingCount,
       applyTemporaryRoute,
     },

--- a/src/features/airport/nearby/nearbyAirportDataClient.js
+++ b/src/features/airport/nearby/nearbyAirportDataClient.js
@@ -5,13 +5,14 @@ import {
   normalizeAiracAirport,
 } from "./nearbyAirportModel.js";
 import { readResponseJson } from "../../../app/api/_shared/apiProxySecurity.js";
+import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
 
 export const AIRAC_AIRPORT_INDEX_CONFIG = {
   country: "US",
   minRunwayLength: 5000,
   maxPages: 25,
   cacheMs: 6 * 60 * 60 * 1000,
-  userAgent: "ADSBao/0.10.0 (https://github.com/orriduck/ADSBao)",
+  userAgent: buildAdsbaoUserAgent(),
 };
 
 export async function fetchAiracAirportIndex({

--- a/src/features/aviation/flight-routes/adsbdbRouteProxyModel.js
+++ b/src/features/aviation/flight-routes/adsbdbRouteProxyModel.js
@@ -2,6 +2,7 @@ import {
   normalizeRouteCallsign,
   sanitizeAirportCode,
 } from "./flightRouteCallsign.js";
+import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
 
 // adsbdb.com is the only normal public callsign-route provider we use.
 // See https://www.adsbdb.com — the v0 API returns
@@ -10,7 +11,7 @@ import {
 export const ADSBDB_BASE = "https://api.adsbdb.com/v0";
 
 export const ADSBDB_USER_AGENT =
-  "ADSBao/1.2.1 (+https://github.com/orriduck/ADSBao) adsbdb/v0";
+  buildAdsbaoUserAgent("adsbdb/v0");
 
 export const ADSBDB_ROUTE_MISS_STATUS = 200;
 

--- a/src/features/aviation/flight-routes/flightawareRouteProxyModel.js
+++ b/src/features/aviation/flight-routes/flightawareRouteProxyModel.js
@@ -2,11 +2,12 @@ import {
   normalizeRouteCallsign,
   sanitizeAirportCode,
 } from "./flightRouteCallsign.js";
+import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
 
 export const FLIGHTAWARE_BASE = "https://www.flightaware.com/live/flight";
 
 export const FLIGHTAWARE_USER_AGENT =
-  "ADSBao/1.3.0 (+https://github.com/orriduck/ADSBao) flightaware/html";
+  buildAdsbaoUserAgent("flightaware/html");
 
 const cleanString = (value) => String(value || "").trim();
 const cleanUpper = (value) => cleanString(value).toUpperCase();

--- a/src/features/aviation/sourceDisplayModel.js
+++ b/src/features/aviation/sourceDisplayModel.js
@@ -1,0 +1,59 @@
+export const DATA_SOURCE = Object.freeze({
+  ADSB_LOL: "adsb.lol",
+  AIRPLANES_LIVE: "airplanes.live",
+  ADSBDB: "adsbdb",
+  FLIGHTAWARE: "flightaware",
+  COMMUNITY_FEEDBACK: "community-feedback",
+});
+
+export const ROUTE_PROVIDER = Object.freeze({
+  ADSBDB: DATA_SOURCE.ADSBDB,
+  FLIGHTAWARE: DATA_SOURCE.FLIGHTAWARE,
+});
+
+const DATA_SOURCE_LABELS = Object.freeze({
+  [DATA_SOURCE.ADSB_LOL]: "adsb.lol",
+  [DATA_SOURCE.AIRPLANES_LIVE]: "airplanes.live",
+  [DATA_SOURCE.ADSBDB]: "adsbdb",
+  [DATA_SOURCE.FLIGHTAWARE]: "FlightAware",
+  [DATA_SOURCE.COMMUNITY_FEEDBACK]: "Community",
+});
+
+const ROUTE_PROVIDER_LABELS = Object.freeze({
+  [ROUTE_PROVIDER.ADSBDB]: DATA_SOURCE_LABELS[DATA_SOURCE.ADSBDB],
+  [ROUTE_PROVIDER.FLIGHTAWARE]: DATA_SOURCE_LABELS[DATA_SOURCE.FLIGHTAWARE],
+});
+
+function normalizeKey(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+export function getDataSourceDisplayName(source) {
+  const raw = String(source || "").trim();
+  if (!raw) return "";
+  return DATA_SOURCE_LABELS[normalizeKey(raw)] || raw;
+}
+
+export function getRouteProviderDisplayName(provider) {
+  const raw = String(provider || "").trim();
+  if (!raw) return "";
+  return ROUTE_PROVIDER_LABELS[normalizeKey(raw)] || raw;
+}
+
+export function resolveRouteProvider({ flightAwareEnabled = false } = {}) {
+  return flightAwareEnabled ? ROUTE_PROVIDER.FLIGHTAWARE : ROUTE_PROVIDER.ADSBDB;
+}
+
+function badgeText(value) {
+  return String(value || "").trim().toUpperCase();
+}
+
+export function buildMobileMapSourceStatus({
+  feedSource = "",
+  routeProvider = "",
+} = {}) {
+  return {
+    feedSource: badgeText(getDataSourceDisplayName(feedSource)),
+    routeProvider: badgeText(getRouteProviderDisplayName(routeProvider)),
+  };
+}

--- a/src/features/aviation/sourceDisplayModel.test.js
+++ b/src/features/aviation/sourceDisplayModel.test.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+
+import {
+  DATA_SOURCE,
+  ROUTE_PROVIDER,
+  buildMobileMapSourceStatus,
+  getDataSourceDisplayName,
+  getRouteProviderDisplayName,
+} from "./sourceDisplayModel.js";
+
+assert.equal(getDataSourceDisplayName(DATA_SOURCE.ADSB_LOL), "adsb.lol");
+assert.equal(
+  getDataSourceDisplayName(DATA_SOURCE.AIRPLANES_LIVE),
+  "airplanes.live",
+);
+assert.equal(getDataSourceDisplayName("custom-feed"), "custom-feed");
+assert.equal(getDataSourceDisplayName(""), "");
+
+assert.equal(
+  getRouteProviderDisplayName(ROUTE_PROVIDER.FLIGHTAWARE),
+  "FlightAware",
+);
+assert.equal(getRouteProviderDisplayName(ROUTE_PROVIDER.ADSBDB), "adsbdb");
+assert.equal(getRouteProviderDisplayName(""), "");
+
+assert.deepEqual(
+  buildMobileMapSourceStatus({
+    feedSource: DATA_SOURCE.AIRPLANES_LIVE,
+    routeProvider: ROUTE_PROVIDER.FLIGHTAWARE,
+  }),
+  {
+    feedSource: "AIRPLANES.LIVE",
+    routeProvider: "FLIGHTAWARE",
+  },
+);
+
+assert.deepEqual(
+  buildMobileMapSourceStatus({
+    feedSource: "",
+    routeProvider: ROUTE_PROVIDER.ADSBDB,
+  }),
+  {
+    feedSource: "",
+    routeProvider: "ADSBDB",
+  },
+);
+
+console.log("sourceDisplayModel.test.js ok");

--- a/src/features/weather/localWeather.models.js
+++ b/src/features/weather/localWeather.models.js
@@ -1,5 +1,6 @@
-export const LOCAL_WEATHER_USER_AGENT =
-  "ADSBao/0.10.0 (https://github.com/orriduck/ADSBao)";
+import { buildAdsbaoUserAgent } from "../../config/siteMeta.js";
+
+export const LOCAL_WEATHER_USER_AGENT = buildAdsbaoUserAgent();
 
 export const LOCAL_WEATHER_MAX_BYTES = 512 * 1024;
 

--- a/src/features/weather/metar/metar.models.js
+++ b/src/features/weather/metar/metar.models.js
@@ -1,5 +1,6 @@
-export const METAR_USER_AGENT =
-  "ADSBao/0.10.0 (https://github.com/orriduck/ADSBao)";
+import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
+
+export const METAR_USER_AGENT = buildAdsbaoUserAgent();
 
 export const METAR_MAX_BYTES = 512 * 1024;
 

--- a/src/style.css
+++ b/src/style.css
@@ -2029,6 +2029,73 @@ body {
     outline-offset: 2px;
 }
 
+.airport-map-source-status {
+    align-items: flex-end;
+    display: none;
+    flex-direction: column;
+    gap: 4px;
+    justify-content: center;
+    left: 110px;
+    min-width: 0;
+    position: absolute;
+    right: 12px;
+    top: calc(100% + 10px);
+    white-space: nowrap;
+}
+
+.airport-map-menu--mobile .airport-map-source-status {
+    display: flex;
+}
+
+.airport-map-source-status__line,
+.airport-map-source-status__route {
+    align-items: center;
+    display: flex;
+    justify-content: flex-end;
+    min-width: 0;
+    text-shadow: 0 1px 8px var(--atc-bg);
+    width: 100%;
+}
+
+.airport-map-source-status__line {
+    gap: 8px;
+}
+
+.airport-map-source-status__route {
+    color: var(--atc-orange);
+    font-size: 10px;
+    font-weight: 900;
+    gap: 6px;
+    letter-spacing: 0.24em;
+    line-height: 1;
+}
+
+.airport-map-source-status__source,
+.airport-map-source-status__time {
+    color: var(--atc-faint);
+    flex: 0 0 auto;
+    font-size: 11px;
+    font-weight: 900;
+    line-height: 1;
+}
+
+.airport-map-source-status__source {
+    overflow: visible;
+}
+
+.airport-map-source-status__diamond {
+    background: var(--atc-orange);
+    display: inline-block;
+    height: 9px;
+    transform: rotate(45deg);
+    width: 9px;
+}
+
+.airport-map-source-status--infer .airport-map-source-status__source,
+.airport-map-source-status--infer .airport-map-source-status__time {
+    color: var(--atc-faint);
+}
+
 .map-ctrl-zone {
     align-items: center;
     display: flex;


### PR DESCRIPTION
## Summary
- Add an enum-backed source display model for ADS-B feeds and route providers.
- Show the mobile map source status as the same compact two-line watermark pattern: feed + pulse + timestamp, then diamond route provider.
- Centralize ADSBao site version/User-Agent construction through `src/config/siteMeta.js` so future version updates touch fewer places.

## Validation
- `pnpm lint`
- `pnpm test` (69 test files passed)
- `pnpm build`
- Mobile DOM verification on `http://localhost:3000/airport/KBOS` confirmed `.airport-map-source-status` renders feed, timestamp, and route provider on the map view.