### PR TITLE
Coordinate FlightAware route and position state

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A modern airport-monitoring HUD with dynamic airport search, METAR context, and 
 ## Overview
 ADSBao provides a search-first airport operations view with weather context and aircraft position overlays. Airport search is backed by public airport directory data.
 
-Current web app version: **1.4.0**. Runtime version strings and ADSBao User-Agent values share `src/config/siteMeta.js`; see `src/config/changelog.js` (rendered at `/changelog`) for product version history.
+Current web app version: **1.5.0**. Runtime version strings and ADSBao User-Agent values share `src/config/siteMeta.js`; see `src/config/changelog.js` (rendered at `/changelog`) for product version history.
 
 ## Tech Stack
 - **Frontend**: React on Next.js App Router, Tailwind CSS v4, DaisyUI, Lucide Icons.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --webpack",

--- a/src/components/changelog/ChangelogPanel.jsx
+++ b/src/components/changelog/ChangelogPanel.jsx
@@ -29,6 +29,17 @@ const KIND_STYLES = {
 };
 
 const CHINESE_RELEASE_COPY = {
+  "v1.5.0": {
+    title: "FlightAware 跟踪状态与虚线预测航路",
+    summary:
+      "飞行跟踪现在会区分实时 ADS-B、FlightAware 活跃兜底、FlightAware 已到达、陈旧位置和完全缺失状态,让航路获取与信号丢失处理保持一致。",
+    highlights: [
+      "跟踪航班使用明确的位置状态,不再把每个 callsign 匹配都当作实时 ADS-B",
+      "开启 FlightAware 的用户可继续使用活跃 FlightAware 位置,不会误触发信号丢失提示",
+      "已到达或终止的 FlightAware 航班会保留最后已知位置,并停止重复航路查询",
+      "FlightAware 预测航路以虚线显示,包括底层 glow 线",
+    ],
+  },
   "v1.4.0": {
     title: "账号登录与更安静的信号丢失处理",
     summary:

--- a/src/components/map/FlightAwareRouteArc.jsx
+++ b/src/components/map/FlightAwareRouteArc.jsx
@@ -5,9 +5,11 @@ import L from "leaflet";
 import { useMapInstance } from "./MapContext.js";
 import {
   AIRPORT_MAP_PANES,
-  SELECTED_AIRCRAFT_TRACE_STYLE,
 } from "@/config/airportMap.js";
 import { resolveDocumentTheme } from "@/features/airport/map/airportMapModel.js";
+import {
+  buildFlightAwareRouteLayerStyles,
+} from "@/features/airport/map/flightAwareRouteArcStyleModel.js";
 import { ensureAirportMapPane } from "@/features/airport/map/mapPane.js";
 
 const getCurrentTheme = () =>
@@ -52,17 +54,14 @@ export default function FlightAwareRouteArc({
 
     const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.trace);
     const effectiveTheme = theme || documentTheme;
-    const traceStyle =
-      effectiveTheme === "light"
-        ? SELECTED_AIRCRAFT_TRACE_STYLE.light
-        : SELECTED_AIRCRAFT_TRACE_STYLE.dark;
-    const color = traceStyle.lineColor;
+    const routeStyles = buildFlightAwareRouteLayerStyles({
+      theme: effectiveTheme,
+      opacity,
+    });
     const layers = [
       L.polyline(path, {
         pane,
-        color,
-        opacity: 0.18 * opacity,
-        weight: traceStyle.glowWeight,
+        ...routeStyles.glow,
         interactive: false,
         lineCap: "round",
         lineJoin: "round",
@@ -70,13 +69,10 @@ export default function FlightAwareRouteArc({
       }).addTo(map),
       L.polyline(path, {
         pane,
-        color,
-        opacity: 0.58 * opacity,
-        weight: Math.max(1, traceStyle.lineWeight - 0.4),
+        ...routeStyles.route,
         interactive: false,
         lineCap: "round",
         lineJoin: "round",
-        dashArray: "10 12",
         className: "aircraft-trace aircraft-trace--flightaware-route",
       }).addTo(map),
     ];

--- a/src/config/changelog.js
+++ b/src/config/changelog.js
@@ -6,6 +6,19 @@
 
 export const CHANGELOG = [
   {
+    version: "v1.5.0",
+    kind: "feat",
+    title: "FlightAware-aware tracking and dashed predicted routes",
+    summary:
+      "Flight tracking now separates live ADS-B, FlightAware active fallback, terminal FlightAware arrivals, stale positions, and fully missing positions so route fetches and lost-signal handling stay coordinated.",
+    highlights: [
+      "Tracked flights use explicit position states instead of treating every callsign match as live ADS-B",
+      "FlightAware-enabled users keep active FlightAware positions without triggering lost-signal prompts",
+      "Arrived / terminal FlightAware flights keep the last known point visible and stop repeated route lookups",
+      "FlightAware predicted route arcs render as dashed lines, including their glow layer",
+    ],
+  },
+  {
     version: "v1.4.0",
     kind: "feat",
     title: "Account sign-in + cleaner lost-signal handling",

--- a/src/config/siteMeta.js
+++ b/src/config/siteMeta.js
@@ -1,5 +1,5 @@
 export const ADSBAO_PRODUCT_NAME = "ADSBao";
-export const ADSBAO_SITE_VERSION = "1.4.0";
+export const ADSBAO_SITE_VERSION = "1.5.0";
 export const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
 
 export function buildAdsbaoUserAgent(suffix = "") {

--- a/src/config/siteMeta.test.js
+++ b/src/config/siteMeta.test.js
@@ -7,14 +7,14 @@ import {
 } from "./siteMeta.js";
 
 assert.equal(ADSBAO_PRODUCT_NAME, "ADSBao");
-assert.equal(ADSBAO_SITE_VERSION, "1.4.0");
+assert.equal(ADSBAO_SITE_VERSION, "1.5.0");
 assert.equal(
   buildAdsbaoUserAgent("adsbdb/v0"),
-  "ADSBao/1.4.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+  "ADSBao/1.5.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
 );
 assert.equal(
   buildAdsbaoUserAgent(),
-  "ADSBao/1.4.0 (+https://github.com/orriduck/ADSBao)",
+  "ADSBao/1.5.0 (+https://github.com/orriduck/ADSBao)",
 );
 
 console.log("siteMeta.test.js ok");

--- a/src/features/aircraft/callsign/aircraftCallsign.mechanism.js
+++ b/src/features/aircraft/callsign/aircraftCallsign.mechanism.js
@@ -163,13 +163,15 @@ async function fetchAllCallsignProviders({ callsign }) {
     .filter(Boolean);
 }
 
-function annotatePayload(payload, { source, now }) {
+function annotatePayload(payload, { source, now, fallback, trackingState }) {
   return {
     ...payload,
     ac: (payload?.ac || []).map((aircraft) =>
       annotateAdsbPosition(aircraft, { source, now }),
     ),
     source,
+    flightAwareFallback: sanitizeFallbackForClient(fallback),
+    trackingState,
   };
 }
 
@@ -181,6 +183,7 @@ function payloadForResolvedPosition({ resolved, callsign, fallback, now }) {
       source: "",
       now: now / 1000,
       flightAwareFallback: clientFallback,
+      trackingState: resolved.trackingState,
     };
   }
 
@@ -190,6 +193,7 @@ function payloadForResolvedPosition({ resolved, callsign, fallback, now }) {
       source: "flightaware",
       now: now / 1000,
       flightAwareFallback: clientFallback,
+      trackingState: resolved.trackingState,
     };
   }
 
@@ -199,6 +203,7 @@ function payloadForResolvedPosition({ resolved, callsign, fallback, now }) {
     now: now / 1000,
     flightAwareFallback: clientFallback,
     callsign,
+    trackingState: resolved.trackingState,
   };
 }
 
@@ -242,6 +247,8 @@ export const fetchTrackedAircraftByCallsign = async ({
       payload: annotatePayload(sourcePayload, {
         source: resolved.source,
         now,
+        fallback: resolved.fallback,
+        trackingState: resolved.trackingState,
       }),
       source: resolved.source,
       attempts,

--- a/src/features/aircraft/callsign/trackedAircraftCallsignFallback.test.js
+++ b/src/features/aircraft/callsign/trackedAircraftCallsignFallback.test.js
@@ -84,6 +84,7 @@ const staleAircraft = {
   assert.equal(result.payload.ac[0].lat, 47.4167);
   assert.equal(result.payload.ac[0].positionQuality.source, "flightaware");
   assert.equal(result.payload.ac[0].positionQuality.kind, "predicted");
+  assert.equal(result.payload.trackingState.status, "flightaware_active");
   assert.equal("raw" in result.payload.flightAwareFallback, false);
   assert.equal(flightAwareCalls, 1);
 }
@@ -105,6 +106,7 @@ const staleAircraft = {
 
   assert.equal(result.source, ADSB_LOL.id);
   assert.equal(result.payload.ac[0].positionQuality.kind, "stale");
+  assert.equal(result.payload.trackingState.status, "stale");
   assert.equal(flightAwareCalls, 0);
 }
 
@@ -138,6 +140,40 @@ const staleAircraft = {
   assert.equal(result.source, ADSB_LOL.id);
   assert.equal(result.payload.ac[0].positionQuality.kind, "stale");
   assert.equal(flightAwareCalls, 0);
+}
+
+{
+  const result = await fetchTrackedAircraftByCallsign({
+    callsign: "AAL100",
+    featureEnabled: true,
+    fetchPrimaryProviders: async () => [
+      providerPayload(ADSB_LOL.id, [staleAircraft]),
+      providerPayload(AIRPLANES_LIVE.id, []),
+    ],
+    getFlightAwareFallback: async () => ({
+      ok: true,
+      hasPosition: true,
+      position: {
+        lat: 47.4167,
+        lon: -46.5833,
+        callsign: "AAL100",
+        terminal: true,
+        status: "arrived",
+        quality: {
+          source: "flightaware",
+          kind: "observed",
+          terminal: true,
+          status: "arrived",
+          fetchedAt: "2026-05-25T03:00:00.000Z",
+        },
+      },
+    }),
+  });
+
+  assert.equal(result.source, ADSB_LOL.id);
+  assert.equal(result.payload.ac[0].lat, 41);
+  assert.equal(result.payload.ac[0].positionQuality.kind, "stale");
+  assert.equal(result.payload.trackingState.status, "flightaware_terminal");
 }
 
 console.log("trackedAircraftCallsignFallback.test.js ok");

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.js
@@ -55,9 +55,24 @@ export function getTrackedAircraftSignalState({
   matchesLength = 0,
   previousMisses = 0,
   flightAwareFallback = null,
+  trackingState = null,
   threshold = LOST_SIGNAL_MISS_THRESHOLD,
 } = {}) {
   const normalizedThreshold = Math.max(1, Number(threshold) || 1);
+  const trackingStatus = String(trackingState?.status || "").trim();
+  if (trackingStatus === "adsb_live" || trackingStatus === "flightaware_active") {
+    return { misses: 0, lostSignal: false };
+  }
+  if (trackingStatus === "flightaware_terminal") {
+    return { misses: normalizedThreshold, lostSignal: true };
+  }
+  if (trackingStatus === "stale" || trackingStatus === "missing") {
+    const misses = Math.max(0, Number(previousMisses) || 0) + 1;
+    return {
+      misses,
+      lostSignal: misses >= normalizedThreshold,
+    };
+  }
   if (Number(matchesLength) > 0) {
     return { misses: 0, lostSignal: false };
   }

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
@@ -110,4 +110,31 @@ assert.deepEqual(
   { misses: 0, lostSignal: false },
 );
 
+assert.deepEqual(
+  getTrackedAircraftSignalState({
+    matchesLength: 1,
+    previousMisses: 19,
+    trackingState: { status: "stale" },
+  }),
+  { misses: 20, lostSignal: true },
+);
+
+assert.deepEqual(
+  getTrackedAircraftSignalState({
+    matchesLength: 1,
+    previousMisses: 19,
+    trackingState: { status: "flightaware_active" },
+  }),
+  { misses: 0, lostSignal: false },
+);
+
+assert.deepEqual(
+  getTrackedAircraftSignalState({
+    matchesLength: 1,
+    previousMisses: 0,
+    trackingState: { status: "flightaware_terminal" },
+  }),
+  { misses: 20, lostSignal: true },
+);
+
 console.log("lostSignalTrackingModel.test.js ok");

--- a/src/features/aircraft/tracking/tracked-flight-route-position-mechanism.md
+++ b/src/features/aircraft/tracking/tracked-flight-route-position-mechanism.md
@@ -1,0 +1,58 @@
+# Tracked Flight Route + Position Mechanism
+
+This mechanism keeps the flight page from treating every callsign poll result
+as the same kind of signal. The callsign endpoint resolves one explicit
+`trackingState`, and the React hook, lost-signal model, and route scheduler all
+consume that state.
+
+## Position States
+
+`resolveTrackedFlightPosition()` returns:
+
+- `adsb_live`: a fresh ADS-B position from adsb.lol or airplanes.live. This is
+  the primary position and resets lost-signal misses.
+- `flightaware_active`: ADS-B is absent or stale, but the FlightAware-enabled
+  path has an active flight. If FlightAware has a public position, the page uses
+  it and labels it as FlightAware estimated / predicted / observed.
+- `flightaware_terminal`: FlightAware says the flight has arrived, landed,
+  diverted, cancelled, or is otherwise terminal. Terminal FlightAware points are
+  not treated as active aircraft positions; the page keeps the last ADS-B /
+  last-known point and shows lost signal.
+- `stale`: only an old ADS-B point remains. The map can keep that point visible,
+  but the state still increments lost-signal misses.
+- `missing`: neither ADS-B nor FlightAware has an active position. The hook does
+  not clear the old aircraft snapshot; it lets the existing lost-signal flow
+  decide when to warn.
+
+Without the FlightAware flag, the resolver never calls FlightAware. Stale ADS-B
+and missing states still increment lost-signal misses instead of pretending a
+stale `ac[0]` is a fresh signal.
+
+## Route Fetch Rules
+
+The route scheduler still owns queueing and cache state. `useFlightRoutes()`
+remains a thin React wrapper.
+
+- `adsb_live` and `flightaware_active` aircraft can enter the route queue.
+- `flightaware_terminal`, `stale`, and `missing` aircraft do not start new route
+  fetches.
+- Route metadata already attached to an aircraft (`origin` + `destination`) can
+  still render as an `aircraft-metadata` route even when route fetches are
+  suppressed.
+- FlightAware route requests continue to use a provider-scoped cache key and
+  `provider=flightaware`, so adsbdb cache entries cannot mask FlightAware
+  results.
+
+## Tab Visibility
+
+The flight page keeps polling while hidden. On visibility return, it performs an
+immediate position refresh and then lets the route scheduler react to the new
+aircraft input. Because terminal / stale / missing states are filtered before
+queueing, returning to an old tab does not create repeated route lookups for a
+flight that has already arrived or lost all live position sources.
+
+## Map Treatment
+
+FlightAware route arcs are predicted context, not observed ADS-B trace. Both the
+foreground route and the glow layer use the same dashed pattern so production
+rendering does not visually collapse into a solid line.

--- a/src/features/aircraft/tracking/trackedFlightPositionResolver.js
+++ b/src/features/aircraft/tracking/trackedFlightPositionResolver.js
@@ -1,5 +1,18 @@
+import {
+  hasActiveFlightAwareFallback,
+  hasTerminalFlightAwareFallback,
+} from "./lostSignalTrackingModel.js";
+
 export const ADSB_FRESH_MAX_AGE_SECONDS = 60;
 export const ADSB_STALE_MIN_AGE_SECONDS = 90;
+
+export const TRACKED_FLIGHT_STATUS = Object.freeze({
+  ADSB_LIVE: "adsb_live",
+  FLIGHTAWARE_ACTIVE: "flightaware_active",
+  FLIGHTAWARE_TERMINAL: "flightaware_terminal",
+  STALE: "stale",
+  MISSING: "missing",
+});
 
 const PROVIDER_SOURCE = Object.freeze({
   "adsb.lol": "adsb_lol",
@@ -14,6 +27,17 @@ const toNumber = (value) => {
 };
 
 const isoFromNow = (now) => new Date(now || Date.now()).toISOString();
+
+function buildTrackingState(status, overrides = {}) {
+  return {
+    status,
+    active:
+      status === TRACKED_FLIGHT_STATUS.ADSB_LIVE ||
+      status === TRACKED_FLIGHT_STATUS.FLIGHTAWARE_ACTIVE,
+    terminal: status === TRACKED_FLIGHT_STATUS.FLIGHTAWARE_TERMINAL,
+    ...overrides,
+  };
+}
 
 export function getAdsbPositionAgeSeconds(position, now = Date.now()) {
   const directAge = toNumber(position?.seen_pos ?? position?.seen);
@@ -147,6 +171,9 @@ export async function resolveTrackedFlightPosition({
         now,
       }),
       fallback: null,
+      trackingState: buildTrackingState(TRACKED_FLIGHT_STATUS.ADSB_LIVE, {
+        source: fresh.source,
+      }),
     };
   }
 
@@ -154,11 +181,30 @@ export async function resolveTrackedFlightPosition({
   if (!fallback && featureEnabled && typeof getFlightAwareFallback === "function") {
     fallback = await getFlightAwareFallback(callsign);
   }
+  const fallbackTerminal = hasTerminalFlightAwareFallback(fallback);
+  const fallbackActive = hasActiveFlightAwareFallback(fallback);
+  const fallbackTrackingState = fallbackTerminal
+    ? buildTrackingState(TRACKED_FLIGHT_STATUS.FLIGHTAWARE_TERMINAL, {
+        source: "flightaware",
+      })
+    : fallbackActive
+      ? buildTrackingState(TRACKED_FLIGHT_STATUS.FLIGHTAWARE_ACTIVE, {
+          source: "flightaware",
+        })
+      : null;
 
-  if (fallback?.ok && fallback.hasPosition) {
+  if (!fallbackTerminal && fallback?.ok && fallback.hasPosition) {
     const position = normalizeFlightAwarePosition(fallback.position);
     if (position) {
-      return { source: "flightaware", position, fallback };
+      return {
+        source: "flightaware",
+        position,
+        fallback,
+        trackingState: fallbackTrackingState ||
+          buildTrackingState(TRACKED_FLIGHT_STATUS.FLIGHTAWARE_ACTIVE, {
+            source: "flightaware",
+          }),
+      };
     }
   }
 
@@ -177,12 +223,19 @@ export async function resolveTrackedFlightPosition({
           }),
       },
       fallback,
+      trackingState: fallbackTrackingState ||
+        buildTrackingState(TRACKED_FLIGHT_STATUS.STALE, {
+          source: "local_projection",
+        }),
     };
   }
 
   const stale = pickStalePrimary(candidates, now);
   const fallbackPosition = stale?.position || lastKnown;
   if (fallbackPosition && hasUsableLatLon(fallbackPosition)) {
+    const staleStatus = stale
+      ? TRACKED_FLIGHT_STATUS.STALE
+      : TRACKED_FLIGHT_STATUS.MISSING;
     return {
       source: stale?.source || "last_known",
       position: {
@@ -196,8 +249,18 @@ export async function resolveTrackedFlightPosition({
         }),
       },
       fallback,
+      trackingState: fallbackTrackingState ||
+        buildTrackingState(staleStatus, {
+          source: stale?.source || fallbackPosition.source || "unknown",
+        }),
     };
   }
 
-  return { source: "", position: null, fallback };
+  return {
+    source: "",
+    position: null,
+    fallback,
+    trackingState: fallbackTrackingState ||
+      buildTrackingState(TRACKED_FLIGHT_STATUS.MISSING),
+  };
 }

--- a/src/features/aircraft/tracking/trackedFlightPositionResolver.test.js
+++ b/src/features/aircraft/tracking/trackedFlightPositionResolver.test.js
@@ -68,6 +68,7 @@ assert.equal(ADSB_FRESH_MAX_AGE_SECONDS, 60);
   assert.equal(resolved.source, "flightaware");
   assert.equal(resolved.position.lat, 47.4167);
   assert.equal(resolved.position.positionQuality.kind, "predicted");
+  assert.equal(resolved.trackingState.status, "flightaware_active");
 }
 
 {
@@ -94,6 +95,7 @@ assert.equal(ADSB_FRESH_MAX_AGE_SECONDS, 60);
   assert.equal(resolved.source, "last_known");
   assert.equal(resolved.position.lat, 40);
   assert.equal(resolved.position.positionQuality.kind, "stale");
+  assert.equal(resolved.trackingState.status, "missing");
   assert.equal(flightAwareCalls, 1);
 }
 
@@ -112,7 +114,41 @@ assert.equal(ADSB_FRESH_MAX_AGE_SECONDS, 60);
   });
 
   assert.equal(resolved.position, null);
+  assert.equal(resolved.trackingState.status, "missing");
   assert.equal(flightAwareCalls, 0);
+}
+
+{
+  const resolved = await resolveTrackedFlightPosition({
+    adsbLolPosition: primary("adsb.lol", 180, { lat: 40, lon: -70 }),
+    airplanesLivePosition: null,
+    getFlightAwareFallback: async () => ({
+      ok: true,
+      hasPosition: true,
+      position: {
+        lat: 47.4167,
+        lon: -46.5833,
+        callsign: "AAL100",
+        terminal: true,
+        status: "arrived",
+        quality: {
+          source: "flightaware",
+          kind: "observed",
+          terminal: true,
+          status: "arrived",
+          fetchedAt: new Date(now).toISOString(),
+        },
+      },
+    }),
+    callsign: "AAL100",
+    featureEnabled: true,
+    now,
+  });
+
+  assert.equal(resolved.source, "adsb.lol");
+  assert.equal(resolved.position.lat, 40);
+  assert.equal(resolved.position.positionQuality.kind, "stale");
+  assert.equal(resolved.trackingState.status, "flightaware_terminal");
 }
 
 console.log("trackedFlightPositionResolver.test.js ok");

--- a/src/features/airport/map/flightAwareRouteArcStyleModel.js
+++ b/src/features/airport/map/flightAwareRouteArcStyleModel.js
@@ -1,0 +1,32 @@
+import { SELECTED_AIRCRAFT_TRACE_STYLE } from "../../../config/airportMap.js";
+
+export const FLIGHTAWARE_ROUTE_DASH_ARRAY = "10 12";
+
+export function buildFlightAwareRouteLayerStyles({
+  theme = "dark",
+  opacity = 1,
+} = {}) {
+  const normalizedOpacity = Number.isFinite(Number(opacity))
+    ? Number(opacity)
+    : 1;
+  const traceStyle =
+    theme === "light"
+      ? SELECTED_AIRCRAFT_TRACE_STYLE.light
+      : SELECTED_AIRCRAFT_TRACE_STYLE.dark;
+  const color = traceStyle.lineColor;
+
+  return {
+    glow: {
+      color,
+      opacity: 0.18 * normalizedOpacity,
+      weight: traceStyle.glowWeight,
+      dashArray: FLIGHTAWARE_ROUTE_DASH_ARRAY,
+    },
+    route: {
+      color,
+      opacity: 0.58 * normalizedOpacity,
+      weight: Math.max(1, traceStyle.lineWeight - 0.4),
+      dashArray: FLIGHTAWARE_ROUTE_DASH_ARRAY,
+    },
+  };
+}

--- a/src/features/airport/map/flightAwareRouteArcStyleModel.test.js
+++ b/src/features/airport/map/flightAwareRouteArcStyleModel.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+
+import {
+  FLIGHTAWARE_ROUTE_DASH_ARRAY,
+  buildFlightAwareRouteLayerStyles,
+} from "./flightAwareRouteArcStyleModel.js";
+
+{
+  const styles = buildFlightAwareRouteLayerStyles({
+    theme: "dark",
+    opacity: 1,
+  });
+
+  assert.equal(FLIGHTAWARE_ROUTE_DASH_ARRAY, "10 12");
+  assert.equal(styles.glow.dashArray, FLIGHTAWARE_ROUTE_DASH_ARRAY);
+  assert.equal(styles.route.dashArray, FLIGHTAWARE_ROUTE_DASH_ARRAY);
+  assert.ok(styles.glow.weight > styles.route.weight);
+}
+
+{
+  const styles = buildFlightAwareRouteLayerStyles({
+    theme: "light",
+    opacity: 0.5,
+  });
+
+  assert.equal(styles.glow.dashArray, FLIGHTAWARE_ROUTE_DASH_ARRAY);
+  assert.equal(styles.route.dashArray, FLIGHTAWARE_ROUTE_DASH_ARRAY);
+  assert.equal(styles.glow.opacity, 0.09);
+  assert.equal(styles.route.opacity, 0.29);
+}
+
+console.log("flightAwareRouteArcStyleModel.test.js ok");

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.js
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.js
@@ -52,6 +52,7 @@ export function getLookupCallsigns(aircraft) {
   return [
     ...new Set(
       (aircraft || [])
+        .filter((item) => !shouldSuppressRouteLookup(item))
         .map((item) => normalizeCallsign(item.callsign))
         .filter(isLookupCallsign),
     ),
@@ -95,6 +96,11 @@ export function buildRouteFromAircraftMetadata(aircraft = {}) {
 }
 
 const EARTH_RADIUS_NM = 3440.065;
+const ROUTE_LOOKUP_SUPPRESSED_TRACKING_STATUSES = new Set([
+  "flightaware_terminal",
+  "missing",
+  "stale",
+]);
 
 const haversineNm = (lat1, lon1, lat2, lon2) => {
   const toRad = (value) => (value * Math.PI) / 180;
@@ -120,6 +126,7 @@ export function rankCandidatesByDistance(aircraft, routeContext = {}) {
   const seen = new Map();
 
   (aircraft || []).forEach((item, index) => {
+    if (shouldSuppressRouteLookup(item)) return;
     const callsign = normalizeCallsign(item?.callsign);
     if (!isLookupCallsign(callsign)) return;
     const lat = Number(item?.lat);
@@ -146,6 +153,12 @@ export function rankCandidatesByDistance(aircraft, routeContext = {}) {
       return leftMeta.index - rightMeta.index;
     })
     .map(([callsign]) => callsign);
+}
+
+export function shouldSuppressRouteLookup(aircraft = {}) {
+  return ROUTE_LOOKUP_SUPPRESSED_TRACKING_STATUSES.has(
+    String(aircraft?.trackingState?.status || "").trim().toLowerCase(),
+  );
 }
 
 export function resolvePendingRouteLookups({

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.test.js
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.test.js
@@ -225,3 +225,45 @@ const route = {
   // Farthest two first, limited to 2.
   assert.deepEqual(pending, ["JBU123", "DAL123"]);
 }
+
+{
+  const aircraft = [
+    {
+      callsign: "AAL100",
+      origin: "KJFK",
+      destination: "KLAX",
+      trackingState: { status: "flightaware_terminal" },
+    },
+    {
+      callsign: "DAL123",
+      lat: 40.64,
+      lon: -73.78,
+      trackingState: { status: "adsb_live" },
+    },
+  ];
+  const pending = resolvePendingRouteLookups({
+    aircraft,
+    cache: new Map(),
+    inFlight: new Set(),
+    queued: new Set(),
+    routeContext: { routeProvider: "flightaware" },
+    now,
+    maxLookups: 3,
+  });
+  const routes = buildRoutesByCallsign({
+    aircraft,
+    cache: new Map(),
+    routeContext: { routeProvider: "flightaware" },
+    now,
+  });
+
+  assert.deepEqual(pending, ["DAL123"]);
+  assert.deepEqual(routes.AAL100, {
+    callsign: "AAL100",
+    origin: { icao: "KJFK" },
+    destination: { icao: "KLAX" },
+    route: { icao: "KJFK-KLAX" },
+    source: "aircraft-metadata",
+    confidence: "position-metadata",
+  });
+}

--- a/src/features/aviation/flight-routes/flightRouteScheduler.test.js
+++ b/src/features/aviation/flight-routes/flightRouteScheduler.test.js
@@ -186,3 +186,67 @@ function createManualTimer() {
   );
   scheduler.dispose();
 }
+
+{
+  const timer = createManualTimer();
+  const scheduler = createFlightRouteScheduler({
+    client: {
+      async fetchFlightRoute() {
+        throw new Error("terminal aircraft should not fetch a route");
+      },
+    },
+    config: {
+      maxConcurrentLookups: 1,
+      maxLookupsPerPass: 2,
+      maxQueueSize: 10,
+      queueIntervalMs: 0,
+      auditLogIntervalMs: 0,
+      hitCacheMs: 60_000,
+      missCacheMs: 10_000,
+    },
+    logger: { info() {}, warn() {} },
+    schedule: timer.schedule,
+    clearSchedule: timer.clear,
+    now: () => 1_700_000_000_000,
+  });
+
+  const routeContext = { routeProvider: "flightaware" };
+  scheduler.syncAircraft({
+    aircraft: [
+      {
+        callsign: "AAL100",
+        origin: "KJFK",
+        destination: "KLAX",
+        trackingState: { status: "flightaware_terminal" },
+      },
+    ],
+    routeContext,
+  });
+
+  assert.equal(scheduler.getLoadingCount(), 0);
+  assert.equal(timer.callbacks.length, 0);
+  assert.deepEqual(
+    scheduler.getRoutesByCallsign({
+      aircraft: [
+        {
+          callsign: "AAL100",
+          origin: "KJFK",
+          destination: "KLAX",
+          trackingState: { status: "flightaware_terminal" },
+        },
+      ],
+      routeContext,
+    }),
+    {
+      AAL100: {
+        callsign: "AAL100",
+        origin: { icao: "KJFK" },
+        destination: { icao: "KLAX" },
+        route: { icao: "KJFK-KLAX" },
+        source: "aircraft-metadata",
+        confidence: "position-metadata",
+      },
+    },
+  );
+  scheduler.dispose();
+}

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -47,6 +47,8 @@ export function useTrackedAircraft(callsign) {
   const [settled, setSettled] = useState(false);
   const [lostSignal, setLostSignal] = useState(false);
   const [pollVersion, setPollVersion] = useState(0);
+  const [trackingState, setTrackingState] = useState(null);
+  const [flightAwareFallback, setFlightAwareFallback] = useState(null);
   const timerRef = useRef(null);
   const disposedRef = useRef(false);
   const missesRef = useRef(0);
@@ -72,6 +74,8 @@ export function useTrackedAircraft(callsign) {
       setError(null);
       setLostSignal(false);
       setPollVersion(0);
+      setTrackingState(null);
+      setFlightAwareFallback(null);
       missesRef.current = 0;
       return undefined;
     }
@@ -99,6 +103,7 @@ export function useTrackedAircraft(callsign) {
         if (disposedRef.current) return;
         const matches = Array.isArray(payload?.ac) ? payload.ac : [];
         const receiveTime = Date.now();
+        const nextTrackingState = payload?.trackingState || null;
         const signalState = getTrackedAircraftSignalState({
           matchesLength: getActiveAdsbMatchesLength({
             matchesLength: matches.length,
@@ -106,12 +111,15 @@ export function useTrackedAircraft(callsign) {
           }),
           previousMisses: missesRef.current,
           flightAwareFallback: payload?.flightAwareFallback,
+          trackingState: nextTrackingState,
         });
         await waitUntil(commitAfter);
         if (disposedRef.current) return;
         setSettled(true);
         setInitialLoading(false);
         setVisibilityRefreshLoading(false);
+        setTrackingState(nextTrackingState);
+        setFlightAwareFallback(payload?.flightAwareFallback || null);
         if (matches.length === 0) {
           // No matches: don't blank the aircraft snapshot — the user
           // is probably watching a flight that just landed and we want
@@ -130,7 +138,10 @@ export function useTrackedAircraft(callsign) {
             responseNow: payload?.now,
             receiveTime,
           });
-          setAircraft(normalized);
+          setAircraft({
+            ...normalized,
+            trackingState: nextTrackingState,
+          });
           missesRef.current = signalState.misses;
           setLostSignal(signalState.lostSignal);
         }
@@ -220,6 +231,8 @@ export function useTrackedAircraft(callsign) {
     error,
     lostSignal,
     pollVersion,
+    trackingState,
+    flightAwareFallback,
     retry,
   };
 }


### PR DESCRIPTION
## Summary
- add explicit tracked-flight position states for ADS-B live, FlightAware active, FlightAware terminal, stale, and missing cases
- suppress new route fetches for terminal/stale/missing tracked aircraft while preserving metadata routes
- render FlightAware predicted route arcs as dashed lines across both foreground and glow layers
- bump ADSBao web version to 1.5.0 and document the mechanism

## Verification
- pnpm test
- pnpm lint
- pnpm build