### PR TITLE
Refactor Endfield motion effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "fflate": "^0.8.2",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.562.0",
-    "motion": "^12.38.0",
     "next": "^16.0.10",
     "ogl": "^1.0.11",
     "postprocessing": "^6.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.5)
-      motion:
-        specifier: ^12.38.0
-        version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next:
         specifier: ^16.0.10
         version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2797,20 +2794,6 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
-  framer-motion@12.38.0:
-    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3293,26 +3276,6 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
-
-  motion-dom@12.38.0:
-    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
-
-  motion-utils@12.36.0:
-    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
-
-  motion@12.38.0:
-    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -6860,15 +6823,6 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
-  framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      motion-dom: 12.38.0
-      motion-utils: 12.36.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-
   fsevents@2.3.3:
     optional: true
 
@@ -7318,20 +7272,6 @@ snapshots:
   minipass@7.1.3: {}
 
   module-details-from-path@1.0.4: {}
-
-  motion-dom@12.38.0:
-    dependencies:
-      motion-utils: 12.36.0
-
-  motion-utils@12.36.0: {}
-
-  motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      framer-motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
 
   ms@2.1.3: {}
 

--- a/src/components/aircraft/preview/AircraftPreviewCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.jsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import AircraftPreviewMediaCard from "./AircraftPreviewMediaCard.jsx";
 import AircraftPreviewMetadataCard from "./AircraftPreviewMetadataCard.jsx";
 import AircraftPreviewMobileCard from "./AircraftPreviewMobileCard.jsx";
@@ -12,22 +11,6 @@ import RouteFeedbackModal from "./RouteFeedbackModal.jsx";
 import { useAircraftPhoto } from "@/features/aircraft/preview/useAircraftPhoto.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel.js";
-
-const POCKET_EASE = [0.16, 1, 0.3, 1];
-
-const STACK_MOTION = {
-  initial: { y: 18 },
-  animate: { y: 0 },
-  exit: { clipPath: "inset(0 0 0 100%)", y: 24 },
-  transition: { duration: 0.2, ease: [1, 0, 0.7, 1] },
-};
-
-const MEDIA_MOTION = {
-  initial: { opacity: 0, y: 96 },
-  animate: { opacity: 1, y: 0 },
-  exit: { opacity: 0, y: 56 },
-  transition: { duration: 0.52, ease: POCKET_EASE },
-};
 
 const PHOTO_TONE_DARK = "dark";
 const PHOTO_TONE_LIGHT = "light";
