### PR TITLE
Avoid slot swaps on structural list changes

### DIFF
--- a/src/components/sidebar/AircraftList.jsx
+++ b/src/components/sidebar/AircraftList.jsx
@@ -6,6 +6,7 @@ import AircraftSlot from "./AircraftSlot.jsx";
 
 export default function AircraftList({
   aircraft = [],
+  resetKey = "",
   selectedAircraftId = "",
   onSelectAircraft,
   flipStaggerStep = 0.02,
@@ -15,16 +16,20 @@ export default function AircraftList({
   // delays its erase/reveal by ordinal × flipStaggerStep, so consecutive swaps
   // fire that step apart top→bottom — unchanged slots in between don't add to the gap.
   const prevKeysRef = useRef([]);
+  const resetKeyRef = useRef(resetKey);
   const currentKeys = aircraft.map(getAircraftIdentity);
   const prevKeys = prevKeysRef.current;
+  const structureChanged = resetKeyRef.current !== resetKey;
   let cascadeCursor = 0;
   const cascadeOrders = currentKeys.map((cur, i) => {
     const prev = prevKeys[i];
+    if (structureChanged) return -1;
     return prev !== undefined && prev !== cur ? cascadeCursor++ : -1;
   });
   useEffect(() => {
     prevKeysRef.current = currentKeys;
-  });
+    resetKeyRef.current = resetKey;
+  }, [currentKeys, resetKey]);
 
   return (
     <ul className="aircraft-table-list">
@@ -34,6 +39,7 @@ export default function AircraftList({
             aircraft={item}
             cascadeOrder={cascadeOrders[index]}
             flipStaggerStep={flipStaggerStep}
+            disableSwap={structureChanged}
             selectedAircraftId={selectedAircraftId}
             onSelectAircraft={onSelectAircraft}
           />

--- a/src/components/sidebar/AircraftSlot.jsx
+++ b/src/components/sidebar/AircraftSlot.jsx
@@ -14,6 +14,7 @@ export default function AircraftSlot({
   aircraft,
   cascadeOrder = -1,
   flipStaggerStep = 0.02,
+  disableSwap = false,
   selectedAircraftId,
   onSelectAircraft,
 }) {
@@ -32,7 +33,8 @@ export default function AircraftSlot({
     identityKey: currentKey,
     value: aircraft,
     delaySeconds: flipDelay,
-    disabled: currentKey === selectedId || previousKey === selectedId,
+    disabled:
+      disableSwap || currentKey === selectedId || previousKey === selectedId,
   });
   useEffect(() => {
     previousKeyRef.current = currentKey;

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -131,6 +131,25 @@ export default function AircraftTable({
       (item) => getAircraftIdentity(item) !== selectedAircraftId,
     );
   }, [pinnedAircraft, filteredAircraft, selectedAircraftId]);
+  const aircraftListResetKey = useMemo(
+    () =>
+      [
+        query.trim().toLowerCase(),
+        trafficFilter,
+        Array.isArray(typeFilter) ? typeFilter.join("|") : typeFilter,
+        altitudeLevel,
+        entityFilter,
+        selectedAircraftId,
+      ].join("::"),
+    [
+      altitudeLevel,
+      entityFilter,
+      query,
+      selectedAircraftId,
+      trafficFilter,
+      typeFilter,
+    ],
+  );
 
   return (
     <div className={`flex flex-col ${fill ? "h-full" : ""}`}>
@@ -256,6 +275,7 @@ export default function AircraftTable({
             {listRows.length > 0 && (
               <AircraftList
                 aircraft={listRows}
+                resetKey={aircraftListResetKey}
                 selectedAircraftId={selectedAircraftId}
                 onSelectAircraft={onSelectAircraft}
               />


### PR DESCRIPTION
## Summary
- explain and fix the blank-row case caused by structural list changes reusing index slots
- snap aircraft list slots when search/filter/entity/pinned-selection inputs restructure the list
- keep Endfield slot swap animation for normal live row tenant changes

## Verification
- pnpm lint
- pnpm test
- pnpm build