### PR TITLE
Prioritize major nearby airports and tune sidebar tone

### DIFF
--- a/src/app/api/dao/airportDirectory.dao.js
+++ b/src/app/api/dao/airportDirectory.dao.js
@@ -45,6 +45,23 @@ const haversineNm = (lat1, lon1, lat2, lon2) => {
 
 export const typeRank = (type) => TYPE_RANK[type] ?? 9;
 
+const nearbyAirportRank = (airport) => {
+  const rank = typeRank(airport?.type);
+  const hasCommercialCode = Boolean(airport?.iata);
+  const hasScheduledService = Boolean(airport?.scheduledService);
+  const codeRank = hasScheduledService && hasCommercialCode ? -0.2 : hasCommercialCode ? -0.1 : 0;
+  return rank + codeRank;
+};
+
+const sortNearbyRows = (table, left, right) => {
+  if (table === "airports") {
+    const leftRank = nearbyAirportRank(left);
+    const rightRank = nearbyAirportRank(right);
+    if (leftRank !== rightRank) return leftRank - rightRank;
+  }
+  return left.distanceNm - right.distanceNm;
+};
+
 export const mapAirportRow = (row) => {
   if (!row) return null;
   return {
@@ -440,7 +457,7 @@ const queryNearby = async ({
       return { ...mapped, distanceNm };
     })
     .filter((row) => row && row.distanceNm <= radius)
-    .sort((left, right) => left.distanceNm - right.distanceNm)
+    .sort((left, right) => sortNearbyRows(table, left, right))
     .slice(0, safeLimit);
 };
 

--- a/src/app/api/dao/airportDirectory.dao.test.js
+++ b/src/app/api/dao/airportDirectory.dao.test.js
@@ -271,6 +271,56 @@ const airports = [
     iso_country: "CA",
     iso_region: "CA-ON",
   },
+  {
+    ...KBOS,
+    ident: "KLGA",
+    icao_code: "KLGA",
+    iata_code: "LGA",
+    name: "LaGuardia Airport",
+    latitude_deg: 40.77725,
+    longitude_deg: -73.872611,
+    municipality: "New York",
+    iso_region: "US-NY",
+  },
+  {
+    ...KBOS,
+    ident: "KEWR",
+    icao_code: "KEWR",
+    iata_code: "EWR",
+    name: "Newark Liberty International Airport",
+    latitude_deg: 40.6925,
+    longitude_deg: -74.168667,
+    municipality: "Newark",
+    iso_region: "US-NJ",
+  },
+  {
+    ...KBOS,
+    ident: "15NY",
+    icao_code: "",
+    iata_code: "",
+    gps_code: "15NY",
+    type: "heliport",
+    name: "Peninsula Hospital Center Heliport",
+    latitude_deg: 40.606,
+    longitude_deg: -73.816,
+    scheduled_service: false,
+    municipality: "New York",
+    iso_region: "US-NY",
+  },
+  {
+    ...KBOS,
+    ident: "US-3183",
+    icao_code: "",
+    iata_code: "",
+    gps_code: "",
+    type: "small_airport",
+    name: "Columbia Aircraft Factory Airfield",
+    latitude_deg: 40.61,
+    longitude_deg: -73.83,
+    scheduled_service: false,
+    municipality: "New York",
+    iso_region: "US-NY",
+  },
 ];
 
 const runways = [
@@ -342,9 +392,9 @@ const nearby = await queries.getNearbyAirports({
   radiusNm: 250,
   limit: 5,
 });
-assert.equal(nearby.length, 1);
-assert.equal(nearby[0].icao, "KJFK");
-assert.ok(nearby[0].distanceNm > 150 && nearby[0].distanceNm < 220);
+const nearbyJfkFromBos = nearby.find((airport) => airport.icao === "KJFK");
+assert.ok(nearbyJfkFromBos);
+assert.ok(nearbyJfkFromBos.distanceNm > 150 && nearbyJfkFromBos.distanceNm < 220);
 
 // Coordinate-based nearby lookup is used by the flight tracking page, where
 // there is no focal airport ident. It must not inherit a US-only country scope.
@@ -357,6 +407,18 @@ const nearbyToronto = await queries.getNearbyAirportsByPosition({
 assert.deepEqual(
   nearbyToronto.map((airport) => airport.icao),
   ["CYTZ", "CYYZ"],
+);
+
+// Nearby airport display should not let very close heliports or minor fields
+// consume the limited label slots ahead of major neighboring airports.
+const nearbyJfk = await queries.getNearbyAirports({
+  ident: "KJFK",
+  radiusNm: 40,
+  limit: 3,
+});
+assert.deepEqual(
+  nearbyJfk.map((airport) => airport.icao),
+  ["KLGA", "KEWR", "US-3183"],
 );
 
 // Get runways

--- a/src/app/api/dao/nearbyAirports.dao.js
+++ b/src/app/api/dao/nearbyAirports.dao.js
@@ -22,7 +22,7 @@ export function buildNearbyAirportCacheKey({
   minRunwayLength,
 } = {}) {
   return [
-    "nearby-airports-v3",
+    "nearby-airports-v4",
     String(country || "").trim().toUpperCase(),
     roundedNumber(minRunwayLength, 0),
     String(icao || "").trim().toUpperCase(),

--- a/src/app/api/dao/nearbyAirports.dao.test.js
+++ b/src/app/api/dao/nearbyAirports.dao.test.js
@@ -60,7 +60,7 @@ assert.equal(
     country: "us",
     minRunwayLength: 5000,
   }),
-  "nearby-airports-v3:US:5000:KJFK:40.639928:-73.778692:30:6",
+  "nearby-airports-v4:US:5000:KJFK:40.639928:-73.778692:30:6",
 );
 
 {
@@ -77,7 +77,7 @@ assert.equal(
     now,
   });
 
-  const payload = await cache.read("nearby-airports-v3:US:5000:KJFK:40.639928:-73.778692:30:6");
+  const payload = await cache.read("nearby-airports-v4:US:5000:KJFK:40.639928:-73.778692:30:6");
 
   assert.deepEqual(payload, {
     airports: [{ icao: "KLGA" }],
@@ -103,7 +103,7 @@ assert.equal(
       {
         type: "eq",
         column: "cache_key",
-        value: "nearby-airports-v3:US:5000:KJFK:40.639928:-73.778692:30:6",
+        value: "nearby-airports-v4:US:5000:KJFK:40.639928:-73.778692:30:6",
       },
       { type: "gt", column: "expires_at", value: "2026-05-10T12:00:00.000Z" },
       { type: "limit", count: 1 },
@@ -122,7 +122,7 @@ assert.equal(
   });
 
   await cache.write({
-    cacheKey: "nearby-airports-v3:US:5000:KJFK:40.639928:-73.778692:30:6",
+    cacheKey: "nearby-airports-v4:US:5000:KJFK:40.639928:-73.778692:30:6",
     query: {
       country: "US",
       minRunwayLength: 5000,
@@ -136,7 +136,7 @@ assert.equal(
   });
 
   const upsertCall = calls.find((call) => call.type === "upsert");
-  assert.equal(upsertCall.row.cache_key, "nearby-airports-v3:US:5000:KJFK:40.639928:-73.778692:30:6");
+  assert.equal(upsertCall.row.cache_key, "nearby-airports-v4:US:5000:KJFK:40.639928:-73.778692:30:6");
   assert.equal(upsertCall.row.expires_at, "2026-08-08T12:00:00.000Z");
   assert.deepEqual(upsertCall.row.response.airports, [{ icao: "KLGA" }]);
   assert.deepEqual(upsertCall.options, { onConflict: "cache_key" });

--- a/src/style.css
+++ b/src/style.css
@@ -129,6 +129,9 @@
                         would be unreadable).
      --primary-ink    : dark companion surface with the same color
                         temperature as the selected primary.
+     --theme-sidebar-bg/card : sidebar-only light surfaces; these follow
+                        the selected primary so teal mode no longer keeps
+                        the warm yellow paper cast.
    The default is yellow. Selecting "teal" in the nav menu sets
    data-primary="teal" on <html>, which the override block below picks
    up — every token that aliases these vars follows automatically. */
@@ -141,6 +144,8 @@
     --theme-primary-bright: #ffe600;
     --theme-primary-deep: #a86a1f;
     --theme-primary-ink: oklch(0.14 0.016 100);
+    --theme-sidebar-bg: oklch(0.925 0.004 100);
+    --theme-sidebar-card: oklch(0.965 0.003 100);
     --primary-bright: var(--theme-primary-bright);
     --primary-deep: var(--theme-primary-deep);
     --primary-ink: var(--theme-primary-ink);
@@ -150,6 +155,8 @@
     --theme-primary-bright: #83d5cf;
     --theme-primary-deep: #2d746d;
     --theme-primary-ink: oklch(0.14 0.016 188);
+    --theme-sidebar-bg: oklch(0.925 0.005 188);
+    --theme-sidebar-card: oklch(0.965 0.004 188);
     --atc-mint: oklch(0.65 0.064 188);
     --aircraft-trace-line: #2d746d;
     --aircraft-trace-glow: #2d746d;
@@ -325,11 +332,11 @@
     --border: var(--atc-line);
     --input: var(--atc-line-strong);
     --ring: var(--atc-accent);
-    --sidebar: var(--atc-bg);
+    --sidebar: var(--theme-sidebar-bg);
     --sidebar-foreground: var(--atc-text);
     --sidebar-primary: var(--atc-text);
     --sidebar-primary-foreground: oklch(0.965 0.003 100);
-    --sidebar-accent: var(--atc-card);
+    --sidebar-accent: var(--theme-sidebar-card);
     --sidebar-accent-foreground: var(--atc-text);
     --sidebar-border: var(--atc-line-strong);
     --sidebar-border-soft: var(--atc-line);
@@ -3995,10 +4002,10 @@ body {
     background:
         linear-gradient(
             180deg,
-            color-mix(in oklab, var(--atc-elev) 18%, transparent),
+            color-mix(in oklab, var(--sidebar-accent) 36%, transparent),
             transparent 24%
         ),
-        var(--atc-bg);
+        var(--sidebar);
     border-right: 1px solid var(--atc-line-strong);
     display: flex;
     flex-direction: column;
@@ -4021,7 +4028,7 @@ body {
             color-mix(in oklab, var(--atc-high) 20%, transparent),
             transparent 28%
         ),
-        var(--atc-card);
+        var(--sidebar);
 }
 
 .airport-map-region {


### PR DESCRIPTION
## Summary
- prioritize nearby airport labels by airport type so LGA/EWR are not displaced by nearby heliports and minor fields
- bump nearby-airport cache to v4 for the new ordering
- add primary-aware sidebar surface tokens so teal mode no longer keeps the warm yellow sidebar cast

## Verification
- pnpm test
- pnpm lint
- pnpm build
- local API smoke: /api/proxy/airports/nearby?lat=40.639928&lon=-73.778692&icao=KJFK&radiusNm=40&limit=12&runways=1 returns KLGA and KEWR first