### PR TITLE
[codex] Add bounded mobile map recentering

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.jsx
+++ b/src/components/airport/explorer/AirportExplorer.jsx
@@ -56,6 +56,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     selectAircraft,
     setSelectedAircraftId,
     selectAirport,
+    pauseMapFollow,
+    resumeMapFollow,
     mapFollowsAircraft,
   } = useExplorerUi();
   const airportProfile = useMemo(
@@ -206,6 +208,9 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             runwayProcedures={null}
             procedureFixLabelRunwayProcedures={procedures.runwayProcedures}
             showProcedureFixLabels
+            mobileMapInteractionEnabled={isMobile}
+            onMapMoveFromCenter={pauseMapFollow}
+            onRecenterMap={resumeMapFollow}
           />
           <AircraftDataLoadingOverlay
             active={

--- a/src/components/explorer/ExplorerUiContext.jsx
+++ b/src/components/explorer/ExplorerUiContext.jsx
@@ -30,8 +30,9 @@ const initialUiState = {
   fitToTraceSignal: 0,
   // When true (default), the map re-centers on every aircraft position
   // poll. The user opts out by clicking "fit to trace" — the map then
-  // stays anchored on the trace bounds. Clicking any preset zoom
-  // re-enables auto-follow.
+  // stays anchored on the trace bounds. A bounded mobile map gesture
+  // also pauses auto-follow until the user taps recenter. Clicking any
+  // preset zoom re-enables auto-follow.
   mapFollowsAircraft: true,
 };
 
@@ -110,6 +111,10 @@ function airportExplorerUiReducer(state, action) {
         fitToTraceSignal: state.fitToTraceSignal + 1,
         mapFollowsAircraft: false,
       };
+    case "pauseMapFollow":
+      return { ...state, mapFollowsAircraft: false };
+    case "resumeMapFollow":
+      return { ...state, mapFollowsAircraft: true };
     default:
       return state;
   }
@@ -206,6 +211,14 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "fitToTrace" });
   }, []);
 
+  const pauseMapFollow = useCallback(() => {
+    dispatch({ type: "pauseMapFollow" });
+  }, []);
+
+  const resumeMapFollow = useCallback(() => {
+    dispatch({ type: "resumeMapFollow" });
+  }, []);
+
   const fitToTraceSignal = state.fitToTraceSignal;
   const mapFollowsAircraft = state.mapFollowsAircraft;
 
