### PR TITLE
fix: refresh traces on tab return

### DIFF
--- a/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
+++ b/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
@@ -61,7 +61,7 @@ export function SelectedAircraftTraceProvider({
     fullTrace: fullTraceForFocal,
     traceStartAtMs: focalTraceStartAtMs,
     persistKey: focalPersistKey,
-    recentRefreshKey: focalTraceRefreshKey,
+    traceRefreshKey: focalTraceRefreshKey,
   });
 
   const primary = useMemo(

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -12,7 +12,7 @@ import {
   getTraceCutoffMs,
 } from "@/features/aircraft/tracking/trackedFlightStorage.js";
 import {
-  getLostSignalTraceRefreshKey,
+  getTrackedFlightTraceRefreshKey,
 } from "@/features/aircraft/tracking/lostSignalTrackingModel.js";
 import {
   getFlightTrackingContextPosition,
@@ -110,6 +110,7 @@ function FlightExplorerContent({ callsign }) {
     settled: trackedAircraftSettled,
     lostSignal,
     pollVersion: trackedPollVersion,
+    visibilityRefreshVersion: trackedVisibilityRefreshVersion,
   } = useTrackedAircraft(callsign);
 
   // Anchor the tracking session as soon as we have a callsign so the
@@ -134,11 +135,12 @@ function FlightExplorerContent({ callsign }) {
   );
   const focalTraceRefreshKey = useMemo(
     () =>
-      getLostSignalTraceRefreshKey({
+      getTrackedFlightTraceRefreshKey({
         lostSignal,
         pollVersion: trackedPollVersion,
+        visibilityRefreshVersion: trackedVisibilityRefreshVersion,
       }),
-    [lostSignal, trackedPollVersion],
+    [lostSignal, trackedPollVersion, trackedVisibilityRefreshVersion],
   );
 
   // User can dismiss the lost-signal toast to keep watching the last

--- a/src/features/aircraft/trace/aircraftTraceRefreshModel.js
+++ b/src/features/aircraft/trace/aircraftTraceRefreshModel.js
@@ -1,0 +1,9 @@
+export function resolveAircraftTraceRefreshSources({
+  refreshKey = "",
+  fullTrace = false,
+} = {}) {
+  if (!String(refreshKey || "").trim()) return [];
+  const sources = [{ source: "recent", full: false }];
+  if (fullTrace) sources.push({ source: "full", full: true });
+  return sources;
+}

--- a/src/features/aircraft/trace/aircraftTraceRefreshModel.test.js
+++ b/src/features/aircraft/trace/aircraftTraceRefreshModel.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+
+import {
+  resolveAircraftTraceRefreshSources,
+} from "./aircraftTraceRefreshModel.js";
+
+assert.deepEqual(
+  resolveAircraftTraceRefreshSources({
+    refreshKey: "",
+    fullTrace: true,
+  }),
+  [],
+);
+
+assert.deepEqual(
+  resolveAircraftTraceRefreshSources({
+    refreshKey: "visibility:1",
+    fullTrace: false,
+  }),
+  [
+    { source: "recent", full: false },
+  ],
+);
+
+assert.deepEqual(
+  resolveAircraftTraceRefreshSources({
+    refreshKey: "visibility:1",
+    fullTrace: true,
+  }),
+  [
+    { source: "recent", full: false },
+    { source: "full", full: true },
+  ],
+);
+
+console.log("aircraftTraceRefreshModel.test.js ok");

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.js
@@ -39,6 +39,18 @@ export function getLostSignalTraceRefreshKey({
   return `lost-signal:${version}`;
 }
 
+export function getTrackedFlightTraceRefreshKey({
+  lostSignal = false,
+  pollVersion = 0,
+  visibilityRefreshVersion = 0,
+} = {}) {
+  const visibilityVersion = Number(visibilityRefreshVersion);
+  if (Number.isFinite(visibilityVersion) && visibilityVersion > 0) {
+    return `visibility:${visibilityVersion}`;
+  }
+  return getLostSignalTraceRefreshKey({ lostSignal, pollVersion });
+}
+
 export function hasActiveFlightAwareFallback(fallback) {
   if (!fallback || typeof fallback !== "object") return false;
   if (fallback.ok !== true) return false;

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   getActiveAdsbMatchesLength,
   getLostSignalTraceRefreshKey,
+  getTrackedFlightTraceRefreshKey,
   getTrackedAircraftSignalState,
   hasActiveFlightAwareFallback,
 } from "./lostSignalTrackingModel.js";
@@ -24,6 +25,33 @@ assert.equal(
 
 assert.equal(
   getLostSignalTraceRefreshKey({ lostSignal: true, pollVersion: 0 }),
+  "",
+);
+
+assert.equal(
+  getTrackedFlightTraceRefreshKey({
+    lostSignal: false,
+    pollVersion: 21,
+    visibilityRefreshVersion: 2,
+  }),
+  "visibility:2",
+);
+
+assert.equal(
+  getTrackedFlightTraceRefreshKey({
+    lostSignal: true,
+    pollVersion: 21,
+    visibilityRefreshVersion: 0,
+  }),
+  "lost-signal:21",
+);
+
+assert.equal(
+  getTrackedFlightTraceRefreshKey({
+    lostSignal: false,
+    pollVersion: 21,
+    visibilityRefreshVersion: 0,
+  }),
   "",
 );
 

--- a/src/hooks/useAircraftTrace.js
+++ b/src/hooks/useAircraftTrace.js
@@ -8,6 +8,9 @@ import {
   normalizeAdsbTracePayload,
 } from "../features/aircraft/trace/aircraftTraceModel.js";
 import {
+  resolveAircraftTraceRefreshSources,
+} from "../features/aircraft/trace/aircraftTraceRefreshModel.js";
+import {
   readTrackedTrace,
   writeTrackedTrace,
 } from "../features/aircraft/tracking/trackedTraceStorage.js";
@@ -116,8 +119,10 @@ export function useAircraftTrace(selectedAircraft = null, options = {}) {
     typeof options?.persistKey === "string" && options.persistKey.trim()
       ? options.persistKey.trim()
       : null;
-  const recentRefreshKey =
-    typeof options?.recentRefreshKey === "string" ? options.recentRefreshKey : "";
+  const traceRefreshKey =
+    typeof options?.traceRefreshKey === "string"
+      ? options.traceRefreshKey
+      : "";
   const traceLabel = formatTraceFetchLabel(selectedAircraft, hex);
 
   const [fullPoints, setFullPoints] = useState([]);
@@ -191,41 +196,59 @@ export function useAircraftTrace(selectedAircraft = null, options = {}) {
     };
   }, [hex, fullTrace, traceLabel]);
 
-  // While the lost-signal overlay is visible on the flight page, the
-  // callsign poll keeps ticking. Use that tick to silently refresh the
-  // recent trace behind the modal so newly-arrived upstream points can
-  // appear without asking the user to dismiss or retry by hand.
+  // While the tracked-flight page is resuming from a background tab (or
+  // keeping the lost-signal overlay alive), silently refresh the upstream
+  // trace sources so browser sleep does not leave a gap in the active path.
   useEffect(() => {
-    if (!hex || !recentRefreshKey) return undefined;
+    const sources = resolveAircraftTraceRefreshSources({
+      refreshKey: traceRefreshKey,
+      fullTrace,
+    });
+    if (!hex || sources.length === 0) return undefined;
 
     let disposed = false;
     const label = traceLabel;
-    setRecentLoading(true);
+    if (sources.some((source) => source.full)) setFullLoading(true);
+    if (sources.some((source) => !source.full)) setRecentLoading(true);
 
-    fetchTraceSource({
-      hex,
-      label,
-      source: "recent",
-      full: false,
-      notify: false,
-    })
-      .then(({ points }) => {
-        if (disposed) return;
-        setRecentPoints(points);
+    sources.forEach(({ source, full }) => {
+      fetchTraceSource({
+        hex,
+        label,
+        source,
+        full,
+        notify: false,
       })
-      .catch((error) => {
-        if (!disposed) {
-          console.warn(`[aircraft-trace:${hex}] background recent fetch failed`, error);
-        }
-      })
-      .finally(() => {
-        if (!disposed) setRecentLoading(false);
-      });
+        .then(({ points }) => {
+          if (disposed) return;
+          if (full) {
+            setFullPoints(points);
+          } else {
+            setRecentPoints(points);
+          }
+        })
+        .catch((error) => {
+          if (!disposed) {
+            console.warn(
+              `[aircraft-trace:${hex}] background ${source} fetch failed`,
+              error,
+            );
+          }
+        })
+        .finally(() => {
+          if (disposed) return;
+          if (full) {
+            setFullLoading(false);
+          } else {
+            setRecentLoading(false);
+          }
+        });
+    });
 
     return () => {
       disposed = true;
     };
-  }, [hex, recentRefreshKey, traceLabel]);
+  }, [hex, traceRefreshKey, fullTrace, traceLabel]);
 
   // Append the latest polled position so the trail extends forward in
   // real time. We don't gate on loading anymore — the priority merge

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -47,6 +47,7 @@ export function useTrackedAircraft(callsign) {
   const [settled, setSettled] = useState(false);
   const [lostSignal, setLostSignal] = useState(false);
   const [pollVersion, setPollVersion] = useState(0);
+  const [visibilityRefreshVersion, setVisibilityRefreshVersion] = useState(0);
   const [trackingState, setTrackingState] = useState(null);
   const [flightAwareFallback, setFlightAwareFallback] = useState(null);
   const timerRef = useRef(null);
@@ -74,6 +75,7 @@ export function useTrackedAircraft(callsign) {
       setError(null);
       setLostSignal(false);
       setPollVersion(0);
+      setVisibilityRefreshVersion(0);
       setTrackingState(null);
       setFlightAwareFallback(null);
       missesRef.current = 0;
@@ -194,6 +196,7 @@ export function useTrackedAircraft(callsign) {
 
       const refresh = () => {
         visibilityRefreshCancelRef.current = null;
+        setVisibilityRefreshVersion((value) => value + 1);
         stopPolling();
         poll({ commitAfter });
         timerRef.current = setInterval(poll, AIRCRAFT_TRAFFIC_CONFIG.pollMs);
@@ -231,6 +234,7 @@ export function useTrackedAircraft(callsign) {
     error,
     lostSignal,
     pollVersion,
+    visibilityRefreshVersion,
     trackingState,
     flightAwareFallback,
     retry,


### PR DESCRIPTION
## Summary
- add a visibility-return trace refresh key for tracked flight pages
- refresh both trace_recent and trace_full when the focal flight uses full trace
- keep lost-signal background trace refresh on the same unified trace refresh path

## Verification
- pnpm test
- pnpm lint
- pnpm build