### PR TITLE
[codex] Use aircraft metadata for route label

### DIFF
--- a/src/features/aviation/flight-routes/flightRouteLookupModel.js
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.js
@@ -58,6 +58,42 @@ export function getLookupCallsigns(aircraft) {
   ];
 }
 
+function airportFromMetadataCode(value) {
+  const code = routeContextCode(value);
+  if (code.length === 3) return { iata: code };
+  if (code.length === 4) return { icao: code };
+  return null;
+}
+
+function routeCode(origin, destination, field) {
+  const from = origin?.[field];
+  const to = destination?.[field];
+  return from && to ? `${from}-${to}` : "";
+}
+
+export function buildRouteFromAircraftMetadata(aircraft = {}) {
+  const callsign = normalizeCallsign(aircraft?.callsign);
+  const origin = airportFromMetadataCode(aircraft?.origin);
+  const destination = airportFromMetadataCode(aircraft?.destination);
+  if (!callsign || !origin || !destination) return null;
+
+  const icao = routeCode(origin, destination, "icao");
+  const iata = routeCode(origin, destination, "iata");
+  if (!icao && !iata) return null;
+
+  return {
+    callsign,
+    origin,
+    destination,
+    route: {
+      ...(icao ? { icao } : {}),
+      ...(iata ? { iata } : {}),
+    },
+    source: "aircraft-metadata",
+    confidence: "position-metadata",
+  };
+}
+
 const EARTH_RADIUS_NM = 3440.065;
 
 const haversineNm = (lat1, lon1, lat2, lon2) => {
@@ -170,7 +206,8 @@ export function buildRoutesByCallsign({
   for (const item of aircraft || []) {
     const callsign = normalizeCallsign(item.callsign);
     const cached = getFreshRouteCacheEntry(cache, callsign, now, routeContext);
-    if (cached?.route) routes[callsign] = cached.route;
+    const route = cached?.route || buildRouteFromAircraftMetadata(item);
+    if (route) routes[callsign] = route;
   }
   return routes;
 }

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.test.js
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.test.js
@@ -138,6 +138,32 @@ const route = {
   assert.deepEqual(routes, { DAL123: route });
 }
 
+{
+  const routes = buildRoutesByCallsign({
+    aircraft: [
+      {
+        callsign: "VIR26Q",
+        origin: "KJFK",
+        destination: "EGLL",
+        positionQuality: { source: "flightaware", kind: "predicted" },
+      },
+    ],
+    cache: new Map(),
+    now,
+  });
+
+  assert.deepEqual(routes, {
+    VIR26Q: {
+      callsign: "VIR26Q",
+      origin: { icao: "KJFK" },
+      destination: { icao: "EGLL" },
+      route: { icao: "KJFK-EGLL" },
+      source: "aircraft-metadata",
+      confidence: "position-metadata",
+    },
+  });
+}
+
 // rankCandidatesByDistance: aircraft farthest from focal airport rank first.
 // KBOS focal -> JBU123 over Lisbon (~3000nm) outranks DAL123 over NYC (~190nm)
 // outranks UAL456 directly over KBOS (~0nm).


### PR DESCRIPTION
## Summary
- derive the visible route label directly from the current aircraft origin/destination metadata when provider route data has not populated the cache
- keep full provider route responses higher priority when present, so richer airport details still win
- cover the VIR26Q FlightAware-predicted case where the aircraft payload has KJFK/EGLL but the preview was rendering N/A

## Validation
- `node src/features/aviation/flight-routes/flightRouteLookupModel.test.js` (red first, then green)
- `node src/features/aviation/flight-routes/flightRouteScheduler.test.js`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