@@ -241,6 +254,8 @@ export function ExplorerUiProvider({ children }) {
       setSelectedAircraftId,
       selectAirport,
       fitToTrace,
+      pauseMapFollow,
+      resumeMapFollow,
     }),
     [
       sidebarMode,
@@ -272,6 +287,8 @@ export function ExplorerUiProvider({ children }) {
       setSelectedAircraftId,
       selectAirport,
       fitToTrace,
+      pauseMapFollow,
+      resumeMapFollow,
     ],
   );
 

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -84,6 +84,8 @@ function FlightExplorerContent({ callsign }) {
     selectAircraft,
     setSelectedAircraftId,
     selectAirport,
+    pauseMapFollow,
+    resumeMapFollow,
     toggleMapLabels,
     fitToTrace,
     mapFollowsAircraft,
@@ -382,6 +384,9 @@ function FlightExplorerContent({ callsign }) {
             showProcedureFixLabels={false}
             focalRangeRings={false}
             nearbyRangeRings={{ intervalNm: 5, maxNm: 5, prominent: true }}
+            mobileMapInteractionEnabled={isMobile}
+            onMapMoveFromCenter={pauseMapFollow}
+            onRecenterMap={resumeMapFollow}
           >
             <FlightAwareRouteArc path={focalFlightAwareRoutePath} />
             <MapFitToTraceController

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import L from "leaflet";
+import { Crosshair } from "lucide-react";
 import { MapContext } from "./MapContext.js";
 import MapTileLayers from "./MapTileLayers.jsx";
 import AreaMarker from "./AreaMarker.jsx";
@@ -19,15 +20,24 @@ import { getAircraftIdentity } from "../../features/airport/context/airportConte
 import { useI18n } from "../../features/app-shell/i18n/useI18n.js";
 import { aircraftMatchesFilters } from "../../features/aircraft/filters/aircraftFilters.js";
 import {
+  clampMapCenterToRadius,
   getMapOverlayTheme,
   getVisibleAircraft,
   resolveDocumentTheme,
 } from "../../features/airport/map/airportMapModel.js";
 
+const MOBILE_MAP_GESTURE_RADIUS_NM = 20;
+const MAP_CENTER_DEADZONE_NM = 0.05;
+
 const resolveCurrentTheme = () =>
   typeof document !== "undefined"
     ? resolveDocumentTheme(document.documentElement)
     : "dark";
+
+const resolveCoordinate = (value) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
 
 export default function AirportMap({
   icao = "",
@@ -55,9 +65,12 @@ export default function AirportMap({
   showProcedureFixLabels = false,
   focalRangeRings = null,
   nearbyRangeRings = null,
+  mobileMapInteractionEnabled = false,
+  onMapMoveFromCenter = null,
+  onRecenterMap = null,
   children = null,
 }) {
-  const { locale } = useI18n();
+  const { locale, t } = useI18n();
   // Single source of truth for the ring bands so the inline labels
   // (AreaMarker), per-airport rings (NearbyAirportLayer), and the
   // bottom-left legend all agree on what to render. Pass `false` to
@@ -74,8 +87,24 @@ export default function AirportMap({
   const mapEl = useRef(null);
   const mapRef = useRef(null);
   const sizeObs = useRef(null);
+  const programmaticMoveRef = useRef(false);
   const [mapInstance, setMapInstance] = useState(null);
   const [currentTheme, setCurrentTheme] = useState(() => resolveCurrentTheme());
+  const focalCenter = useMemo(() => {
+    const focalLat = resolveCoordinate(lat);
+    const focalLon = resolveCoordinate(lon);
+    if (focalLat == null || focalLon == null) return null;
+    return { lat: focalLat, lon: focalLon };
+  }, [lat, lon]);
+  const boundedMobileInteraction =
+    mobileMapInteractionEnabled && Boolean(focalCenter);
+  const runProgrammaticMapMove = useCallback((move) => {
+    programmaticMoveRef.current = true;
+    move();
+    window.setTimeout(() => {
+      programmaticMoveRef.current = false;
+    }, 0);
+  }, []);
 
   useEffect(() => {
     setCurrentTheme(resolveCurrentTheme());
@@ -126,15 +155,87 @@ export default function AirportMap({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (!mapInstance) return;
+
+    mapInstance.dragging.disable();
+    if (boundedMobileInteraction) {
+      mapInstance.touchZoom?.enable();
+      return;
+    }
+
+    mapInstance.touchZoom?.disable();
+  }, [boundedMobileInteraction, mapInstance]);
+
   // followsCenter controls whether the map re-centers on every poll.
   // After "fit to trace" the caller flips this to false so the map
   // stays anchored to the trace bounds even though the aircraft keeps
   // moving; clicking a preset zoom flips it back to true upstream.
   useEffect(() => {
-    if (mapRef.current && lat && lon && followsCenter) {
-      mapRef.current.setView([lat, lon], zoom);
+    if (mapRef.current && focalCenter && followsCenter) {
+      runProgrammaticMapMove(() => {
+        mapRef.current.setView([focalCenter.lat, focalCenter.lon], zoom, {
+          animate: false,
+        });
+      });
     }
-  }, [lat, lon, zoom, followsCenter]);
+  }, [focalCenter, followsCenter, runProgrammaticMapMove, zoom]);
+
+  useEffect(() => {
+    if (!mapInstance || !boundedMobileInteraction || !focalCenter) {
+      return undefined;
+    }
+
+    const getCenterDistanceNm = () =>
+      mapInstance.distance(
+        [focalCenter.lat, focalCenter.lon],
+        mapInstance.getCenter(),
+      ) / 1852;
+
+    const clampToMobileRadius = () => {
+      const center = mapInstance.getCenter();
+      const clamped = clampMapCenterToRadius({
+        center: { lat: center.lat, lon: center.lng },
+        focalCenter,
+        radiusNm: MOBILE_MAP_GESTURE_RADIUS_NM,
+      });
+      if (
+        !clamped ||
+        (Math.abs(clamped.lat - center.lat) < 0.000001 &&
+          Math.abs(clamped.lon - center.lng) < 0.000001)
+      ) {
+        return;
+      }
+
+      runProgrammaticMapMove(() => {
+        mapInstance.setView([clamped.lat, clamped.lon], mapInstance.getZoom(), {
+          animate: false,
+        });
+      });
+    };
+
+    const handleMoveEnd = () => {
+      const wasProgrammatic = programmaticMoveRef.current;
+      clampToMobileRadius();
+
+      if (!wasProgrammatic && getCenterDistanceNm() > MAP_CENTER_DEADZONE_NM) {
+        onMapMoveFromCenter?.();
+      }
+    };
+
+    mapInstance.on("moveend", handleMoveEnd);
+    clampToMobileRadius();
+
+    return () => {
+      mapInstance.off("moveend", handleMoveEnd);
+    };
+  }, [
+    boundedMobileInteraction,
+    focalCenter,
+    mapInstance,
+    onMapMoveFromCenter,
+    runProgrammaticMapMove,
+  ]);
 
   // Clicks on the map background (not on an aircraft marker) clear the
   // selection so the user can drop "trace mode" without targeting an
@@ -175,7 +276,15 @@ export default function AirportMap({
       zoom,
       groundAreaRadiusNm: effectiveFocalRings?.intervalNm,
     });
-  }, [aircraft, icao, lat, lon, nearbyAirports, zoom, effectiveFocalRings?.intervalNm]);
+  }, [
+    aircraft,
+    icao,
+    lat,
+    lon,
+    nearbyAirports,
+    zoom,
+    effectiveFocalRings?.intervalNm,
+  ]);
   const selectedAircraft = useMemo(
     () =>
       visibleAircraft.find(
@@ -188,6 +297,21 @@ export default function AirportMap({
   const selectionActive = Boolean(selectedAircraftId && selectedAircraft);
 
   const overlayTheme = getMapOverlayTheme(currentTheme);
+
+  const handleRecenter = () => {
+    if (!mapRef.current || !focalCenter) return;
+
+    onRecenterMap?.();
+    runProgrammaticMapMove(() => {
+      mapRef.current.setView(
+        [focalCenter.lat, focalCenter.lon],
+        mapRef.current.getZoom(),
+        {
+          animate: false,
+        },
+      );
+    });
+  };
 
   return (
     <div className="relative h-full w-full bg-atc-bg">
@@ -281,6 +405,18 @@ export default function AirportMap({
           color={overlayTheme.attributionColor}
           shadowColor={overlayTheme.labelShadowColor}
         />
+      )}
+
+      {mapInstance && boundedMobileInteraction && (
+        <button
+          type="button"
+          className="ctrl-btn map-recenter-btn"
+          aria-label={t("map.recenter")}
+          title={t("map.recenter")}
+          onClick={handleRecenter}
+        >
+          <Crosshair aria-hidden="true" />
+        </button>
       )}
 
       {!mapInstance && <MapLoadingState />}

--- a/src/config/i18n/en.js
+++ b/src/config/i18n/en.js
@@ -212,6 +212,7 @@ const en = {
     layerOverlaysAria: "Map layer overlays",
     toggleSidebar: "Toggle sidebar",
     fitTrace: "Fit map to trace",
+    recenter: "Return to center",
     approachingView: "Approaching view (click to cycle)",
     themeButtonAria: "Theme: {label} (click to switch)",
     themeLight: "Light",

--- a/src/config/i18n/zh-CN.js
+++ b/src/config/i18n/zh-CN.js
@@ -207,6 +207,7 @@ const zhCN = {
     layerOverlaysAria: "地图图层叠加",
     toggleSidebar: "切换侧栏",
     fitTrace: "适配航迹",
+    recenter: "回到中心点",
     approachingView: "进近视图(点击循环)",
     themeButtonAria: "主题:{label}(点击切换)",
     themeLight: "明亮",

--- a/src/features/airport/map/airportMapModel.js
+++ b/src/features/airport/map/airportMapModel.js
@@ -5,6 +5,9 @@ import { getDistanceNm } from "../../../utils/aircraftTrafficIntent.js";
 // Matches the focal-airport's default first-ring interval so the
 // ground filter aligns with the visual layer.
 const DEFAULT_GROUND_AREA_RADIUS_NM = 3;
+const EARTH_RADIUS_NM = 3440.065;
+const DEG_TO_RAD = Math.PI / 180;
+const RAD_TO_DEG = 180 / Math.PI;
 
 export const resolveDocumentTheme = (documentElement) =>
   documentElement?.getAttribute("data-theme") === "light" ? "light" : "dark";
@@ -19,6 +22,76 @@ export const getMapOverlayTheme = (theme) =>
         labelShadowColor: "var(--map-label-shadow)",
         attributionColor: "var(--map-attribution)",
       };
+
+const toFiniteCoordinate = (value) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const normalizeLongitude = (lon) => ((((lon + 180) % 360) + 360) % 360) - 180;
+
+const getBearingRad = (from, to) => {
+  const fromLat = from.lat * DEG_TO_RAD;
+  const toLat = to.lat * DEG_TO_RAD;
+  const deltaLon = (to.lon - from.lon) * DEG_TO_RAD;
+  const y = Math.sin(deltaLon) * Math.cos(toLat);
+  const x =
+    Math.cos(fromLat) * Math.sin(toLat) -
+    Math.sin(fromLat) * Math.cos(toLat) * Math.cos(deltaLon);
+  return Math.atan2(y, x);
+};
+
+const destinationPoint = (origin, bearingRad, distanceNm) => {
+  const angularDistance = distanceNm / EARTH_RADIUS_NM;
+  const originLat = origin.lat * DEG_TO_RAD;
+  const originLon = origin.lon * DEG_TO_RAD;
+  const destinationLat = Math.asin(
+    Math.sin(originLat) * Math.cos(angularDistance) +
+      Math.cos(originLat) * Math.sin(angularDistance) * Math.cos(bearingRad),
+  );
+  const destinationLon =
+    originLon +
+    Math.atan2(
+      Math.sin(bearingRad) * Math.sin(angularDistance) * Math.cos(originLat),
+      Math.cos(angularDistance) - Math.sin(originLat) * Math.sin(destinationLat),
+    );
+
+  return {
+    lat: destinationLat * RAD_TO_DEG,
+    lon: normalizeLongitude(destinationLon * RAD_TO_DEG),
+  };
+};
+
+export const clampMapCenterToRadius = ({ center, focalCenter, radiusNm }) => {
+  const centerLat = toFiniteCoordinate(center?.lat);
+  const centerLon = toFiniteCoordinate(center?.lon);
+  const focalLat = toFiniteCoordinate(focalCenter?.lat);
+  const focalLon = toFiniteCoordinate(focalCenter?.lon);
+  const limitNm = toFiniteCoordinate(radiusNm);
+
+  if (
+    centerLat == null ||
+    centerLon == null ||
+    focalLat == null ||
+    focalLon == null ||
+    limitNm == null ||
+    limitNm <= 0
+  ) {
+    return null;
+  }
+
+  const currentCenter = { lat: centerLat, lon: centerLon };
+  const focal = { lat: focalLat, lon: focalLon };
+  const distanceNm = getDistanceNm(
+    focal.lat,
+    focal.lon,
+    currentCenter.lat,
+    currentCenter.lon,
+  );
+  if (distanceNm == null || distanceNm <= limitNm) return currentCenter;
+
+  return destinationPoint(focal, getBearingRad(focal, currentCenter), limitNm);
+};
 
 export const formatCoordinateLabel = (value, axis) => {
   if (!value) return "";

--- a/src/features/airport/map/airportMapModel.test.js
+++ b/src/features/airport/map/airportMapModel.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import { ZOOM_AIRPORT, ZOOM_APPROACH } from "../../../utils/airportMapDisplay.js";
 import {
+  clampMapCenterToRadius,
   formatCoordinateLabel,
   getMapOverlayTheme,
   getVisibleAircraft,
@@ -51,3 +52,33 @@ assert.equal(
   "var(--map-label-shadow)",
 );
 assert.equal(getMapOverlayTheme("dark").attributionColor, "var(--map-attribution)");
+
+const focalCenter = { lat: 42.3656, lon: -71.0096 };
+
+assert.deepEqual(
+  clampMapCenterToRadius({
+    center: { lat: 42.45, lon: -71.0096 },
+    focalCenter,
+    radiusNm: 20,
+  }),
+  { lat: 42.45, lon: -71.0096 },
+);
+
+const clampedNorth = clampMapCenterToRadius({
+  center: { lat: 42.8656, lon: -71.0096 },
+  focalCenter,
+  radiusNm: 20,
+});
+assert.ok(clampedNorth);
+assert.ok(clampedNorth.lat > focalCenter.lat);
+assert.ok(clampedNorth.lat < 42.8656);
+assert.ok(Math.abs(clampedNorth.lon - focalCenter.lon) < 0.000001);
+
+const clampedEast = clampMapCenterToRadius({
+  center: { lat: 42.3656, lon: -70.4096 },
+  focalCenter,
+  radiusNm: 20,
+});
+assert.ok(clampedEast);
+assert.ok(clampedEast.lon > focalCenter.lon);
+assert.ok(clampedEast.lon < -70.4096);

--- a/src/style.css
+++ b/src/style.css
@@ -5639,7 +5639,7 @@ body {
         inset 0 1px 0 color-mix(in oklab, var(--atc-text) 9%, transparent);
 }
 
-/* Primary CTA inside the preview card — italic-bold Inter that reads
+/* Primary CTA inside the preview card — Saira display type reads
    as a confident action ("Track this aircraft"). Card itself has
    pointer-events:none, so the button restores its own pointer-events. */
 .aircraft-preview-card__track-btn {
@@ -5660,10 +5660,10 @@ body {
         0 8px 18px color-mix(in oklab, var(--primary-bright) 22%, transparent),
         inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 26%, transparent);
     color: var(--primary-ink);
-    font-family: var(--font-sans);
+    font-family: var(--font-display);
     font-size: 13px;
     font-weight: 800;
-    font-style: italic;
+    font-style: normal;
     letter-spacing: 0.08em;
     line-height: 1;
     text-align: center;
@@ -6005,10 +6005,10 @@ body {
         0 10px 22px color-mix(in oklab, var(--primary-bright) 22%, transparent),
         inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 28%, transparent);
     color: var(--primary-ink);
-    font-family: var(--font-sans);
+    font-family: var(--font-display);
     font-size: 13px;
     font-weight: 800;
-    font-style: italic;
+    font-style: normal;
     letter-spacing: 0.08em;
     line-height: 1;
     text-transform: uppercase;

--- a/src/style.css
+++ b/src/style.css
@@ -2740,6 +2740,15 @@ body {
     box-shadow: inset 0 -2px 0 var(--endf-yellow);
 }
 
+.map-recenter-btn {
+    bottom: max(18px, env(safe-area-inset-bottom));
+    box-shadow:
+        0 12px 26px color-mix(in oklab, var(--atc-bg) 58%, transparent),
+        inset 0 -2px 0 color-mix(in oklab, var(--atc-orange) 60%, transparent);
+    position: absolute;
+    right: max(12px, env(safe-area-inset-right));
+    z-index: 900;
+}
 
 .ctrl-sep {
     background: linear-gradient(

--- a/src/style.css
+++ b/src/style.css
@@ -5647,47 +5647,63 @@ body {
     box-sizing: border-box;
     width: 100%;
     margin-top: 14px;
-    padding: 10px 14px;
-    border: none;
-    border: 1px solid color-mix(in oklab, var(--primary-bright) 46%, var(--primary-ink));
+    padding: 11px 14px;
+    border: 1px solid color-mix(in oklab, var(--primary-bright) 88%, var(--primary-ink));
     border-radius: var(--atc-radius-control);
     background:
         linear-gradient(
             180deg,
-            color-mix(in oklab, var(--primary-bright) 24%, var(--primary-ink)),
-            color-mix(in oklab, var(--primary-bright) 14%, var(--primary-ink))
+            color-mix(in oklab, var(--primary-bright) 96%, white 4%),
+            var(--primary-bright)
         );
-    color: var(--primary-foreground);
+    box-shadow:
+        0 8px 18px color-mix(in oklab, var(--primary-bright) 22%, transparent),
+        inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 26%, transparent);
+    color: var(--primary-ink);
     font-family: var(--font-sans);
     font-size: 13px;
-    font-weight: 700;
+    font-weight: 800;
     font-style: italic;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
     line-height: 1;
     text-align: center;
     text-decoration: none;
     text-transform: uppercase;
     cursor: pointer;
     pointer-events: auto;
-    transition: opacity 0.15s ease-out, transform 0.15s ease-out;
+    transition:
+        background 0.15s ease-out,
+        box-shadow 0.15s ease-out,
+        filter 0.15s ease-out,
+        transform 0.15s ease-out;
 }
 
 .aircraft-preview-card__track-btn:visited {
-    color: var(--primary-foreground);
+    color: var(--primary-ink);
 }
 
 :root[data-theme="dark"] .aircraft-preview-card__track-btn,
 :root[data-theme="dark"] .aircraft-preview-card__track-btn:visited,
 :root[data-theme="dark"] .aircraft-preview-mobile-card__track {
-    color: var(--atc-text);
+    color: var(--primary-ink);
 }
 
 .aircraft-preview-card__track-btn:hover {
-    opacity: 0.92;
+    filter: brightness(1.04);
+    box-shadow:
+        0 10px 22px color-mix(in oklab, var(--primary-bright) 28%, transparent),
+        inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 30%, transparent);
+}
+
+.aircraft-preview-card__track-btn:focus-visible,
+.aircraft-preview-mobile-card__track:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--primary-bright) 72%, white);
+    outline-offset: 3px;
 }
 
 .aircraft-preview-card__track-btn:active {
     transform: scale(0.98);
+    filter: brightness(0.96);
 }
 
 .aircraft-preview-card__track-btn:disabled {
@@ -5975,31 +5991,43 @@ body {
 
 .aircraft-preview-mobile-card__track {
     margin: 4px 14px 0;
-    padding: 9px 14px;
-    border: none;
+    min-height: 44px;
+    padding: 0 16px;
+    border: 1px solid color-mix(in oklab, var(--primary-bright) 88%, var(--primary-ink));
     border-radius: 2px;
     background:
         linear-gradient(
             180deg,
-            color-mix(in oklab, var(--primary-bright) 24%, var(--primary-ink)),
-            color-mix(in oklab, var(--primary-bright) 14%, var(--primary-ink))
+            color-mix(in oklab, var(--primary-bright) 96%, white 4%),
+            var(--primary-bright)
         );
-    color: var(--primary-foreground);
+    box-shadow:
+        0 10px 22px color-mix(in oklab, var(--primary-bright) 22%, transparent),
+        inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 28%, transparent);
+    color: var(--primary-ink);
     font-family: var(--font-sans);
-    font-size: 12px;
-    font-weight: 700;
+    font-size: 13px;
+    font-weight: 800;
     font-style: italic;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
     line-height: 1;
     text-transform: uppercase;
     cursor: pointer;
     pointer-events: auto;
     -webkit-tap-highlight-color: transparent;
-    transition: opacity 0.15s ease-out, transform 0.12s ease-out;
+    transition:
+        box-shadow 0.15s ease-out,
+        filter 0.15s ease-out,
+        transform 0.12s ease-out;
+}
+
+.aircraft-preview-mobile-card__track:hover {
+    filter: brightness(1.04);
 }
 
 .aircraft-preview-mobile-card__track:active {
     transform: scale(0.97);
+    filter: brightness(0.96);
 }
 
 .aircraft-preview-mobile-card__track:disabled {


### PR DESCRIPTION
## Summary
- Enable mobile-only two-finger map movement/zoom around the focal airport or tracked aircraft.
- Clamp the mobile map center to a 20nm radius, matching half of the 40nm nearby-data fetch radius.
- Add a bottom-right recenter control that restores the focal center and resumes map follow mode.

## Impact
Mobile users can inspect nearby traffic without losing the map's focal context. Desktop map behavior stays unchanged.

## Verification
- `pnpm lint`
- `pnpm test` (86 test files passed)
- `pnpm build`
- Mobile viewport smoke check on `http://localhost:3000/airport/KBOS` confirmed Leaflet rendering and the recenter button placement.
