### PR TITLE
Fix flight tracking loading state

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewType.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewType.jsx
@@ -1,13 +1,12 @@
 "use client";
 
+import { getAircraftPreviewTypeDisplay } from "@/features/aircraft/preview/aircraftPreviewTypeModel.js";
+
 // Aircraft type designator + ADS-B emitter category. Sits next to the
 // silhouette in the card header. Falls back gracefully when one or both
 // fields are missing — the row stays the same height either way.
 export default function AircraftPreviewType({ aircraft }) {
-  const type = (aircraft?.type || "").trim().toUpperCase();
-  const category = (aircraft?.category || "").trim().toUpperCase();
-  const primary = type || category || "Unknown type";
-  const secondary = type && category ? category : null;
+  const { primary, secondary } = getAircraftPreviewTypeDisplay(aircraft);
 
   return (
     <div className="aircraft-preview-type">

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -14,6 +14,10 @@ import {
 import {
   getLostSignalTraceRefreshKey,
 } from "@/features/aircraft/tracking/lostSignalTrackingModel.js";
+import {
+  getFlightTrackingContextPosition,
+  shouldShowFlightTrackingLoadingOverlay,
+} from "@/features/aircraft/tracking/flightTrackingContextModel.js";
 import { buildGreatCirclePath } from "@/features/aviation/flight-routes/greatCircleRouteModel.js";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled.js";
 import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel.js";
@@ -161,21 +165,28 @@ function FlightExplorerContent({ callsign }) {
   }
   const focalLat = lastKnownRef.current.lat;
   const focalLon = lastKnownRef.current.lon;
+  const contextPosition = useMemo(
+    () =>
+      getFlightTrackingContextPosition({
+        lat: focalLat,
+        lon: focalLon,
+      }),
+    [focalLat, focalLon],
+  );
+  const contextLat = contextPosition?.lat ?? null;
+  const contextLon = contextPosition?.lon ?? null;
 
   const {
     aircraft: nearbyAircraft,
-    loadingOverlayActive: nearbyLoadingOverlayActive,
-    settled: nearbyAircraftSettled,
-  } = useAircraftPositions(callsign || "", focalLat, focalLon);
+  } = useAircraftPositions(callsign || "", contextLat, contextLon);
 
   // Pull airports around the focal so the sidebar list and the map's
   // airport layer both show context relative to the moving flight.
   const {
     airports: nearbyAirports,
-    settled: nearbyAirportsSettled,
   } = useNearbyAirports({
-    lat: focalLat || 0,
-    lon: focalLon || 0,
+    lat: contextLat,
+    lon: contextLon,
     radiusNm: 40,
     limit: 12,
   });
@@ -291,11 +302,11 @@ function FlightExplorerContent({ callsign }) {
     lastUpdated,
     onBack: handleBack,
   };
-  const hasFocalLocation = focalLat != null && focalLon != null;
-  const flightCriticalLoadingSettled =
-    trackedAircraftSettled &&
-    (!hasFocalLocation ||
-      (nearbyAircraftSettled && nearbyAirportsSettled));
+  const flightTrackingLoadingActive = shouldShowFlightTrackingLoadingOverlay({
+    hasActiveFlight: Boolean(callsign),
+    trackedAircraftSettled,
+    trackedLoadingOverlayActive,
+  });
 
   return (
     <SelectedAircraftTraceProvider
@@ -377,9 +388,7 @@ function FlightExplorerContent({ callsign }) {
             variant="flight"
             callsign={callsign}
             active={
-              !flightCriticalLoadingSettled ||
-              trackedLoadingOverlayActive ||
-              nearbyLoadingOverlayActive
+              flightTrackingLoadingActive
             }
           />
 

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.js
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.js
@@ -23,8 +23,12 @@ export function shouldShowAircraftLoadingOverlay({
 
 export function shouldTriggerVisibilityRefreshOverlay({
   wasActive = false,
+  hiddenSince = 0,
+  now = Date.now(),
+  minHiddenMs = 0,
 } = {}) {
-  return Boolean(wasActive);
+  const hiddenDuration = Math.max(0, Number(now) - Number(hiddenSince));
+  return Boolean(wasActive && hiddenSince > 0 && hiddenDuration >= minHiddenMs);
 }
 
 export function getLoadingOverlayExitDelay({

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js
@@ -38,10 +38,31 @@ assert.equal(
 assert.equal(
   shouldTriggerVisibilityRefreshOverlay({
     wasActive: true,
-    hiddenSince: 0,
-    now: 1_050,
+    hiddenSince: 1_000,
+    now: 7_000,
+    minHiddenMs: 5_000,
   }),
   true,
+);
+
+assert.equal(
+  shouldTriggerVisibilityRefreshOverlay({
+    wasActive: true,
+    hiddenSince: 1_000,
+    now: 1_050,
+    minHiddenMs: 5_000,
+  }),
+  false,
+);
+
+assert.equal(
+  shouldTriggerVisibilityRefreshOverlay({
+    wasActive: true,
+    hiddenSince: 0,
+    now: 7_000,
+    minHiddenMs: 5_000,
+  }),
+  false,
 );
 
 assert.equal(
@@ -49,6 +70,7 @@ assert.equal(
     wasActive: false,
     hiddenSince: 1_000,
     now: 1_050,
+    minHiddenMs: 5_000,
   }),
   false,
 );

--- a/src/features/aircraft/preview/aircraftPreviewTypeModel.js
+++ b/src/features/aircraft/preview/aircraftPreviewTypeModel.js
@@ -1,0 +1,9 @@
+export function getAircraftPreviewTypeDisplay(aircraft) {
+  const type = (aircraft?.type || "").trim().toUpperCase();
+  const category = (aircraft?.category || "").trim().toUpperCase();
+
+  return {
+    primary: type || category || "N/A",
+    secondary: type && category ? category : null,
+  };
+}

--- a/src/features/aircraft/preview/aircraftPreviewTypeModel.test.js
+++ b/src/features/aircraft/preview/aircraftPreviewTypeModel.test.js
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+
+import { getAircraftPreviewTypeDisplay } from "./aircraftPreviewTypeModel.js";
+
+assert.deepEqual(
+  getAircraftPreviewTypeDisplay({ type: " b789 ", category: " a5 " }),
+  {
+    primary: "B789",
+    secondary: "A5",
+  },
+);
+
+assert.deepEqual(
+  getAircraftPreviewTypeDisplay({ category: " a3 " }),
+  {
+    primary: "A3",
+    secondary: null,
+  },
+);
+
+assert.deepEqual(getAircraftPreviewTypeDisplay({}), {
+  primary: "N/A",
+  secondary: null,
+});

--- a/src/features/aircraft/tracking/flightTrackingContextModel.js
+++ b/src/features/aircraft/tracking/flightTrackingContextModel.js
@@ -1,0 +1,55 @@
+import { toFiniteNumber } from "../../../utils/math.js";
+
+export const DEFAULT_TRACKING_CONTEXT_COORDINATE_PRECISION = 1;
+
+export function normalizeLatitude(value) {
+  if (value == null || value === "") return null;
+  const coordinate = toFiniteNumber(value);
+  return coordinate != null && coordinate >= -90 && coordinate <= 90
+    ? coordinate
+    : null;
+}
+
+export function normalizeLongitude(value) {
+  if (value == null || value === "") return null;
+  const coordinate = toFiniteNumber(value);
+  return coordinate != null && coordinate >= -180 && coordinate <= 180
+    ? coordinate
+    : null;
+}
+
+export function hasFiniteFlightPosition({ lat, lon } = {}) {
+  return normalizeLatitude(lat) != null && normalizeLongitude(lon) != null;
+}
+
+export function getFlightTrackingContextPosition({
+  lat,
+  lon,
+  precision = DEFAULT_TRACKING_CONTEXT_COORDINATE_PRECISION,
+} = {}) {
+  const normalizedLat = normalizeLatitude(lat);
+  const normalizedLon = normalizeLongitude(lon);
+  if (normalizedLat == null || normalizedLon == null) return null;
+
+  return {
+    lat: roundCoordinate(normalizedLat, precision),
+    lon: roundCoordinate(normalizedLon, precision),
+  };
+}
+
+export function shouldShowFlightTrackingLoadingOverlay({
+  hasActiveFlight = false,
+  trackedAircraftSettled = false,
+  trackedLoadingOverlayActive = false,
+} = {}) {
+  return Boolean(
+    hasActiveFlight && (!trackedAircraftSettled || trackedLoadingOverlayActive),
+  );
+}
+
+function roundCoordinate(value, precision) {
+  const numericPrecision = Math.max(0, Math.min(6, Number(precision) || 0));
+  const factor = 10 ** numericPrecision;
+  const rounded = Math.round(value * factor) / factor;
+  return Object.is(rounded, -0) ? 0 : rounded;
+}

--- a/src/features/aircraft/tracking/flightTrackingContextModel.test.js
+++ b/src/features/aircraft/tracking/flightTrackingContextModel.test.js
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+
+import {
+  getFlightTrackingContextPosition,
+  hasFiniteFlightPosition,
+  shouldShowFlightTrackingLoadingOverlay,
+} from "./flightTrackingContextModel.js";
+
+assert.equal(hasFiniteFlightPosition({ lat: 0, lon: 0 }), true);
+assert.equal(hasFiniteFlightPosition({ lat: "0", lon: "-0.25" }), true);
+assert.equal(hasFiniteFlightPosition({ lat: 91, lon: 0 }), false);
+assert.equal(hasFiniteFlightPosition({ lat: 0, lon: 181 }), false);
+assert.equal(hasFiniteFlightPosition({ lat: null, lon: 0 }), false);
+
+assert.deepEqual(
+  getFlightTrackingContextPosition({ lat: 51.421, lon: -12.456 }),
+  {
+    lat: 51.4,
+    lon: -12.5,
+  },
+);
+
+assert.deepEqual(
+  getFlightTrackingContextPosition({ lat: 0.04, lon: -0.04 }),
+  {
+    lat: 0,
+    lon: 0,
+  },
+);
+
+assert.equal(
+  shouldShowFlightTrackingLoadingOverlay({
+    hasActiveFlight: true,
+    trackedAircraftSettled: false,
+    trackedLoadingOverlayActive: false,
+  }),
+  true,
+);
+
+assert.equal(
+  shouldShowFlightTrackingLoadingOverlay({
+    hasActiveFlight: true,
+    trackedAircraftSettled: true,
+    trackedLoadingOverlayActive: true,
+  }),
+  true,
+);
+
+assert.equal(
+  shouldShowFlightTrackingLoadingOverlay({
+    hasActiveFlight: true,
+    trackedAircraftSettled: true,
+    trackedLoadingOverlayActive: false,
+    nearbyAircraftSettled: false,
+    nearbyAirportsSettled: false,
+    nearbyLoadingOverlayActive: true,
+  }),
+  false,
+);
+
+assert.equal(
+  shouldShowFlightTrackingLoadingOverlay({
+    hasActiveFlight: false,
+    trackedAircraftSettled: false,
+    trackedLoadingOverlayActive: true,
+  }),
+  false,
+);

--- a/src/hooks/useAircraftPositions.js
+++ b/src/hooks/useAircraftPositions.js
@@ -19,6 +19,11 @@ import {
   shouldShowAircraftLoadingOverlay,
   shouldTriggerVisibilityRefreshOverlay,
 } from "../features/aircraft/positions/aircraftLoadingOverlayModel.js";
+import {
+  hasFiniteFlightPosition,
+  normalizeLatitude,
+  normalizeLongitude,
+} from "../features/aircraft/tracking/flightTrackingContextModel.js";
 
 const HIDDEN_POLL_GRACE_MS = AIRCRAFT_TRAFFIC_CONFIG.hiddenPollGraceMs;
 
@@ -31,7 +36,11 @@ const waitUntil = (timestamp) => {
 };
 
 export function useAircraftPositions(icao, lat, lon) {
-  const hasActiveQuery = Boolean(icao && lat && lon);
+  const queryLat = normalizeLatitude(lat);
+  const queryLon = normalizeLongitude(lon);
+  const hasActiveQuery = Boolean(
+    icao && hasFiniteFlightPosition({ lat: queryLat, lon: queryLon }),
+  );
   const [aircraft, setAircraft] = useState([]);
   const [loading, setLoading] = useState(false);
   const [initialLoading, setInitialLoading] = useState(false);
@@ -67,12 +76,12 @@ export function useAircraftPositions(icao, lat, lon) {
     };
 
     const poll = async ({ commitAfter = 0 } = {}) => {
-      if (!lat || !lon) return;
+      if (queryLat == null || queryLon == null) return;
       setLoading(true);
       try {
         const aircraftJson = await aircraftPositionClient.fetchNearbyAircraft({
-          lat,
-          lon,
+          lat: queryLat,
+          lon: queryLon,
           distNm: DEFAULT_AIRCRAFT_RANGE_NM,
         });
         if (disposed) return;
@@ -144,6 +153,7 @@ export function useAircraftPositions(icao, lat, lon) {
       const showRefreshOverlay = shouldTriggerVisibilityRefreshOverlay({
         wasActive: wasActiveRef.current,
         hiddenSince: hiddenSinceRef.current,
+        minHiddenMs: HIDDEN_POLL_GRACE_MS,
       });
       hiddenSinceRef.current = 0;
       const overlayShownAt = Date.now();
@@ -193,7 +203,7 @@ export function useAircraftPositions(icao, lat, lon) {
       cancelPendingVisibilityRefresh();
       stop();
     };
-  }, [hasActiveQuery, icao, lat, lon]);
+  }, [hasActiveQuery, icao, queryLat, queryLon]);
 
   return {
     aircraft,

--- a/src/hooks/useNearbyAirports.js
+++ b/src/hooks/useNearbyAirports.js
@@ -2,6 +2,10 @@
 
 import { useEffect, useState } from "react";
 import { nearbyAirportClient } from "../features/airport/nearby/nearbyAirportClient.js";
+import {
+  normalizeLatitude,
+  normalizeLongitude,
+} from "../features/aircraft/tracking/flightTrackingContextModel.js";
 
 export function useNearbyAirports({
   icao = "",
@@ -14,12 +18,14 @@ export function useNearbyAirports({
   const [loading, setLoading] = useState(false);
   const [settled, setSettled] = useState(false);
   const [error, setError] = useState(null);
+  const queryLat = normalizeLatitude(lat);
+  const queryLon = normalizeLongitude(lon);
 
   useEffect(() => {
     let disposed = false;
 
     const load = async () => {
-      if (!lat || !lon) {
+      if (queryLat == null || queryLon == null) {
         setAirports([]);
         setError(null);
         setLoading(false);
@@ -33,8 +39,8 @@ export function useNearbyAirports({
       try {
         const payload = await nearbyAirportClient.fetchNearbyAirports({
           icao,
-          lat,
-          lon,
+          lat: queryLat,
+          lon: queryLon,
           radiusNm,
           limit,
         });
@@ -58,7 +64,7 @@ export function useNearbyAirports({
     return () => {
       disposed = true;
     };
-  }, [icao, lat, lon, radiusNm, limit]);
+  }, [icao, queryLat, queryLon, radiusNm, limit]);
 
   return {
     airports,

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -47,6 +47,7 @@ export function useTrackedAircraft(callsign) {
   const timerRef = useRef(null);
   const disposedRef = useRef(false);
   const missesRef = useRef(0);
+  const hiddenSinceRef = useRef(0);
   // Caller can dispatch a manual retry from the overlay. We bounce the
   // poll cadence by incrementing this counter — the effect listens for
   // changes and triggers an immediate fetch.
@@ -151,13 +152,17 @@ export function useTrackedAircraft(callsign) {
     const handleVisibility = () => {
       if (document.hidden) {
         cancelPendingVisibilityRefresh();
+        hiddenSinceRef.current = Date.now();
         stopPolling();
         return;
       }
       cancelPendingVisibilityRefresh();
       const showRefreshOverlay = shouldTriggerVisibilityRefreshOverlay({
         wasActive: hasActiveQuery,
+        hiddenSince: hiddenSinceRef.current,
+        minHiddenMs: AIRCRAFT_TRAFFIC_CONFIG.hiddenPollGraceMs,
       });
+      hiddenSinceRef.current = 0;
       if (showRefreshOverlay) {
         setVisibilityRefreshLoading(true);
       }


### PR DESCRIPTION
## Summary
- show N/A instead of Unknown type when FlightAware-only tracked aircraft lack ADS-B type metadata
- keep the flight tracking overlay tied to the focal aircraft load instead of nearby context refreshes
- quantize flight context refresh coordinates and treat zero latitude/longitude as valid coordinates
- only show visibility-return refresh overlay after the page was hidden longer than the poll grace window

## Verification
- node src/features/aircraft/preview/aircraftPreviewTypeModel.test.js && node src/features/aircraft/tracking/flightTrackingContextModel.test.js && node src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js
- pnpm test
- pnpm lint
- pnpm build