### PR TITLE
[codex] Delay tab-return aircraft refresh until overlay paints

### DIFF
--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.js
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.js
@@ -34,3 +34,38 @@ export function getLoadingOverlayExitDelay({
 } = {}) {
   return Math.max(0, minVisibleMs - Math.max(0, now - shownAt));
 }
+
+export function scheduleAfterOverlayPaint(
+  callback,
+  {
+    requestAnimationFrame = globalThis.requestAnimationFrame?.bind(globalThis),
+    cancelAnimationFrame = globalThis.cancelAnimationFrame?.bind(globalThis),
+    setTimeout = globalThis.setTimeout?.bind(globalThis),
+    clearTimeout = globalThis.clearTimeout?.bind(globalThis),
+  } = {},
+) {
+  if (
+    typeof requestAnimationFrame === "function" &&
+    typeof cancelAnimationFrame === "function"
+  ) {
+    let secondFrame = 0;
+    const firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(callback);
+    });
+
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      if (secondFrame) cancelAnimationFrame(secondFrame);
+    };
+  }
+
+  if (typeof setTimeout !== "function") {
+    callback();
+    return () => {};
+  }
+
+  const timeout = setTimeout(callback, 0);
+  return () => {
+    if (typeof clearTimeout === "function") clearTimeout(timeout);
+  };
+}

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js
@@ -4,6 +4,7 @@ import {
   AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
   areCriticalLoadingRequestsSettled,
   getLoadingOverlayExitDelay,
+  scheduleAfterOverlayPaint,
   shouldShowAircraftLoadingOverlay,
   shouldTriggerVisibilityRefreshOverlay,
 } from "./aircraftLoadingOverlayModel.js";
@@ -91,3 +92,39 @@ assert.equal(
   }),
   false,
 );
+
+{
+  const frameCallbacks = [];
+  const cancelledFrames = [];
+  let calls = 0;
+  let frameId = 0;
+
+  const cancel = scheduleAfterOverlayPaint(
+    () => {
+      calls += 1;
+    },
+    {
+      requestAnimationFrame(callback) {
+        frameCallbacks.push(callback);
+        frameId += 1;
+        return frameId;
+      },
+      cancelAnimationFrame(id) {
+        cancelledFrames.push(id);
+      },
+    },
+  );
+
+  assert.equal(calls, 0);
+  assert.equal(frameCallbacks.length, 1);
+
+  frameCallbacks.shift()();
+  assert.equal(calls, 0);
+  assert.equal(frameCallbacks.length, 1);
+
+  frameCallbacks.shift()();
+  assert.equal(calls, 1);
+
+  cancel();
+  assert.deepEqual(cancelledFrames, [1, 2]);
+}

--- a/src/hooks/useAircraftPositions.js
+++ b/src/hooks/useAircraftPositions.js
@@ -14,11 +14,21 @@ import {
 } from "../features/aircraft/positions/aircraftPositionsModel.js";
 import { createAircraftTraceTracker } from "../features/aircraft/trace/aircraftTraceModel.js";
 import {
+  AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
+  scheduleAfterOverlayPaint,
   shouldShowAircraftLoadingOverlay,
   shouldTriggerVisibilityRefreshOverlay,
 } from "../features/aircraft/positions/aircraftLoadingOverlayModel.js";
 
 const HIDDEN_POLL_GRACE_MS = AIRCRAFT_TRAFFIC_CONFIG.hiddenPollGraceMs;