@@ -41,7 +24,6 @@ export default function AircraftPreviewCard({
   onApplyTemporaryRoute,
 }) {
   const { t } = useI18n();
-  const reducedMotion = useReducedMotion();
   const photoState = useAircraftPhoto(aircraft);
   const photo = photoState.photo;
   const hasPhoto = Boolean(photo?.src);
@@ -78,8 +60,7 @@ export default function AircraftPreviewCard({
   // The desktop inline form (in AircraftPreviewMetadataCard) is more
   // ergonomic at 280px, but on touch we don't have the space to expand
   // inline without crowding the existing telemetry. The modal is mounted
-  // outside the motion.aside so closing it doesn't ride the card's
-  // animation curve.
+  // outside the card so closing it doesn't reuse the preview reveal.
   const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
   const aircraftCallsign = (aircraft?.callsign || "").trim().toUpperCase();
   const showMobileFeedbackTrigger =
@@ -93,36 +74,23 @@ export default function AircraftPreviewCard({
 
   return (
     <>
-    <AnimatePresence>
       {entity && !isMobile && (
-        <motion.aside
+        <aside
           key={identityKey}
           className={`aircraft-preview-card aircraft-preview-card--desktop-reveal ${
             !isAirport && hasPhoto ? "aircraft-preview-card--has-photo" : ""
           } aircraft-preview-card--photo-${photoTone}`}
           aria-label={isAirport ? t("preview.airportPreview") : t("preview.aircraftPreview")}
-          {...(reducedMotion
-            ? {
-                initial: false,
-                animate: { opacity: 1 },
-                exit: { opacity: 0 },
-              }
-            : STACK_MOTION)}
         >
           {!isAirport && (
-            <AnimatePresence>
-              {hasPhoto && (
-                <motion.div
-                  className="aircraft-preview-card__media-slot"
-                  key={`photo-${photo.src}`}
-                  {...(reducedMotion
-                    ? { initial: false, animate: { opacity: 1 }, exit: { opacity: 0 } }
-                    : MEDIA_MOTION)}
-                >
-                  <AircraftPreviewMediaCard photo={photo} />
-                </motion.div>
-              )}
-            </AnimatePresence>
+            hasPhoto && (
+              <div
+                className="aircraft-preview-card__media-slot"
+                key={`photo-${photo.src}`}
+              >
+                <AircraftPreviewMediaCard photo={photo} />
+              </div>
+            )
           )}
           {isAirport ? (
             <AirportPreviewMetadataCard airport={airport} />
@@ -134,21 +102,13 @@ export default function AircraftPreviewCard({
               onApplyTemporaryRoute={onApplyTemporaryRoute}
             />
           )}
-        </motion.aside>
+        </aside>
       )}
       {showMobile && (
-        <motion.aside
+        <aside
           key={`mobile-${identityKey}`}
           className="aircraft-preview-mobile-card aircraft-preview-mobile-card--stacked"
           aria-label={isAirport ? t("preview.airportPreview") : t("preview.aircraftPreview")}
-          style={{ x: "-50%" }}
-          {...(reducedMotion
-            ? {
-                initial: false,
-                animate: { y: 0 },
-                exit: { clipPath: "inset(0 0% 0 0)", y: 0 },
-              }
-            : STACK_MOTION)}
         >
           {isAirport ? (
             <AirportPreviewMobileCard airport={airport} />
@@ -174,9 +134,8 @@ export default function AircraftPreviewCard({
               {mobileFeedbackLabel}
             </button>
           )}
-        </motion.aside>
+        </aside>
       )}
-    </AnimatePresence>
     {showMobileFeedbackTrigger && (
       <RouteFeedbackModal
         aircraft={aircraft}

--- a/src/components/effects/EndfieldValueSwap.jsx
+++ b/src/components/effects/EndfieldValueSwap.jsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEndfieldContentSwap } from "./useEndfieldContentSwap.js";
+
+export default function EndfieldValueSwap({
+  identityKey,
+  value,
+  className = "",
+  direction = "forward",
+}) {
+  const swap = useEndfieldContentSwap({
+    identityKey,
+    value,
+    delaySeconds: 0,
+  });
+  const contentPhaseClass = swap.contentPhaseClass.replace(
+    "endf-content-swap",
+    "endf-value-swap",
+  );
+
+  return (
+    <span
+      style={swap.style}
+      className={`endf-value-swap ${
+        swap.replacing ? "endf-value-swap--replacing" : ""
+      } ${
+        direction === "reverse" ? "endf-value-swap--reverse" : ""
+      } ${className}`}
+    >
+      <span
+        className={`endf-value-swap__content ${contentPhaseClass}`}
+      >
+        {swap.displayedValue}
+      </span>
+    </span>
+  );
+}

--- a/src/components/effects/useEndfieldContentSwap.js
+++ b/src/components/effects/useEndfieldContentSwap.js
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { usePrefersReducedMotion } from "./usePrefersReducedMotion.js";
+
+const ERASE_MS = 140;
+const HOLD_MS = 100;
+const REVEAL_MS = 220;
+const SETTLE_MS = 30;
+
+export function useEndfieldContentSwap({
+  identityKey,
+  value,
+  delaySeconds = 0,
+  disabled = false,
+}) {
+  const reducedMotion = usePrefersReducedMotion();
+  const liveValueRef = useRef(value);
+  const previousValueRef = useRef(value);
+  const lastKeyRef = useRef(identityKey);
+  const phaseRef = useRef("idle");
+  const timersRef = useRef([]);
+  const [displayedValue, setDisplayedValue] = useState(value);
+  const [phase, setPhaseState] = useState("idle");
+  const [replaceDelay, setReplaceDelay] = useState(0);
+  liveValueRef.current = value;
+
+  const setPhase = (nextPhase) => {
+    phaseRef.current = nextPhase;
+    setPhaseState(nextPhase);
+  };
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    timersRef.current = [];
+  }, []);
+
+  useEffect(() => {
+    if (phaseRef.current === "idle") {
+      previousValueRef.current = value;
+      setDisplayedValue(value);
+    }
+  }, [identityKey, value]);
+
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  useLayoutEffect(() => {
+    if (identityKey === lastKeyRef.current) return undefined;
+    const previousValue = previousValueRef.current;
+    lastKeyRef.current = identityKey;
+    clearTimers();
+
+    if (disabled || reducedMotion) {
+      const nextValue = liveValueRef.current;
+      setDisplayedValue(nextValue);
+      previousValueRef.current = nextValue;
+      setReplaceDelay(0);
+      setPhase("idle");
+      return undefined;
+    }
+
+    const delayMs = Math.max(delaySeconds, 0) * 1000;
+    setDisplayedValue(previousValue);
+    setReplaceDelay(Math.max(delaySeconds, 0));
+    setPhase("erasing");
+
+    timersRef.current = [
+      window.setTimeout(() => {
+        setDisplayedValue(liveValueRef.current);
+        setPhase("hidden");
+      }, delayMs + ERASE_MS),
+      window.setTimeout(() => {
+        setPhase("revealing");
+      }, delayMs + ERASE_MS + HOLD_MS),
+      window.setTimeout(() => {
+        const nextValue = liveValueRef.current;
+        previousValueRef.current = nextValue;
+        setDisplayedValue(nextValue);
+        setPhase("idle");
+      }, delayMs + ERASE_MS + HOLD_MS + REVEAL_MS + SETTLE_MS),
+    ];
+
+    return clearTimers;
+  }, [identityKey, delaySeconds, disabled, reducedMotion, clearTimers]);
+
+  const contentPhaseClass =
+    phase === "erasing"
+      ? "endf-content-swap__content--erasing"
+      : phase === "hidden"
+        ? "endf-content-swap__content--hidden"
+        : phase === "revealing"
+          ? "endf-content-swap__content--revealing"
+          : "";
+
+  return {
+    displayedValue,
+    replacing: phase !== "idle",
+    contentPhaseClass,
+    style: { "--endf-content-swap-delay": `${replaceDelay}s` },
+  };
+}

--- a/src/components/effects/usePrefersReducedMotion.js
+++ b/src/components/effects/usePrefersReducedMotion.js
@@ -1,0 +1,47 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+let mediaQuery = null;
+const subscribers = new Set();
+
+function getMediaQuery() {
+  if (typeof window === "undefined" || !window.matchMedia) return null;
+  if (!mediaQuery) {
+    mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  }
+  return mediaQuery;
+}
+
+function notifySubscribers() {
+  subscribers.forEach((callback) => callback());
+}
+
+export function prefersReducedMotion() {
+  return getMediaQuery()?.matches || false;
+}
+
+export function usePrefersReducedMotion() {
+  return useSyncExternalStore(
+    subscribeReducedMotion,
+    prefersReducedMotion,
+    () => false,
+  );
+}
+
+function subscribeReducedMotion(callback) {
+  const query = getMediaQuery();
+  if (!query) return () => {};
+
+  subscribers.add(callback);
+  if (subscribers.size === 1) {
+    query.addEventListener("change", notifySubscribers);
+  }
+
+  return () => {
+    subscribers.delete(callback);
+    if (subscribers.size === 0) {
+      query.removeEventListener("change", notifySubscribers);
+    }
+  };
+}

--- a/src/components/explorer/MobileMapSourceStatus.jsx
+++ b/src/components/explorer/MobileMapSourceStatus.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap.jsx";
 import RequestPulseDots from "@/components/ui/RequestPulseDots";
 import {
   ROUTE_PROVIDER,
@@ -24,13 +25,25 @@ export default function MobileMapSourceStatus({
       {status.feedSource || updatedLabel ? (
         <span className="airport-map-source-status__line">
           {status.feedSource ? (
-            <span className="airport-map-source-status__source notranslate" translate="no">
-              {status.feedSource}
-            </span>
+            <EndfieldValueSwap
+              identityKey={`source:${status.feedSource}`}
+              value={(
+                <span className="notranslate" translate="no">
+                  {status.feedSource}
+                </span>
+              )}
+              className="airport-map-source-status__source"
+              direction="reverse"
+            />
           ) : null}
           {status.feedSource ? <RequestPulseDots ariaLabel="ADS-B feed live" /> : null}
           {updatedLabel ? (
-            <span className="airport-map-source-status__time">{updatedLabel}</span>
+            <EndfieldValueSwap
+              identityKey={`updated:${updatedLabel}`}
+              value={<span>{updatedLabel}</span>}
+              className="airport-map-source-status__time"
+              direction="reverse"
+            />
           ) : null}
         </span>
       ) : null}
@@ -40,9 +53,15 @@ export default function MobileMapSourceStatus({
             aria-hidden="true"
             className="airport-map-source-status__diamond"
           />
-          <span className="notranslate" translate="no">
-            {status.routeProvider}
-          </span>
+          <EndfieldValueSwap
+            identityKey={`route-provider:${status.routeProvider}`}
+            value={(
+              <span className="notranslate" translate="no">
+                {status.routeProvider}
+              </span>
+            )}
+            direction="reverse"
+          />
         </span>
       ) : null}
     </div>

--- a/src/components/map/SelectedAircraftTrace.jsx
+++ b/src/components/map/SelectedAircraftTrace.jsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import L from "leaflet";
-import { useReducedMotion } from "motion/react";
+import { usePrefersReducedMotion } from "@/components/effects/usePrefersReducedMotion.js";
 import { useMapInstance } from "./MapContext.js";
 import {
   AIRPORT_MAP_PANES,
@@ -20,11 +20,8 @@ import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 import { AIRCRAFT_COLORS } from "../../constants/aircraft.js";
 import { ARRIVAL, DEPARTURE } from "../../utils/aircraftMovement.js";
 
-const TRACE_GROWTH_DURATION_MS = 900;
 const TRACE_LABEL_FADE_STAGGER_MS = 70;
 const TRACE_LABEL_FADE_DURATION_MS = 360;
-const TRACE_REVEAL_EASING = "cubic-bezier(0.25, 1, 0.5, 1)";
-const TRACE_REVEAL_SETTLE_MS = 80;
 const SVG_NS = "http://www.w3.org/2000/svg";
 
 // Core trace gradient opacity envelope. Tail floor keeps the oldest segment
@@ -194,7 +191,7 @@ function SingleAircraftTrace({
   const completedRevealKeyRef = useRef("");
   const isAnimatingRef = useRef(false);
   const pendingTraceRef = useRef(null);
-  const reducedMotion = useReducedMotion();
+  const reducedMotion = usePrefersReducedMotion();
 
   // Local "committed" trace points decouple render from context. While the
   // growth fade is running, live poll appends are held in pendingTraceRef
@@ -277,7 +274,9 @@ function SingleAircraftTrace({
   // -------------------------------------------------------------------
   // Effect 1: line + glow + sample dots. Re-runs on every geometry change
   // (poll-driven head extensions are visible here as the curve extends).
-  // Handles the opacity-fade reveal animation when the aircraft is fresh.
+  // Trace paths now mount settled. The Endfield-style loading and row
+  // replacement effects carry motion elsewhere, so the map trace avoids the
+  // old long opacity animation on production hot paths.
   // -------------------------------------------------------------------
   useEffect(() => {
     if (rafIdRef.current) {
@@ -299,9 +298,6 @@ function SingleAircraftTrace({
       return undefined;
     }
 
-    const shouldAnimateReveal =
-      traceRevealKey && completedRevealKeyRef.current !== traceRevealKey;
-
     const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.trace);
     const traceStyle = getTraceStyle(theme);
     const lineColor = accentColor || traceStyle.lineColor;
@@ -310,7 +306,6 @@ function SingleAircraftTrace({
     const layers = [];
     const gradientEls = [];
     const gradientBase = `${gradientIdPart(aircraftHex)}-${Date.now().toString(36)}`;
-    const revealPolylines = [];
 
     geometry.connectors.forEach((connector) => {
       const connectorPolyline = L.polyline(connector.curve.slice().reverse(), {
@@ -325,7 +320,6 @@ function SingleAircraftTrace({
         className: "aircraft-trace aircraft-trace--connector",
       }).addTo(map);
       layers.push(connectorPolyline);
-      revealPolylines.push(connectorPolyline);
     });
 
     geometry.segments.forEach((segment) => {
@@ -341,7 +335,6 @@ function SingleAircraftTrace({
         className: "aircraft-trace aircraft-trace--core",
       }).addTo(map);
       layers.push(corePolyline);
-      revealPolylines.push(corePolyline);
       gradientEls.push(
         applyTraceGradient({
           map,
@@ -366,7 +359,6 @@ function SingleAircraftTrace({
         className: "aircraft-trace aircraft-trace--glow",
       }).addTo(map);
       layers.push(glowPolyline);
-      revealPolylines.push(glowPolyline);
       gradientEls.push(
         applyTraceGradient({
           map,
@@ -399,74 +391,9 @@ function SingleAircraftTrace({
 
     lineLayersRef.current = layers;
     gradientElsRef.current = gradientEls.filter(Boolean);
-
-    const flushPendingTrace = () => {
-      if (pendingTraceRef.current?.aircraftHex !== aircraftHex) return;
-      const pending = pendingTraceRef.current;
-      pendingTraceRef.current = null;
-      setCommittedTrace(pending);
-    };
-    const finishReveal = (paths = []) => {
-      rafIdRef.current = null;
-      revealTimeoutRef.current = null;
-      isAnimatingRef.current = false;
-      paths.forEach((path) => {
-        path.style.transition = "";
-        path.style.opacity = "";
-      });
-      completedRevealKeyRef.current = traceRevealKey;
-      flushPendingTrace();
-    };
-
-    if (!shouldAnimateReveal || reducedMotion) {
-      if (traceRevealKey) completedRevealKeyRef.current = traceRevealKey;
-      return () => {
-        if (rafIdRef.current) {
-          cancelAnimationFrame(rafIdRef.current);
-          rafIdRef.current = null;
-        }
-        removeLayers(lineLayersRef.current, map);
-        lineLayersRef.current = [];
-        removeElements(gradientElsRef.current);
-        gradientElsRef.current = [];
-      };
-    }
-
-    const revealPaths = revealPolylines
-      .map((polyline) => polyline.getElement?.())
-      .filter(Boolean);
-
-    if (revealPaths.length === 0) {
-      completedRevealKeyRef.current = traceRevealKey;
-      flushPendingTrace();
-      return () => {
-        if (rafIdRef.current) {
-          cancelAnimationFrame(rafIdRef.current);
-          rafIdRef.current = null;
-        }
-        removeLayers(lineLayersRef.current, map);
-        lineLayersRef.current = [];
-        removeElements(gradientElsRef.current);
-        gradientElsRef.current = [];
-      };
-    }
-
-    isAnimatingRef.current = true;
-    revealPaths.forEach((path) => {
-      path.style.transition = "none";
-      path.style.opacity = "0";
-    });
-
-    rafIdRef.current = requestAnimationFrame(() => {
-      revealPaths.forEach((path) => {
-        path.style.transition = `opacity ${TRACE_GROWTH_DURATION_MS}ms ${TRACE_REVEAL_EASING}`;
-        path.style.opacity = "1";
-      });
-      revealTimeoutRef.current = setTimeout(
-        () => finishReveal(revealPaths),
-        TRACE_GROWTH_DURATION_MS + TRACE_REVEAL_SETTLE_MS,
-      );
-    });
+    if (traceRevealKey) completedRevealKeyRef.current = traceRevealKey;
+    pendingTraceRef.current = null;
+    isAnimatingRef.current = false;
 
     return () => {
       if (rafIdRef.current) {
@@ -477,10 +404,6 @@ function SingleAircraftTrace({
         clearTimeout(revealTimeoutRef.current);
         revealTimeoutRef.current = null;
       }
-      revealPaths.forEach((path) => {
-        path.style.transition = "";
-        path.style.opacity = "";
-      });
       isAnimatingRef.current = false;
       removeLayers(lineLayersRef.current, map);
       lineLayersRef.current = [];
@@ -493,7 +416,6 @@ function SingleAircraftTrace({
     geometry,
     aircraftHex,
     accentColor,
-    reducedMotion,
     traceRevealKey,
     opacity,
   ]);
@@ -553,7 +475,7 @@ function SingleAircraftTrace({
         // Stagger only meaningful for the fresh reveal; recomputed below.
         el.style.transitionDelay = `${getTraceLabelRevealDelay({
           index,
-          growthDurationMs: TRACE_GROWTH_DURATION_MS,
+          growthDurationMs: 0,
           staggerMs: TRACE_LABEL_FADE_STAGGER_MS,
           reducedMotion,
         })}ms`;

--- a/src/components/sidebar/AircraftList.jsx
+++ b/src/components/sidebar/AircraftList.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { getAircraftIdentity } from "../../features/airport/context/airportContextUiModel.js";
 import AircraftSlot from "./AircraftSlot.jsx";
 
@@ -11,7 +10,6 @@ export default function AircraftList({
   onSelectAircraft,
   flipStaggerStep = 0.02,
 }) {
-  const reducedMotion = useReducedMotion();
   // Assign each slot whose tenant changed since last render a cascade ordinal
   // (0, 1, 2, ...) in slot order; unchanged slots get -1. Each replacing slot
   // delays its erase/reveal by ordinal × flipStaggerStep, so consecutive swaps
@@ -30,32 +28,17 @@ export default function AircraftList({
 
   return (
     <ul className="aircraft-table-list">
-      <AnimatePresence initial={false}>
-        {aircraft.map((item, index) => (
-          <motion.li
-            key={index}
-            initial={false}
-            exit={
-              reducedMotion
-                ? { clipPath: "inset(0 0% 0 0)" }
-                : {
-                    clipPath: "inset(0 0 0 100%)",
-                    transition: { duration: 0.14, ease: "easeIn" },
-                  }
-            }
-            transition={reducedMotion ? { duration: 0 } : { duration: 0.14 }}
-            className="aircraft-table-list__item"
-          >
-            <AircraftSlot
-              aircraft={item}
-              cascadeOrder={cascadeOrders[index]}
-              flipStaggerStep={flipStaggerStep}
-              selectedAircraftId={selectedAircraftId}
-              onSelectAircraft={onSelectAircraft}
-            />
-          </motion.li>
-        ))}
-      </AnimatePresence>
+      {aircraft.map((item, index) => (
+        <li key={index} className="aircraft-table-list__item">
+          <AircraftSlot
+            aircraft={item}
+            cascadeOrder={cascadeOrders[index]}
+            flipStaggerStep={flipStaggerStep}
+            selectedAircraftId={selectedAircraftId}
+            onSelectAircraft={onSelectAircraft}
+          />
+        </li>
+      ))}
     </ul>
   );
 }

--- a/src/components/sidebar/AircraftRow.jsx
+++ b/src/components/sidebar/AircraftRow.jsx
@@ -6,6 +6,7 @@ import {
   formatFlightRouteMunicipalityLabel,
   getFlightRouteAirlineIconUrl,
 } from "../../utils/flightRouteDisplay.js";
+import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap.jsx";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 
 // Tiny self-contained <img> that hides itself if the URL 404s. Avoids
@@ -173,23 +174,27 @@ function AircraftIdentityCell({
 // great on a couple of metric cards, but rendering ~290 instances (145
 // aircraft × 2 columns) every poll tick costs framerate. Static text
 // via Intl.NumberFormat keeps locale-correct separators without the
-// per-row custom-element overhead. We get a "value refreshed" feedback
-// by keying the inner span on the formatted value — React remounts on
-// change and the .number-fade CSS animation fades the new value in.
+// per-row custom-element overhead. The compact value group uses the same
+// Endfield content-swap hook as row replacement, so the old numeric value
+// is erased before the refreshed value is injected.
 function NumberWithUnit({ value, unit, format }) {
   const formatted = new Intl.NumberFormat(undefined, format).format(value);
   return (
-    <span className="inline-flex items-baseline justify-end gap-0.5 tabular-nums">
-      <span key={formatted} className="number-fade">
-        {formatted}
-      </span>
-      <sub
-        className="notranslate relative top-[0.22em] text-[7px] font-semibold leading-none text-atc-dim"
-        translate="no"
-      >
-        {unit}
-      </sub>
-    </span>
+    <EndfieldValueSwap
+      identityKey={`${formatted}:${unit}`}
+      value={(
+        <>
+          <span>{formatted}</span>
+          <sub
+            className="notranslate relative top-[0.22em] text-[7px] font-semibold leading-none text-atc-dim"
+            translate="no"
+          >
+            {unit}
+          </sub>
+        </>
+      )}
+      className="inline-flex items-baseline justify-end gap-0.5 tabular-nums"
+    />
   );
 }
 

--- a/src/components/sidebar/AircraftRow.jsx
+++ b/src/components/sidebar/AircraftRow.jsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { Plane } from "lucide-react";
 import {
   formatFlightRouteMunicipalityLabel,
   getFlightRouteAirlineIconUrl,
@@ -61,7 +62,9 @@ export default function AircraftRow({
       aria-pressed={selected}
       onClick={() => aircraftId && onSelectAircraft?.(aircraftId)}
     >
-      <span aria-hidden="true" className="endf-row-glyph" />
+      <span aria-hidden="true" className="endf-row-glyph">
+        <Plane size={13} strokeWidth={2.4} />
+      </span>
       <AircraftIdentityCell
         callsign={callsign}
         route={route}

--- a/src/components/sidebar/AircraftSlot.jsx
+++ b/src/components/sidebar/AircraftSlot.jsx
@@ -1,11 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import {
-  motion,
-  useAnimationControls,
-  useReducedMotion,
-} from "motion/react";
+import { useEffect, useRef } from "react";
+import { useEndfieldContentSwap } from "@/components/effects/useEndfieldContentSwap.js";
 import { getAircraftIdentity } from "../../features/airport/context/airportContextUiModel.js";
 import AircraftRow from "./AircraftRow.jsx";
 
@@ -22,97 +18,38 @@ export default function AircraftSlot({
   onSelectAircraft,
 }) {
   const currentKey = getAircraftIdentity(aircraft);
-  const lastKeyRef = useRef(currentKey);
-  const prevAircraftRef = useRef(aircraft);
+  const previousKeyRef = useRef(currentKey);
   const cascadeOrderRef = useRef(cascadeOrder);
   cascadeOrderRef.current = cascadeOrder;
   const flipStaggerStepRef = useRef(flipStaggerStep);
   flipStaggerStepRef.current = flipStaggerStep;
-  const selectedAircraftIdRef = useRef(selectedAircraftId);
-  selectedAircraftIdRef.current = selectedAircraftId;
-  const [freezeAircraft, setFreezeAircraft] = useState(null);
-  const [replacing, setReplacing] = useState(false);
-  const [replaceDelay, setReplaceDelay] = useState(0);
-  const controls = useAnimationControls();
-  const reducedMotion = useReducedMotion();
 
-  useEffect(() => {
-    if (currentKey === lastKeyRef.current) return;
-    const oldKey = lastKeyRef.current;
-    const oldAircraft = prevAircraftRef.current;
-    lastKeyRef.current = currentKey;
-
-    if (reducedMotion) return;
-
-    // Skip the flip animation when the swap is caused by a selection
-    // change. Two cases:
-    //   1. List slot's old aircraft just became selected and moved to
-    //      the pin slot (oldKey === selectedAircraftId). Animating the
-    //      frozen old aircraft would fade an ink+yellow row, which in
-    //      light theme looks like ink washing to white.
-    //   2. Pin slot's incoming aircraft is the just-clicked one
-    //      (currentKey === selectedAircraftId). The frozen previous
-    //      aircraft would briefly render as non-selected (light+ink),
-    //      flashing the pin from ink to light before the swap. Snap
-    //      instead so the pin transitions cleanly from one focused
-    //      aircraft to the next.
-    const selectedId = selectedAircraftIdRef.current;
-    if (oldKey === selectedId || currentKey === selectedId) {
-      setFreezeAircraft(null);
-      setReplacing(false);
-      controls.set({ clipPath: "inset(0 0% 0 0)" });
-      return;
-    }
-
-    const flipDelay =
-      Math.max(cascadeOrderRef.current, 0) * flipStaggerStepRef.current;
-
-    setFreezeAircraft(oldAircraft);
-    setReplaceDelay(flipDelay);
-    setReplacing(true);
-    let cancelled = false;
-    (async () => {
-      // Erase old tenant, swap data while hidden, then scan the new
-      // tenant in from the left. No opacity blending on light surfaces.
-      await controls.start({
-        clipPath: "inset(0 0 0 100%)",
-        transition: { duration: 0.14, ease: [1, 0, 0.7, 1], delay: flipDelay },
-      });
-      if (cancelled) return;
-      setFreezeAircraft(null);
-      await controls.set({ clipPath: "inset(0 100% 0 0)" });
-      await controls.start({
-        clipPath: "inset(0 0% 0 0)",
-        transition: { duration: 0.22, ease: [1, 0, 0.7, 1], delay: 0.1 },
-      });
-      if (!cancelled) setReplacing(false);
-    })();
-    return () => {
-      cancelled = true;
-      setReplacing(false);
-    };
-  }, [currentKey, controls, reducedMotion]);
-
-  // Track the latest live aircraft so the next tenant swap can freeze on it.
-  // Skip while frozen — that's when the displayed row is intentionally stale.
-  useEffect(() => {
-    if (freezeAircraft === null) prevAircraftRef.current = aircraft;
+  const selectedId = selectedAircraftId || "";
+  const previousKey = previousKeyRef.current;
+  const flipDelay =
+    Math.max(cascadeOrderRef.current, 0) * flipStaggerStepRef.current;
+  const swap = useEndfieldContentSwap({
+    identityKey: currentKey,
+    value: aircraft,
+    delaySeconds: flipDelay,
+    disabled: currentKey === selectedId || previousKey === selectedId,
   });
-
-  const displayed = freezeAircraft ?? aircraft;
+  useEffect(() => {
+    previousKeyRef.current = currentKey;
+  }, [currentKey]);
+  const displayed = swap.displayedValue;
   const aircraftId = getAircraftIdentity(displayed);
   const selected = Boolean(aircraftId) && aircraftId === selectedAircraftId;
 
   return (
     <div
-      style={{ "--aircraft-row-replace-delay": `${replaceDelay}s` }}
-      className={`aircraft-row-flip-surface ${
-        replacing ? "aircraft-row-flip-surface--replacing" : ""
+      style={swap.style}
+      className={`endf-content-swap ${
+        swap.replacing ? "endf-content-swap--replacing" : ""
       }`}
     >
-      <motion.div
-        animate={controls}
-        className="aircraft-row-flip-surface__content"
+      <div
+        className={`endf-content-swap__content ${swap.contentPhaseClass}`}
       >
         <AircraftRow
           aircraft={displayed}
@@ -120,7 +57,7 @@ export default function AircraftSlot({
           selected={selected}
           onSelectAircraft={onSelectAircraft}
         />
-      </motion.div>
+      </div>
     </div>
   );
 }

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -3,7 +3,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import NumberFlow from "@number-flow/react";
-import { AnimatePresence, motion } from "motion/react";
 import { Check, Minus, Search } from "lucide-react";
 import {
   Select,
@@ -38,7 +37,7 @@ import { formatFlightRouteMunicipalityLabel } from "../../utils/flightRouteDispl
 import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
 import AircraftList from "./AircraftList.jsx";
 import AircraftSlot from "./AircraftSlot.jsx";
-import AirportRow from "./AirportRow.jsx";
+import AirportSlot from "./AirportSlot.jsx";
 
 export default function AircraftTable({
   aircraft = [],
@@ -230,38 +229,20 @@ export default function AircraftTable({
           <span className="text-right">{t("sidebar.altitude")}</span>
         </div>
 
-        <AnimatePresence initial={false}>
-          {pinnedAircraft && (
-            <motion.div
-              key="aircraft-table-pin"
-              className="aircraft-table-pin"
-              // Animate only height — the inner row paints at full ink
-              // opacity from the first frame, and the growing height
-              // reveals it cleanly. Fading opacity would blend the ink
-              // with the light sidebar mid-animation and read as a
-              // white→black flash in light theme.
-              initial={{ height: 0 }}
-              animate={{ height: "auto" }}
-              exit={{ height: 0 }}
-              transition={{ duration: 0.22, ease: [0.25, 0.46, 0.45, 0.94] }}
-              style={{ overflow: "hidden" }}
-            >
-              <AircraftSlot
-                aircraft={pinnedAircraft}
-                cascadeOrder={0}
-                flipStaggerStep={0}
-                selectedAircraftId={selectedAircraftId}
-                onSelectAircraft={onSelectAircraft}
-              />
-            </motion.div>
-          )}
-        </AnimatePresence>
+        {pinnedAircraft && (
+          <div className="aircraft-table-pin">
+            <AircraftSlot
+              aircraft={pinnedAircraft}
+              cascadeOrder={0}
+              flipStaggerStep={0}
+              selectedAircraftId={selectedAircraftId}
+              onSelectAircraft={onSelectAircraft}
+            />
+          </div>
+        )}
       </div>
 
-      <motion.div
-        layoutScroll
-        className={fill ? "flex-1 overflow-y-auto" : "overflow-visible"}
-      >
+      <div className={fill ? "flex-1 overflow-y-auto" : "overflow-visible"}>
         {listRows.length === 0 &&
         filteredAirports.length === 0 &&
         !pinnedAircraft ? (
@@ -286,8 +267,9 @@ export default function AircraftTable({
                     key={`airport:${airport.icao}`}
                     className="aircraft-table-list__item"
                   >
-                    <AirportRow
+                    <AirportSlot
                       airport={airport}
+                      cascadeOrder={-1}
                       airportId={airport.icao}
                       selected={airport.icao === selectedAirportIcao}
                       onSelectAirport={onSelectAirport}
@@ -298,7 +280,7 @@ export default function AircraftTable({
             )}
           </>
         )}
-      </motion.div>
+      </div>
     </div>
   );
 }

--- a/src/components/sidebar/AirportRow.jsx
+++ b/src/components/sidebar/AirportRow.jsx
@@ -3,6 +3,7 @@
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 import { airportCityName, airportDisplayName } from "@/utils/airport.js";
 import { countryName } from "@/utils/flag.js";
+import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap.jsx";
 
 // Airport equivalent of AircraftRow — same column rhythm so an
 // "airports & aircraft" mixed list reads as one coherent table.
@@ -74,17 +75,21 @@ export default function AirportRow({
 function NumberWithUnit({ value, unit, format }) {
   const formatted = new Intl.NumberFormat(undefined, format).format(value);
   return (
-    <span className="inline-flex items-baseline justify-end gap-0.5 tabular-nums">
-      <span key={formatted} className="number-fade">
-        {formatted}
-      </span>
-      <sub
-        className="notranslate relative top-[0.22em] text-[7px] font-semibold leading-none text-atc-dim"
-        translate="no"
-      >
-        {unit}
-      </sub>
-    </span>
+    <EndfieldValueSwap
+      identityKey={`${formatted}:${unit}`}
+      value={(
+        <>
+          <span>{formatted}</span>
+          <sub
+            className="notranslate relative top-[0.22em] text-[7px] font-semibold leading-none text-atc-dim"
+            translate="no"
+          >
+            {unit}
+          </sub>
+        </>
+      )}
+      className="inline-flex items-baseline justify-end gap-0.5 tabular-nums"
+    />
   );
 }
 

--- a/src/components/sidebar/AirportRow.jsx
+++ b/src/components/sidebar/AirportRow.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { TowerControl } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 import { airportCityName, airportDisplayName } from "@/utils/airport.js";
 import { countryName } from "@/utils/flag.js";
@@ -36,7 +37,9 @@ export default function AirportRow({
       aria-pressed={selected}
       onClick={() => airportId && onSelectAirport?.(airportId)}
     >
-      <span aria-hidden="true" className="endf-row-glyph" />
+      <span aria-hidden="true" className="endf-row-glyph">
+        <TowerControl size={13} strokeWidth={2.4} />
+      </span>
       <div className="aircraft-table-identity aircraft-table-identity--solo min-w-0">
         <span
           className="aircraft-table-callsign airport-sidebar-display-mono notranslate truncate text-[12px] font-semibold text-atc-text"

--- a/src/components/sidebar/AirportSlot.jsx
+++ b/src/components/sidebar/AirportSlot.jsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEndfieldContentSwap } from "@/components/effects/useEndfieldContentSwap.js";
+import AirportRow from "./AirportRow.jsx";
+
+function getAirportIdentity(airport) {
+  return airport?.icao || airport?.iata || airport?.id || airport?.name || "";
+}
+
+export default function AirportSlot({
+  airport,
+  cascadeOrder = -1,
+  flipStaggerStep = 0.02,
+  airportId,
+  selected,
+  onSelectAirport,
+}) {
+  const currentKey = getAirportIdentity(airport);
+  const flipDelay = Math.max(cascadeOrder, 0) * flipStaggerStep;
+  const swap = useEndfieldContentSwap({
+    identityKey: currentKey,
+    value: airport,
+    delaySeconds: flipDelay,
+    disabled: selected,
+  });
+  const displayed = swap.displayedValue;
+  const displayedId = displayed?.icao || airportId;
+
+  return (
+    <div
+      style={swap.style}
+      className={`endf-content-swap ${
+        swap.replacing ? "endf-content-swap--replacing" : ""
+      }`}
+    >
+      <div
+        className={`endf-content-swap__content ${swap.contentPhaseClass}`}
+      >
+        <AirportRow
+          airport={displayed}
+          airportId={displayedId}
+          selected={selected}
+          onSelectAirport={onSelectAirport}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/sidebar/SidebarShell.jsx
+++ b/src/components/sidebar/SidebarShell.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap.jsx";
 import RequestPulseDots from "@/components/ui/RequestPulseDots";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
@@ -72,19 +73,36 @@ export default function SidebarShell({
               className={`airport-feed-status airport-feed-status--${feedStatus} inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-normal text-atc-dim tabular-nums`}
             >
               {feedSource ? (
-                <span className="airport-feed-status__source">{feedSource}</span>
+                <EndfieldValueSwap
+                  identityKey={`source:${feedSource}`}
+                  value={<span>{feedSource}</span>}
+                  className="airport-feed-status__source"
+                  direction="reverse"
+                />
               ) : null}
               <RequestPulseDots ariaLabel={t("app.feedLive")} />
-              {updatedLabel ? <span key={updatedLabel}>{updatedLabel}</span> : null}
+              {updatedLabel ? (
+                <EndfieldValueSwap
+                  identityKey={`updated:${updatedLabel}`}
+                  value={<span>{updatedLabel}</span>}
+                  direction="reverse"
+                />
+              ) : null}
             </span>
             <span className="inline-flex items-center gap-1 text-[9px] font-bold uppercase tracking-[0.18em] text-atc-orange">
               <span
                 aria-hidden="true"
                 className="inline-block h-1.5 w-1.5 rotate-45 bg-atc-orange"
               />
-              <span className="notranslate" translate="no">
-                {routeProviderLabel}
-              </span>
+              <EndfieldValueSwap
+                identityKey={`route-provider:${routeProviderLabel}`}
+                value={(
+                  <span className="notranslate" translate="no">
+                    {routeProviderLabel}
+                  </span>
+                )}
+                direction="reverse"
+              />
             </span>
           </div>
         )}

--- a/src/style.css
+++ b/src/style.css
@@ -3528,13 +3528,9 @@ body {
     width: 18px;
 }
 
-.endf-row-glyph::before {
-    border-bottom: 2px solid currentColor;
-    border-right: 2px solid currentColor;
-    content: "";
-    height: 8px;
-    transform: translateX(-1px) rotate(-45deg);
-    width: 8px;
+.endf-row-glyph svg {
+    display: block;
+    flex: 0 0 auto;
 }
 
 .endf-row-active .endf-row-glyph {

--- a/src/style.css
+++ b/src/style.css
@@ -3104,19 +3104,34 @@ body {
     border-top: 1px solid var(--atc-line);
 }
 
-.aircraft-row-flip-surface {
+.endf-content-swap {
     isolation: isolate;
     overflow: hidden;
     position: relative;
+    --endf-content-swap-delay: 0s;
 }
 
-.aircraft-row-flip-surface__content {
+.endf-content-swap__content {
     will-change: clip-path;
 }
 
-.aircraft-row-flip-surface--replacing::before {
-    animation: aircraft-row-replace-placeholder 470ms steps(1, end)
-        var(--aircraft-row-replace-delay, 0s) both;
+.endf-content-swap__content--erasing {
+    animation: endf-content-swap-erase 140ms cubic-bezier(1, 0, 0.7, 1)
+        var(--endf-content-swap-delay, 0s) both;
+}
+
+.endf-content-swap__content--hidden {
+    clip-path: inset(0 100% 0 0);
+}
+
+.endf-content-swap__content--revealing {
+    animation: endf-content-swap-reveal 220ms cubic-bezier(1, 0, 0.7, 1)
+        both;
+}
+
+.endf-content-swap--replacing::before {
+    animation: endf-content-swap-placeholder 470ms steps(1, end)
+        var(--endf-content-swap-delay, 0s) both;
     background:
         radial-gradient(
             circle,
@@ -3137,9 +3152,9 @@ body {
     z-index: 5;
 }
 
-.aircraft-row-flip-surface--replacing::after {
-    animation: aircraft-row-replace-cursor 470ms steps(1, end)
-        var(--aircraft-row-replace-delay, 0s) both;
+.endf-content-swap--replacing::after {
+    animation: endf-content-swap-cursor 470ms steps(1, end)
+        var(--endf-content-swap-delay, 0s) both;
     background: color-mix(in oklab, var(--endf-yellow) 70%, transparent);
     box-shadow: 0 0 12px color-mix(in oklab, var(--endf-yellow) 24%, transparent);
     content: "";
@@ -3150,6 +3165,42 @@ body {
     top: calc(50% - 11px);
     width: 3px;
     z-index: 6;
+}
+
+@keyframes endf-content-swap-erase {
+    from {
+        clip-path: inset(0 0 0 0);
+    }
+    to {
+        clip-path: inset(0 0 0 100%);
+    }
+}
+
+@keyframes endf-content-swap-reveal {
+    from {
+        clip-path: inset(0 100% 0 0);
+    }
+    to {
+        clip-path: inset(0 0 0 0);
+    }
+}
+
+@keyframes endf-content-swap-erase-reverse {
+    from {
+        clip-path: inset(0 0 0 0);
+    }
+    to {
+        clip-path: inset(0 100% 0 0);
+    }
+}
+
+@keyframes endf-content-swap-reveal-reverse {
+    from {
+        clip-path: inset(0 0 0 100%);
+    }
+    to {
+        clip-path: inset(0 0 0 0);
+    }
 }
 
 @keyframes endf-cursor-wipe {
@@ -3279,7 +3330,7 @@ body {
     }
 }
 
-@keyframes aircraft-row-replace-placeholder {
+@keyframes endf-content-swap-placeholder {
     0%,
     52% {
         opacity: 1;
@@ -3290,7 +3341,7 @@ body {
     }
 }
 
-@keyframes aircraft-row-replace-cursor {
+@keyframes endf-content-swap-cursor {
     0%,
     8% {
         opacity: 0;
@@ -3314,19 +3365,6 @@ body {
     53%,
     100% {
         opacity: 0;
-    }
-}
-
-/* Refreshed numeric values now reveal by a compact scan instead of
-   fading through the row surface. Triggered by key={formattedValue}. */
-@keyframes number-wipe-in {
-    0% {
-        clip-path: inset(0 100% 0 0);
-        transform: translateX(-1px);
-    }
-    100% {
-        clip-path: inset(0 0% 0 0);
-        transform: translateX(0);
     }
 }
 
@@ -3354,18 +3392,101 @@ body {
     }
 }
 
-.number-fade {
-    animation:
-        number-wipe-in 180ms cubic-bezier(1, 0, 0.7, 1),
-        endf-data-flicker 160ms steps(1, end);
-    display: inline-block;
+.endf-value-swap {
+    display: inline-flex;
+    isolation: isolate;
+    line-height: 1;
+    overflow: hidden;
+    position: relative;
+    --endf-value-swap-surface: var(--sidebar);
+}
+
+.endf-value-swap__content {
     will-change: clip-path;
 }
 
+.endf-value-swap__content--erasing {
+    animation: endf-content-swap-erase 140ms cubic-bezier(1, 0, 0.7, 1)
+        var(--endf-content-swap-delay, 0s) both;
+}
+
+.endf-value-swap__content--hidden {
+    clip-path: inset(0 100% 0 0);
+}
+
+.endf-value-swap__content--revealing {
+    animation: endf-content-swap-reveal 220ms cubic-bezier(1, 0, 0.7, 1)
+        both;
+}
+
+.endf-value-swap--reverse .endf-value-swap__content--erasing {
+    animation-name: endf-content-swap-erase-reverse;
+}
+
+.endf-value-swap--reverse .endf-value-swap__content--hidden {
+    clip-path: inset(0 0 0 100%);
+}
+
+.endf-value-swap--reverse .endf-value-swap__content--revealing {
+    animation-name: endf-content-swap-reveal-reverse;
+}
+
+.endf-value-swap--replacing::before {
+    animation: endf-content-swap-placeholder 470ms steps(1, end) both;
+    background:
+        radial-gradient(
+            circle,
+            color-mix(in oklab, var(--atc-text) 18%, transparent) 0 1px,
+            transparent 1.4px
+        )
+        0 0 / 6px 6px,
+        linear-gradient(
+            90deg,
+            color-mix(in oklab, var(--endf-value-swap-surface) 88%, transparent),
+            color-mix(in oklab, var(--endf-yellow) 12%, var(--endf-value-swap-surface))
+                52%,
+            color-mix(in oklab, var(--endf-value-swap-surface) 88%, transparent)
+        );
+    content: "";
+    inset: -1px 0;
+    pointer-events: none;
+    position: absolute;
+    z-index: 2;
+}
+
+.endf-row-active .endf-value-swap {
+    --endf-value-swap-surface: var(--endf-ink);
+}
+
+.endf-value-swap--replacing::after {
+    animation: endf-content-swap-cursor 470ms steps(1, end) both;
+    background: color-mix(in oklab, var(--endf-yellow) 86%, transparent);
+    box-shadow: 0 0 10px color-mix(in oklab, var(--endf-yellow) 34%, transparent);
+    content: "";
+    height: 1.1em;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    top: calc(50% - 0.55em);
+    width: 3px;
+    z-index: 3;
+}
+
+.endf-value-swap--reverse::after {
+    left: auto;
+    right: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
-    .number-fade,
-    .aircraft-row-flip-surface,
-    .aircraft-row-flip-surface__content {
+    .endf-value-swap--replacing::before,
+    .endf-value-swap--replacing::after {
+        display: none;
+    }
+
+    .endf-value-swap,
+    .endf-value-swap__content,
+    .endf-content-swap,
+    .endf-content-swap__content {
         animation: none;
         clip-path: none;
         filter: none;
@@ -3373,12 +3494,12 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .aircraft-row-flip-surface--replacing::before,
-    .aircraft-row-flip-surface--replacing::after {
+    .endf-content-swap--replacing::before,
+    .endf-content-swap--replacing::after {
         display: none;
     }
 
-    .aircraft-row-flip-surface {
+    .endf-content-swap {
         animation: none;
         transition: none;
     }
@@ -3943,9 +4064,7 @@ body {
 }
 
 .airport-feed-status {
-    animation: airport-feed-status-fade 240ms cubic-bezier(0.22, 1, 0.36, 1)
-        both;
-    will-change: opacity, transform;
+    will-change: auto;
 }
 
 .airport-feed-status--infer {
@@ -4774,17 +4893,6 @@ body {
     border-top: 1px solid color-mix(in oklab, var(--atc-line) 60%, transparent);
 }
 
-@keyframes airport-feed-status-fade {
-    from {
-        opacity: 0;
-        transform: translateY(2px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
 /* Override carousel slide flex to fit narrower sidebar column */
 .airport-sidebar .weather-carousel-track,
 [data-sidebar="sidebar"] .weather-carousel-track {
@@ -5408,7 +5516,20 @@ body {
     right: 0;
     bottom: calc(100% - 22px);
     left: 0;
+    animation: aircraft-preview-media-reveal 520ms cubic-bezier(0.16, 1, 0.3, 1)
+        both;
     z-index: 1;
+}
+
+@keyframes aircraft-preview-media-reveal {
+    from {
+        clip-path: inset(0 0 100% 0);
+        transform: translateY(22px);
+    }
+    to {
+        clip-path: inset(0 0 0 0);
+        transform: translateY(0);
+    }
 }
 
 .aircraft-preview-metadata-card {
@@ -5719,6 +5840,7 @@ body {
     isolation: isolate;
     overflow: hidden;
     pointer-events: none;
+    transform: translateX(-50%);
     user-select: none;
 }
 
@@ -6456,6 +6578,7 @@ body {
 
     .aircraft-preview-card--desktop-reveal > *,
     .aircraft-preview-card--desktop-reveal .aircraft-preview-metadata-card,
+    .aircraft-preview-card__media-slot,
     .aircraft-preview-mobile-card__inner > *,
     .aircraft-preview-mobile-card__track,
     .aircraft-table-route-cycle--alternate::before,


### PR DESCRIPTION
## Summary
- extract reusable Endfield content/value swap primitives for list rows, numeric fields, feed source, and route-provider watermark
- replace motion/react driven sidebar, preview, and trace animations with CSS-driven swap/reveal behavior
- remove the unused motion dependency after eliminating component imports

## Verification
- pnpm lint
- pnpm test
- pnpm build
- rg found no motion/react, AnimatePresence, framer-motion, old number-fade, or old row flip animation names