### PR TITLE
[codex] Fix mobile trace fit without aircraft position

### DIFF
--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -272,7 +272,9 @@ function FlightExplorerContent({ callsign }) {
   }, [aircraft, trackedAircraft]);
   const focalFlightAwareRoutePath = useMemo(() => {
     const route = enrichedTrackedAircraft?.flightRoute;
-    if (route?.source !== "flightaware") return [];
+    if (route?.source !== "flightaware" || focalLat == null || focalLon == null) {
+      return [];
+    }
     return buildGreatCirclePath({
       from: { lat: focalLat, lon: focalLon },
       to: route.destination,
@@ -360,8 +362,8 @@ function FlightExplorerContent({ callsign }) {
           )}
           <AirportMap
             icao=""
-            lat={focalLat || 0}
-            lon={focalLon || 0}
+            lat={focalLat}
+            lon={focalLon}
             zoom={mapZoom}
             aircraft={aircraft}
             nearbyAirports={nearbyAirports}

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -23,6 +23,7 @@ import {
   clampMapCenterToRadius,
   getMapOverlayTheme,
   getVisibleAircraft,
+  resolveAirportMapFocalCenter,
   resolveDocumentTheme,
 } from "../../features/airport/map/airportMapModel.js";
 
@@ -34,15 +35,10 @@ const resolveCurrentTheme = () =>
     ? resolveDocumentTheme(document.documentElement)
     : "dark";
 
-const resolveCoordinate = (value) => {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : null;
-};
-
 export default function AirportMap({
   icao = "",
-  lat = 0,
-  lon = 0,
+  lat = null,
+  lon = null,
   zoom = 13,
   aircraft = [],
   nearbyAirports = [],
@@ -90,12 +86,10 @@ export default function AirportMap({
   const programmaticMoveRef = useRef(false);
   const [mapInstance, setMapInstance] = useState(null);
   const [currentTheme, setCurrentTheme] = useState(() => resolveCurrentTheme());
-  const focalCenter = useMemo(() => {
-    const focalLat = resolveCoordinate(lat);
-    const focalLon = resolveCoordinate(lon);
-    if (focalLat == null || focalLon == null) return null;
-    return { lat: focalLat, lon: focalLon };
-  }, [lat, lon]);
+  const focalCenter = useMemo(
+    () => resolveAirportMapFocalCenter({ lat, lon }),
+    [lat, lon],
+  );
   const boundedMobileInteraction =
     mobileMapInteractionEnabled && Boolean(focalCenter);
   const runProgrammaticMapMove = useCallback((move) => {
@@ -123,8 +117,8 @@ export default function AirportMap({
     if (!mapEl.current || mapRef.current) return undefined;
     const map = L.map(mapEl.current, {
       center: [
-        lat || AIRPORT_MAP_FALLBACK_CENTER.lat,
-        lon || AIRPORT_MAP_FALLBACK_CENTER.lon,
+        focalCenter?.lat ?? AIRPORT_MAP_FALLBACK_CENTER.lat,
+        focalCenter?.lon ?? AIRPORT_MAP_FALLBACK_CENTER.lon,
       ],
       zoom,
       zoomControl: false,

--- a/src/features/airport/map/airportMapModel.js
+++ b/src/features/airport/map/airportMapModel.js
@@ -24,8 +24,16 @@ export const getMapOverlayTheme = (theme) =>
       };
 
 const toFiniteCoordinate = (value) => {
+  if (value == null || value === "") return null;
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : null;
+};
+
+export const resolveAirportMapFocalCenter = ({ lat, lon } = {}) => {
+  const focalLat = toFiniteCoordinate(lat);
+  const focalLon = toFiniteCoordinate(lon);
+  if (focalLat == null || focalLon == null) return null;
+  return { lat: focalLat, lon: focalLon };
 };
 
 const normalizeLongitude = (lon) => ((((lon + 180) % 360) + 360) % 360) - 180;

--- a/src/features/airport/map/airportMapModel.test.js
+++ b/src/features/airport/map/airportMapModel.test.js
@@ -6,6 +6,7 @@ import {
   formatCoordinateLabel,
   getMapOverlayTheme,
   getVisibleAircraft,
+  resolveAirportMapFocalCenter,
   resolveDocumentTheme,
 } from "./airportMapModel.js";
 
@@ -23,6 +24,13 @@ assert.equal(resolveDocumentTheme({ getAttribute: () => null }), "dark");
 assert.equal(formatCoordinateLabel(42.3656, "lat"), "42.37N");
 assert.equal(formatCoordinateLabel(-71.0096, "lon"), "71.01W");
 assert.equal(formatCoordinateLabel(0, "lat"), "");
+
+assert.equal(resolveAirportMapFocalCenter({ lat: null, lon: null }), null);
+assert.equal(resolveAirportMapFocalCenter({ lat: 42.3656, lon: null }), null);
+assert.deepEqual(resolveAirportMapFocalCenter({ lat: "0", lon: "0" }), {
+  lat: 0,
+  lon: 0,
+});
 
 assert.deepEqual(
   getVisibleAircraft({ aircraft, airportLat: 42.3656, airportLon: -71.0096, zoom: ZOOM_AIRPORT })


### PR DESCRIPTION
## Summary
- keep missing flight-page focal coordinates as `null` instead of coercing them to `0,0`
- share focal-center coordinate resolution in the airport map model
- only build FlightAware route arcs when the tracked aircraft has a real position

## Root Cause
Mobile-only bounded map interaction used the flight page focal coordinates as its clamp center. For inactive or temporarily positionless aircraft, `null` coordinates were converted through `Number(null)` or explicit `|| 0`, so the map treated `0,0` as a valid aircraft center. Clicking fit-to-trace on mobile could then fight the trace bounds with the 20nm mobile clamp, while desktop never enabled that mobile clamp path.

## Verification
- `node src/features/airport/map/airportMapModel.test.js`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- Mobile Playwright smoke on `http://localhost:3000/aircraft/JBU1323` with a fixture callsign response and trace payload: clicked "Fit map to trace" without page errors; map fitted to the trace region and did not show the mobile recenter control without a real focal position.
