### PR TITLE
[codex] Fix tracking tab freshness

### DIFF
--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.js
@@ -43,7 +43,10 @@ export async function GET(request, { params }) {
       .trim()
       .toLowerCase();
     const providerSpecificRequest = requestedProvider === "flightaware";
-    const body = await resolveFlightRoute({ callsign });
+    const body = await resolveFlightRoute({
+      callsign,
+      requestedProvider,
+    });
 
     return Response.json(body, {
       status: body ? 200 : ROUTE_MISS_STATUS,

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -178,7 +178,9 @@ function FlightExplorerContent({ callsign }) {
 
   const {
     aircraft: nearbyAircraft,
-  } = useAircraftPositions(callsign || "", contextLat, contextLon);
+  } = useAircraftPositions(callsign || "", contextLat, contextLon, {
+    pollWhenHidden: true,
+  });
 
   // Pull airports around the focal so the sidebar list and the map's
   // airport layer both show context relative to the moving flight.

--- a/src/features/aircraft/positions/aircraftVisibilityPollingModel.js
+++ b/src/features/aircraft/positions/aircraftVisibilityPollingModel.js
@@ -1,0 +1,34 @@
+import {
+  shouldTriggerVisibilityRefreshOverlay,
+} from "./aircraftLoadingOverlayModel.js";
+
+export function resolveAircraftVisibilityPolling({
+  documentHidden = false,
+  hasActiveQuery = false,
+  wasActive = false,
+  pollWhenHidden = false,
+  hiddenSince = 0,
+  now = Date.now(),
+  minHiddenMs = 0,
+} = {}) {
+  const active = Boolean(hasActiveQuery || wasActive);
+
+  if (documentHidden) {
+    return {
+      shouldStopPolling: Boolean(active && !pollWhenHidden),
+      shouldRefreshNow: false,
+      shouldShowRefreshOverlay: false,
+    };
+  }
+
+  return {
+    shouldStopPolling: false,
+    shouldRefreshNow: Boolean(active),
+    shouldShowRefreshOverlay: shouldTriggerVisibilityRefreshOverlay({
+      wasActive: active,
+      hiddenSince,
+      now,
+      minHiddenMs,
+    }),
+  };
+}

--- a/src/features/aircraft/positions/aircraftVisibilityPollingModel.test.js
+++ b/src/features/aircraft/positions/aircraftVisibilityPollingModel.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+
+import {
+  resolveAircraftVisibilityPolling,
+} from "./aircraftVisibilityPollingModel.js";
+
+assert.deepEqual(
+  resolveAircraftVisibilityPolling({
+    documentHidden: true,
+    hasActiveQuery: true,
+    pollWhenHidden: false,
+  }),
+  {
+    shouldStopPolling: true,
+    shouldRefreshNow: false,
+    shouldShowRefreshOverlay: false,
+  },
+);
+
+assert.deepEqual(
+  resolveAircraftVisibilityPolling({
+    documentHidden: true,
+    hasActiveQuery: true,
+    pollWhenHidden: true,
+  }),
+  {
+    shouldStopPolling: false,
+    shouldRefreshNow: false,
+    shouldShowRefreshOverlay: false,
+  },
+);
+
+assert.deepEqual(
+  resolveAircraftVisibilityPolling({
+    documentHidden: false,
+    hasActiveQuery: true,
+    wasActive: true,
+    hiddenSince: 1_000,
+    now: 8_000,
+    minHiddenMs: 5_000,
+  }),
+  {
+    shouldStopPolling: false,
+    shouldRefreshNow: true,
+    shouldShowRefreshOverlay: true,
+  },
+);
+
+assert.deepEqual(
+  resolveAircraftVisibilityPolling({
+    documentHidden: false,
+    hasActiveQuery: false,
+    wasActive: false,
+    hiddenSince: 1_000,
+    now: 8_000,
+    minHiddenMs: 5_000,
+  }),
+  {
+    shouldStopPolling: false,
+    shouldRefreshNow: false,
+    shouldShowRefreshOverlay: false,
+  },
+);
+
+console.log("aircraftVisibilityPollingModel.test.js ok");

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.js
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.js
@@ -36,6 +36,18 @@ export function getFreshRouteCacheEntry(
   return null;
 }
 
+export function writeRouteCacheEntry(cache, callsign, route, time, routeContext = {}) {
+  const cacheKeys = new Set(
+    [callsign, route?.callsign, route?.callsignIcao, route?.callsignIata]
+      .map((value) => buildRouteCacheKey(value, routeContext))
+      .filter(Boolean),
+  );
+
+  for (const cacheKey of cacheKeys) {
+    cache.set(cacheKey, { route, time });
+  }
+}
+
 export function getLookupCallsigns(aircraft) {
   return [
     ...new Set(

--- a/src/features/aviation/flight-routes/flightRouteScheduler.js
+++ b/src/features/aviation/flight-routes/flightRouteScheduler.js
@@ -6,6 +6,7 @@ import {
   buildRoutesByCallsign,
   getRouteLookupStats,
   resolvePendingRouteLookups,
+  writeRouteCacheEntry,
 } from "./flightRouteLookupModel.js";
 
 function callsignSetForRouteContext(keys, routeContext) {
@@ -100,7 +101,12 @@ export function createFlightRouteScheduler({
     auditRouteQueue();
     try {
       const route = await client.fetchFlightRoute(callsign, routeContext);
-      cache.set(cacheKey, { route, time: now() });
+      const timestamp = now();
+      if (route) {
+        writeRouteCacheEntry(cache, callsign, route, timestamp, routeContext);
+      } else {
+        cache.set(cacheKey, { route: null, time: timestamp });
+      }
       auditRouteQueue();
     } catch (error) {
       logger.warn?.(

--- a/src/features/aviation/flight-routes/flightRouteScheduler.test.js
+++ b/src/features/aviation/flight-routes/flightRouteScheduler.test.js
@@ -138,3 +138,51 @@ function createManualTimer() {
   assert.equal(timer.callbacks.length, 0);
   scheduler.dispose();
 }
+
+{
+  const timer = createManualTimer();
+  const route = {
+    callsign: "VIR26Q",
+    callsignIcao: "VIR26Q",
+    callsignIata: "VS26Q",
+    origin: { icao: "KJFK", iata: "JFK" },
+    destination: { icao: "EGLL", iata: "LHR" },
+  };
+  const scheduler = createFlightRouteScheduler({
+    client: {
+      async fetchFlightRoute() {
+        return route;
+      },
+    },
+    config: {
+      maxConcurrentLookups: 1,
+      maxLookupsPerPass: 2,
+      maxQueueSize: 10,
+      queueIntervalMs: 0,
+      auditLogIntervalMs: 0,
+      hitCacheMs: 60_000,
+      missCacheMs: 10_000,
+    },
+    logger: { info() {}, warn() {} },
+    schedule: timer.schedule,
+    clearSchedule: timer.clear,
+    now: () => 1_700_000_000_000,
+  });
+
+  const routeContext = { routeProvider: "flightaware" };
+  scheduler.syncAircraft({
+    aircraft: [{ callsign: "VIR26Q" }],
+    routeContext,
+  });
+  timer.runNext();
+  await flushPromises();
+
+  assert.deepEqual(
+    scheduler.getRoutesByCallsign({
+      aircraft: [{ callsign: "VS26Q" }],
+      routeContext,
+    }),
+    { VS26Q: route },
+  );
+  scheduler.dispose();
+}

--- a/src/features/aviation/flight-routes/flightRoutes.mechanism.js
+++ b/src/features/aviation/flight-routes/flightRoutes.mechanism.js
@@ -157,6 +157,7 @@ async function readCommunityFeedbackOverride({
 //   3. All other users → adsbdb.
 export const resolveFlightRoute = async ({
   callsign,
+  requestedProvider = "",
   feedbackRepository = createRouteFeedbackReportsRepositoryFromEnv(),
   shouldUseFlightAwareRouteProvider = isFlightAwareRouteProviderEnabled,
   fetchFlightAwareRoute: fetchFlightAwareRouteImpl = fetchFlightAwareRoute,
@@ -171,9 +172,10 @@ export const resolveFlightRoute = async ({
   });
   if (override) return override;
 
-  let useFlightAware = false;
+  const provider = String(requestedProvider || "").trim().toLowerCase();
+  let flightAwareAllowed = false;
   try {
-    useFlightAware = Boolean(
+    flightAwareAllowed = Boolean(
       await shouldUseFlightAwareRouteProvider(normalizedCallsign),
     );
   } catch (err) {
@@ -182,6 +184,9 @@ export const resolveFlightRoute = async ({
       err.message,
     );
   }
+
+  const useFlightAware =
+    flightAwareAllowed && (provider === "flightaware" || provider === "");
 
   if (useFlightAware) {
     return fetchFlightAwareRouteImpl(normalizedCallsign);

--- a/src/features/aviation/flight-routes/flightRoutes.mechanism.test.js
+++ b/src/features/aviation/flight-routes/flightRoutes.mechanism.test.js
@@ -63,6 +63,48 @@ const OVERRIDE_ROUTE = Object.freeze({
   const calls = [];
   const route = await resolveFlightRoute({
     callsign: "AAL1234",
+    requestedProvider: "flightaware",
+    feedbackRepository: null,
+    shouldUseFlightAwareRouteProvider: async () => true,
+    fetchFlightAwareRoute: async () => {
+      calls.push("flightaware");
+      return FLIGHTAWARE_ROUTE;
+    },
+    fetchAdsbdbRoute: async () => {
+      calls.push("adsbdb");
+      return ADSBDB_ROUTE;
+    },
+  });
+
+  assert.equal(route, FLIGHTAWARE_ROUTE);
+  assert.deepEqual(calls, ["flightaware"]);
+}
+
+{
+  const calls = [];
+  const route = await resolveFlightRoute({
+    callsign: "AAL1234",
+    requestedProvider: "flightaware",
+    feedbackRepository: null,
+    shouldUseFlightAwareRouteProvider: async () => false,
+    fetchFlightAwareRoute: async () => {
+      calls.push("flightaware");
+      return FLIGHTAWARE_ROUTE;
+    },
+    fetchAdsbdbRoute: async () => {
+      calls.push("adsbdb");
+      return ADSBDB_ROUTE;
+    },
+  });
+
+  assert.equal(route, ADSBDB_ROUTE);
+  assert.deepEqual(calls, ["adsbdb"]);
+}
+
+{
+  const calls = [];
+  const route = await resolveFlightRoute({
+    callsign: "AAL1234",
     feedbackRepository: null,
     shouldUseFlightAwareRouteProvider: async () => true,
     fetchFlightAwareRoute: async () => {

--- a/src/hooks/useAircraftPositions.js
+++ b/src/hooks/useAircraftPositions.js
@@ -17,8 +17,10 @@ import {
   AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
   scheduleAfterOverlayPaint,
   shouldShowAircraftLoadingOverlay,
-  shouldTriggerVisibilityRefreshOverlay,
 } from "../features/aircraft/positions/aircraftLoadingOverlayModel.js";
+import {
+  resolveAircraftVisibilityPolling,
+} from "../features/aircraft/positions/aircraftVisibilityPollingModel.js";
 import {
   hasFiniteFlightPosition,
   normalizeLatitude,
@@ -35,7 +37,8 @@ const waitUntil = (timestamp) => {
   });
 };
 
-export function useAircraftPositions(icao, lat, lon) {
+export function useAircraftPositions(icao, lat, lon, options = {}) {
+  const pollWhenHidden = options?.pollWhenHidden === true;
   const queryLat = normalizeLatitude(lat);
   const queryLon = normalizeLongitude(lon);
   const hasActiveQuery = Boolean(
@@ -141,31 +144,39 @@ export function useAircraftPositions(icao, lat, lon) {
     };
 
     const handleVisibility = () => {
+      const visibilityAction = resolveAircraftVisibilityPolling({
+        documentHidden: document.hidden,
+        hasActiveQuery,
+        wasActive: wasActiveRef.current,
+        pollWhenHidden,
+        hiddenSince: hiddenSinceRef.current,
+        minHiddenMs: HIDDEN_POLL_GRACE_MS,
+      });
+
       if (document.hidden) {
         cancelPendingVisibilityRefresh();
         hiddenSinceRef.current = Date.now();
-        stop({ clearAircraft: false, clearTrace: false });
+        if (visibilityAction.shouldStopPolling) {
+          stop({ clearAircraft: false, clearTrace: false });
+        }
         return;
       }
       cancelPendingVisibilityRefresh();
       const hiddenDuration =
         hiddenSinceRef.current > 0 ? Date.now() - hiddenSinceRef.current : 0;
-      const showRefreshOverlay = shouldTriggerVisibilityRefreshOverlay({
-        wasActive: wasActiveRef.current,
-        hiddenSince: hiddenSinceRef.current,
-        minHiddenMs: HIDDEN_POLL_GRACE_MS,
-      });
       hiddenSinceRef.current = 0;
       const overlayShownAt = Date.now();
-      if (showRefreshOverlay) setVisibilityRefreshLoading(true);
-      if (!wasActiveRef.current) return;
-      const commitAfter = showRefreshOverlay
+      if (visibilityAction.shouldShowRefreshOverlay) {
+        setVisibilityRefreshLoading(true);
+      }
+      if (!visibilityAction.shouldRefreshNow) return;
+      const commitAfter = visibilityAction.shouldShowRefreshOverlay
         ? overlayShownAt + AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS
         : 0;
 
       const refresh = () => {
         visibilityRefreshCancelRef.current = null;
-        if (hiddenDuration > HIDDEN_POLL_GRACE_MS) {
+        if (!pollWhenHidden && hiddenDuration > HIDDEN_POLL_GRACE_MS) {
           traceTrackerRef.current.clear();
           start({ commitAfter });
           return;
@@ -175,7 +186,7 @@ export function useAircraftPositions(icao, lat, lon) {
         timerRef.current = setInterval(poll, DEFAULT_AIRCRAFT_POLL_MS);
       };
 
-      if (showRefreshOverlay) {
+      if (visibilityAction.shouldShowRefreshOverlay) {
         visibilityRefreshCancelRef.current = scheduleAfterOverlayPaint(refresh);
       } else {
         refresh();
@@ -203,7 +214,7 @@ export function useAircraftPositions(icao, lat, lon) {
       cancelPendingVisibilityRefresh();
       stop();
     };
-  }, [hasActiveQuery, icao, queryLat, queryLon]);
+  }, [hasActiveQuery, icao, pollWhenHidden, queryLat, queryLon]);
 
   return {
     aircraft,

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -14,8 +14,10 @@ import {
   AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
   scheduleAfterOverlayPaint,
   shouldShowAircraftLoadingOverlay,
-  shouldTriggerVisibilityRefreshOverlay,
 } from "../features/aircraft/positions/aircraftLoadingOverlayModel.js";
+import {
+  resolveAircraftVisibilityPolling,
+} from "../features/aircraft/positions/aircraftVisibilityPollingModel.js";
 
 const waitUntil = (timestamp) => {
   const delay = Math.max(0, timestamp - Date.now());
@@ -154,24 +156,28 @@ export function useTrackedAircraft(callsign) {
     };
 
     const handleVisibility = () => {
-      if (document.hidden) {
-        cancelPendingVisibilityRefresh();
-        hiddenSinceRef.current = Date.now();
-        stopPolling();
-        return;
-      }
-      cancelPendingVisibilityRefresh();
-      const showRefreshOverlay = shouldTriggerVisibilityRefreshOverlay({
-        wasActive: hasActiveQuery,
+      const visibilityAction = resolveAircraftVisibilityPolling({
+        documentHidden: document.hidden,
+        hasActiveQuery,
+        pollWhenHidden: true,
         hiddenSince: hiddenSinceRef.current,
         minHiddenMs: AIRCRAFT_TRAFFIC_CONFIG.hiddenPollGraceMs,
       });
+
+      if (document.hidden) {
+        cancelPendingVisibilityRefresh();
+        hiddenSinceRef.current = Date.now();
+        if (visibilityAction.shouldStopPolling) stopPolling();
+        return;
+      }
+      cancelPendingVisibilityRefresh();
       hiddenSinceRef.current = 0;
-      if (showRefreshOverlay) {
+      if (!visibilityAction.shouldRefreshNow) return;
+      if (visibilityAction.shouldShowRefreshOverlay) {
         setVisibilityRefreshLoading(true);
       }
       const overlayShownAt = Date.now();
-      const commitAfter = showRefreshOverlay
+      const commitAfter = visibilityAction.shouldShowRefreshOverlay
         ? overlayShownAt + AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS
         : 0;
 
@@ -182,7 +188,7 @@ export function useTrackedAircraft(callsign) {
         timerRef.current = setInterval(poll, AIRCRAFT_TRAFFIC_CONFIG.pollMs);
       };
 
-      if (showRefreshOverlay) {
+      if (visibilityAction.shouldShowRefreshOverlay) {
         visibilityRefreshCancelRef.current = scheduleAfterOverlayPaint(refresh);
       } else {
         refresh();


### PR DESCRIPTION
## Summary
- keep flight tracking callsign and nearby-position polling alive while the tab is hidden
- preserve airport-tracking behavior by stopping airport nearby-position polling in hidden tabs
- force tracking pages to refresh when the tab becomes active again, with flight pages reusing the fresh background position cache
- pass explicit route provider requests into route resolution and share cached routes across FlightAware ICAO/IATA callsign aliases such as `VIR26Q` / `VS26Q`

## Root cause
Both tracking hooks treated `document.hidden` the same way: cancel pending refreshes and stop polling. That was correct for airport pages, but flight tracking reuses the nearby-position hook, so the focal aircraft and nearby aircraft data went stale while the tab was inactive.

The route issue in the VIR26Q case had two contributing factors: the route endpoint read `provider=flightaware` only for cache-control, not route resolution, and route cache entries were stored only under the requested callsign. FlightAware can return both an ICAO callsign and IATA callsign for the same flight, so a route fetched under one alias could still leave the other alias rendering `N/A`.

## Validation
- `node src/features/aircraft/positions/aircraftVisibilityPollingModel.test.js` (red first, then green)
- `node src/features/aviation/flight-routes/flightRoutes.mechanism.test.js`
- `node src/features/aviation/flight-routes/flightRouteScheduler.test.js` (red first, then green for route alias cache)
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- Vercel preview checks passed for commit `89031eb`
- Preview HTTP checks returned 200 for:
  - `https://adsbao-git-codex-fix-tracking-tab-staleness-orri-duck-day.vercel.app/aircraft/VIR26Q`
  - `https://adsbao-git-codex-fix-tracking-tab-staleness-orri-duck-day.vercel.app/api/proxy/flight-routes/callsign/VIR26Q`
  - `https://adsbao-git-codex-fix-tracking-tab-staleness-orri-duck-day.vercel.app/api/proxy/flight-routes/callsign/VIR26Q?provider=flightaware`
