### PR TITLE
[codex] fix flight tracking oceanic fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,6 @@
 # ADSBao — Codex Guide
 
 Use `CLAUDE.md` as the canonical local agent guide for this repository.
+
+For end-to-end verification, push the work to a PR first, then use the Vercel
+preview URL generated for that PR as the verification target.

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -17,6 +17,7 @@ import {
 import { buildGreatCirclePath } from "@/features/aviation/flight-routes/greatCircleRouteModel.js";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled.js";
 import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel.js";
+import { mergeTrackedAircraftIntoNearby } from "@/features/airport/explorer/airportExplorerModel.js";
 
 // These map helpers import Leaflet, which evaluates `window` at module
 // top — SSR-incompatible. Dynamic-import keeps those helpers
@@ -190,12 +191,10 @@ function FlightExplorerContent({ callsign }) {
   // Merge tracked aircraft into the nearby list so the map always renders
   // it (the radius poll can lag a beat behind the callsign poll).
   const rawAircraft = useMemo(() => {
-    if (!trackedAircraft) return nearbyAircraft;
-    const trackedKey = getAircraftIdentity(trackedAircraft);
-    const alreadyIn = nearbyAircraft.some(
-      (entry) => getAircraftIdentity(entry) === trackedKey,
-    );
-    return alreadyIn ? nearbyAircraft : [trackedAircraft, ...nearbyAircraft];
+    return mergeTrackedAircraftIntoNearby({
+      trackedAircraft,
+      nearbyAircraft,
+    });
   }, [trackedAircraft, nearbyAircraft]);
 
   // Look up routes for the tracked aircraft and any nearby traffic the user

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.js
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.js
@@ -217,7 +217,7 @@ export function buildFlightAwareFallbackUrl(callsign) {
 }
 
 export function isFlightAwareFallbackEnabled(env = process.env) {
-  return String(env?.FLIGHTAWARE_FALLBACK_ENABLED || "").toLowerCase() === "true";
+  return String(env?.FLIGHTAWARE_FALLBACK_ENABLED || "true").toLowerCase() !== "false";
 }
 
 export function parseFlightAwareFallbackPage({ callsign, html, fetchedAt } = {}) {

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js
@@ -146,6 +146,23 @@ assert.equal(buildFlightAwareFallbackUrl("bad-call"), "");
 {
   clearFlightAwareFallbackCache();
   let fetchCalls = 0;
+  const enabledByDefault = await getFlightAwareFallbackByCallsign("AAL100", {
+    env: {},
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response(activeHtml, { status: 200 });
+    },
+    now: () => Date.parse(fetchedAt),
+  });
+
+  assert.equal(enabledByDefault.ok, true);
+  assert.equal(enabledByDefault.hasPosition, true);
+  assert.equal(fetchCalls, 1);
+}
+
+{
+  clearFlightAwareFallbackCache();
+  let fetchCalls = 0;
   const disabled = await getFlightAwareFallbackByCallsign("AAL100", {
     env: { FLIGHTAWARE_FALLBACK_ENABLED: "false" },
     fetchImpl: async () => {

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.js
@@ -1,3 +1,8 @@
+export const LOST_SIGNAL_MISS_THRESHOLD = 20;
+
+const ACTIVE_FLIGHTAWARE_STATUS =
+  /\b(enroute|airborne|in[-\s]?flight|departed|active)\b/i;
+
 export function getLostSignalTraceRefreshKey({
   lostSignal = false,
   pollVersion = 0,
@@ -5,4 +10,33 @@ export function getLostSignalTraceRefreshKey({
   const version = Number(pollVersion);
   if (!lostSignal || !Number.isFinite(version) || version <= 0) return "";
   return `lost-signal:${version}`;
+}
+
+export function hasActiveFlightAwareFallback(fallback) {
+  if (!fallback || typeof fallback !== "object") return false;
+  if (fallback.ok !== true) return false;
+  if (fallback.hasPosition === true) return true;
+
+  const status = String(
+    fallback.metadata?.status || fallback.position?.quality?.status || "",
+  ).trim();
+  return ACTIVE_FLIGHTAWARE_STATUS.test(status);
+}
+
+export function getTrackedAircraftSignalState({
+  matchesLength = 0,
+  previousMisses = 0,
+  flightAwareFallback = null,
+  threshold = LOST_SIGNAL_MISS_THRESHOLD,
+} = {}) {
+  if (Number(matchesLength) > 0 || hasActiveFlightAwareFallback(flightAwareFallback)) {
+    return { misses: 0, lostSignal: false };
+  }
+
+  const misses = Math.max(0, Number(previousMisses) || 0) + 1;
+  const normalizedThreshold = Math.max(1, Number(threshold) || 1);
+  return {
+    misses,
+    lostSignal: misses >= normalizedThreshold,
+  };
 }

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
-import { getLostSignalTraceRefreshKey } from "./lostSignalTrackingModel.js";
+import {
+  getLostSignalTraceRefreshKey,
+  getTrackedAircraftSignalState,
+} from "./lostSignalTrackingModel.js";
 
 assert.equal(
   getLostSignalTraceRefreshKey({ lostSignal: false, pollVersion: 12 }),
@@ -20,6 +23,35 @@ assert.equal(
 assert.equal(
   getLostSignalTraceRefreshKey({ lostSignal: true, pollVersion: 0 }),
   "",
+);
+
+assert.deepEqual(
+  getTrackedAircraftSignalState({
+    matchesLength: 0,
+    previousMisses: 2,
+    flightAwareFallback: {
+      ok: true,
+      hasPosition: false,
+      metadata: { status: "enroute" },
+    },
+  }),
+  { misses: 0, lostSignal: false },
+);
+
+assert.deepEqual(
+  getTrackedAircraftSignalState({
+    matchesLength: 0,
+    previousMisses: 19,
+  }),
+  { misses: 20, lostSignal: true },
+);
+
+assert.deepEqual(
+  getTrackedAircraftSignalState({
+    matchesLength: 1,
+    previousMisses: 19,
+  }),
+  { misses: 0, lostSignal: false },
 );
 
 console.log("lostSignalTrackingModel.test.js ok");

--- a/src/features/airport/explorer/airportExplorerModel.js
+++ b/src/features/airport/explorer/airportExplorerModel.js
@@ -57,6 +57,49 @@ export function enrichAircraftWithRoutes({
 
 const aircraftSelectionId = (aircraft) => aircraft?.icao24 || aircraft?.callsign || "";
 
+const LIVE_POSITION_FIELDS = [
+  "lat",
+  "lon",
+  "altitude",
+  "baroRate",
+  "geomRate",
+  "navAltitudeMcp",
+  "onGround",
+  "velocity",
+  "track",
+  "positionTime",
+  "receiveTime",
+  "positionQuality",
+];
+
+export function mergeTrackedAircraftIntoNearby({
+  trackedAircraft = null,
+  nearbyAircraft = [],
+} = {}) {
+  if (!trackedAircraft) return nearbyAircraft;
+
+  const trackedKey = aircraftSelectionId(trackedAircraft);
+  const matchIndex = nearbyAircraft.findIndex(
+    (item) => trackedKey && aircraftSelectionId(item) === trackedKey,
+  );
+
+  if (matchIndex < 0) return [trackedAircraft, ...nearbyAircraft];
+
+  const nearbyMatch = nearbyAircraft[matchIndex];
+  const merged = {
+    ...nearbyMatch,
+    ...trackedAircraft,
+  };
+
+  for (const field of LIVE_POSITION_FIELDS) {
+    if (nearbyMatch[field] != null) merged[field] = nearbyMatch[field];
+  }
+
+  return nearbyAircraft.map((item, index) =>
+    index === matchIndex ? merged : item,
+  );
+}
+
 export function resolveAirportExplorerSelection({
   aircraft = [],
   selectedAircraftId = "",

--- a/src/features/airport/explorer/airportExplorerModel.test.js
+++ b/src/features/airport/explorer/airportExplorerModel.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import {
   enrichAircraftWithRoutes,
+  mergeTrackedAircraftIntoNearby,
   resolveAirportProfile,
   resolveAirportExplorerSelection,
 } from "./airportExplorerModel.js";
@@ -88,3 +89,40 @@ const missingSelection = resolveAirportExplorerSelection({
 assert.equal(missingSelection.selectedAircraft, null);
 assert.equal(missingSelection.selectedAircraftStillVisible, false);
 assert.equal(missingSelection.selectedAirport, null);
+
+const mergedTracked = mergeTrackedAircraftIntoNearby({
+  trackedAircraft: {
+    icao24: "406e10",
+    callsign: "VIR26Q",
+    origin: "JFK",
+    destination: "LHR",
+    route: "JFK LHR",
+    flightRoute: {
+      origin: { iata: "JFK" },
+      destination: { iata: "LHR" },
+    },
+    flightRouteLabel: "JFK -> LHR",
+    lat: 46.1,
+    lon: -64.1,
+    altitude: 41000,
+    positionTime: 1,
+  },
+  nearbyAircraft: [
+    {
+      icao24: "406e10",
+      callsign: "G-VDIA",
+      lat: 46.5,
+      lon: -63.5,
+      altitude: 40975,
+      positionTime: 2,
+    },
+  ],
+});
+
+assert.equal(mergedTracked.length, 1);
+assert.equal(mergedTracked[0].callsign, "VIR26Q");
+assert.equal(mergedTracked[0].origin, "JFK");
+assert.equal(mergedTracked[0].destination, "LHR");
+assert.equal(mergedTracked[0].flightRouteLabel, "JFK -> LHR");
+assert.equal(mergedTracked[0].lat, 46.5);
+assert.equal(mergedTracked[0].altitude, 40975);

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -7,18 +7,14 @@ import {
   normalizeAdsbAircraft,
 } from "../features/aircraft/positions/aircraftPositionsModel.js";
 import {
+  getTrackedAircraftSignalState,
+} from "../features/aircraft/tracking/lostSignalTrackingModel.js";
+import {
   AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
   scheduleAfterOverlayPaint,
   shouldShowAircraftLoadingOverlay,
   shouldTriggerVisibilityRefreshOverlay,
 } from "../features/aircraft/positions/aircraftLoadingOverlayModel.js";
-
-// Number of consecutive empty callsign responses (no aircraft reporting
-// for that callsign) before we surface lostSignal=true to callers. With
-// the standard 3s poll interval this is ~9s of silence — long enough to
-// ride out a single dropped sample but short enough to react when the
-// flight actually lands.
-const LOST_SIGNAL_THRESHOLD = 3;
 
 const waitUntil = (timestamp) => {
   const delay = Math.max(0, timestamp - Date.now());
@@ -107,13 +103,17 @@ export function useTrackedAircraft(callsign) {
         if (matches.length === 0) {
           // No matches: don't blank the aircraft snapshot — the user
           // is probably watching a flight that just landed and we want
-          // to keep the last position visible while the overlay asks
-          // them what to do. The threshold avoids flapping on a single
-          // dropped sample.
-          missesRef.current += 1;
-          if (missesRef.current >= LOST_SIGNAL_THRESHOLD) {
-            setLostSignal(true);
-          }
+          // to keep the last position visible while the overlay asks them
+          // what to do. Cross-ocean flights can disappear from ADS-B
+          // callsign lookup while FlightAware still knows they are enroute,
+          // so the state model accounts for that benchmark before warning.
+          const signalState = getTrackedAircraftSignalState({
+            matchesLength: matches.length,
+            previousMisses: missesRef.current,
+            flightAwareFallback: payload?.flightAwareFallback,
+          });
+          missesRef.current = signalState.misses;
+          setLostSignal(signalState.lostSignal);
         } else {
           // Pick the freshest entry — multiple aircraft can share a
           // callsign across operators; the one currently broadcasting is


### PR DESCRIPTION
## Summary
- make FlightAware fallback active by default for tracked aircraft callsign lookup, while preserving explicit opt-out with `FLIGHTAWARE_FALLBACK_ENABLED=false`
- make lost-signal detection more conservative for oceanic flights and suppress false alerts when FlightAware still reports an active flight
- preserve tracked-flight callsign/route metadata when merging the focal aircraft with fresher nearby ADS-B position rows
- document that end-to-end verification should use PR-generated Vercel preview URLs

## Root Cause
Oceanic flights can temporarily disappear from ADS-B callsign lookups even while FlightAware still reports the flight in progress. The UI treated three empty callsign polls as a stopped-reporting flight, and the nearby-aircraft merge could replace the focal callsign/route metadata with a registration-only row for the same ICAO24 hex.

## Validation
- `pnpm test` — 80 test files passed
- `pnpm lint`
- `pnpm build`
