### PR TITLE
Fix production metadata domain

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -10,10 +10,20 @@ import {
   SITE_DESCRIPTION,
   SITE_KEYWORDS,
   SITE_NAME,
+  SITE_SOCIAL_IMAGE,
   SITE_TITLE,
+  getSocialImageUrl,
   getSiteUrl,
 } from "@/config/site";
 import "../style.css";
+
+const socialImage = {
+  url: getSocialImageUrl(),
+  width: SITE_SOCIAL_IMAGE.width,
+  height: SITE_SOCIAL_IMAGE.height,
+  type: SITE_SOCIAL_IMAGE.type,
+  alt: SITE_SOCIAL_IMAGE.alt,
+};
 
 export const metadata = {
   metadataBase: getSiteUrl(),
@@ -38,11 +48,13 @@ export const metadata = {
     siteName: SITE_NAME,
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
+    images: [socialImage],
   },
   twitter: {
     card: "summary_large_image",
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
+    images: [socialImage],
   },
   robots: {
     index: true,

--- a/src/app/opengraph-image/route.js
+++ b/src/app/opengraph-image/route.js
@@ -1,14 +1,12 @@
 import { ImageResponse } from "next/og";
-import { SITE_DESCRIPTION, SITE_NAME } from "@/config/site";
+import { SITE_DESCRIPTION, SITE_NAME, SITE_SOCIAL_IMAGE } from "@/config/site";
 
-export const size = {
-  width: 1200,
-  height: 630,
+const imageSize = {
+  width: SITE_SOCIAL_IMAGE.width,
+  height: SITE_SOCIAL_IMAGE.height,
 };
 
-export const contentType = "image/png";
-
-export default function Image() {
+export function GET() {
   return new ImageResponse(
     (
       <div
@@ -24,7 +22,7 @@ export default function Image() {
           fontFamily: "system-ui, sans-serif",
         }}
       >
-        {/* Brand row — diamond + // ADSBAO wordmark + section label */}
+        {/* Brand row: diamond + // ADSBAO wordmark + section label */}
         <div
           style={{
             display: "flex",
@@ -50,7 +48,9 @@ export default function Image() {
             }}
           >
             <span style={{ color: "#ffe600", fontSize: 56 }}>{"//"}</span>
-            <span style={{ fontSize: 72, color: "#f5f3ee" }}>{SITE_NAME.toUpperCase()}</span>
+            <span style={{ fontSize: 72, color: "#f5f3ee" }}>
+              {SITE_NAME.toUpperCase()}
+            </span>
           </div>
           <div
             style={{
@@ -125,6 +125,6 @@ export default function Image() {
         </div>
       </div>
     ),
-    size,
+    imageSize,
   );
 }

--- a/src/config/site.js
+++ b/src/config/site.js
@@ -1,7 +1,14 @@
 export const SITE_NAME = "ADSBao";
-export const SITE_URL = "https://adsbao.vercel.app";
+export const SITE_URL = "https://adsbao.dev";
 export const SITE_TITLE = "ADSBao - Airport weather and traffic context";
 export const SITE_DESCRIPTION = "Airport context with METAR weather, nearby aircraft, route hints, and map overlays.";
+export const SITE_SOCIAL_IMAGE = {
+  path: "/opengraph-image",
+  type: "image/png",
+  width: 1200,
+  height: 630,
+  alt: SITE_TITLE,
+};
 
 export const SITE_KEYWORDS = [
   "ADSBao",
@@ -17,3 +24,5 @@ export const FEATURED_AIRPORT_CODES = ["KBOS", "KLAX", "KJFK", "KORD", "KSFO", "
 export const getSiteUrl = () => new URL(process.env.NEXT_PUBLIC_SITE_URL || SITE_URL);
 
 export const getAbsoluteUrl = (path = "/") => new URL(path, getSiteUrl()).toString();
+
+export const getSocialImageUrl = () => getAbsoluteUrl(SITE_SOCIAL_IMAGE.path);

--- a/src/config/site.test.js
+++ b/src/config/site.test.js
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+
+import {
+  SITE_SOCIAL_IMAGE,
+  SITE_URL,
+  getAbsoluteUrl,
+  getSiteUrl,
+  getSocialImageUrl,
+} from "./site.js";
+
+const originalSiteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+try {
+  delete process.env.NEXT_PUBLIC_SITE_URL;
+
+  assert.equal(SITE_URL, "https://adsbao.dev");
+  assert.equal(getSiteUrl().toString(), "https://adsbao.dev/");
+  assert.equal(getAbsoluteUrl("/airport/KBOS"), "https://adsbao.dev/airport/KBOS");
+  assert.equal(getAbsoluteUrl("opengraph-image"), "https://adsbao.dev/opengraph-image");
+  assert.equal(SITE_SOCIAL_IMAGE.path, "/opengraph-image");
+  assert.equal(SITE_SOCIAL_IMAGE.type, "image/png");
+  assert.equal(SITE_SOCIAL_IMAGE.width, 1200);
+  assert.equal(SITE_SOCIAL_IMAGE.height, 630);
+  assert.equal(getSocialImageUrl(), "https://adsbao.dev/opengraph-image");
+
+  process.env.NEXT_PUBLIC_SITE_URL = "https://preview.adsbao.dev";
+  assert.equal(getSiteUrl().toString(), "https://preview.adsbao.dev/");
+  assert.equal(
+    getAbsoluteUrl("/airport/KJFK"),
+    "https://preview.adsbao.dev/airport/KJFK",
+  );
+  assert.equal(getSocialImageUrl(), "https://preview.adsbao.dev/opengraph-image");
+} finally {
+  if (originalSiteUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  } else {
+    process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl;
+  }
+}
+
+console.log("site.test.js ok");

--- a/src/config/siteDomain.test.js
+++ b/src/config/siteDomain.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const rootDir = process.cwd();
+const ignoredDirs = new Set([
+  ".git",
+  ".next",
+  ".playwright-mcp",
+  "dist",
+  "node_modules",
+]);
+const scannedExtensions = new Set([".js", ".jsx", ".mjs", ".md", ".json"]);
+const legacyDomain = ["adsbao", "vercel", "app"].join(".");
+
+function extensionOf(fileName) {
+  const dotIndex = fileName.lastIndexOf(".");
+  return dotIndex === -1 ? "" : fileName.slice(dotIndex);
+}
+
+function collectFiles(dir) {
+  return readdirSync(dir).flatMap((entry) => {
+    if (ignoredDirs.has(entry)) return [];
+
+    const path = join(dir, entry);
+    const stats = statSync(path);
+    if (stats.isDirectory()) return collectFiles(path);
+    if (!stats.isFile() || !scannedExtensions.has(extensionOf(entry))) return [];
+    return [path];
+  });
+}
+
+const offenders = collectFiles(rootDir)
+  .map((file) => ({
+    file,
+    content: readFileSync(file, "utf8"),
+  }))
+  .filter(({ content }) => content.includes(legacyDomain))
+  .map(({ file }) => relative(rootDir, file));
+
+assert.deepEqual(offenders, []);
+
+console.log("siteDomain.test.js ok");


### PR DESCRIPTION
## Summary
- change the default site URL from adsbao.vercel.app to adsbao.dev
- centralize social image metadata and use it for Open Graph/Twitter image tags
- keep /opengraph-image available as a regular route while avoiding file-convention metadata overriding the configured URL
- add tests for production URL resolution and legacy domain references

Fixes #164

## Verification
- node src/config/site.test.js
- node src/config/siteDomain.test.js
- pnpm test
- pnpm lint
- pnpm build
- curl homepage metadata confirmed canonical, og:url, og:image, and twitter:image use https://adsbao.dev