### PR TITLE
[codex] add branding video background

### DIFF
--- a/src/components/app-shell/DitherPageShell.jsx
+++ b/src/components/app-shell/DitherPageShell.jsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Waves from "@/components/effects/Waves.jsx";
 import BrandLogo from "@/components/brand/BrandLogo.jsx";
+import BrandingVideoBackground from "@/components/effects/BrandingVideoBackground.jsx";
 import MobileTopNav from "@/components/navigation/MobileTopNav.jsx";
 import { SITE_DESCRIPTION } from "@/config/site.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
@@ -61,19 +61,7 @@ export default function DitherPageShell({
       </div>
 
       <div className="dither-page-background relative isolate flex-1 overflow-hidden">
-        <Waves
-          lineColor="rgba(150, 150, 150, 0.35)"
-          backgroundColor="transparent"
-          waveSpeedX={0.018}
-          waveSpeedY={0.008}
-          waveAmpX={36}
-          waveAmpY={18}
-          xGap={14}
-          yGap={32}
-          friction={0.92}
-          tension={0.008}
-          maxCursorMove={140}
-        />
+        <BrandingVideoBackground />
       </div>
     </div>
   );

--- a/src/components/effects/BrandingVideoBackground.jsx
+++ b/src/components/effects/BrandingVideoBackground.jsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const DEFAULT_SOURCE = "/brand/adsbao-aircraft-brand-loop.mp4";
+const CROSSFADE_SECONDS = 1.8;
+
+export default function BrandingVideoBackground({ source = DEFAULT_SOURCE }) {
+  const primaryVideoRef = useRef(null);
+  const secondaryVideoRef = useRef(null);
+  const [visibleIndex, setVisibleIndex] = useState(0);
+  const crossingRef = useRef(false);
+  const visibleIndexRef = useRef(0);
+
+  useEffect(() => {
+    visibleIndexRef.current = visibleIndex;
+  }, [visibleIndex]);
+
+  useEffect(() => {
+    const videos = [primaryVideoRef.current, secondaryVideoRef.current];
+    if (videos.some((video) => !video)) return undefined;
+
+    let frameId = null;
+    let fadeTimer = null;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    const playVideo = (video) => {
+      video.muted = true;
+      const playPromise = video.play();
+      if (playPromise?.catch) {
+        playPromise.catch(() => {});
+      }
+    };
+
+    const resetVideo = (video) => {
+      video.pause();
+      try {
+        video.currentTime = 0;
+      } catch {
+        // Browsers can reject seeks before metadata is available.
+      }
+    };
+
+    const startCrossfade = () => {
+      if (crossingRef.current) return;
+      crossingRef.current = true;
+
+      const currentIndex = visibleIndexRef.current;
+      const nextIndex = currentIndex === 0 ? 1 : 0;
+      const current = videos[currentIndex];
+      const next = videos[nextIndex];
+
+      next.currentTime = 0;
+      playVideo(next);
+      setVisibleIndex(nextIndex);
+
+      fadeTimer = window.setTimeout(() => {
+        resetVideo(current);
+        crossingRef.current = false;
+      }, CROSSFADE_SECONDS * 1000);
+    };
+
+    const tick = () => {
+      const current = videos[visibleIndexRef.current];
+      if (current?.duration && current.duration - current.currentTime <= CROSSFADE_SECONDS) {
+        startCrossfade();
+      }
+      frameId = window.requestAnimationFrame(tick);
+    };
+
+    if (reduceMotion) {
+      resetVideo(videos[0]);
+      resetVideo(videos[1]);
+      setVisibleIndex(0);
+      return () => {
+        videos.forEach((video) => video.pause());
+      };
+    }
+
+    resetVideo(videos[1]);
+    playVideo(videos[0]);
+    frameId = window.requestAnimationFrame(tick);
+
+    return () => {
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+      if (fadeTimer !== null) window.clearTimeout(fadeTimer);
+      videos.forEach((video) => video.pause());
+    };
+  }, [source]);
+
+  return (
+    <div className="branding-video-background" aria-hidden="true">
+      {[0, 1].map((index) => (
+        <video
+          key={`${source}-${index}`}
+          ref={index === 0 ? primaryVideoRef : secondaryVideoRef}
+          className={`branding-video-background__media ${
+            visibleIndex === index ? "is-visible" : ""
+          }`.trim()}
+          src={source}
+          muted
+          playsInline
+          preload="auto"
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -719,8 +719,8 @@ body {
     z-index: 1;
 }
 
-/* Right-side decorative pane — hosts a <Waves /> animation that follows
-   the canvas color (light grey in light mode, ink in dark mode). */
+/* Right-side decorative pane — hosts the aircraft branding video layer.
+   The video stays neutral; CSS filters and overlays bind it to theme tokens. */
 .dither-page-background {
     background: var(--atc-bg);
     min-width: 0;
@@ -824,6 +824,89 @@ body {
 [data-theme="light"] .background-rays .light-rays-container {
     mix-blend-mode: multiply;
     opacity: 0.35;
+}
+
+.branding-video-background {
+    background:
+        radial-gradient(
+            circle at 72% 38%,
+            color-mix(in oklab, var(--atc-accent) 15%, transparent),
+            transparent 32%
+        ),
+        var(--atc-bg);
+    inset: 0;
+    isolation: isolate;
+    overflow: hidden;
+    position: absolute;
+}
+
+.branding-video-background::after {
+    content: "";
+    inset: 0;
+    pointer-events: none;
+    position: absolute;
+    z-index: 2;
+}
+
+.branding-video-background::after {
+    background:
+        linear-gradient(
+            color-mix(in oklab, var(--atc-text) 9%, transparent) 1px,
+            transparent 1px
+        ),
+        linear-gradient(
+            115deg,
+            transparent 0 38%,
+            color-mix(in oklab, var(--atc-orange) 16%, transparent) 48%,
+            transparent 58% 100%
+        );
+    background-size:
+        100% 4px,
+        100% 100%;
+    mix-blend-mode: screen;
+    opacity: 0.34;
+}
+
+.branding-video-background__media {
+    filter: grayscale(1) contrast(1.42) brightness(0.72);
+    height: 100%;
+    inset: 0;
+    mix-blend-mode: screen;
+    object-fit: cover;
+    opacity: 0;
+    position: absolute;
+    transform: scale(1.015);
+    transition: opacity 1.8s cubic-bezier(0.25, 1, 0.5, 1);
+    width: 100%;
+    z-index: 1;
+}
+
+.branding-video-background__media.is-visible {
+    opacity: 0.54;
+}
+
+:root[data-theme="light"] .branding-video-background {
+    background:
+        radial-gradient(
+            circle at 74% 42%,
+            color-mix(in oklab, var(--atc-accent) 12%, transparent),
+            transparent 34%
+        ),
+        var(--atc-bg);
+}
+
+:root[data-theme="light"] .branding-video-background::after {
+    mix-blend-mode: multiply;
+    opacity: 0.16;
+}
+
+:root[data-theme="light"] .branding-video-background__media {
+    filter: grayscale(1) contrast(1.28) brightness(1.08);
+    mix-blend-mode: multiply;
+}
+
+:root[data-theme="light"] .branding-video-background__media.is-visible {
+    opacity: 0.28;
 }
 
 .about-hero {
@@ -3056,10 +3139,8 @@ body {
 }
 
 /* =====================================================================
-   <Waves /> — Perlin-driven animated background layer on the right
-   pane. The component itself paints a canvas with mouse-reactive
-   flowing lines (see effects/Waves.jsx); this rule fades the layer in
-   on mount so the home → about / changelog transitions don't snap.
+   Right-pane media background — fades in on mount so the home → about /
+   changelog transitions don't snap.
    ===================================================================== */
 
 .dither-page-background > div {


### PR DESCRIPTION
## Summary
- Replace the search/about right-pane Waves canvas with a reusable branding video background component.
- Add muted dual-video crossfade playback so a future aircraft brand loop can cycle without a hard cut.
- Keep theme-aware CSS filters, scanline treatment, and the post-review removal of the left-side mask, without committing generated video assets.

## Validation
- pnpm test
- pnpm lint
- pnpm build
