### PR TITLE
Fix flight nearby airports outside US

### DIFF
--- a/src/app/api/dao/airportDirectory.dao.js
+++ b/src/app/api/dao/airportDirectory.dao.js
@@ -339,6 +339,34 @@ export const createOurAirportsQueries = ({ client } = {}) => {
       });
     },
 
+    async getNearbyAirportsByPosition({
+      lat,
+      lon,
+      radiusNm = 60,
+      limit = 12,
+      excludeIdent = "",
+    } = {}) {
+      const originLat = toFiniteNumber(lat);
+      const originLon = toFiniteNumber(lon);
+      if (!Number.isFinite(originLat) || !Number.isFinite(originLon)) {
+        return [];
+      }
+      return queryNearby({
+        client,
+        table: "airports",
+        columns: AIRPORT_COLUMNS,
+        origin: {
+          ident: normalizeIdent(excludeIdent),
+          lat: originLat,
+          lon: originLon,
+        },
+        radiusNm,
+        limit,
+        excludeIdent: normalizeIdent(excludeIdent),
+        rowMapper: mapAirportRow,
+      });
+    },
+
     async getNearbyNavaids({ ident, radiusNm = 60, limit = 12 } = {}) {
       const origin = await this.getAirportByIdent(ident);
       if (!origin || !Number.isFinite(origin.lat) || !Number.isFinite(origin.lon)) {

--- a/src/app/api/dao/airportDirectory.dao.test.js
+++ b/src/app/api/dao/airportDirectory.dao.test.js
@@ -247,6 +247,30 @@ const airports = [
     municipality: "London",
     iso_country: "GB",
   },
+  {
+    ...KBOS,
+    ident: "CYYZ",
+    icao_code: "CYYZ",
+    iata_code: "YYZ",
+    name: "Toronto Pearson International Airport",
+    latitude_deg: 43.6772,
+    longitude_deg: -79.6306,
+    municipality: "Toronto",
+    iso_country: "CA",
+    iso_region: "CA-ON",
+  },
+  {
+    ...KBOS,
+    ident: "CYTZ",
+    icao_code: "CYTZ",
+    iata_code: "YTZ",
+    name: "Billy Bishop Toronto City Centre Airport",
+    latitude_deg: 43.6275,
+    longitude_deg: -79.3962,
+    municipality: "Toronto",
+    iso_country: "CA",
+    iso_region: "CA-ON",
+  },
 ];
 
 const runways = [
@@ -321,6 +345,19 @@ const nearby = await queries.getNearbyAirports({
 assert.equal(nearby.length, 1);
 assert.equal(nearby[0].icao, "KJFK");
 assert.ok(nearby[0].distanceNm > 150 && nearby[0].distanceNm < 220);
+
+// Coordinate-based nearby lookup is used by the flight tracking page, where
+// there is no focal airport ident. It must not inherit a US-only country scope.
+const nearbyToronto = await queries.getNearbyAirportsByPosition({
+  lat: 43.73,
+  lon: -79.45,
+  radiusNm: 25,
+  limit: 5,
+});
+assert.deepEqual(
+  nearbyToronto.map((airport) => airport.icao),
+  ["CYTZ", "CYYZ"],
+);
 
 // Get runways
 const runwaysOut = await queries.getRunwaysByAirport("KBOS");

--- a/src/app/api/dao/nearbyAirports.dao.js
+++ b/src/app/api/dao/nearbyAirports.dao.js
@@ -22,7 +22,7 @@ export function buildNearbyAirportCacheKey({
   minRunwayLength,
 } = {}) {
   return [
-    "nearby-airports",
+    "nearby-airports-v2",
     String(country || "").trim().toUpperCase(),
     roundedNumber(minRunwayLength, 0),
     String(icao || "").trim().toUpperCase(),

--- a/src/app/api/dao/nearbyAirports.dao.test.js
+++ b/src/app/api/dao/nearbyAirports.dao.test.js
@@ -60,7 +60,7 @@ assert.equal(
     country: "us",
     minRunwayLength: 5000,
   }),
-  "nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6",
+  "nearby-airports-v2:US:5000:KJFK:40.639928:-73.778692:30:6",
 );
 
 {
@@ -77,7 +77,7 @@ assert.equal(
     now,
   });
 
-  const payload = await cache.read("nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6");
+  const payload = await cache.read("nearby-airports-v2:US:5000:KJFK:40.639928:-73.778692:30:6");
 
   assert.deepEqual(payload, {
     airports: [{ icao: "KLGA" }],
@@ -103,7 +103,7 @@ assert.equal(
       {
         type: "eq",
         column: "cache_key",
-        value: "nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6",
+        value: "nearby-airports-v2:US:5000:KJFK:40.639928:-73.778692:30:6",
       },
       { type: "gt", column: "expires_at", value: "2026-05-10T12:00:00.000Z" },
       { type: "limit", count: 1 },
@@ -122,7 +122,7 @@ assert.equal(
   });
 
   await cache.write({
-    cacheKey: "nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6",
+    cacheKey: "nearby-airports-v2:US:5000:KJFK:40.639928:-73.778692:30:6",
     query: {
       country: "US",
       minRunwayLength: 5000,
@@ -136,7 +136,7 @@ assert.equal(
   });
 
   const upsertCall = calls.find((call) => call.type === "upsert");
-  assert.equal(upsertCall.row.cache_key, "nearby-airports:US:5000:KJFK:40.639928:-73.778692:30:6");
+  assert.equal(upsertCall.row.cache_key, "nearby-airports-v2:US:5000:KJFK:40.639928:-73.778692:30:6");
   assert.equal(upsertCall.row.expires_at, "2026-08-08T12:00:00.000Z");
   assert.deepEqual(upsertCall.row.response.airports, [{ icao: "KLGA" }]);
   assert.deepEqual(upsertCall.options, { onConflict: "cache_key" });

--- a/src/features/airport/nearby/nearbyAirports.mechanism.js
+++ b/src/features/airport/nearby/nearbyAirports.mechanism.js
@@ -7,6 +7,12 @@ import {
   buildNearbyAirportCacheKey,
   createNearbyAirportSupabaseCacheFromEnv,
 } from "../../../app/api/dao/nearbyAirports.dao.js";
+import {
+  createOurAirportsQueriesFromEnv,
+} from "../../../app/api/dao/airportDirectory.dao.js";
+import {
+  buildRunwayMapFromOurAirports,
+} from "../map/ourAirportsRunwayMap.js";
 
 import {
   NEARBY_AIRPORT_INDEX_CACHE_MS,
@@ -61,6 +67,65 @@ const attachRunwayMaps = async (airports, fetchDetail = fetchAiracAirportDetail)
   }));
 };
 
+const attachOurAirportsRunwayMaps = async (
+  airports,
+  queries,
+  { minRunwayLength = 0 } = {},
+) => {
+  const runwayRows = await Promise.all(
+    airports.map((airport) =>
+      queries.getRunwaysByAirport(airport.ident || airport.icao).catch((error) => {
+        console.warn(
+          `[airports/nearby] OurAirports runway load failed for ${airport.icao}`,
+          error,
+        );
+        return [];
+      }),
+    ),
+  );
+
+  return airports.map((airport, index) => {
+    const runways = runwayRows[index] || [];
+    const hasQualifyingRunway =
+      !minRunwayLength ||
+      runways.some((runway) => Number(runway?.lengthFt) >= minRunwayLength);
+
+    return {
+      ...airport,
+      hasQualifyingRunway,
+      runwayMap: buildRunwayMapFromOurAirports(
+        airport.ident || airport.icao,
+        runways,
+      ),
+    };
+  });
+};
+
+const getNearbyAirportsFromOurAirports = async ({ query, queries }) => {
+  if (!queries) return null;
+  const candidateLimit = Math.min(Math.max(query.limit * 8, query.limit), 100);
+  const nearbyAirports = await queries.getNearbyAirportsByPosition({
+    lat: query.lat,
+    lon: query.lon,
+    radiusNm: query.radiusNm,
+    limit: candidateLimit,
+    excludeIdent: query.icao,
+  });
+  const airports = (await attachOurAirportsRunwayMaps(nearbyAirports, queries, {
+    minRunwayLength: query.minRunwayLength,
+  }))
+    .filter((airport) => airport.hasQualifyingRunway)
+    .slice(0, query.limit)
+    .map(({ hasQualifyingRunway, ...airport }) => airport);
+
+  return {
+    airports,
+    source: "ourairports",
+    radiusNm: query.radiusNm,
+    limit: query.limit,
+  };
+};
+
 const logSupabaseCacheWarning = (action, error) => {
   console.warn(`[airports/nearby] Supabase cache ${action} failed`, error);
 };
@@ -68,6 +133,7 @@ const logSupabaseCacheWarning = (action, error) => {
 export const getNearbyAirports = async ({
   query,
   airportCache = createNearbyAirportSupabaseCacheFromEnv(),
+  ourAirportsQueries = createOurAirportsQueriesFromEnv(),
 } = {}) => {
   const airportCacheKey = buildNearbyAirportCacheKey(query);
 
@@ -78,6 +144,29 @@ export const getNearbyAirports = async ({
     } catch (error) {
       logSupabaseCacheWarning("read", error);
     }
+  }
+
+  try {
+    const payload = await getNearbyAirportsFromOurAirports({
+      query,
+      queries: ourAirportsQueries,
+    });
+    if (payload) {
+      if (airportCache) {
+        try {
+          await airportCache.write({
+            cacheKey: airportCacheKey,
+            query,
+            response: payload,
+          });
+        } catch (error) {
+          logSupabaseCacheWarning("write", error);
+        }
+      }
+      return payload;
+    }
+  } catch (error) {
+    console.warn("[airports/nearby] OurAirports nearby query failed", error);
   }
 
   const index = await getCachedAirportIndex({

--- a/src/features/airport/nearby/nearbyAirports.mechanism.test.js
+++ b/src/features/airport/nearby/nearbyAirports.mechanism.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+
+import { getNearbyAirports } from "./nearbyAirports.mechanism.js";
+
+const calls = [];
+
+const payload = await getNearbyAirports({
+  query: {
+    lat: 43.73,
+    lon: -79.45,
+    icao: "",
+    radiusNm: 40,
+    limit: 12,
+    country: "US",
+    minRunwayLength: 5000,
+  },
+  airportCache: null,
+  ourAirportsQueries: {
+    async getNearbyAirportsByPosition(options) {
+      calls.push({ type: "nearby", options });
+      return [
+        {
+          ident: "CYYZ",
+          icao: "CYYZ",
+          iata: "YYZ",
+          name: "Toronto Pearson International Airport",
+          country: "CA",
+          lat: 43.6772,
+          lon: -79.6306,
+          distanceNm: 8.7,
+        },
+      ];
+    },
+    async getRunwaysByAirport(ident) {
+      calls.push({ type: "runways", ident });
+      return [
+        {
+          lengthFt: 11120,
+          closed: false,
+          le: { ident: "05", lat: 43.674, lon: -79.642 },
+          he: { ident: "23", lat: 43.681, lon: -79.62 },
+        },
+      ];
+    },
+  },
+});
+
+assert.equal(payload.source, "ourairports");
+assert.equal(payload.airports[0].icao, "CYYZ");
+assert.equal(payload.airports[0].country, "CA");
+assert.equal(payload.airports[0].runwayMap.airport, "CYYZ");
+assert.deepEqual(
+  calls.map((call) => call.type),
+  ["nearby", "runways"],
+);
+assert.deepEqual(calls[0].options, {
+  lat: 43.73,
+  lon: -79.45,
+  radiusNm: 40,
+  limit: 96,
+  excludeIdent: "",
+});
+
+console.log("nearbyAirports.mechanism.test.js ok");


### PR DESCRIPTION
## Summary
- Use the global OurAirports coordinate query for flight-page nearby airports instead of the old US-scoped AIRAC index.
- Attach OurAirports runway maps and filter by qualifying runway length before returning flight nearby airport markers.
- Bump the nearby-airport cache key so production does not reuse US-scoped empty responses.

## Test Plan
- pnpm test
- pnpm lint
- pnpm build
- Local verification: /aircraft/FLE648 showed YYZ/CYYZ and CYZD nearby airport markers around Toronto.