### PR TITLE
Snap aircraft slots on live order changes

### DIFF
--- a/src/components/sidebar/AircraftList.jsx
+++ b/src/components/sidebar/AircraftList.jsx
@@ -19,7 +19,9 @@ export default function AircraftList({
   const resetKeyRef = useRef(resetKey);
   const currentKeys = aircraft.map(getAircraftIdentity);
   const prevKeys = prevKeysRef.current;
-  const structureChanged = resetKeyRef.current !== resetKey;
+  const structureChanged =
+    resetKeyRef.current !== resetKey ||
+    didListStructureChange(prevKeys, currentKeys);
   let cascadeCursor = 0;
   const cascadeOrders = currentKeys.map((cur, i) => {
     const prev = prevKeys[i];
@@ -47,4 +49,17 @@ export default function AircraftList({
       ))}
     </ul>
   );
+}
+
+function didListStructureChange(prevKeys, currentKeys) {
+  if (prevKeys.length === 0) return false;
+  if (prevKeys.length !== currentKeys.length) return true;
+
+  const previousSet = new Set(prevKeys);
+  const currentSet = new Set(currentKeys);
+  return currentKeys.some((key, index) => {
+    const prev = prevKeys[index];
+    if (prev === key) return false;
+    return previousSet.has(key) || currentSet.has(prev);
+  });
 }


### PR DESCRIPTION
## Summary
- handle the production blank-row case from ADS-B live poll resorting the aircraft list by altitude/speed
- snap slot content when the identity sequence is reordered, inserted, or removed
- preserve Endfield content-swap animation only for true same-slot tenant replacement

## Verification
- pnpm lint
- pnpm test
- pnpm build