### PR TITLE
fix: improve dark preview track button contrast

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -5667,6 +5667,12 @@ body {
     color: var(--primary-foreground);
 }
 
+:root[data-theme="dark"] .aircraft-preview-card__track-btn,
+:root[data-theme="dark"] .aircraft-preview-card__track-btn:visited,
+:root[data-theme="dark"] .aircraft-preview-mobile-card__track {
+    color: var(--atc-text);
+}
+
 .aircraft-preview-card__track-btn:hover {
     opacity: 0.92;
 }


### PR DESCRIPTION
## Summary
- make preview track CTA text use dark-theme foreground color on dark theme
- apply the same contrast fix to the mobile stacked track CTA

## Verification
- pnpm lint
- pnpm build

Tests intentionally skipped per request.