### PR TITLE
[codex] Theme map and sidebar presentation tokens

### DIFF
--- a/src/components/map/MapRangeLegend.jsx
+++ b/src/components/map/MapRangeLegend.jsx
@@ -14,7 +14,7 @@ const NICE_NM_STEPS = [
   1, 2, 3, 5, 10, 15, 20, 30, 50, 75, 100, 150, 200, 300, 500,
 ];
 
-export default function MapRangeLegend({ theme = "dark" }) {
+export default function MapRangeLegend() {
   const { t } = useI18n();
   const map = useMapInstance();
   const [scale, setScale] = useState(null);
@@ -55,21 +55,14 @@ export default function MapRangeLegend({ theme = "dark" }) {
 
   if (!scale) return null;
 
-  const isLight = theme === "light";
-  const backdrop = isLight
-    ? "bg-[rgba(250,249,245,0.45)]"
-    : "bg-[rgba(8,12,20,0.4)]";
-  const textTone = isLight ? "text-[#1a1a18]" : "text-[#f5f3ee]";
-  const labelTone = isLight ? "text-[#1a1a18]/70" : "text-[#f5f3ee]/70";
-
   return (
     <div
       role="note"
       aria-label={t("map.distanceAria", { distance: scale.nm })}
-      className={`pointer-events-none absolute bottom-3 left-3 z-[400] flex items-center gap-2 px-2 py-1 font-mono ${backdrop} ${textTone} backdrop-blur-sm`}
+      className="pointer-events-none absolute bottom-3 left-3 z-[400] flex items-center gap-2 bg-[var(--map-range-background)] px-2 py-1 font-mono text-[var(--map-range-text)] backdrop-blur-sm"
     >
       <span
-        className={`text-[9px] font-semibold uppercase tracking-[0.22em] ${labelTone}`}
+        className="text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--map-range-label)]"
       >
         {t("map.distanceLabel")}
       </span>

--- a/src/components/map/NearbyAirportLayer.jsx
+++ b/src/components/map/NearbyAirportLayer.jsx
@@ -48,12 +48,12 @@ const markerHtml = (airport) => {
 const runwayLineStyle = (theme) =>
   theme === "light"
     ? {
-        color: "#24231f",
+        color: "var(--nearby-runway-line)",
         weight: 3,
         opacity: 0.5,
       }
     : {
-        color: "#ffe900",
+        color: "var(--nearby-runway-line)",
         weight: 3,
         opacity: 0.5,
       };

--- a/src/components/map/RunwayAnnotationLayer.jsx
+++ b/src/components/map/RunwayAnnotationLayer.jsx
@@ -50,15 +50,12 @@ const runwayLabelIcon = (ident, theme) =>
 // style block would be artificial.
 const buildApproachLayer = ({ kind, data, theme }) => {
   if (kind === "approach-lines") {
-    // Endfield palette — ink on light, warm amber on dark. No blues.
-    const stroke =
-      theme === "light" ? "rgba(26,26,24,0.62)" : "rgba(216,189,131,0.78)";
     const layer = L.geoJSON(data, {
       interactive: false,
       style(feature) {
         return {
           className: "runway-approach-line",
-          color: stroke,
+          color: "var(--runway-approach-line)",
           weight: 1.4,
           opacity: feature?.properties?.beamOpacity != null
             ? Math.min(1, 0.55 + Number(feature.properties.beamOpacity))

--- a/src/config/airportMap.js
+++ b/src/config/airportMap.js
@@ -23,29 +23,29 @@ export const AIRPORT_MAP_PANES = {
   },
 };
 
-// Endfield palette: yellow trail in dark mode, ink trail in light mode.
-// No blues — keeps the map mono with a single saturated yellow accent.
+// Color values intentionally resolve through CSS variables so each
+// theme/palette can own the map treatment without changing JS.
 export const SELECTED_AIRCRAFT_TRACE_STYLE = {
   maxRenderPoints: 140,
   dark: {
-    glowColor: "#ffe600",
+    glowColor: "var(--aircraft-trace-glow)",
     glowOpacity: 0.22,
     glowWeight: 12,
-    lineColor: "#ffe600",
+    lineColor: "var(--aircraft-trace-line)",
     lineOpacity: 0.94,
     lineWeight: 3.2,
-    pointColor: "#ffe600",
+    pointColor: "var(--aircraft-trace-point)",
     pointFillOpacity: 0.5,
     pointRadius: 2,
   },
   light: {
-    glowColor: "#b88a00",
+    glowColor: "var(--aircraft-trace-glow)",
     glowOpacity: 0.18,
     glowWeight: 9,
-    lineColor: "#1a1a18",
+    lineColor: "var(--aircraft-trace-line)",
     lineOpacity: 0.82,
     lineWeight: 3,
-    pointColor: "#1a1a18",
+    pointColor: "var(--aircraft-trace-point)",
     pointFillOpacity: 0.34,
     pointRadius: 1.8,
   },
@@ -84,24 +84,22 @@ export const RUNWAY_APPROACH_BEAM_CONFIG = {
   ],
 };
 
-// Endfield palette: warm amber/yellow on dark, ink on light. The
-// previous blues clashed with the yellow-and-grey theme.
 export const RUNWAY_ANNOTATION_STYLE_CONFIG = {
   lineStyles: {
     dark: {
-      color: "#d8bd83",
+      color: "var(--runway-annotation-line)",
       weight: 3,
       opacity: 0.55,
     },
     light: {
-      color: "#1a1a18",
+      color: "var(--runway-annotation-line)",
       weight: 3,
       opacity: 0.42,
     },
   },
   beamColors: {
-    dark: "#d8bd83",
-    light: "#8a6a1e",
+    dark: "var(--runway-approach-beam)",
+    light: "var(--runway-approach-beam)",
   },
   beamGradientStops: [
     { offset: "0%", opacityScale: 1, maxOpacity: 0.42 },

--- a/src/config/airportMapThemeContract.test.js
+++ b/src/config/airportMapThemeContract.test.js
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  RUNWAY_ANNOTATION_STYLE_CONFIG,
+  SELECTED_AIRCRAFT_TRACE_STYLE,
+} from "./airportMap.js";
+import { buildProcedureRenderLayers } from "../features/airport/map/procedureOverlayModel.js";
+import { getProcedureSegmentStyle } from "../features/airport/map/procedureSegmentModel.js";
+
+const assertThemeVar = (value, label) => {
+  assert.match(
+    value,
+    /^var\(--[a-z0-9-]+\)$/,
+    `${label} should resolve through a CSS theme variable`,
+  );
+};
+
+const styleCss = readFileSync(new URL("../style.css", import.meta.url), "utf8");
+
+[
+  "--theme-font-sans",
+  "--theme-font-mono",
+  "--theme-primary-bright",
+  "--theme-primary-deep",
+  "--sidebar-muted",
+  "--sidebar-faint",
+  "--sidebar-signal",
+  "--map-label-shadow",
+  "--map-attribution",
+  "--airport-range-ring-minor",
+  "--airport-range-ring-major",
+  "--airport-range-ring-band",
+  "--aircraft-trace-line",
+  "--aircraft-trace-glow",
+  "--aircraft-trace-point",
+  "--runway-annotation-line",
+  "--runway-approach-line",
+  "--runway-approach-beam",
+  "--nearby-runway-line",
+  "--procedure-segment-line",
+  "--procedure-silk-blur",
+  "--procedure-silk-body",
+  "--procedure-silk-thread",
+].forEach((token) => {
+  assert.match(styleCss, new RegExp(`${token}\\s*:`), `${token} should be defined`);
+});
+
+assert.match(
+  styleCss,
+  /--font-sans:\s*var\(--theme-font-sans\)/,
+  "Tailwind font utility should resolve through the theme font token",
+);
+
+for (const theme of ["light", "dark"]) {
+  const trace = SELECTED_AIRCRAFT_TRACE_STYLE[theme];
+  assertThemeVar(trace.lineColor, `${theme} selected trace line`);
+  assertThemeVar(trace.glowColor, `${theme} selected trace glow`);
+  assertThemeVar(trace.pointColor, `${theme} selected trace point`);
+
+  assertThemeVar(
+    RUNWAY_ANNOTATION_STYLE_CONFIG.lineStyles[theme].color,
+    `${theme} runway annotation line`,
+  );
+  assertThemeVar(
+    RUNWAY_ANNOTATION_STYLE_CONFIG.beamColors[theme],
+    `${theme} runway beam`,
+  );
+
+  assertThemeVar(
+    getProcedureSegmentStyle(theme).color,
+    `${theme} procedure segment`,
+  );
+
+  buildProcedureRenderLayers({ type: "FeatureCollection", features: [] }, theme).forEach(
+    (layer, index) =>
+      assertThemeVar(layer.style.color, `${theme} procedure silk layer ${index}`),
+  );
+}
+
+console.log("airportMapThemeContract.test.js ok");

--- a/src/features/airport/map/airportMapModel.js
+++ b/src/features/airport/map/airportMapModel.js
@@ -12,12 +12,12 @@ export const resolveDocumentTheme = (documentElement) =>
 export const getMapOverlayTheme = (theme) =>
   theme === "light"
     ? {
-        labelShadowColor: "rgba(245,243,238,0.95)",
-        attributionColor: "rgba(26,26,24,0.45)",
+        labelShadowColor: "var(--map-label-shadow)",
+        attributionColor: "var(--map-attribution)",
       }
     : {
-        labelShadowColor: "#1a1a18",
-        attributionColor: "rgba(245,243,238,0.3)",
+        labelShadowColor: "var(--map-label-shadow)",
+        attributionColor: "var(--map-attribution)",
       };
 
 export const formatCoordinateLabel = (value, axis) => {

--- a/src/features/airport/map/airportMapModel.test.js
+++ b/src/features/airport/map/airportMapModel.test.js
@@ -48,6 +48,6 @@ assert.deepEqual(
 
 assert.equal(
   getMapOverlayTheme("light").labelShadowColor,
-  "rgba(245,243,238,0.95)",
+  "var(--map-label-shadow)",
 );
-assert.equal(getMapOverlayTheme("dark").attributionColor, "rgba(245,243,238,0.3)");
+assert.equal(getMapOverlayTheme("dark").attributionColor, "var(--map-attribution)");

--- a/src/features/airport/map/airportRangeRings.js
+++ b/src/features/airport/map/airportRangeRings.js
@@ -7,15 +7,15 @@ const NM_TO_METERS = 1852;
 function ringColors(theme) {
   if (theme === "light") {
     return {
-      minorStroke: "rgba(18,21,26,0.11)",
-      majorStroke: "rgba(18,21,26,0.20)",
-      band: "rgba(18,21,26,0.05)",
+      minorStroke: "var(--airport-range-ring-minor)",
+      majorStroke: "var(--airport-range-ring-major)",
+      band: "var(--airport-range-ring-band)",
     };
   }
   return {
-    minorStroke: "rgba(255,255,255,0.11)",
-    majorStroke: "rgba(255,255,255,0.20)",
-    band: "rgba(255,255,255,0.05)",
+    minorStroke: "var(--airport-range-ring-minor)",
+    majorStroke: "var(--airport-range-ring-major)",
+    band: "var(--airport-range-ring-band)",
   };
 }
 

--- a/src/features/airport/map/procedureOverlayModel.js
+++ b/src/features/airport/map/procedureOverlayModel.js
@@ -1,21 +1,19 @@
-// Endfield silk — warm amber glow on dark, ink hairline on light. No
-// blues. Three layers stack to give the approach a soft glowing thread.
 const SILK_STYLES = {
   dark: [
     {
-      color: "#3a3424",
+      color: "var(--procedure-silk-blur)",
       weight: 12,
       opacity: 0.085,
       className: "procedure-silk procedure-silk--blur",
     },
     {
-      color: "#c79b1f",
+      color: "var(--procedure-silk-body)",
       weight: 5.2,
       opacity: 0.16,
       className: "procedure-silk procedure-silk--body",
     },
     {
-      color: "#ffe600",
+      color: "var(--procedure-silk-thread)",
       weight: 1.15,
       opacity: 0.32,
       className: "procedure-silk procedure-silk--thread",
@@ -23,19 +21,19 @@ const SILK_STYLES = {
   ],
   light: [
     {
-      color: "#2a2a26",
+      color: "var(--procedure-silk-blur)",
       weight: 12,
       opacity: 0.07,
       className: "procedure-silk procedure-silk--blur",
     },
     {
-      color: "#1a1a18",
+      color: "var(--procedure-silk-body)",
       weight: 5.2,
       opacity: 0.1,
       className: "procedure-silk procedure-silk--body",
     },
     {
-      color: "#1a1a18",
+      color: "var(--procedure-silk-thread)",
       weight: 1.15,
       opacity: 0.55,
       className: "procedure-silk procedure-silk--thread",

--- a/src/features/airport/map/procedureOverlayModel.test.js
+++ b/src/features/airport/map/procedureOverlayModel.test.js
@@ -64,7 +64,11 @@ const darkStyles = getProcedureSilkStyles("dark");
 assert.equal(darkStyles.length, 3);
 assert.deepEqual(
   darkStyles.map((style) => style.color),
-  ["#3a3424", "#c79b1f", "#ffe600"],
+  [
+    "var(--procedure-silk-blur)",
+    "var(--procedure-silk-body)",
+    "var(--procedure-silk-thread)",
+  ],
 );
 assert.deepEqual(
   darkStyles.map((style) => style.className),

--- a/src/features/airport/map/procedureSegmentModel.js
+++ b/src/features/airport/map/procedureSegmentModel.js
@@ -1,12 +1,11 @@
-// Endfield palette — warm amber on dark, ink on light. No blues.
 const PROCEDURE_SEGMENT_STYLES = {
   light: {
-    color: "#1a1a18",
+    color: "var(--procedure-segment-line)",
     weight: 3.8,
     opacity: 0.55,
   },
   dark: {
-    color: "#d8bd83",
+    color: "var(--procedure-segment-line)",
     weight: 4.2,
     opacity: 0.78,
   },

--- a/src/features/airport/map/procedureSegmentModel.test.js
+++ b/src/features/airport/map/procedureSegmentModel.test.js
@@ -112,12 +112,12 @@ assert.deepEqual(
 );
 
 assert.deepEqual(getProcedureSegmentStyle("light"), {
-  color: "#1a1a18",
+  color: "var(--procedure-segment-line)",
   weight: 3.8,
   opacity: 0.55,
 });
 assert.deepEqual(getProcedureSegmentStyle("dark"), {
-  color: "#d8bd83",
+  color: "var(--procedure-segment-line)",
   weight: 4.2,
   opacity: 0.78,
 });

--- a/src/style.css
+++ b/src/style.css
@@ -43,10 +43,10 @@
        Single family used everywhere; display moments lean on weight 800–
        900 + wider letter-spacing to hit the "Novecento" poster feel.
        Noto Sans SC carries CJK glyphs. */
-    --font-sans: "Saira", "Noto Sans SC", system-ui, sans-serif;
-    --font-mono: "Saira", "Noto Sans SC", system-ui, sans-serif;
-    --font-nav: "Saira", "Noto Sans SC", system-ui, sans-serif;
-    --font-display: "Saira", "Noto Sans SC", system-ui, sans-serif;
+    --font-sans: var(--theme-font-sans);
+    --font-mono: var(--theme-font-mono);
+    --font-nav: var(--theme-font-nav);
+    --font-display: var(--theme-font-display);
 
     --radius: var(--atc-radius-control);
     --radius-xs: calc(var(--radius) * 0.5);
@@ -67,6 +67,9 @@
     --color-sidebar-primary: var(--sidebar-primary);
     --color-sidebar-foreground: var(--sidebar-foreground);
     --color-sidebar: var(--sidebar);
+    --color-sidebar-muted: var(--sidebar-muted);
+    --color-sidebar-faint: var(--sidebar-faint);
+    --color-sidebar-signal: var(--sidebar-signal);
 }
 
 @keyframes pulseDot {
@@ -122,17 +125,33 @@
    data-primary="teal" on <html>, which the override block below picks
    up — every token that aliases these vars follows automatically. */
 :root {
-    --primary-bright: #ffe600;
-    --primary-deep: #a86a1f;
+    --theme-font-sans: "Saira", "Noto Sans SC", system-ui, sans-serif;
+    --theme-font-mono: "Saira", "Noto Sans SC", system-ui, sans-serif;
+    --theme-font-nav: "Saira", "Noto Sans SC", system-ui, sans-serif;
+    --theme-font-display: "Saira", "Noto Sans SC", system-ui, sans-serif;
+    --theme-primary-bright: #ffe600;
+    --theme-primary-deep: #a86a1f;
+    --primary-bright: var(--theme-primary-bright);
+    --primary-deep: var(--theme-primary-deep);
 }
 
 :root[data-primary="teal"] {
-    --primary-bright: #5fb8b9;
-    --primary-deep: #397e7f;
+    --theme-primary-bright: #5fb8b9;
+    --theme-primary-deep: #397e7f;
+    --aircraft-trace-line: #397e7f;
+    --aircraft-trace-glow: #397e7f;
+    --aircraft-trace-point: #397e7f;
+    --runway-annotation-line: #397e7f;
+    --runway-approach-line: rgba(57,126,127,0.62);
+    --runway-approach-beam: #397e7f;
+    --nearby-runway-line: #397e7f;
+    --procedure-segment-line: #397e7f;
+    --procedure-silk-body: #397e7f;
+    --procedure-silk-thread: #397e7f;
 }
 
 :root {
-    font-family: "Saira", "Noto Sans SC", system-ui, sans-serif;
+    font-family: var(--theme-font-sans);
     line-height: 1.5;
     font-weight: 400;
     -webkit-font-smoothing: antialiased;
@@ -182,6 +201,25 @@
     --glass-card-border: color-mix(in oklab, var(--atc-text) 13%, transparent);
     --glass-card-inset: color-mix(in oklab, var(--atc-bg) 32%, transparent);
     --traffic-level-color: oklch(0.46 0.006 100);
+    --map-label-shadow: rgba(245,243,238,0.95);
+    --map-attribution: rgba(26,26,24,0.45);
+    --map-range-background: rgba(250,249,245,0.45);
+    --map-range-text: #1a1a18;
+    --map-range-label: rgba(26,26,24,0.7);
+    --airport-range-ring-minor: rgba(18,21,26,0.11);
+    --airport-range-ring-major: rgba(18,21,26,0.20);
+    --airport-range-ring-band: rgba(18,21,26,0.05);
+    --aircraft-trace-line: #1a1a18;
+    --aircraft-trace-glow: #b88a00;
+    --aircraft-trace-point: #1a1a18;
+    --runway-annotation-line: #1a1a18;
+    --runway-approach-line: rgba(26,26,24,0.62);
+    --runway-approach-beam: #8a6a1e;
+    --nearby-runway-line: #24231f;
+    --procedure-segment-line: #1a1a18;
+    --procedure-silk-blur: #2a2a26;
+    --procedure-silk-body: #1a1a18;
+    --procedure-silk-thread: #1a1a18;
 
     /* Single grey for every aircraft regardless of departure/arrival —
        the airport is the only thing painted yellow on the map. */
@@ -281,6 +319,10 @@
     --sidebar-accent: var(--atc-card);
     --sidebar-accent-foreground: var(--atc-text);
     --sidebar-border: var(--atc-line-strong);
+    --sidebar-border-soft: var(--atc-line);
+    --sidebar-muted: var(--atc-dim);
+    --sidebar-faint: var(--atc-faint);
+    --sidebar-signal: var(--atc-orange);
     --sidebar-ring: var(--atc-accent);
 }
 
@@ -322,6 +364,25 @@
     --glass-card-border: color-mix(in oklab, var(--atc-text) 14%, transparent);
     --glass-card-inset: color-mix(in oklab, var(--atc-text) 15%, transparent);
     --traffic-level-color: oklch(0.72 0.006 100);
+    --map-label-shadow: #1a1a18;
+    --map-attribution: rgba(245,243,238,0.3);
+    --map-range-background: rgba(8,12,20,0.4);
+    --map-range-text: #f5f3ee;
+    --map-range-label: rgba(245,243,238,0.7);
+    --airport-range-ring-minor: rgba(255,255,255,0.11);
+    --airport-range-ring-major: rgba(255,255,255,0.20);
+    --airport-range-ring-band: rgba(255,255,255,0.05);
+    --aircraft-trace-line: var(--primary-bright);
+    --aircraft-trace-glow: var(--primary-bright);
+    --aircraft-trace-point: var(--primary-bright);
+    --runway-annotation-line: #d8bd83;
+    --runway-approach-line: rgba(216,189,131,0.78);
+    --runway-approach-beam: #d8bd83;
+    --nearby-runway-line: var(--primary-bright);
+    --procedure-segment-line: #d8bd83;
+    --procedure-silk-blur: #3a3424;
+    --procedure-silk-body: #c79b1f;
+    --procedure-silk-thread: var(--primary-bright);
 
     /* Dark theme: same single grey for every aircraft. */
     --aircraft-departure: oklch(0.62 0.006 100);
@@ -364,6 +425,10 @@
     --sidebar-accent: var(--atc-elev);
     --sidebar-accent-foreground: var(--atc-text);
     --sidebar-border: var(--atc-line-strong);
+    --sidebar-border-soft: var(--atc-line);
+    --sidebar-muted: var(--atc-dim);
+    --sidebar-faint: var(--atc-faint);
+    --sidebar-signal: var(--atc-orange);
     --sidebar-ring: var(--atc-accent);
 
     /* Brighter glow stops for the dark canvas and yellow active state. */
@@ -376,6 +441,14 @@
     );
 }
 
+:root[data-theme="dark"][data-primary="teal"] {
+    --runway-annotation-line: #5fb8b9;
+    --runway-approach-line: rgba(95,184,185,0.78);
+    --runway-approach-beam: #5fb8b9;
+    --procedure-segment-line: #5fb8b9;
+    --procedure-silk-body: #397e7f;
+}
+
 body {
     margin: 0;
     min-width: 320px;
@@ -383,6 +456,18 @@ body {
     background: var(--atc-bg);
     color: var(--atc-text);
     font-family: var(--font-sans);
+}
+
+.sidebar-shell {
+    --atc-bg: var(--sidebar);
+    --atc-card: var(--sidebar-accent);
+    --atc-elev: var(--sidebar-accent);
+    --atc-text: var(--sidebar-foreground);
+    --atc-dim: var(--sidebar-muted);
+    --atc-faint: var(--sidebar-faint);
+    --atc-orange: var(--sidebar-signal);
+    --atc-line: var(--sidebar-border-soft);
+    --atc-line-strong: var(--sidebar-border);
 }
 
 /* Anything previously tagged as monospace (telemetry, METAR, ICAO) now


### PR DESCRIPTION
## Summary
- Route font, sidebar, map overlay, trace, runway, and procedure presentation colors through CSS theme tokens.
- Add teal primary overrides for themed map/trace accents without changing JS constants.
- Add a theme contract test so map presentation colors stay CSS-variable driven.

## Test Plan
- pnpm lint
- pnpm test
- pnpm build
- Opened local /airport/KBOS in Chrome for a visual smoke check
