### PR TITLE
[codex] add social presence reactions

### DIFF
--- a/src/app/api/dao/social.dao.js
+++ b/src/app/api/dao/social.dao.js
@@ -1,0 +1,198 @@
+import { createServerSupabaseClient } from "./supabaseClient.js";
+import {
+  SOCIAL_ACTIVE_WINDOW_MS,
+  buildSocialSummary,
+} from "../../../features/social/socialModel.js";
+
+export const SOCIAL_PRESENCE_TABLE = "social_presence";
+export const SOCIAL_REACTIONS_TABLE = "social_reactions";
+
+const REACTION_SELECT_COLUMNS = "id,deleted_at";
+
+const isoNow = (now) => new Date(now()).toISOString();
+
+const applyEntityFilters = (query, {
+  entityType,
+  entityKey,
+  contextAirportIcao = "",
+} = {}) =>
+  query
+    .eq("entity_type", entityType)
+    .eq("entity_key", entityKey)
+    .eq("context_airport_icao", contextAirportIcao || "");
+
+export function createSocialRepository({
+  supabaseUrl,
+  supabaseKey,
+  createClientImpl,
+  now = Date.now,
+} = {}) {
+  const client = createServerSupabaseClient({
+    supabaseUrl,
+    supabaseKey,
+    createClientImpl,
+  });
+  if (!client) return null;
+
+  return {
+    async heartbeatPresence({
+      sessionHash,
+      entityType,
+      entityKey,
+      contextAirportIcao = "",
+    } = {}) {
+      if (!sessionHash || !entityType || !entityKey) return null;
+      const seenAt = isoNow(now);
+      const row = {
+        session_hash: sessionHash,
+        entity_type: entityType,
+        entity_key: entityKey,
+        context_airport_icao: contextAirportIcao || "",
+        last_seen_at: seenAt,
+        deleted_at: null,
+      };
+
+      const { data, error } = await client
+        .from(SOCIAL_PRESENCE_TABLE)
+        .upsert(row, {
+          onConflict: "session_hash,entity_type,entity_key,context_airport_icao",
+        })
+        .select("session_hash,entity_type,entity_key,context_airport_icao,last_seen_at,deleted_at")
+        .single();
+
+      if (error) {
+        throw new Error(`Social presence heartbeat failed (${error.message})`);
+      }
+      return data;
+    },
+
+    async toggleReaction({
+      sessionHash,
+      entityType,
+      entityKey,
+      contextAirportIcao = "",
+      reaction,
+    } = {}) {
+      if (!sessionHash || !entityType || !entityKey || !reaction) return null;
+      const timestamp = isoNow(now);
+      const base = {
+        session_hash: sessionHash,
+        entity_type: entityType,
+        entity_key: entityKey,
+        context_airport_icao: contextAirportIcao || "",
+        reaction,
+      };
+
+      const { data: existing, error: readError } = await applyEntityFilters(
+        client
+          .from(SOCIAL_REACTIONS_TABLE)
+          .select(REACTION_SELECT_COLUMNS)
+          .eq("session_hash", sessionHash)
+          .eq("reaction", reaction),
+        base,
+      )
+        .order("updated_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (readError && readError.code !== "PGRST116") {
+        throw new Error(`Social reaction read failed (${readError.message})`);
+      }
+
+      if (existing?.id) {
+        const active = Boolean(existing.deleted_at);
+        const row = active
+          ? { deleted_at: null, updated_at: timestamp }
+          : { deleted_at: timestamp, updated_at: timestamp };
+        const { error } = await client
+          .from(SOCIAL_REACTIONS_TABLE)
+          .update(row)
+          .eq("id", existing.id)
+          .select(REACTION_SELECT_COLUMNS)
+          .single();
+        if (error) {
+          throw new Error(`Social reaction update failed (${error.message})`);
+        }
+        return { active, reaction };
+      }
+
+      const { error } = await client
+        .from(SOCIAL_REACTIONS_TABLE)
+        .insert({
+          ...base,
+          created_at: timestamp,
+          updated_at: timestamp,
+          deleted_at: null,
+        })
+        .select(REACTION_SELECT_COLUMNS)
+        .single();
+      if (error) {
+        throw new Error(`Social reaction insert failed (${error.message})`);
+      }
+      return { active: true, reaction };
+    },
+
+    async readSummary({
+      sessionHash = "",
+      entityType,
+      entityKey,
+      contextAirportIcao = "",
+    } = {}) {
+      if (!entityType || !entityKey) return null;
+      const activeSince = new Date(now() - SOCIAL_ACTIVE_WINDOW_MS).toISOString();
+
+      const [presenceResult, reactionResult, viewerResult] = await Promise.all([
+        applyEntityFilters(
+          client.from(SOCIAL_PRESENCE_TABLE).select("session_hash"),
+          { entityType, entityKey, contextAirportIcao },
+        )
+          .is("deleted_at", null)
+          .gt("last_seen_at", activeSince),
+        applyEntityFilters(
+          client.from(SOCIAL_REACTIONS_TABLE).select("reaction"),
+          { entityType, entityKey, contextAirportIcao },
+        ).is("deleted_at", null),
+        sessionHash
+          ? applyEntityFilters(
+              client
+                .from(SOCIAL_REACTIONS_TABLE)
+                .select("reaction")
+                .eq("session_hash", sessionHash),
+              { entityType, entityKey, contextAirportIcao },
+            ).is("deleted_at", null)
+          : Promise.resolve({ data: [], error: null }),
+      ]);
+
+      for (const result of [presenceResult, reactionResult, viewerResult]) {
+        if (result.error) {
+          throw new Error(`Social summary read failed (${result.error.message})`);
+        }
+      }
+
+      return buildSocialSummary({
+        entityType,
+        entityKey,
+        watching: presenceResult.data?.length || 0,
+        reactionRows: reactionResult.data || [],
+        viewerRows: viewerResult.data || [],
+      });
+    },
+  };
+}
+
+export function createSocialRepositoryFromEnv({
+  env = process.env,
+  createClientImpl,
+  now = Date.now,
+} = {}) {
+  return createSocialRepository({
+    supabaseUrl: env.NEXT_PUBLIC_SUPABASE_URL || env.SUPABASE_URL,
+    supabaseKey:
+      env.SUPABASE_SECRET_KEY ||
+      env.SUPABASE_SERVICE_ROLE_KEY ||
+      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
+      env.SUPABASE_PUBLISHABLE_KEY,
+    createClientImpl,
+    now,
+  });
+}