+
+const waitUntil = (timestamp) => {
+  const delay = Math.max(0, timestamp - Date.now());
+  if (delay <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, delay);
+  });
+};
 
 export function useAircraftPositions(icao, lat, lon) {
   const hasActiveQuery = Boolean(icao && lat && lon);
@@ -32,6 +42,7 @@ export function useAircraftPositions(icao, lat, lon) {
   const [feedStatus, setFeedStatus] = useState("live");
   const [feedSource, setFeedSource] = useState("");
   const timerRef = useRef(null);
+  const visibilityRefreshCancelRef = useRef(null);
   const wasActiveRef = useRef(false);
   const hiddenSinceRef = useRef(0);
   const consecutiveFailuresRef = useRef(0);
@@ -49,7 +60,13 @@ export function useAircraftPositions(icao, lat, lon) {
       if (!disposed && clearAircraft) setAircraft([]);
     };
 
-    const poll = async () => {
+    const cancelPendingVisibilityRefresh = () => {
+      if (!visibilityRefreshCancelRef.current) return;
+      visibilityRefreshCancelRef.current();
+      visibilityRefreshCancelRef.current = null;
+    };
+
+    const poll = async ({ commitAfter = 0 } = {}) => {
       if (!lat || !lon) return;
       setLoading(true);
       try {
@@ -70,6 +87,8 @@ export function useAircraftPositions(icao, lat, lon) {
           snapshot,
           receiveTime,
         );
+        await waitUntil(commitAfter);
+        if (disposed) return;
         setAircraft(nextAircraft);
         consecutiveFailuresRef.current = 0;
         setFeedStatus(isStale ? "infer" : "live");
@@ -91,6 +110,8 @@ export function useAircraftPositions(icao, lat, lon) {
         );
       } finally {
         if (!disposed) {
+          await waitUntil(commitAfter);
+          if (disposed) return;
           setSettled(true);
           setInitialLoading(false);
           setVisibilityRefreshLoading(false);
@@ -99,23 +120,25 @@ export function useAircraftPositions(icao, lat, lon) {
       }
     };
 
-    const start = () => {
+    const start = ({ commitAfter = 0 } = {}) => {
       stop({ clearAircraft: false });
       consecutiveFailuresRef.current = 0;
       setFeedStatus("live");
       setSettled(false);
       setInitialLoading(true);
       setLastUpdated(null);
-      poll();
+      poll({ commitAfter });
       timerRef.current = setInterval(poll, DEFAULT_AIRCRAFT_POLL_MS);
     };
 
     const handleVisibility = () => {
       if (document.hidden) {
+        cancelPendingVisibilityRefresh();
         hiddenSinceRef.current = Date.now();
         stop({ clearAircraft: false, clearTrace: false });
         return;
       }
+      cancelPendingVisibilityRefresh();
       const hiddenDuration =
         hiddenSinceRef.current > 0 ? Date.now() - hiddenSinceRef.current : 0;
       const showRefreshOverlay = shouldTriggerVisibilityRefreshOverlay({
@@ -123,14 +146,29 @@ export function useAircraftPositions(icao, lat, lon) {
         hiddenSince: hiddenSinceRef.current,
       });
       hiddenSinceRef.current = 0;
+      const overlayShownAt = Date.now();
       if (showRefreshOverlay) setVisibilityRefreshLoading(true);
-      if (wasActiveRef.current && hiddenDuration > HIDDEN_POLL_GRACE_MS) {
-        traceTrackerRef.current.clear();
-        start();
-      } else if (wasActiveRef.current) {
+      if (!wasActiveRef.current) return;
+      const commitAfter = showRefreshOverlay
+        ? overlayShownAt + AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS
+        : 0;
+
+      const refresh = () => {
+        visibilityRefreshCancelRef.current = null;
+        if (hiddenDuration > HIDDEN_POLL_GRACE_MS) {
+          traceTrackerRef.current.clear();
+          start({ commitAfter });
+          return;
+        }
         stop({ clearAircraft: false, clearTrace: false });
-        poll();
+        poll({ commitAfter });
         timerRef.current = setInterval(poll, DEFAULT_AIRCRAFT_POLL_MS);
+      };
+
+      if (showRefreshOverlay) {
+        visibilityRefreshCancelRef.current = scheduleAfterOverlayPaint(refresh);
+      } else {
+        refresh();
       }
     };
 
@@ -152,6 +190,7 @@ export function useAircraftPositions(icao, lat, lon) {
     return () => {
       disposed = true;
       document.removeEventListener("visibilitychange", handleVisibility);
+      cancelPendingVisibilityRefresh();
       stop();
     };
   }, [hasActiveQuery, icao, lat, lon]);

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -7,6 +7,8 @@ import {
   normalizeAdsbAircraft,
 } from "../features/aircraft/positions/aircraftPositionsModel.js";
 import {
+  AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
+  scheduleAfterOverlayPaint,
   shouldShowAircraftLoadingOverlay,
   shouldTriggerVisibilityRefreshOverlay,
 } from "../features/aircraft/positions/aircraftLoadingOverlayModel.js";
@@ -17,6 +19,14 @@ import {
 // ride out a single dropped sample but short enough to react when the
 // flight actually lands.
 const LOST_SIGNAL_THRESHOLD = 3;
+
+const waitUntil = (timestamp) => {
+  const delay = Math.max(0, timestamp - Date.now());
+  if (delay <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, delay);
+  });
+};
 
 // Polls the upstream ADS-B feed for the focal callsign so the flight
 // tracking page knows where the aircraft is right now and where to center
@@ -45,6 +55,7 @@ export function useTrackedAircraft(callsign) {
   // poll cadence by incrementing this counter — the effect listens for
   // changes and triggers an immediate fetch.
   const [retrySignal, setRetrySignal] = useState(0);
+  const visibilityRefreshCancelRef = useRef(null);
   const retry = useCallback(() => {
     setRetrySignal((value) => value + 1);
   }, []);
@@ -74,7 +85,13 @@ export function useTrackedAircraft(callsign) {
       timerRef.current = null;
     };
 
-    const poll = async () => {
+    const cancelPendingVisibilityRefresh = () => {
+      if (!visibilityRefreshCancelRef.current) return;
+      visibilityRefreshCancelRef.current();
+      visibilityRefreshCancelRef.current = null;
+    };
+
+    const poll = async ({ commitAfter = 0 } = {}) => {
       try {
         const payload = await aircraftCallsignClient.fetchByCallsign({
           callsign,
@@ -82,6 +99,8 @@ export function useTrackedAircraft(callsign) {
         if (disposedRef.current) return;
         const matches = Array.isArray(payload?.ac) ? payload.ac : [];
         const receiveTime = Date.now();
+        await waitUntil(commitAfter);
+        if (disposedRef.current) return;
         setSettled(true);
         setInitialLoading(false);
         setVisibilityRefreshLoading(false);
@@ -119,6 +138,8 @@ export function useTrackedAircraft(callsign) {
         setError(err);
       } finally {
         if (!disposedRef.current) {
+          await waitUntil(commitAfter);
+          if (disposedRef.current) return;
           setSettled(true);
           setInitialLoading(false);
           setVisibilityRefreshLoading(false);
@@ -129,19 +150,34 @@ export function useTrackedAircraft(callsign) {
 
     const handleVisibility = () => {
       if (document.hidden) {
+        cancelPendingVisibilityRefresh();
         stopPolling();
         return;
       }
-      if (
-        shouldTriggerVisibilityRefreshOverlay({
-          wasActive: hasActiveQuery,
-        })
-      ) {
+      cancelPendingVisibilityRefresh();
+      const showRefreshOverlay = shouldTriggerVisibilityRefreshOverlay({
+        wasActive: hasActiveQuery,
+      });
+      if (showRefreshOverlay) {
         setVisibilityRefreshLoading(true);
       }
-      stopPolling();
-      poll();
-      timerRef.current = setInterval(poll, AIRCRAFT_TRAFFIC_CONFIG.pollMs);
+      const overlayShownAt = Date.now();
+      const commitAfter = showRefreshOverlay
+        ? overlayShownAt + AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS
+        : 0;
+
+      const refresh = () => {
+        visibilityRefreshCancelRef.current = null;
+        stopPolling();
+        poll({ commitAfter });
+        timerRef.current = setInterval(poll, AIRCRAFT_TRAFFIC_CONFIG.pollMs);
+      };
+
+      if (showRefreshOverlay) {
+        visibilityRefreshCancelRef.current = scheduleAfterOverlayPaint(refresh);
+      } else {
+        refresh();
+      }
     };
 
     poll();
@@ -151,6 +187,7 @@ export function useTrackedAircraft(callsign) {
     return () => {
       disposedRef.current = true;
       document.removeEventListener("visibilitychange", handleVisibility);
+      cancelPendingVisibilityRefresh();
       stopPolling();
     };
   }, [callsign, hasActiveQuery, retrySignal]);


### PR DESCRIPTION
## Summary
- Reproduced the tab-return issue in Chrome on `adsbao.dev/airport/KBOS`: after hiding the tab for two minutes, the aircraft list/map updated to fresh positions immediately as the tab became visible.
- Add an overlay-paint scheduler so visibility-return refresh polls wait until the loading overlay has had a real paint opportunity before making network requests.
- Defer the tab-return aircraft response commit until the 500ms minimum overlay window has elapsed, covering both airport nearby aircraft and aircraft-detail focal callsign refreshes.

## Validation
- Reproduced on `https://adsbao.dev/airport/KBOS` by switching to other Chrome tabs for two minutes, then returning.
- Verified locally on `http://localhost:3000/airport/KBOS` with the same two-minute Chrome tab-switch flow: the loading overlay is present on return instead of exposing a bare map refresh.
- `node src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js`
- `pnpm lint`
- `pnpm test` (73 test files)
- `pnpm build`
- `git diff --check`
