### PR TITLE
Detect arrived FlightAware tracking fallback

### DIFF
--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.js
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.js
@@ -131,6 +131,22 @@ function normalizePositionKind({ point, flight }) {
   return "observed";
 }
 
+function isTerminalFlight(flight, status = "") {
+  if (!flight || typeof flight !== "object") return false;
+  if (
+    flight?.landingTimes?.actual != null ||
+    flight?.gateArrivalTimes?.actual != null ||
+    flight?.cancelled ||
+    flight?.resultUnknown
+  ) {
+    return true;
+  }
+
+  return /\b(arrived|landed|cancelled|canceled|diverted|result unknown)\b/i.test(
+    status,
+  );
+}
+
 function selectBestFlight(flights) {
   const list = Object.values(flights || {}).filter(
     (flight) => flight && typeof flight === "object",
@@ -192,6 +208,8 @@ function buildMetadata({ callsign, flight, fetchedAt, html }) {
   const planSpeed = toNumber(flight?.flightPlan?.speed);
   const planAltitude = altitudeFt(flight?.flightPlan?.altitude);
   const sourceUpdatedAt = timestampIso(flight?.timestamp);
+  const status = cleanString(flight?.flightStatus) || undefined;
+  const terminal = isTerminalFlight(flight, status);
 
   return {
     callsign,
@@ -203,7 +221,8 @@ function buildMetadata({ callsign, flight, fetchedAt, html }) {
     groundSpeedKt: toNumber(flight?.groundspeed) ?? planSpeed ?? undefined,
     groundSpeedMph: undefined,
     trackDeg: toNumber(flight?.heading) ?? undefined,
-    status: cleanString(flight?.flightStatus) || undefined,
+    status,
+    terminal,
     sourceUpdatedAt,
     fetchedAt,
     notes: ["flightaware-public-page"],
@@ -287,6 +306,8 @@ export function parseFlightAwareFallbackPage({ callsign, html, fetchedAt } = {})
       origin: metadata.origin,
       destination: metadata.destination,
       route: metadata.route,
+      status: metadata.status,
+      terminal: metadata.terminal,
       quality: {
         source: "flightaware",
         kind,
@@ -297,6 +318,8 @@ export function parseFlightAwareFallbackPage({ callsign, html, fetchedAt } = {})
         sourceUpdatedAt,
         fetchedAt: fetched,
         confidence: kind === "observed" ? "medium" : "low",
+        status: metadata.status,
+        terminal: metadata.terminal,
         notes: ["flightaware-public-page"],
       },
     },

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js
@@ -60,6 +60,37 @@ const metadataOnlyHtml = `
       }
     }};
   </script>
+	`;
+
+const arrivedHtml = `
+  <title>BA242 (BAW242) British Airways Flight Tracking and History - FlightAware</title>
+  <meta name="origin" content="MMMX" />
+  <meta name="destination" content="EGLL" />
+  <script>
+    var trackpollBootstrap = {"version":"2.24","flights":{
+      "BAW242-1":{
+        "ident":"BAW242",
+        "displayIdent":"BAW242",
+        "flightStatus":"arrived",
+        "historical":false,
+        "coord":null,
+        "altitude":null,
+        "groundspeed":null,
+        "heading":null,
+        "timestamp":1779721705,
+        "landingTimes":{"actual":1779721260},
+        "gateArrivalTimes":{"actual":1779721680},
+        "origin":{"icao":"MMMX","iata":"MEX","friendlyName":"Mexico City Intl","coord":[-99.0721,19.4363]},
+        "destination":{"icao":"EGLL","iata":"LHR","friendlyName":"London Heathrow","coord":[-0.4614,51.4775]},
+        "flightPlan":{"speed":488,"altitude":410,"route":"NATV DOGAL"},
+        "track":[
+          {"timestamp":1779721196,"coord":[-0.5086,51.4774],"alt":0,"gs":147,"type":"","isolated":false},
+          {"timestamp":1779721212,"coord":[-0.4884,51.4775],"alt":0,"gs":153,"type":"","isolated":false}
+        ],
+        "updateType":""
+      }
+    }};
+  </script>
 `;
 
 assert.equal(
@@ -107,6 +138,23 @@ assert.equal(buildFlightAwareFallbackUrl("bad-call"), "");
   assert.equal(result.metadata.altitudeFt, 37000);
   assert.equal(result.metadata.groundSpeedKt, 464);
   assert.equal("raw" in result, false);
+}
+
+{
+  const result = parseFlightAwareFallbackPage({
+    callsign: "BAW242",
+    html: arrivedHtml,
+    fetchedAt,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.hasPosition, true);
+  assert.equal(result.position.altitudeFt, 0);
+  assert.equal(result.position.status, "arrived");
+  assert.equal(result.position.terminal, true);
+  assert.equal(result.position.quality.status, "arrived");
+  assert.equal(result.position.quality.terminal, true);
+  assert.equal(result.position.quality.sourceUpdatedAt, "2026-05-25T15:00:12.000Z");
 }
 
 {

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.js
@@ -2,6 +2,33 @@ export const LOST_SIGNAL_MISS_THRESHOLD = 20;
 
 const ACTIVE_FLIGHTAWARE_STATUS =
   /\b(enroute|airborne|in[-\s]?flight|departed|active)\b/i;
+const TERMINAL_FLIGHTAWARE_STATUS =
+  /\b(arrived|landed|cancelled|canceled|diverted|result unknown)\b/i;
+
+export function getActiveAdsbMatchesLength({ matchesLength = 0, source = "" } = {}) {
+  if (String(source || "").trim().toLowerCase() === "flightaware") return 0;
+  return Math.max(0, Number(matchesLength) || 0);
+}
+
+export function hasTerminalFlightAwareFallback(fallback) {
+  if (!fallback || typeof fallback !== "object") return false;
+  if (fallback.ok !== true) return false;
+  if (
+    fallback.position?.terminal === true ||
+    fallback.position?.quality?.terminal === true ||
+    fallback.metadata?.terminal === true
+  ) {
+    return true;
+  }
+
+  const status = String(
+    fallback.metadata?.status ||
+      fallback.position?.status ||
+      fallback.position?.quality?.status ||
+      "",
+  ).trim();
+  return TERMINAL_FLIGHTAWARE_STATUS.test(status);
+}
 
 export function getLostSignalTraceRefreshKey({
   lostSignal = false,
@@ -15,6 +42,7 @@ export function getLostSignalTraceRefreshKey({
 export function hasActiveFlightAwareFallback(fallback) {
   if (!fallback || typeof fallback !== "object") return false;
   if (fallback.ok !== true) return false;
+  if (hasTerminalFlightAwareFallback(fallback)) return false;
   if (fallback.hasPosition === true) return true;
 
   const status = String(
@@ -29,12 +57,18 @@ export function getTrackedAircraftSignalState({
   flightAwareFallback = null,
   threshold = LOST_SIGNAL_MISS_THRESHOLD,
 } = {}) {
-  if (Number(matchesLength) > 0 || hasActiveFlightAwareFallback(flightAwareFallback)) {
+  const normalizedThreshold = Math.max(1, Number(threshold) || 1);
+  if (Number(matchesLength) > 0) {
+    return { misses: 0, lostSignal: false };
+  }
+  if (hasTerminalFlightAwareFallback(flightAwareFallback)) {
+    return { misses: normalizedThreshold, lostSignal: true };
+  }
+  if (hasActiveFlightAwareFallback(flightAwareFallback)) {
     return { misses: 0, lostSignal: false };
   }
 
   const misses = Math.max(0, Number(previousMisses) || 0) + 1;
-  const normalizedThreshold = Math.max(1, Number(threshold) || 1);
   return {
     misses,
     lostSignal: misses >= normalizedThreshold,

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 
 import {
+  getActiveAdsbMatchesLength,
   getLostSignalTraceRefreshKey,
   getTrackedAircraftSignalState,
+  hasActiveFlightAwareFallback,
 } from "./lostSignalTrackingModel.js";
 
 assert.equal(
@@ -36,6 +38,60 @@ assert.deepEqual(
     },
   }),
   { misses: 0, lostSignal: false },
+);
+
+assert.equal(
+  hasActiveFlightAwareFallback({
+    ok: true,
+    hasPosition: true,
+    position: {
+      status: "arrived",
+    },
+  }),
+  false,
+);
+
+assert.equal(
+  hasActiveFlightAwareFallback({
+    ok: true,
+    hasPosition: true,
+    position: {
+      status: "arriving shortly",
+    },
+  }),
+  true,
+);
+
+assert.deepEqual(
+  getTrackedAircraftSignalState({
+    matchesLength: 0,
+    previousMisses: 0,
+    flightAwareFallback: {
+      ok: true,
+      hasPosition: true,
+      position: {
+        status: "arrived",
+        terminal: true,
+      },
+    },
+  }),
+  { misses: 20, lostSignal: true },
+);
+
+assert.equal(
+  getActiveAdsbMatchesLength({
+    matchesLength: 1,
+    source: "flightaware",
+  }),
+  0,
+);
+
+assert.equal(
+  getActiveAdsbMatchesLength({
+    matchesLength: 1,
+    source: "adsb.lol",
+  }),
+  1,
 );
 
 assert.deepEqual(

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -7,6 +7,7 @@ import {
   normalizeAdsbAircraft,
 } from "../features/aircraft/positions/aircraftPositionsModel.js";
 import {
+  getActiveAdsbMatchesLength,
   getTrackedAircraftSignalState,
 } from "../features/aircraft/tracking/lostSignalTrackingModel.js";
 import {
@@ -96,6 +97,14 @@ export function useTrackedAircraft(callsign) {
         if (disposedRef.current) return;
         const matches = Array.isArray(payload?.ac) ? payload.ac : [];
         const receiveTime = Date.now();
+        const signalState = getTrackedAircraftSignalState({
+          matchesLength: getActiveAdsbMatchesLength({
+            matchesLength: matches.length,
+            source: payload?.source,
+          }),
+          previousMisses: missesRef.current,
+          flightAwareFallback: payload?.flightAwareFallback,
+        });
         await waitUntil(commitAfter);
         if (disposedRef.current) return;
         setSettled(true);
@@ -108,11 +117,6 @@ export function useTrackedAircraft(callsign) {
           // what to do. Cross-ocean flights can disappear from ADS-B
           // callsign lookup while FlightAware still knows they are enroute,
           // so the state model accounts for that benchmark before warning.
-          const signalState = getTrackedAircraftSignalState({
-            matchesLength: matches.length,
-            previousMisses: missesRef.current,
-            flightAwareFallback: payload?.flightAwareFallback,
-          });
           missesRef.current = signalState.misses;
           setLostSignal(signalState.lostSignal);
         } else {
@@ -125,8 +129,8 @@ export function useTrackedAircraft(callsign) {
             receiveTime,
           });
           setAircraft(normalized);
-          missesRef.current = 0;
-          setLostSignal(false);
+          missesRef.current = signalState.misses;
+          setLostSignal(signalState.lostSignal);
         }
         setFeedSource(
           typeof payload?.source === "string" ? payload.source : "",


### PR DESCRIPTION
## Summary
- carry FlightAware terminal arrival status through fallback parsing
- treat FlightAware fallback-only pseudo positions as non-ADS-B matches in tracked signal state
- trigger the lost-signal confirmation immediately for terminal FlightAware fallbacks while preserving active enroute fallback behavior

## Verification
- node src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js && node src/features/aircraft/tracking/lostSignalTrackingModel.test.js
- pnpm lint
- pnpm test
- pnpm build