--- a/src/app/api/dao/social.dao.test.js
+++ b/src/app/api/dao/social.dao.test.js
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+
+import {
+  SOCIAL_PRESENCE_TABLE,
+  SOCIAL_REACTIONS_TABLE,
+  createSocialRepository,
+  createSocialRepositoryFromEnv,
+} from "./social.dao.js";
+
+const now = () => Date.parse("2026-05-24T12:00:00.000Z");
+
+function createFakeSupabaseClient({
+  existingReaction = null,
+  existingReactionError = null,
+  summaryRows = [],
+  viewerRows = [],
+  presenceRows = [],
+  writeError = null,
+} = {}) {
+  const calls = [];
+  const createClientImpl = (supabaseUrl, supabaseKey, options) => {
+    calls.push({ type: "createClient", supabaseUrl, supabaseKey, options });
+    return {
+      from(table) {
+        calls.push({ type: "from", table });
+        const builder = {
+          insertedRow: null,
+          updatedRow: null,
+          selectColumns: "",
+          hasSessionHashFilter: false,
+          select(columns) {
+            this.selectColumns = columns;
+            calls.push({ type: "select", columns });
+            return this;
+          },
+          eq(column, value) {
+            if (column === "session_hash") this.hasSessionHashFilter = true;
+            calls.push({ type: "eq", column, value });
+            return this;
+          },
+          is(column, value) {
+            calls.push({ type: "is", column, value });
+            return this;
+          },
+          gt(column, value) {
+            calls.push({ type: "gt", column, value });
+            return this;
+          },
+          upsert(row, options) {
+            this.insertedRow = row;
+            calls.push({ type: "upsert", row, options });
+            return this;
+          },
+          insert(row) {
+            this.insertedRow = row;
+            calls.push({ type: "insert", row });
+            return this;
+          },
+          update(row) {
+            this.updatedRow = row;
+            calls.push({ type: "update", row });
+            return this;
+          },
+          order(column, options) {
+            calls.push({ type: "order", column, options });
+            return this;
+          },
+          limit(count) {
+            calls.push({ type: "limit", count });
+            return this;
+          },
+          async maybeSingle() {
+            calls.push({ type: "maybeSingle" });
+            return { data: existingReaction, error: existingReactionError };
+          },
+          async single() {
+            calls.push({ type: "single" });
+            return { data: this.insertedRow || this.updatedRow, error: writeError };
+          },
+          then(resolve) {
+            calls.push({ type: "then", columns: this.selectColumns });
+            if (table === SOCIAL_PRESENCE_TABLE) {
+              return resolve({ data: presenceRows, error: null });
+            }
+            if (this.hasSessionHashFilter) {
+              return resolve({ data: viewerRows, error: null });
+            }
+            return resolve({ data: summaryRows, error: null });
+          },
+        };
+        return builder;
+      },
+    };
+  };
+  return { calls, createClientImpl };
+}
+
+assert.equal(SOCIAL_PRESENCE_TABLE, "social_presence");
+assert.equal(SOCIAL_REACTIONS_TABLE, "social_reactions");
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient();
+  const repo = createSocialRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    createClientImpl,
+    now,
+  });
+
+  await repo.heartbeatPresence({
+    sessionHash: "hash-1",
+    entityType: "airport",
+    entityKey: "KBOS",
+    contextAirportIcao: "KBOS",
+  });
+
+  const upsert = calls.find((call) => call.type === "upsert");
+  assert.equal(upsert.row.session_hash, "hash-1");
+  assert.equal(upsert.row.entity_type, "airport");
+  assert.equal(upsert.row.entity_key, "KBOS");
+  assert.equal(upsert.row.context_airport_icao, "KBOS");
+  assert.equal(upsert.row.last_seen_at, "2026-05-24T12:00:00.000Z");
+  assert.equal(upsert.row.deleted_at, null);
+  assert.equal(
+    upsert.options.onConflict,
+    "session_hash,entity_type,entity_key,context_airport_icao",
+  );
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    existingReaction: { id: "r1", deleted_at: null },
+  });
+  const repo = createSocialRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    createClientImpl,
+    now,
+  });
+
+  const result = await repo.toggleReaction({
+    sessionHash: "hash-1",
+    entityType: "aircraft",
+    entityKey: "A1B2C3",
+    contextAirportIcao: "KBOS",
+    reaction: "camera",
+  });
+
+  assert.deepEqual(result, { active: false, reaction: "camera" });
+  const update = calls.find((call) => call.type === "update");
+  assert.equal(update.row.deleted_at, "2026-05-24T12:00:00.000Z");
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    existingReaction: { id: "r1", deleted_at: "2026-05-24T11:00:00.000Z" },
+  });
+  const repo = createSocialRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    createClientImpl,
+    now,
+  });
+
+  const result = await repo.toggleReaction({
+    sessionHash: "hash-1",
+    entityType: "aircraft",
+    entityKey: "A1B2C3",
+    contextAirportIcao: "KBOS",
+    reaction: "camera",
+  });
+
+  assert.deepEqual(result, { active: true, reaction: "camera" });
+  const update = calls.find((call) => call.type === "update");
+  assert.equal(update.row.deleted_at, null);
+  assert.equal(update.row.updated_at, "2026-05-24T12:00:00.000Z");
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient();
+  const repo = createSocialRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    createClientImpl,
+    now,
+  });
+
+  const result = await repo.toggleReaction({
+    sessionHash: "hash-1",
+    entityType: "airport",
+    entityKey: "KBOS",
+    contextAirportIcao: "KBOS",
+    reaction: "like",
+  });
+
+  assert.deepEqual(result, { active: true, reaction: "like" });
+  const insert = calls.find((call) => call.type === "insert");
+  assert.equal(insert.row.session_hash, "hash-1");
+  assert.equal(insert.row.reaction, "like");
+  assert.equal(insert.row.deleted_at, null);
+}
+
+{
+  const { createClientImpl } = createFakeSupabaseClient({
+    presenceRows: [{ session_hash: "a" }, { session_hash: "b" }],
+    summaryRows: [{ reaction: "fire" }, { reaction: "fire" }, { reaction: "camera" }],
+    viewerRows: [{ reaction: "camera" }],
+  });
+  const repo = createSocialRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    createClientImpl,
+    now,
+  });
+
+  const summary = await repo.readSummary({
+    sessionHash: "hash-1",
+    entityType: "airport",
+    entityKey: "KBOS",
+    contextAirportIcao: "KBOS",
+  });
+
+  assert.equal(summary.watching, 2);
+  assert.equal(summary.reactions.fire, 2);
+  assert.equal(summary.reactions.camera, 1);
+  assert.deepEqual(summary.viewerReactions, ["camera"]);
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient();
+  const repo = createSocialRepositoryFromEnv({
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SECRET_KEY: "sb_secret_from_env",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_unused",
+    },
+    createClientImpl,
+    now,
+  });
+  await repo.heartbeatPresence({
+    sessionHash: "hash-1",
+    entityType: "airport",
+    entityKey: "KBOS",
+    contextAirportIcao: "KBOS",
+  });
+  assert.equal(calls[0].supabaseKey, "sb_secret_from_env");
+}
+
+assert.equal(
+  createSocialRepository({
+    supabaseUrl: "",
+    supabaseKey: "sb_secret",
+    createClientImpl: () => ({}),
+  }),
+  null,
+);

