### PR TITLE
fix: enforce FlightAware route dashes

### DIFF
--- a/src/config/airportMapThemeContract.test.js
+++ b/src/config/airportMapThemeContract.test.js
@@ -52,6 +52,12 @@ assert.match(
   "Tailwind font utility should resolve through the theme font token",
 );
 
+assert.match(
+  styleCss,
+  /\.aircraft-trace--flightaware-route(?:-glow)?[\s\S]*stroke-dasharray:\s*10 12/,
+  "FlightAware route SVG classes should enforce dashed rendering in production",
+);
+
 for (const theme of ["light", "dark"]) {
   const trace = SELECTED_AIRCRAFT_TRACE_STYLE[theme];
   assertThemeVar(trace.lineColor, `${theme} selected trace line`);

--- a/src/style.css
+++ b/src/style.css
@@ -2894,6 +2894,11 @@ body {
     mix-blend-mode: screen;
 }
 
+.aircraft-trace--flightaware-route,
+.aircraft-trace--flightaware-route-glow {
+    stroke-dasharray: 10 12 !important;
+}
+
 .aircraft-trace-point {
     filter: drop-shadow(
         0 0 7px color-mix(in oklab, var(--atc-accent) 24%, transparent)


### PR DESCRIPTION
## Summary
- enforce FlightAware route dash rendering on both foreground and glow SVG classes
- add a CSS contract test for the production FlightAware route class

## Verification
- pnpm test
- pnpm lint
- pnpm build