### PR TITLE
[codex] Polish Endfield-inspired typography

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,7 +29,7 @@ Clicked or selected controls use a near-black surface with yellow text. In dark 
 
 ## Typography
 
-Use the existing Google Sans Flex / Manrope-style sans stack for product text and JetBrains Mono for identifiers, telemetry, METAR fragments, aircraft IDs, runway labels, and control microcopy. Avoid display fonts in operational UI. Prefer compact uppercase labels only for short categories and keep letter spacing subtle.
+Use Saira for dense product text and Saira Condensed for short display moments: page titles, airport or aircraft identity codes, command inputs, tabs, and compact section labels. This borrows the source reference's heavy engineered typography without copying its assets or turning dense product UI into game UI. Keep body copy and long labels in the regular Saira role, reserve Condensed for short scannable strings, and use tabular numerals for telemetry, METAR fragments, aircraft IDs, runway labels, and control microcopy. Prefer compact uppercase labels only for short categories and keep letter spacing subtle outside those labels.
 
 ## Shape
 

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -121,7 +121,7 @@ export default async function RootLayout({ children }) {
           crossOrigin=""
         />
         <link
-          href="https://fonts.googleapis.com/css2?family=Saira:ital,wght@0,300..900;1,300..900&family=Noto+Sans+SC:wght@300;400;500;600;700;800;900&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Saira:ital,wght@0,300..900;1,300..900&family=Saira+Condensed:wght@500;600;700;800;900&family=Noto+Sans+SC:wght@300;400;500;600;700;800;900&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/src/components/airport/search/AirportRow.jsx
+++ b/src/components/airport/search/AirportRow.jsx
@@ -23,10 +23,10 @@ export default function AirportRow({ airport, onOpen, featured = false }) {
           <span>{airport.iata || airport.icao || airport.code}</span>
         </span>
         <span className="min-w-0">
-          <strong className="block truncate text-[13px] font-semibold text-atc-text">
+          <strong className="endf-row-title block truncate text-atc-text">
             {airportDisplayName(airport, locale)}
           </strong>
-          <small className="mt-0.5 block truncate text-[11.5px] text-atc-dim">
+          <small className="endf-row-subtitle mt-0.5 block truncate text-atc-dim">
             {airportSubtitle(airport, locale)}
           </small>
         </span>

--- a/src/components/airport/search/AirportSearchPanel.jsx
+++ b/src/components/airport/search/AirportSearchPanel.jsx
@@ -65,13 +65,13 @@ export default function AirportSearchPanel({ onOpenAirport }) {
     >
       <form
         onSubmit={doSearch}
-        className="flex-none mx-6 flex items-center gap-3 border-b border-[var(--atc-line)] py-3.5"
+        className="endf-command-bar mx-6 flex-none"
       >
         <Search className="h-5 w-5 shrink-0 text-atc-orange" />
         <Input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          className="flex-1 p-0 text-base font-semibold tracking-normal text-atc-text"
+          className="endf-command-input flex-1 p-0 text-atc-text"
           placeholder={t("search.placeholder")}
         />
         <kbd className="endf-chip hidden shrink-0 sm:inline-flex">

--- a/src/components/app-shell/DitherPageShell.jsx
+++ b/src/components/app-shell/DitherPageShell.jsx
@@ -39,9 +39,9 @@ export default function DitherPageShell({
               className="h-px flex-1 bg-[var(--atc-line-strong)]"
             />
           </div>
+          <span className="endf-kicker mt-5">Field terminal</span>
           <h1
-            className="endf-page-title mt-4 flex items-center gap-2 text-[28px] leading-[1.05] uppercase text-atc-text"
-            style={{ fontFamily: "var(--font-display)", letterSpacing: "0" }}
+            className="endf-page-title mt-2 flex items-center gap-2 uppercase text-atc-text"
           >
             <span aria-hidden="true" className="endf-page-title__bracket">&lt;</span>
             <span className="truncate">{resolvedTitle}</span>

--- a/src/components/sidebar/SidebarIdentityHero.jsx
+++ b/src/components/sidebar/SidebarIdentityHero.jsx
@@ -22,7 +22,7 @@ export default function SidebarIdentityHero({
       <div className="mt-3 flex items-baseline gap-3">
         <span aria-hidden="true" className="endf-diamond self-center" />
         <span
-          className={`airport-sidebar-display-mono airport-sidebar-display-mono--hero notranslate text-[28px] font-extrabold text-atc-text ${codeClassName}`}
+          className={`endf-display-frame airport-sidebar-display-mono airport-sidebar-display-mono--hero notranslate text-atc-text ${codeClassName}`}
           translate="no"
         >
           {code}

--- a/src/style.css
+++ b/src/style.css
@@ -38,10 +38,9 @@
     --color-atc-line: var(--atc-line);
     --color-atc-line-strong: var(--atc-line-strong);
 
-    /* Endfield typography. Closest free analog to Novecento Sans Wide is
-       Saira — a wide geometric grotesque with full 300–900 weights.
-       Single family used everywhere; display moments lean on weight 800–
-       900 + wider letter-spacing to hit the "Novecento" poster feel.
+    /* Endfield-inspired typography. Saira carries dense product text;
+       Saira Condensed handles short display moments where the source
+       site's heavy, engineered title treatment is the useful reference.
        Noto Sans SC carries CJK glyphs. */
     --font-sans: var(--theme-font-sans);
     --font-mono: var(--theme-font-mono);
@@ -128,7 +127,16 @@
     --theme-font-sans: "Saira", "Noto Sans SC", system-ui, sans-serif;
     --theme-font-mono: "Saira", "Noto Sans SC", system-ui, sans-serif;
     --theme-font-nav: "Saira", "Noto Sans SC", system-ui, sans-serif;
-    --theme-font-display: "Saira", "Noto Sans SC", system-ui, sans-serif;
+    --theme-font-display: "Saira Condensed", "Saira", "Noto Sans SC", system-ui, sans-serif;
+    --type-caption: 0.6875rem;
+    --type-micro: 0.625rem;
+    --type-body: 0.8125rem;
+    --type-subhead: 0.9375rem;
+    --type-title: 2rem;
+    --type-display: 2.25rem;
+    --type-letter-ui: 0.04em;
+    --type-letter-code: 0.055em;
+    --type-letter-label: 0.16em;
     --theme-primary-bright: #ffe600;
     --theme-primary-deep: #a86a1f;
     --primary-bright: var(--theme-primary-bright);
@@ -719,6 +727,22 @@ body {
     z-index: 1;
 }
 
+.dither-page-panel::before {
+    background:
+        linear-gradient(90deg, var(--endf-accent-ink), transparent 28%),
+        repeating-linear-gradient(
+            90deg,
+            color-mix(in oklab, var(--atc-text) 8%, transparent) 0 1px,
+            transparent 1px 16px
+        );
+    content: "";
+    height: 2px;
+    inset: 0 0 auto;
+    opacity: 0.76;
+    pointer-events: none;
+    position: absolute;
+}
+
 /* Right-side decorative pane — hosts the aircraft branding video layer.
    The video stays neutral; CSS filters and overlays bind it to theme tokens. */
 .dither-page-background {
@@ -737,6 +761,77 @@ body {
         box-shadow: none;
         width: 100vw !important;
     }
+}
+
+.endf-kicker {
+    color: var(--atc-faint);
+    display: inline-flex;
+    font-family: var(--font-display);
+    font-size: var(--type-micro);
+    font-weight: 800;
+    letter-spacing: 0.22em;
+    line-height: 1;
+    text-transform: uppercase;
+}
+
+.endf-kicker::before {
+    color: var(--endf-accent-ink);
+    content: "00//";
+    margin-right: 8px;
+}
+
+.endf-command-bar {
+    align-items: center;
+    background:
+        linear-gradient(
+            90deg,
+            color-mix(in oklab, var(--atc-card) 82%, transparent),
+            color-mix(in oklab, var(--atc-elev) 48%, transparent)
+        );
+    border-bottom: 1px solid var(--atc-line);
+    border-top: 1px solid color-mix(in oklab, var(--atc-text) 7%, transparent);
+    display: flex;
+    gap: 12px;
+    min-height: 58px;
+    padding: 0 0 0 12px;
+    position: relative;
+}
+
+.endf-command-bar::before,
+.endf-command-bar::after {
+    background: var(--endf-accent-ink);
+    content: "";
+    pointer-events: none;
+    position: absolute;
+}
+
+.endf-command-bar::before {
+    height: 18px;
+    left: 0;
+    top: 0;
+    width: 2px;
+}
+
+.endf-command-bar::after {
+    bottom: -1px;
+    height: 2px;
+    left: 0;
+    width: 42px;
+}
+
+.endf-command-input {
+    font-family: var(--font-display);
+    font-size: 1.125rem;
+    font-weight: 800;
+    letter-spacing: var(--type-letter-ui);
+    line-height: 1;
+    text-transform: uppercase;
+}
+
+.endf-command-input::placeholder {
+    color: color-mix(in oklab, var(--atc-text) 36%, transparent);
+    font-weight: 700;
+    opacity: 1;
 }
 
 .search-screen > main,
@@ -3639,23 +3734,24 @@ body {
     color: inherit;
     display: inline-block;
     font-family: var(--font-display);
-    font-feature-settings: "tnum" 1;
+    font-feature-settings: "tnum" 1, "ss01" 1;
     font-weight: 900;
-    letter-spacing: 0.04em;
+    letter-spacing: var(--type-letter-code);
     mask: none;
     -webkit-mask: none;
     -webkit-text-fill-color: currentColor;
 }
 
 .airport-sidebar-display-mono--hero {
+    font-size: var(--type-display);
     font-weight: 900;
-    letter-spacing: -0.005em;
-    line-height: 0.95;
+    letter-spacing: 0;
+    line-height: 0.88;
 }
 
 .airport-sidebar-display-mono--metric {
     font-weight: 900;
-    letter-spacing: -0.005em;
+    letter-spacing: 0;
     line-height: 0.9;
 }
 
@@ -3673,6 +3769,53 @@ body {
         );
     border-bottom: 1px solid var(--atc-line);
     padding: 28px var(--airport-sidebar-inset) 24px;
+    position: relative;
+}
+
+.airport-sidebar-identity::after {
+    background:
+        linear-gradient(90deg, var(--endf-accent-ink), transparent 60%),
+        repeating-linear-gradient(
+            90deg,
+            color-mix(in oklab, var(--atc-text) 8%, transparent) 0 1px,
+            transparent 1px 12px
+        );
+    bottom: -1px;
+    content: "";
+    height: 2px;
+    left: var(--airport-sidebar-inset);
+    pointer-events: none;
+    position: absolute;
+    width: calc(100% - (var(--airport-sidebar-inset) * 2));
+}
+
+.endf-display-frame {
+    isolation: isolate;
+    padding: 2px 0 4px;
+    position: relative;
+}
+
+.endf-display-frame::before {
+    border: 1px solid color-mix(in oklab, var(--endf-accent-ink) 70%, transparent);
+    border-right: 0;
+    content: "";
+    height: 0.58em;
+    left: -0.28em;
+    pointer-events: none;
+    position: absolute;
+    top: 0.08em;
+    width: 0.2em;
+}
+
+.endf-display-frame::after {
+    background: color-mix(in oklab, var(--endf-accent-ink) 78%, transparent);
+    bottom: 0;
+    content: "";
+    height: 2px;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    width: min(100%, 3.8em);
 }
 
 /* Two-column metric grid shared between the airport sidebar (interactive
@@ -5649,10 +5792,10 @@ body {
     color: var(--atc-faint);
     display: inline-flex;
     font-family: var(--font-display);
-    font-size: 10px;
+    font-size: var(--type-micro);
     font-weight: 900;
     gap: 6px;
-    letter-spacing: 0.18em;
+    letter-spacing: var(--type-letter-label);
     line-height: 1;
     text-transform: uppercase;
 }
@@ -5685,9 +5828,9 @@ body {
 .endf-section-head__count {
     color: var(--atc-dim);
     font-family: var(--font-display);
-    font-size: 10px;
+    font-size: var(--type-micro);
     font-weight: 900;
-    letter-spacing: 0.16em;
+    letter-spacing: var(--type-letter-label);
 }
 
 /* Yellow skewed/clipped parallelogram. Used for active tabs, version
@@ -5699,9 +5842,9 @@ body {
     display: inline-flex;
     align-items: center;
     font-family: var(--font-display);
-    font-size: 11px;
+    font-size: 0.6875rem;
     font-weight: 900;
-    letter-spacing: 0.06em;
+    letter-spacing: var(--type-letter-code);
     line-height: 1;
     padding: 6px 14px;
     text-transform: uppercase;
@@ -5733,9 +5876,9 @@ body {
    weight-900 face. Matches the search bar's ENTER chip family but sized
    for IATA codes (LAX, JFK, ORD) in list rows. */
 .endf-tab--code {
-    font-size: 13px;
+    font-size: 0.9375rem;
     justify-content: center;
-    letter-spacing: 0.04em;
+    letter-spacing: var(--type-letter-code);
     min-width: 56px;
     padding: 5px 10px;
 }
@@ -5746,9 +5889,9 @@ body {
     display: inline-flex;
     align-items: center;
     font-family: var(--font-display);
-    font-size: 9px;
+    font-size: 0.5625rem;
     font-weight: 900;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.12em;
     line-height: 1;
     padding: 3px 8px;
     text-transform: uppercase;
@@ -5837,8 +5980,32 @@ body {
    uppercase with subtle yellow brackets that scale with the text. The
    wider tracking emulates Novecento Sans Wide's poster proportions. */
 .endf-page-title {
+    font-family: var(--font-display);
+    font-size: var(--type-title);
     font-weight: 800;
-    letter-spacing: 0.01em;
+    letter-spacing: -0.01em;
+    line-height: 0.88;
+    max-width: 100%;
+    padding-bottom: 8px;
+    position: relative;
+    transform: scaleY(0.98);
+}
+
+.endf-page-title::after {
+    background:
+        linear-gradient(90deg, var(--endf-accent-ink), transparent 44%),
+        repeating-linear-gradient(
+            90deg,
+            color-mix(in oklab, var(--atc-text) 12%, transparent) 0 1px,
+            transparent 1px 12px
+        );
+    bottom: 0;
+    content: "";
+    height: 2px;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    width: 100%;
 }
 
 .endf-page-title__bracket {
@@ -5937,6 +6104,23 @@ body {
 .endf-row-active .text-atc-faint,
 .endf-row-active .aircraft-table-route-cycle {
     color: color-mix(in oklab, var(--endf-yellow) 72%, transparent);
+}
+
+.endf-row-title {
+    font-family: var(--font-display);
+    font-size: var(--type-subhead);
+    font-weight: 800;
+    letter-spacing: 0.01em;
+    line-height: 1.05;
+    text-transform: uppercase;
+}
+
+.endf-row-subtitle {
+    font-family: var(--font-sans);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    letter-spacing: 0.015em;
+    line-height: 1.2;
 }
 
 /* Featured row — left yellow rhombus marker + warm ink background. */


### PR DESCRIPTION
## Summary

- add Saira Condensed as the short display role for Endfield-inspired typography
- sharpen the home/search shell with command-bar input treatment, terminal kicker text, and heavier page title styling
- apply the display treatment to airport rows and sidebar identity codes without changing routes, data flow, or theme colors
- update `DESIGN.md` so future design passes use the same typography direction

## Validation

- `pnpm lint`
- `pnpm build`
- local desktop and mobile screenshot smoke checks at `http://localhost:3000`