--- a/src/app/api/social/presence/route.js
+++ b/src/app/api/social/presence/route.js
@@ -1,0 +1,71 @@
+import {
+  buildProxyHeaders,
+  createCorsPreflightResponse,
+  enforceProxyRequest,
+  jsonProxyResponse,
+} from "@/app/api/_shared/apiProxySecurity.js";
+import { createSocialRepositoryFromEnv } from "@/app/api/dao/social.dao.js";
+import { normalizeSocialEntityInput } from "@/features/social/socialModel.js";
+import { getSocialSessionHash } from "../socialRouteModel.js";
+
+const rateLimit = {
+  key: "social:presence",
+  maxRequests: 40,
+  windowMs: 60_000,
+};
+
+export function OPTIONS(request) {
+  return createCorsPreflightResponse(request, {
+    allowedMethods: ["POST", "OPTIONS"],
+  });
+}
+
+export async function POST(request) {
+  const securityResponse = enforceProxyRequest(request, { rateLimit });
+  if (securityResponse) return securityResponse;
+
+  let rawBody;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return jsonProxyResponse(request, { error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const normalized = normalizeSocialEntityInput(rawBody);
+  if (!normalized.ok) {
+    return jsonProxyResponse(request, { error: normalized.error }, { status: 400 });
+  }
+
+  const repo = createSocialRepositoryFromEnv();
+  if (!repo) {
+    return jsonProxyResponse(
+      request,
+      { error: "Social storage unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const sessionHash = getSocialSessionHash(request, { rawBody });
+  try {
+    await repo.heartbeatPresence({ ...normalized.value, sessionHash });
+  } catch (err) {
+    console.error("[social-presence] heartbeat failed:", err);
+    return jsonProxyResponse(
+      request,
+      { error: "Could not update presence" },
+      { status: 500 },
+    );
+  }
+
+  return Response.json(
+    { ok: true },
+    {
+      status: 200,
+      headers: buildProxyHeaders(
+        request,
+        { "Cache-Control": "no-store" },
+        { varyOrigin: false },
+      ),
+    },
+  );
+}

--- a/src/app/api/social/reaction/route.js
+++ b/src/app/api/social/reaction/route.js
@@ -1,0 +1,72 @@
+import {
+  buildProxyHeaders,
+  createCorsPreflightResponse,
+  enforceProxyRequest,
+  jsonProxyResponse,
+} from "@/app/api/_shared/apiProxySecurity.js";
+import { createSocialRepositoryFromEnv } from "@/app/api/dao/social.dao.js";
+import { normalizeSocialReactionInput } from "@/features/social/socialModel.js";
+import { getSocialSessionHash } from "../socialRouteModel.js";
+
+const rateLimit = {
+  key: "social:reaction",
+  maxRequests: 30,
+  windowMs: 60_000,
+};
+
+export function OPTIONS(request) {
+  return createCorsPreflightResponse(request, {
+    allowedMethods: ["POST", "OPTIONS"],
+  });
+}
+
+export async function POST(request) {
+  const securityResponse = enforceProxyRequest(request, { rateLimit });
+  if (securityResponse) return securityResponse;
+
+  let rawBody;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return jsonProxyResponse(request, { error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const normalized = normalizeSocialReactionInput(rawBody);
+  if (!normalized.ok) {
+    return jsonProxyResponse(request, { error: normalized.error }, { status: 400 });
+  }
+
+  const repo = createSocialRepositoryFromEnv();
+  if (!repo) {
+    return jsonProxyResponse(
+      request,
+      { error: "Social storage unavailable" },
+      { status: 503 },
+    );
+  }
+
+  const sessionHash = getSocialSessionHash(request, { rawBody });
+  let result;
+  try {
+    result = await repo.toggleReaction({ ...normalized.value, sessionHash });
+  } catch (err) {
+    console.error("[social-reaction] toggle failed:", err);
+    return jsonProxyResponse(
+      request,
+      { error: "Could not update reaction" },
+      { status: 500 },
+    );
+  }
+
+  return Response.json(
+    { ok: true, ...result },
+    {
+      status: 200,
+      headers: buildProxyHeaders(
+        request,
+        { "Cache-Control": "no-store" },
+        { varyOrigin: false },
+      ),
+    },
+  );
+}

--- a/src/app/api/social/socialRouteModel.js
+++ b/src/app/api/social/socialRouteModel.js
@@ -1,0 +1,44 @@
+import { createHash } from "node:crypto";
+
+import { getClientIp } from "../_shared/apiProxySecurity.js";
+import { normalizeSocialEntityInput } from "../../../features/social/socialModel.js";
+
+const SESSION_HEADER = "x-adsbao-session";
+const DEFAULT_SESSION_SALT = "adsbao-social-v1";
+
+export function getSocialSessionSeed(request, rawBody = null) {
+  const headerSeed = request.headers.get(SESSION_HEADER);
+  if (headerSeed) return headerSeed.trim();
+  const bodySeed =
+    rawBody && typeof rawBody === "object" ? String(rawBody.sessionId || "") : "";
+  if (bodySeed.trim()) return bodySeed.trim();
+  return `${getClientIp(request)}|${request.headers.get("user-agent") || ""}`;
+}
+
+export function buildSocialSessionHash(seed, {
+  env = process.env,
+} = {}) {
+  const salt =
+    env.SOCIAL_SESSION_SALT ||
+    env.NEXT_PUBLIC_SITE_URL ||
+    env.VERCEL_URL ||
+    DEFAULT_SESSION_SALT;
+  return createHash("sha256")
+    .update(`${salt}:${String(seed || "")}`)
+    .digest("hex");
+}
+
+export function getSocialSessionHash(request, {
+  rawBody = null,
+  env = process.env,
+} = {}) {
+  return buildSocialSessionHash(getSocialSessionSeed(request, rawBody), { env });
+}
+
+export function normalizeSocialSummarySearchParams(searchParams) {
+  return normalizeSocialEntityInput({
+    entityType: searchParams.get("entityType"),
+    entityKey: searchParams.get("entityKey"),
+    contextAirportIcao: searchParams.get("contextAirportIcao"),
+  });
+}

--- a/src/app/api/social/socialRouteModel.test.js
+++ b/src/app/api/social/socialRouteModel.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+
+import {
+  buildSocialSessionHash,
+  getSocialSessionSeed,
+  normalizeSocialSummarySearchParams,
+} from "./socialRouteModel.js";
+
+{
+  const request = new Request("https://adsbao.test/api/social/summary", {
+    headers: {
+      "x-adsbao-session": "browser-session-1",
+      "user-agent": "ignored",
+      "x-forwarded-for": "203.0.113.10",
+    },
+  });
+  assert.equal(getSocialSessionSeed(request), "browser-session-1");
+  const hash = buildSocialSessionHash("browser-session-1", {
+    env: { SOCIAL_SESSION_SALT: "salt-a" },
+  });
+  assert.match(hash, /^[a-f0-9]{64}$/);
+  assert.notEqual(hash, "browser-session-1");
+  assert.notEqual(
+    hash,
+    buildSocialSessionHash("browser-session-1", {
+      env: { SOCIAL_SESSION_SALT: "salt-b" },
+    }),
+  );
+}
+
+{
+  const request = new Request("https://adsbao.test/api/social/summary", {
+    headers: {
+      "user-agent": "Mozilla/5.0",
+      "x-forwarded-for": "203.0.113.10, 198.51.100.2",
+    },
+  });
+  assert.equal(
+    getSocialSessionSeed(request),
+    "203.0.113.10|Mozilla/5.0",
+  );
+}
+
+{
+  const params = new URLSearchParams({
+    entityType: "aircraft",
+    entityKey: "dal 977",
+    contextAirportIcao: "kbos",
+  });
+  assert.deepEqual(normalizeSocialSummarySearchParams(params), {
+    ok: true,
+    value: {
+      entityType: "aircraft",
+      entityKey: "DAL977",
+      contextAirportIcao: "KBOS",
+    },
+  });
+}

--- a/src/app/api/social/summary/route.js
+++ b/src/app/api/social/summary/route.js
@@ -1,0 +1,67 @@
+import {
+  buildProxyHeaders,
+  createCorsPreflightResponse,
+  enforceProxyRequest,
+  jsonProxyResponse,
+} from "@/app/api/_shared/apiProxySecurity.js";
+import { createSocialRepositoryFromEnv } from "@/app/api/dao/social.dao.js";
+import {
+  getSocialSessionHash,
+  normalizeSocialSummarySearchParams,
+} from "../socialRouteModel.js";
+
+const rateLimit = {
+  key: "social:summary",
+  maxRequests: 90,
+  windowMs: 60_000,
+};
+
+export function OPTIONS(request) {
+  return createCorsPreflightResponse(request, {
+    allowedMethods: ["GET", "OPTIONS"],
+  });
+}
+
+export async function GET(request) {
+  const securityResponse = enforceProxyRequest(request, { rateLimit });
+  if (securityResponse) return securityResponse;
+
+  const url = new URL(request.url);
+  const normalized = normalizeSocialSummarySearchParams(url.searchParams);
+  if (!normalized.ok) {
+    return jsonProxyResponse(request, { error: normalized.error }, { status: 400 });
+  }
+
+  const repo = createSocialRepositoryFromEnv();
+  if (!repo) {
+    return jsonProxyResponse(
+      request,
+      { error: "Social storage unavailable" },
+      { status: 503 },
+    );
+  }
+
+  let summary;
+  try {
+    summary = await repo.readSummary({
+      ...normalized.value,
+      sessionHash: getSocialSessionHash(request),
+    });
+  } catch (err) {
+    console.error("[social-summary] read failed:", err);
+    return jsonProxyResponse(
+      request,
+      { error: "Could not read social summary" },
+      { status: 500 },
+    );
+  }
+
+  return Response.json(summary, {
+    status: 200,
+    headers: buildProxyHeaders(
+      request,
+      { "Cache-Control": "no-store" },
+      { varyOrigin: false },
+    ),
+  });
+}

--- a/src/components/aircraft/preview/AircraftPreviewCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.jsx
@@ -38,6 +38,8 @@ export default function AircraftPreviewCard({
   isMobile = false,
   sidebarOpen = false,
   airportProfile = null,
+  aircraftSocialSummary = null,
+  airportSocialSummary = null,
   onApplyTemporaryRoute,
 }) {
   const { t } = useI18n();
@@ -125,12 +127,16 @@ export default function AircraftPreviewCard({
             </AnimatePresence>
           )}
           {isAirport ? (
-            <AirportPreviewMetadataCard airport={airport} />
+            <AirportPreviewMetadataCard
+              airport={airport}
+              socialSummary={airportSocialSummary}
+            />
           ) : (
             <AircraftPreviewMetadataCard
               aircraft={aircraft}
               photo={photo}
               airportProfile={airportProfile}
+              socialSummary={aircraftSocialSummary}
               onApplyTemporaryRoute={onApplyTemporaryRoute}
             />
           )}
@@ -147,9 +153,15 @@ export default function AircraftPreviewCard({
             : STACK_MOTION)}
         >
           {isAirport ? (
-            <AirportPreviewMobileCard airport={airport} />
+            <AirportPreviewMobileCard
+              airport={airport}
+              socialSummary={airportSocialSummary}
+            />
           ) : (
-            <AircraftPreviewMobileCard aircraft={aircraft} />
+            <AircraftPreviewMobileCard
+              aircraft={aircraft}
+              socialSummary={aircraftSocialSummary}
+            />
           )}
           {trackHref && (
             <button

--- a/src/components/aircraft/preview/AircraftPreviewMetadataCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewMetadataCard.jsx
@@ -7,11 +7,13 @@ import AircraftPreviewMetadata from "./AircraftPreviewMetadata.jsx";
 import AircraftPreviewTelemetry from "./AircraftPreviewTelemetry.jsx";
 import RouteFeedbackForm from "./RouteFeedbackForm.jsx";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
+import SocialActivitySummary from "@/components/social/SocialActivitySummary.jsx";
 
 export default function AircraftPreviewMetadataCard({
   aircraft,
   photo,
   airportProfile = null,
+  socialSummary = null,
   onApplyTemporaryRoute,
 }) {
   const { t } = useI18n();
@@ -31,6 +33,7 @@ export default function AircraftPreviewMetadataCard({
       )}
       <AircraftPreviewIdentity aircraft={aircraft} />
       <AircraftPreviewTelemetry aircraft={aircraft} />
+      <SocialActivitySummary summary={socialSummary} compact />
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
       <AircraftPreviewMetadata aircraft={aircraft} />
       {trackHref && !alreadyTracking ? (

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.jsx
@@ -6,6 +6,7 @@ import NumberFlow from "@number-flow/react";
 import { toFiniteNumber } from "@/utils/math.js";
 import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
+import SocialActivitySummary from "@/components/social/SocialActivitySummary.jsx";
 
 // Same self-hiding-on-error pattern as the list row's logo. Keeps the
 // mobile card tidy when an airline isn't covered by the icon CDN.
@@ -24,7 +25,7 @@ function AirlineLogo({ src, className }) {
   );
 }
 
-export default function AircraftPreviewMobileCard({ aircraft }) {
+export default function AircraftPreviewMobileCard({ aircraft, socialSummary = null }) {
   const { t } = useI18n();
   const callsign =
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
@@ -74,6 +75,7 @@ export default function AircraftPreviewMobileCard({ aircraft }) {
           </span>
         </div>
       )}
+      <SocialActivitySummary summary={socialSummary} compact />
       {hasStats && (
         <div className="aircraft-preview-mobile-card__row2">
           {speed != null && (

--- a/src/components/aircraft/preview/AirportPreviewMetadataCard.jsx
+++ b/src/components/aircraft/preview/AirportPreviewMetadataCard.jsx
@@ -7,11 +7,12 @@ import { countryName, flagEmoji } from "@/utils/flag.js";
 import { airportCityName, airportDisplayName } from "@/utils/airport.js";
 import { toFiniteNumber } from "@/utils/math.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
+import SocialActivitySummary from "@/components/social/SocialActivitySummary.jsx";
 
 // Airport variant of the bottom-right preview card. Mirrors the aircraft
 // card's chrome (same container class so the slide-in / blur / sizing
 // match) and exposes a Track link that lands on /airport/[icao].
-export default function AirportPreviewMetadataCard({ airport }) {
+export default function AirportPreviewMetadataCard({ airport, socialSummary = null }) {
   const { locale, t } = useI18n();
   const pathname = usePathname();
   const icao = (airport?.icao || "").trim().toUpperCase();
@@ -46,6 +47,8 @@ export default function AirportPreviewMetadataCard({ airport }) {
           <span className="text-[12px] text-atc-dim">{placeLine}</span>
         ) : null}
       </div>
+
+      <SocialActivitySummary summary={socialSummary} />
 
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
 

--- a/src/components/aircraft/preview/AirportPreviewMobileCard.jsx
+++ b/src/components/aircraft/preview/AirportPreviewMobileCard.jsx
@@ -5,13 +5,14 @@ import { countryName, flagEmoji } from "@/utils/flag.js";
 import { airportCityName } from "@/utils/airport.js";
 import { toFiniteNumber } from "@/utils/math.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
+import SocialActivitySummary from "@/components/social/SocialActivitySummary.jsx";
 
 // Airport variant of the bottom-of-screen mobile preview card. Code line
 // is the prominent identifier (same font as the aircraft callsign so
 // swapping selections keeps the card's silhouette stable); the place
 // line drops to a smaller secondary style and is allowed to wrap inside
 // the card's max-width so long airport names stay tidy.
-export default function AirportPreviewMobileCard({ airport }) {
+export default function AirportPreviewMobileCard({ airport, socialSummary = null }) {
   const { locale } = useI18n();
   const icao = (airport?.icao || "").trim().toUpperCase();
   const iata = (airport?.iata || "").trim().toUpperCase();
@@ -38,6 +39,7 @@ export default function AirportPreviewMobileCard({ airport }) {
       {placeLine && (
         <div className="airport-preview-mobile-card__place">{placeLine}</div>
       )}
+      <SocialActivitySummary summary={socialSummary} compact />
       {hasStats && (
         <div className="aircraft-preview-mobile-card__row2">
           {distance != null && (

--- a/src/components/airport/explorer/AirportExplorer.jsx
+++ b/src/components/airport/explorer/AirportExplorer.jsx
@@ -17,9 +17,11 @@ import {
 import { useAirportExplorerData } from "@/features/airport/explorer/useAirportExplorerData.js";
 import { useAirportProcedures } from "@/hooks/useAirportProcedures.js";
 import { useNearbyAirports } from "@/hooks/useNearbyAirports.js";
+import { useSocialEntity } from "@/hooks/useSocialEntity.js";
 import { SelectedAircraftTraceProvider } from "../../aircraft/trace/SelectedAircraftTraceContext.jsx";
 import AircraftPreviewCard from "../../aircraft/preview/AircraftPreviewCard.jsx";
 import { areCriticalLoadingRequestsSettled } from "@/features/aircraft/positions/aircraftLoadingOverlayModel.js";
+import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel.js";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -84,6 +86,36 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
       traffic.aircraft,
     ],
   );
+  const airportSocial = useSocialEntity(
+    {
+      entityType: "airport",
+      entityKey: airportProfile.icao,
+      contextAirportIcao: airportProfile.icao,
+    },
+    { enabled: Boolean(airportProfile.icao) },
+  );
+  const selectedAircraftSocialEntity = useMemo(() => {
+    if (!selection.selectedAircraft) return null;
+    return {
+      entityType: "aircraft",
+      entityKey: getAircraftIdentity(selection.selectedAircraft),
+      contextAirportIcao: airportProfile.icao,
+    };
+  }, [airportProfile.icao, selection.selectedAircraft]);
+  const selectedAircraftSocial = useSocialEntity(selectedAircraftSocialEntity, {
+    enabled: Boolean(selectedAircraftSocialEntity),
+  });
+  const selectedAirportSocialEntity = useMemo(() => {
+    if (!selection.selectedAirport?.icao) return null;
+    return {
+      entityType: "airport",
+      entityKey: selection.selectedAirport.icao,
+      contextAirportIcao: selection.selectedAirport.icao,
+    };
+  }, [selection.selectedAirport]);
+  const selectedAirportSocial = useSocialEntity(selectedAirportSocialEntity, {
+    enabled: Boolean(selectedAirportSocialEntity),
+  });
 
   useEffect(() => {
     if (!selectedAircraftId) return;
@@ -137,6 +169,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     lastUpdated: traffic.lastUpdated,
     feedStatus: traffic.feedStatus,
     feedSource: traffic.feedSource,
+    airportSocialSummary: airportSocial.summary,
     onSelectAircraft: selectAircraft,
     onSelectAirport: selectAirport,
     onBack,
@@ -156,6 +189,12 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
         isMobile={isMobile}
         sidebarOpen={sidebarOpen}
         airportProfile={airportProfile}
+        aircraftSocialSummary={selectedAircraftSocial.summary}
+        airportSocialSummary={
+          selection.selectedAirport
+            ? selectedAirportSocial.summary
+            : airportSocial.summary
+        }
         onApplyTemporaryRoute={traffic.applyTemporaryRoute}
       />
       <div
@@ -206,6 +245,12 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             runwayProcedures={null}
             procedureFixLabelRunwayProcedures={procedures.runwayProcedures}
             showProcedureFixLabels
+            airportSocialSummary={airportSocial.summary}
+            selectedAircraftSocialSummary={selectedAircraftSocial.summary}
+            onAirportSocialReaction={airportSocial.toggleReaction}
+            onSelectedAircraftSocialReaction={
+              selectedAircraftSocial.toggleReaction
+            }
           />
           <AircraftDataLoadingOverlay
             active={

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -35,6 +35,7 @@ import {
 import { useAircraftPositions } from "@/hooks/useAircraftPositions.js";
 import { useFlightRoutes } from "@/hooks/useFlightRoutes.js";
 import { useNearbyAirports } from "@/hooks/useNearbyAirports.js";
+import { useSocialEntity } from "@/hooks/useSocialEntity.js";
 import { useTrackedAircraft } from "@/hooks/useTrackedAircraft.js";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel.js";
 import { normalizeCallsign } from "@/utils/callsign.js";
@@ -239,6 +240,28 @@ function FlightExplorerContent({ callsign }) {
       ) || null,
     [aircraft, selectedAircraftId],
   );
+  const selectedAircraftSocialEntity = useMemo(() => {
+    if (!selectedAircraft) return null;
+    return {
+      entityType: "aircraft",
+      entityKey: getAircraftIdentity(selectedAircraft),
+      contextAirportIcao: selectedAirport?.icao || "",
+    };
+  }, [selectedAircraft, selectedAirport?.icao]);
+  const selectedAircraftSocial = useSocialEntity(selectedAircraftSocialEntity, {
+    enabled: Boolean(selectedAircraftSocialEntity),
+  });
+  const selectedAirportSocialEntity = useMemo(() => {
+    if (!selectedAirport?.icao) return null;
+    return {
+      entityType: "airport",
+      entityKey: selectedAirport.icao,
+      contextAirportIcao: selectedAirport.icao,
+    };
+  }, [selectedAirport]);
+  const selectedAirportSocial = useSocialEntity(selectedAirportSocialEntity, {
+    enabled: Boolean(selectedAirportSocialEntity),
+  });
 
   // The sidebar reads `aircraft.flightRoute` / `flightRouteLabel` to paint
   // the route header. `trackedAircraft` straight out of useTrackedAircraft
@@ -311,6 +334,8 @@ function FlightExplorerContent({ callsign }) {
         airport={selectedAirport}
         isMobile={isMobile}
         sidebarOpen={sidebarOpen}
+        aircraftSocialSummary={selectedAircraftSocial.summary}
+        airportSocialSummary={selectedAirportSocial.summary}
         onApplyTemporaryRoute={applyTemporaryRoute}
       />
       <div
@@ -361,6 +386,10 @@ function FlightExplorerContent({ callsign }) {
             showProcedureFixLabels={false}
             focalRangeRings={false}
             nearbyRangeRings={{ intervalNm: 5, maxNm: 5, prominent: true }}
+            selectedAircraftSocialSummary={selectedAircraftSocial.summary}
+            onSelectedAircraftSocialReaction={
+              selectedAircraftSocial.toggleReaction
+            }
           >
             <FlightAwareRouteArc path={focalFlightAwareRoutePath} />
             <MapFitToTraceController

--- a/src/components/map/AircraftPosition.jsx
+++ b/src/components/map/AircraftPosition.jsx
@@ -19,6 +19,8 @@ import {
   resolveAircraftIcon,
   resolveAircraftSizeScale,
 } from "../../utils/aircraftIcon.js";
+import SocialReactionRing from "../social/SocialReactionRing.jsx";
+import { getSocialActivityLevel } from "../../features/social/socialModel.js";
 
 // Match the arrow size (18×18) so the icon stays anchored on the marker's
 // geo coordinate without shifting the label layout. Silhouettes are still
@@ -42,6 +44,8 @@ export default function AircraftPosition({
   selectionActive = false,
   traceActive = false,
   forceSilhouette = false,
+  socialSummary = null,
+  onSocialReaction,
   onSelectAircraft,
 }) {
   const map = useMapInstance();
@@ -135,14 +139,21 @@ export default function AircraftPosition({
   });
   const rot = Math.round(aircraft.track || 0);
   const label = (aircraft.callsign || aircraft.icao24 || "").trim();
+  const activityLevel = getSocialActivityLevel(socialSummary);
 
   return createPortal(
     <div
       className={`aircraft-marker ${
         selected ? "aircraft-marker--selected" : ""
       }`}
+      data-social-activity={activityLevel}
       style={{ opacity: emphasis.opacity }}
     >
+      <SocialReactionRing
+        open={selected}
+        summary={socialSummary}
+        onReaction={onSocialReaction}
+      />
       <Pointer
         color={color}
         rot={rot}

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -54,6 +54,10 @@ export default function AirportMap({
   showProcedureFixLabels = false,
   focalRangeRings = null,
   nearbyRangeRings = null,
+  airportSocialSummary = null,
+  selectedAircraftSocialSummary = null,
+  onAirportSocialReaction,
+  onSelectedAircraftSocialReaction,
   children = null,
 }) {
   // Single source of truth for the ring bands so the inline labels
@@ -217,6 +221,8 @@ export default function AirportMap({
               aircraft={aircraft}
               zoom={zoom}
               groundRadiusNm={effectiveFocalRings?.intervalNm}
+              socialSummary={airportSocialSummary}
+              onSocialReaction={onAirportSocialReaction}
             />
           )}
           <NearbyAirportLayer
@@ -266,6 +272,16 @@ export default function AirportMap({
               forceSilhouette={
                 Boolean(focalAircraftId) &&
                 getAircraftIdentity(ac) === focalAircraftId
+              }
+              socialSummary={
+                getAircraftIdentity(ac) === selectedAircraftId
+                  ? selectedAircraftSocialSummary
+                  : null
+              }
+              onSocialReaction={
+                getAircraftIdentity(ac) === selectedAircraftId
+                  ? onSelectedAircraftSocialReaction
+                  : undefined
               }
               onSelectAircraft={onSelectAircraft}
             />

--- a/src/components/map/AirportMarker.jsx
+++ b/src/components/map/AirportMarker.jsx
@@ -11,6 +11,8 @@ import {
 } from "../../features/airport/map/leafletLayerSafety.js";
 import { ZOOM_APPROACH } from "../../utils/airportMapDisplay.js";
 import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
+import SocialReactionRing from "../social/SocialReactionRing.jsx";
+import { getSocialActivityLevel } from "../../features/social/socialModel.js";
 
 export default function AirportMarker({
   lat,
@@ -20,12 +22,15 @@ export default function AirportMarker({
   aircraft = [],
   zoom = null,
   groundRadiusNm = 3,
+  socialSummary = null,
+  onSocialReaction,
 }) {
   const map = useMapInstance();
   const markerRef = useRef(null);
   const [container] = useState(() =>
     typeof document !== "undefined" ? document.createElement("div") : null,
   );
+  const [ringOpen, setRingOpen] = useState(false);
 
   // Count aircraft within `groundRadiusNm` of the focal airport, shown
   // as a "NEAR n" line under the badge. Only computed at approach zoom
@@ -44,7 +49,7 @@ export default function AirportMarker({
       return undefined;
     const marker = safeAddToMap(
       L.marker([lat, lon], {
-        interactive: false,
+        interactive: true,
         icon: L.divIcon({
           className: "",
           html: container,
@@ -76,8 +81,26 @@ export default function AirportMarker({
     details.push({ key: "app", label: "APP", value: approachCount });
   }
 
+  const activityLevel = getSocialActivityLevel(socialSummary);
+
   return createPortal(
-    <div className="airport-overlay-label notranslate" translate="no">
+    <div
+      className="airport-overlay-label notranslate"
+      data-social-activity={activityLevel}
+      translate="no"
+      onMouseEnter={() => setRingOpen(true)}
+      onMouseLeave={() => setRingOpen(false)}
+      onClick={(event) => {
+        event.stopPropagation();
+        setRingOpen((current) => !current);
+      }}
+    >
+      <SocialReactionRing
+        open={ringOpen}
+        summary={socialSummary}
+        onReaction={onSocialReaction}
+        className="social-reaction-ring--airport"
+      />
       <span className="airport-overlay-label__code endf-tab endf-tab--code">
         <span>{code}</span>
       </span>

--- a/src/components/sidebar/AirportSidebar.jsx
+++ b/src/components/sidebar/AirportSidebar.jsx
@@ -6,6 +6,7 @@ import AirportIdentity from "./AirportIdentity";
 import SidebarShell from "./SidebarShell";
 import SidebarViewSwitch from "./SidebarViewSwitch";
 import WeatherBriefingStack from "./WeatherBriefingStack";
+import SocialActivitySummary from "@/components/social/SocialActivitySummary.jsx";
 
 export default function AirportSidebar({
   icao = "",
@@ -28,6 +29,7 @@ export default function AirportSidebar({
   lastUpdated = null,
   feedStatus = "live",
   feedSource = "",
+  airportSocialSummary = null,
   onSelectAircraft,
   onSelectAirport,
   onBack,
@@ -46,6 +48,10 @@ export default function AirportSidebar({
         country={country}
         lat={lat}
         lon={lon}
+      />
+      <SocialActivitySummary
+        summary={airportSocialSummary}
+        className="airport-sidebar-social"
       />
       <SidebarViewSwitch
         activeView={activeView}

--- a/src/components/social/SocialActivitySummary.jsx
+++ b/src/components/social/SocialActivitySummary.jsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { SOCIAL_REACTIONS } from "@/features/social/socialModel.js";
+import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
+
+export default function SocialActivitySummary({
+  summary,
+  compact = false,
+  className = "",
+}) {
+  const { t } = useI18n();
+  const watching = Number(summary?.watching || 0);
+  const activeReactions = SOCIAL_REACTIONS.filter(
+    (reaction) => Number(summary?.reactions?.[reaction.key] || 0) > 0,
+  );
+  if (!watching && activeReactions.length === 0) return null;
+
+  return (
+    <div
+      className={`social-activity-summary ${
+        compact ? "social-activity-summary--compact" : ""
+      } ${className}`}
+    >
+      <div className="social-activity-summary__label">
+        {compact ? t("social.live") : t("social.liveInterest")}
+        {watching > 0 && (
+          <>
+            <span aria-hidden="true"> · </span>
+            <span>{t("social.watchingCount", { count: watching })}</span>
+          </>
+        )}
+      </div>
+      {activeReactions.length > 0 && (
+        <div className="social-activity-summary__reactions">
+          {activeReactions.map((reaction) => (
+            <span
+              key={reaction.key}
+              className="social-activity-summary__reaction"
+              title={t(reaction.labelKey)}
+            >
+              <span aria-hidden="true">{reaction.icon}</span>
+              <span>{summary.reactions[reaction.key]}</span>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/social/SocialReactionRing.jsx
+++ b/src/components/social/SocialReactionRing.jsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { SOCIAL_REACTIONS } from "@/features/social/socialModel.js";
+import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
+
+const POSITIONS = {
+  fire: [0, -50],
+  walk: [-42, -18],
+  like: [42, -18],
+  ticket: [-38, 36],
+  camera: [38, 36],
+};
+
+export default function SocialReactionRing({
+  summary,
+  open = false,
+  onReaction,
+  className = "",
+}) {
+  const { t } = useI18n();
+  const [pending, setPending] = useState("");
+  if (!open) return null;
+  const viewerReactions = new Set(summary?.viewerReactions || []);
+
+  const handleClick = async (event, reaction) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!onReaction || pending) return;
+    setPending(reaction.key);
+    try {
+      await onReaction(reaction.key);
+    } finally {
+      setPending("");
+    }
+  };
+
+  return (
+    <div className={`social-reaction-ring ${className}`} aria-label={t("social.reactAria")}>
+      {SOCIAL_REACTIONS.map((reaction) => {
+        const [x, y] = POSITIONS[reaction.key];
+        const selected = viewerReactions.has(reaction.key);
+        return (
+          <button
+            key={reaction.key}
+            type="button"
+            className="social-reaction-ring__button"
+            data-selected={selected ? "true" : undefined}
+            data-pending={pending === reaction.key ? "true" : undefined}
+            style={{ "--social-x": `${x}px`, "--social-y": `${y}px` }}
+            aria-label={t(reaction.labelKey)}
+            title={t(reaction.labelKey)}
+            disabled={Boolean(pending)}
+            onClick={(event) => handleClick(event, reaction)}
+          >
+            <span aria-hidden="true">{reaction.icon}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/config/i18n/en.js
+++ b/src/config/i18n/en.js
@@ -372,6 +372,19 @@ const en = {
     unknown: "Unknown",
     traffic: "Traffic",
   },
+  social: {
+    live: "Live",
+    liveInterest: "Live interest",
+    watchingCount: "{count} watching",
+    reactAria: "React to this target",
+    reactions: {
+      fire: "Fire",
+      walk: "Walk",
+      like: "Like",
+      ticket: "Ticket",
+      camera: "Camera",
+    },
+  },
   changelog: {
     title: "Changelog",
     description: "Product release history. Currently shipping {version}.",

--- a/src/config/i18n/zh-CN.js
+++ b/src/config/i18n/zh-CN.js
@@ -352,6 +352,19 @@ const zhCN = {
     unknown: "未知",
     traffic: "交通",
   },
+  social: {
+    live: "实时",
+    liveInterest: "实时关注",
+    watchingCount: "{count} 人在看",
+    reactAria: "对该目标做出反应",
+    reactions: {
+      fire: "火",
+      walk: "路过",
+      like: "赞",
+      ticket: "想坐",
+      camera: "拍它",
+    },
+  },
   changelog: {
     title: "更新日志",
     description: "产品发布历史。当前版本 {version}。",

--- a/src/features/social/socialClient.js
+++ b/src/features/social/socialClient.js
@@ -1,0 +1,76 @@
+"use client";
+
+export const SOCIAL_SESSION_STORAGE_KEY = "adsbao:social:session";
+
+function createSessionId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `session-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+}
+
+export function getSocialSessionId({
+  storage = typeof window !== "undefined" ? window.localStorage : null,
+} = {}) {
+  if (!storage) return "";
+  try {
+    const existing = storage.getItem(SOCIAL_SESSION_STORAGE_KEY);
+    if (existing) return existing;
+    const next = createSessionId();
+    storage.setItem(SOCIAL_SESSION_STORAGE_KEY, next);
+    return next;
+  } catch {
+    return "";
+  }
+}
+
+function buildSocialHeaders() {
+  const headers = { "Content-Type": "application/json" };
+  const sessionId = getSocialSessionId();
+  if (sessionId) headers["x-adsbao-session"] = sessionId;
+  return headers;
+}
+
+const encodeQuery = (entity) => {
+  const params = new URLSearchParams({
+    entityType: entity.entityType,
+    entityKey: entity.entityKey,
+  });
+  if (entity.contextAirportIcao) {
+    params.set("contextAirportIcao", entity.contextAirportIcao);
+  }
+  return params.toString();
+};
+
+export async function postSocialPresence(entity, { signal } = {}) {
+  const response = await fetch("/api/social/presence", {
+    method: "POST",
+    headers: buildSocialHeaders(),
+    body: JSON.stringify(entity),
+    signal,
+  });
+  if (!response.ok) throw new Error(`Presence failed (${response.status})`);
+  return response.json();
+}
+
+export async function postSocialReaction(entity, reaction, { signal } = {}) {
+  const response = await fetch("/api/social/reaction", {
+    method: "POST",
+    headers: buildSocialHeaders(),
+    body: JSON.stringify({ ...entity, reaction }),
+    signal,
+  });
+  if (!response.ok) throw new Error(`Reaction failed (${response.status})`);
+  return response.json();
+}
+
+export async function fetchSocialSummary(entity, { signal } = {}) {
+  const response = await fetch(`/api/social/summary?${encodeQuery(entity)}`, {
+    headers: buildSocialHeaders(),
+    signal,
+  });
+  if (!response.ok) throw new Error(`Summary failed (${response.status})`);
+  return response.json();
+}

--- a/src/features/social/socialModel.js
+++ b/src/features/social/socialModel.js
@@ -1,0 +1,124 @@
+export const SOCIAL_ACTIVE_WINDOW_MS = 90_000;
+
+export const SOCIAL_REACTIONS = Object.freeze([
+  { key: "fire", icon: "🔥", labelKey: "social.reactions.fire" },
+  { key: "walk", icon: "🚶", labelKey: "social.reactions.walk" },
+  { key: "like", icon: "👍", labelKey: "social.reactions.like" },
+  { key: "ticket", icon: "🎫", labelKey: "social.reactions.ticket" },
+  { key: "camera", icon: "📷", labelKey: "social.reactions.camera" },
+]);
+
+export const SOCIAL_REACTION_KEYS = Object.freeze(
+  SOCIAL_REACTIONS.map((reaction) => reaction.key),
+);
+
+export const SOCIAL_REACTION_KEY_SET = new Set(SOCIAL_REACTION_KEYS);
+
+const SOCIAL_ENTITY_TYPES = new Set(["airport", "aircraft"]);
+
+const normalizeAirportCode = (value) => {
+  const code = String(value || "").trim().toUpperCase();
+  return /^[A-Z0-9]{3,4}$/.test(code) ? code : "";
+};
+
+export const normalizeAircraftSocialKey = (value) => {
+  const key = String(value || "")
+    .trim()
+    .toUpperCase()
+    .replace(/\s+/g, "");
+  if (/^~?[0-9A-F]{6}$/.test(key)) return key.replace(/^~/, "");
+  return /^[A-Z0-9]{2,12}$/.test(key) ? key : "";
+};
+
+export function normalizeSocialEntityInput(rawBody) {
+  if (!rawBody || typeof rawBody !== "object") {
+    return { ok: false, error: "Invalid request body" };
+  }
+
+  const entityType = String(rawBody.entityType || "").trim().toLowerCase();
+  if (!SOCIAL_ENTITY_TYPES.has(entityType)) {
+    return { ok: false, error: "Invalid social entity" };
+  }
+
+  const entityKey =
+    entityType === "airport"
+      ? normalizeAirportCode(rawBody.entityKey)
+      : normalizeAircraftSocialKey(rawBody.entityKey);
+  if (!entityKey) return { ok: false, error: "Invalid social entity key" };
+
+  const contextAirportIcao =
+    normalizeAirportCode(rawBody.contextAirportIcao) ||
+    (entityType === "airport" ? entityKey : "");
+
+  return {
+    ok: true,
+    value: {
+      entityType,
+      entityKey,
+      contextAirportIcao,
+    },
+  };
+}
+
+export function normalizeSocialReactionInput(rawBody) {
+  const entity = normalizeSocialEntityInput(rawBody);
+  if (!entity.ok) return entity;
+
+  const reaction = String(rawBody.reaction || "").trim().toLowerCase();
+  if (!SOCIAL_REACTION_KEY_SET.has(reaction)) {
+    return { ok: false, error: "Invalid reaction" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      ...entity.value,
+      reaction,
+    },
+  };
+}
+
+export function emptyReactionCounts() {
+  return Object.fromEntries(SOCIAL_REACTION_KEYS.map((key) => [key, 0]));
+}
+
+export function countReactionRows(rows = []) {
+  const reactions = emptyReactionCounts();
+  for (const row of rows) {
+    const reaction = row?.reaction;
+    if (SOCIAL_REACTION_KEY_SET.has(reaction)) {
+      reactions[reaction] += Number(row.count || 1);
+    }
+  }
+  return reactions;
+}
+
+export function buildSocialSummary({
+  entityType,
+  entityKey,
+  watching = 0,
+  reactionRows = [],
+  viewerRows = [],
+} = {}) {
+  return {
+    entityType,
+    entityKey,
+    watching: Math.max(0, Number(watching) || 0),
+    reactions: countReactionRows(reactionRows),
+    viewerReactions: viewerRows
+      .map((row) => row?.reaction)
+      .filter((reaction) => SOCIAL_REACTION_KEY_SET.has(reaction)),
+  };
+}
+
+export function getSocialActivityLevel(summary = {}) {
+  const reactionTotal = Object.values(summary.reactions || {}).reduce(
+    (total, count) => total + (Number(count) || 0),
+    0,
+  );
+  const activity = (Number(summary.watching) || 0) + reactionTotal;
+  if (activity >= 10) return "strong";
+  if (activity >= 4) return "pulse";
+  if (activity >= 1) return "subtle";
+  return "none";
+}

--- a/src/features/social/socialModel.test.js
+++ b/src/features/social/socialModel.test.js
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+
+import {
+  SOCIAL_ACTIVE_WINDOW_MS,
+  SOCIAL_REACTION_KEYS,
+  buildSocialSummary,
+  normalizeSocialEntityInput,
+  normalizeSocialReactionInput,
+} from "./socialModel.js";
+
+assert.equal(SOCIAL_ACTIVE_WINDOW_MS, 90_000);
+assert.deepEqual(SOCIAL_REACTION_KEYS, [
+  "fire",
+  "walk",
+  "like",
+  "ticket",
+  "camera",
+]);
+
+{
+  const airport = normalizeSocialEntityInput({
+    entityType: "airport",
+    entityKey: "kbos",
+    contextAirportIcao: "kbos",
+  });
+  assert.deepEqual(airport, {
+    ok: true,
+    value: {
+      entityType: "airport",
+      entityKey: "KBOS",
+      contextAirportIcao: "KBOS",
+    },
+  });
+
+  const aircraft = normalizeSocialEntityInput({
+    entityType: "aircraft",
+    entityKey: " dal 977 ",
+    contextAirportIcao: "kbos",
+  });
+  assert.deepEqual(aircraft.value, {
+    entityType: "aircraft",
+    entityKey: "DAL977",
+    contextAirportIcao: "KBOS",
+  });
+}
+
+assert.deepEqual(normalizeSocialEntityInput(null), {
+  ok: false,
+  error: "Invalid request body",
+});
+assert.equal(
+  normalizeSocialEntityInput({ entityType: "ship", entityKey: "KBOS" }).error,
+  "Invalid social entity",
+);
+assert.equal(
+  normalizeSocialEntityInput({ entityType: "airport", entityKey: "??" }).error,
+  "Invalid social entity key",
+);
+
+{
+  const reaction = normalizeSocialReactionInput({
+    entityType: "aircraft",
+    entityKey: "a1b2c3",
+    contextAirportIcao: "kbos",
+    reaction: "camera",
+  });
+  assert.deepEqual(reaction.value, {
+    entityType: "aircraft",
+    entityKey: "A1B2C3",
+    contextAirportIcao: "KBOS",
+    reaction: "camera",
+  });
+}
+
+assert.equal(
+  normalizeSocialReactionInput({
+    entityType: "airport",
+    entityKey: "KBOS",
+    reaction: "clap",
+  }).error,
+  "Invalid reaction",
+);
+
+{
+  const summary = buildSocialSummary({
+    entityType: "airport",
+    entityKey: "KBOS",
+    watching: 8,
+    reactionRows: [
+      { reaction: "fire", count: 4 },
+      { reaction: "like", count: 8 },
+      { reaction: "nonsense", count: 99 },
+    ],
+    viewerRows: [{ reaction: "like" }],
+  });
+
+  assert.deepEqual(summary, {
+    entityType: "airport",
+    entityKey: "KBOS",
+    watching: 8,
+    reactions: {
+      fire: 4,
+      walk: 0,
+      like: 8,
+      ticket: 0,
+      camera: 0,
+    },
+    viewerReactions: ["like"],
+  });
+}

--- a/src/hooks/useSocialEntity.js
+++ b/src/hooks/useSocialEntity.js
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  fetchSocialSummary,
+  postSocialPresence,
+  postSocialReaction,
+} from "@/features/social/socialClient.js";
+import { emptyReactionCounts } from "@/features/social/socialModel.js";
+
+const HEARTBEAT_MS = 30_000;
+const SUMMARY_REFRESH_MS = 30_000;
+
+const EMPTY_SUMMARY = Object.freeze({
+  entityType: "",
+  entityKey: "",
+  watching: 0,
+  reactions: emptyReactionCounts(),
+  viewerReactions: [],
+});
+
+export function useSocialEntity(entity, {
+  enabled = true,
+  heartbeatMs = HEARTBEAT_MS,
+  refreshMs = SUMMARY_REFRESH_MS,
+} = {}) {
+  const entityType = enabled ? entity?.entityType || "" : "";
+  const entityKey = enabled ? entity?.entityKey || "" : "";
+  const contextAirportIcao = enabled ? entity?.contextAirportIcao || "" : "";
+  const stableEntity = useMemo(() => {
+    if (!entityType || !entityKey) return null;
+    return {
+      entityType,
+      entityKey,
+      contextAirportIcao,
+    };
+  }, [contextAirportIcao, entityKey, entityType]);
+  const [summary, setSummary] = useState(EMPTY_SUMMARY);
+
+  const refreshSummary = useCallback(async ({ signal } = {}) => {
+    if (!stableEntity) return null;
+    const next = await fetchSocialSummary(stableEntity, { signal });
+    setSummary(next || EMPTY_SUMMARY);
+    return next;
+  }, [stableEntity]);
+
+  useEffect(() => {
+    if (!stableEntity) {
+      setSummary(EMPTY_SUMMARY);
+      return undefined;
+    }
+    const controller = new AbortController();
+
+    const heartbeat = () => {
+      postSocialPresence(stableEntity, { signal: controller.signal }).catch(
+        () => {},
+      );
+    };
+    const refresh = () => {
+      refreshSummary({ signal: controller.signal }).catch(() => {});
+    };
+
+    heartbeat();
+    refresh();
+    const heartbeatId = setInterval(heartbeat, heartbeatMs);
+    const refreshId = setInterval(refresh, refreshMs);
+
+    return () => {
+      controller.abort();
+      clearInterval(heartbeatId);
+      clearInterval(refreshId);
+    };
+  }, [heartbeatMs, refreshMs, refreshSummary, stableEntity]);
+
+  const toggleReaction = useCallback(async (reaction) => {
+    if (!stableEntity || !reaction) return null;
+    const result = await postSocialReaction(stableEntity, reaction);
+    await refreshSummary();
+    return result;
+  }, [refreshSummary, stableEntity]);
+
+  return {
+    summary,
+    refreshSummary,
+    toggleReaction,
+  };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -2866,6 +2866,68 @@ body {
     filter: saturate(1.22) brightness(1.16);
 }
 
+.aircraft-marker::before,
+.airport-overlay-label::before {
+    position: absolute;
+    z-index: -1;
+    border: 1px solid color-mix(in oklab, var(--atc-orange) 62%, transparent);
+    border-radius: 999px;
+    content: "";
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+}
+
+.aircraft-marker::before {
+    left: 9px;
+    top: 9px;
+    width: 34px;
+    height: 34px;
+}
+
+.airport-overlay-label::before {
+    left: 22px;
+    top: 13px;
+    width: 64px;
+    height: 34px;
+}
+
+.aircraft-marker[data-social-activity="subtle"]::before,
+.airport-overlay-label[data-social-activity="subtle"]::before {
+    opacity: 0.42;
+    box-shadow: 0 0 12px color-mix(in oklab, var(--atc-orange) 22%, transparent);
+}
+
+.aircraft-marker[data-social-activity="pulse"]::before,
+.airport-overlay-label[data-social-activity="pulse"]::before {
+    opacity: 0.58;
+    animation: social-halo-pulse 2.8s ease-out infinite;
+    box-shadow: 0 0 18px color-mix(in oklab, var(--atc-orange) 30%, transparent);
+}
+
+.aircraft-marker[data-social-activity="strong"]::before,
+.airport-overlay-label[data-social-activity="strong"]::before {
+    opacity: 0.72;
+    animation: social-halo-pulse 2.1s ease-out infinite;
+    box-shadow:
+        0 0 18px color-mix(in oklab, var(--atc-orange) 36%, transparent),
+        0 0 34px color-mix(in oklab, var(--atc-orange) 18%, transparent);
+}
+
+@keyframes social-halo-pulse {
+    0% {
+        transform: translate(-50%, -50%) scale(0.92);
+    }
+    70% {
+        opacity: 0.08;
+        transform: translate(-50%, -50%) scale(1.35);
+    }
+    100% {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(1.35);
+    }
+}
+
 /* Wrapper carries the rotation so the dark-theme nose beam orbits
    with the heading. Sits ABOVE the silhouette's drop-shadow halo via
    overflow: visible. */
@@ -3268,6 +3330,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 3px;
+    position: relative;
 }
 
 .airport-overlay-label__detail {
@@ -3279,6 +3342,159 @@ body {
     letter-spacing: 0.08em;
     padding: 1px 5px;
     text-transform: uppercase;
+}
+
+.social-reaction-ring {
+    position: absolute;
+    left: 9px;
+    top: 9px;
+    z-index: 20;
+    width: 1px;
+    height: 1px;
+    pointer-events: none;
+}
+
+.social-reaction-ring--airport {
+    left: 22px;
+    top: 13px;
+}
+
+.social-reaction-ring__button {
+    position: absolute;
+    left: 0;
+    top: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border: 1px solid color-mix(in oklab, var(--atc-orange) 45%, transparent);
+    border-radius: 999px;
+    background:
+        radial-gradient(
+            circle at 50% 35%,
+            color-mix(in oklab, var(--atc-text) 18%, transparent),
+            transparent 54%
+        ),
+        color-mix(in oklab, var(--atc-card) 88%, transparent);
+    box-shadow:
+        0 8px 18px color-mix(in oklab, var(--atc-bg) 74%, transparent),
+        inset 0 1px 0 color-mix(in oklab, var(--atc-text) 16%, transparent);
+    cursor: pointer;
+    font-size: 15px;
+    line-height: 1;
+    pointer-events: auto;
+    transform:
+        translate(-50%, -50%)
+        translate(var(--social-x), var(--social-y))
+        scale(0.96);
+    transition:
+        border-color 0.16s ease,
+        opacity 0.16s ease,
+        transform 0.16s ease;
+}
+
+.social-reaction-ring__button:hover,
+.social-reaction-ring__button[data-selected="true"] {
+    border-color: color-mix(in oklab, var(--atc-orange) 86%, white);
+    transform:
+        translate(-50%, -50%)
+        translate(var(--social-x), var(--social-y))
+        scale(1.08);
+}
+
+.social-reaction-ring__button[data-selected="true"] {
+    animation: social-reaction-pop 0.42s ease-out;
+    background:
+        radial-gradient(
+            circle at 50% 35%,
+            color-mix(in oklab, var(--atc-orange) 36%, transparent),
+            transparent 60%
+        ),
+        color-mix(in oklab, var(--atc-card) 88%, transparent);
+}
+
+.social-reaction-ring__button:disabled {
+    cursor: default;
+    opacity: 0.62;
+}
+
+@keyframes social-reaction-pop {
+    0% {
+        transform:
+            translate(-50%, -50%)
+            translate(var(--social-x), var(--social-y))
+            scale(0.9);
+    }
+    55% {
+        transform:
+            translate(-50%, -50%)
+            translate(var(--social-x), var(--social-y))
+            scale(1.18);
+    }
+    100% {
+        transform:
+            translate(-50%, -50%)
+            translate(var(--social-x), var(--social-y))
+            scale(1.08);
+    }
+}
+
+.social-activity-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    margin-top: 10px;
+}
+
+.social-activity-summary__label {
+    color: var(--atc-faint);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.social-activity-summary--compact .social-activity-summary__label {
+    font-size: 9px;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+.social-activity-summary__reactions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.social-activity-summary__reaction {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-height: 22px;
+    padding: 2px 7px;
+    border: 1px solid color-mix(in oklab, var(--atc-line) 70%, transparent);
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--tone-card-soft) 72%, transparent);
+    color: var(--atc-text);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 800;
+}
+
+.airport-sidebar-social {
+    margin-top: 12px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .aircraft-marker[data-social-activity="pulse"]::before,
+    .airport-overlay-label[data-social-activity="pulse"]::before,
+    .aircraft-marker[data-social-activity="strong"]::before,
+    .airport-overlay-label[data-social-activity="strong"]::before,
+    .social-reaction-ring__button[data-selected="true"] {
+        animation: none;
+    }
 }
 
 .airport-ground-count {

--- a/supabase/migrations/20260524120000_create_social_presence_reactions.sql
+++ b/supabase/migrations/20260524120000_create_social_presence_reactions.sql
@@ -1,0 +1,57 @@
+create table if not exists public.social_presence (
+  id uuid primary key default gen_random_uuid(),
+  session_hash text not null,
+  entity_type text not null check (entity_type in ('airport', 'aircraft')),
+  entity_key text not null,
+  context_airport_icao text not null default '',
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  deleted_at timestamptz,
+  unique (session_hash, entity_type, entity_key, context_airport_icao)
+);
+
+create index if not exists social_presence_live_idx
+  on public.social_presence (
+    entity_type,
+    entity_key,
+    context_airport_icao,
+    last_seen_at desc
+  )
+  where deleted_at is null;
+
+alter table public.social_presence enable row level security;
+
+create table if not exists public.social_reactions (
+  id uuid primary key default gen_random_uuid(),
+  session_hash text not null,
+  entity_type text not null check (entity_type in ('airport', 'aircraft')),
+  entity_key text not null,
+  context_airport_icao text not null default '',
+  reaction text not null check (
+    reaction in ('fire', 'walk', 'like', 'ticket', 'camera')
+  ),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz,
+  unique (
+    session_hash,
+    entity_type,
+    entity_key,
+    context_airport_icao,
+    reaction
+  )
+);
+
+create index if not exists social_reactions_entity_idx
+  on public.social_reactions (
+    entity_type,
+    entity_key,
+    context_airport_icao,
+    reaction
+  )
+  where deleted_at is null;
+
+alter table public.social_reactions enable row level security;
+
+revoke all on table public.social_presence from anon, authenticated;
+revoke all on table public.social_reactions from anon, authenticated;


### PR DESCRIPTION
## Summary
- add anonymous social presence and fixed emoji reaction APIs backed by Supabase DAO + migration
- add client heartbeat/summary hook and wire airport/aircraft social aggregates into sidebar and preview cards
- add transient radial reaction rings and subtle activity halos for focused airport and aircraft targets

## Validation
- node src/app/api/social/socialRouteModel.test.js && node src/features/social/socialModel.test.js && node src/app/api/dao/social.dao.test.js
- pnpm test
- pnpm lint
- pnpm build
- curl smoke: invalid reaction and invalid entity return 400 before storage access

## Notes
- Supabase CLI was not installed locally, so the schema change is committed as a migration file rather than applied from this checkout.
- Codex in-app Browser was unavailable in this session; local HTTP smoke checks against the existing dev server were used instead.

Closes #213