### PR TITLE
Keep polling behind lost signal modal

### DIFF
--- a/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
+++ b/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
@@ -46,6 +46,7 @@ export function SelectedAircraftTraceProvider({
   fullTraceForFocal = false,
   focalTraceStartAtMs = null,
   focalPersistKey = null,
+  focalTraceRefreshKey = "",
   children,
 }) {
   const primaryHook = useAircraftTrace(selectedAircraft);
@@ -60,6 +61,7 @@ export function SelectedAircraftTraceProvider({
     fullTrace: fullTraceForFocal,
     traceStartAtMs: focalTraceStartAtMs,
     persistKey: focalPersistKey,
+    recentRefreshKey: focalTraceRefreshKey,
   });
 
   const primary = useMemo(

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -10,6 +10,9 @@ import {
   getOrCreateTrackedFlight,
   getTraceCutoffMs,
 } from "@/features/aircraft/tracking/trackedFlightStorage.js";
+import {
+  getLostSignalTraceRefreshKey,
+} from "@/features/aircraft/tracking/lostSignalTrackingModel.js";
 import { buildGreatCirclePath } from "@/features/aviation/flight-routes/greatCircleRouteModel.js";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled.js";
 
@@ -96,6 +99,7 @@ function FlightExplorerContent({ callsign }) {
     feedSource,
     lastUpdated,
     lostSignal,
+    pollVersion: trackedPollVersion,
   } = useTrackedAircraft(callsign);
 
   // Anchor the tracking session as soon as we have a callsign so the
@@ -117,6 +121,14 @@ function FlightExplorerContent({ callsign }) {
   const focalTraceStartAtMs = useMemo(
     () => getTraceCutoffMs(trackingSession),
     [trackingSession],
+  );
+  const focalTraceRefreshKey = useMemo(
+    () =>
+      getLostSignalTraceRefreshKey({
+        lostSignal,
+        pollVersion: trackedPollVersion,
+      }),
+    [lostSignal, trackedPollVersion],
   );
 
   // User can dismiss the lost-signal overlay to keep watching the last
@@ -281,6 +293,7 @@ function FlightExplorerContent({ callsign }) {
       fullTraceForFocal
       focalTraceStartAtMs={focalTraceStartAtMs}
       focalPersistKey={callsign || null}
+      focalTraceRefreshKey={focalTraceRefreshKey}
     >
       <AircraftPreviewCard
         aircraft={selectedAircraft}

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.js
@@ -1,0 +1,8 @@
+export function getLostSignalTraceRefreshKey({
+  lostSignal = false,
+  pollVersion = 0,
+} = {}) {
+  const version = Number(pollVersion);
+  if (!lostSignal || !Number.isFinite(version) || version <= 0) return "";
+  return `lost-signal:${version}`;
+}

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+
+import { getLostSignalTraceRefreshKey } from "./lostSignalTrackingModel.js";
+
+assert.equal(
+  getLostSignalTraceRefreshKey({ lostSignal: false, pollVersion: 12 }),
+  "",
+);
+
+assert.equal(
+  getLostSignalTraceRefreshKey({ lostSignal: true, pollVersion: 12 }),
+  "lost-signal:12",
+);
+
+assert.equal(
+  getLostSignalTraceRefreshKey({ lostSignal: true, pollVersion: 13 }),
+  "lost-signal:13",
+);
+
+assert.equal(
+  getLostSignalTraceRefreshKey({ lostSignal: true, pollVersion: 0 }),
+  "",
+);
+
+console.log("lostSignalTrackingModel.test.js ok");

--- a/src/hooks/useAircraftTrace.js
+++ b/src/hooks/useAircraftTrace.js
@@ -27,7 +27,7 @@ function formatTracePointTime(point) {
   return Number.isFinite(timestampMs) ? new Date(timestampMs).toISOString() : null;
 }
 
-function fetchTraceSource({ hex, label, source, full }) {
+function fetchTraceSource({ hex, label, source, full, notify = true }) {
   const promise = aircraftTraceClient
     .fetchAircraftTrace({ hex, full })
     .then((payload) => {
@@ -44,12 +44,14 @@ function fetchTraceSource({ hex, label, source, full }) {
       return { payload, points };
     });
 
-  toast.promise(promise, {
-    loading: `Fetching ${source} trace for ${label}...`,
-    success: ({ points }) => `${label} ${source} trace: ${points.length} pts`,
-    error: (error) =>
-      `${label} ${source} trace failed: ${error?.message || "unknown error"}`,
-  });
+  if (notify) {
+    toast.promise(promise, {
+      loading: `Fetching ${source} trace for ${label}...`,
+      success: ({ points }) => `${label} ${source} trace: ${points.length} pts`,
+      error: (error) =>
+        `${label} ${source} trace failed: ${error?.message || "unknown error"}`,
+    });
+  }
 
   return promise;
 }
@@ -114,6 +116,8 @@ export function useAircraftTrace(selectedAircraft = null, options = {}) {
     typeof options?.persistKey === "string" && options.persistKey.trim()
       ? options.persistKey.trim()
       : null;
+  const recentRefreshKey =
+    typeof options?.recentRefreshKey === "string" ? options.recentRefreshKey : "";
   const traceLabel = formatTraceFetchLabel(selectedAircraft, hex);
 
   const [fullPoints, setFullPoints] = useState([]);
@@ -186,6 +190,42 @@ export function useAircraftTrace(selectedAircraft = null, options = {}) {
       disposed = true;
     };
   }, [hex, fullTrace, traceLabel]);
+
+  // While the lost-signal overlay is visible on the flight page, the
+  // callsign poll keeps ticking. Use that tick to silently refresh the
+  // recent trace behind the modal so newly-arrived upstream points can
+  // appear without asking the user to dismiss or retry by hand.
+  useEffect(() => {
+    if (!hex || !recentRefreshKey) return undefined;
+
+    let disposed = false;
+    const label = traceLabel;
+    setRecentLoading(true);
+
+    fetchTraceSource({
+      hex,
+      label,
+      source: "recent",
+      full: false,
+      notify: false,
+    })
+      .then(({ points }) => {
+        if (disposed) return;
+        setRecentPoints(points);
+      })
+      .catch((error) => {
+        if (!disposed) {
+          console.warn(`[aircraft-trace:${hex}] background recent fetch failed`, error);
+        }
+      })
+      .finally(() => {
+        if (!disposed) setRecentLoading(false);
+      });
+
+    return () => {
+      disposed = true;
+    };
+  }, [hex, recentRefreshKey, traceLabel]);
 
   // Append the latest polled position so the trail extends forward in
   // real time. We don't gate on loading anymore — the priority merge

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -29,6 +29,7 @@ export function useTrackedAircraft(callsign) {
   const [error, setError] = useState(null);
   const [initialLoading, setInitialLoading] = useState(false);
   const [lostSignal, setLostSignal] = useState(false);
+  const [pollVersion, setPollVersion] = useState(0);
   const timerRef = useRef(null);
   const disposedRef = useRef(false);
   const missesRef = useRef(0);
@@ -49,6 +50,7 @@ export function useTrackedAircraft(callsign) {
       setLastUpdated(null);
       setError(null);
       setLostSignal(false);
+      setPollVersion(0);
       missesRef.current = 0;
       return undefined;
     }
@@ -97,7 +99,10 @@ export function useTrackedAircraft(callsign) {
         console.warn(`[tracked-aircraft] ${callsign} fetch failed`, err);
         setError(err);
       } finally {
-        if (!disposedRef.current) setInitialLoading(false);
+        if (!disposedRef.current) {
+          setPollVersion((value) => value + 1);
+          setInitialLoading(false);
+        }
       }
     };
 
@@ -118,6 +123,7 @@ export function useTrackedAircraft(callsign) {
     initialLoading,
     error,
     lostSignal,
+    pollVersion,
     retry,
   };
 }


### PR DESCRIPTION
## Summary
- expose a tracked-flight poll tick from useTrackedAircraft
- use that tick only while lost signal is active to refresh the focal recent trace behind the modal
- keep the background trace refresh silent so it does not spam trace toasts while the modal is open
- add a small model test for the lost-signal refresh gate

## Verification
- node src/features/aircraft/tracking/lostSignalTrackingModel.test.js
- pnpm lint
- pnpm test
- pnpm build