### PR TITLE
[codex] Add flight sidebar metric unit toggles

### DIFF
--- a/src/components/sidebar/FlightSidebar.jsx
+++ b/src/components/sidebar/FlightSidebar.jsx
@@ -12,6 +12,10 @@ import {
   getFlightRouteAirlineIconUrl,
 } from "@/utils/flightRouteDisplay.js";
 import { getAircraftPositionSourceBadge } from "@/features/aviation/sourceDisplayModel.js";
+import {
+  formatFlightTelemetryMetric,
+  resolveTrackDirection,
+} from "@/features/aircraft/tracking/flightTelemetryDisplayModel.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 import { toFiniteNumber } from "@/utils/math.js";
 
@@ -163,14 +167,33 @@ function FlightTelemetryGrid({ speed, altitude, vs, track, onGround, hex }) {
   const [activeMetric, setActiveMetric] = useState(null);
   const toggle = (id) =>
     setActiveMetric((current) => (current === id ? null : id));
+  const speedDisplay = formatFlightTelemetryMetric({
+    metric: "speed",
+    value: speed,
+    alternate: activeMetric === "speed",
+  });
+  const altitudeDisplay = formatFlightTelemetryMetric({
+    metric: "altitude",
+    value: altitude,
+    alternate: activeMetric === "altitude",
+  });
+  const verticalSpeedDisplay = formatFlightTelemetryMetric({
+    metric: "verticalSpeed",
+    value: vs,
+    alternate: activeMetric === "vs",
+  });
+  const trackDirection = resolveTrackDirection(track);
 
   return (
     <SidebarMetricGrid label={t("sidebar.flightTelemetry")}>
       <SidebarMetricCard
         label={t("metrics.speed")}
         value={
-          speed != null ? (
-            <MetricNumberFlow value={Math.round(speed)} suffix="kt" />
+          speedDisplay ? (
+            <MetricNumberFlow
+              value={speedDisplay.value}
+              suffix={speedDisplay.suffix}
+            />
           ) : (
             "—"
           )
@@ -183,8 +206,13 @@ function FlightTelemetryGrid({ speed, altitude, vs, track, onGround, hex }) {
         value={
           onGround
             ? t("aircraft.gnd")
-            : altitude != null
-              ? <MetricNumberFlow value={Math.round(altitude)} suffix="ft" />
+            : altitudeDisplay
+              ? (
+                  <MetricNumberFlow
+                    value={altitudeDisplay.value}
+                    suffix={altitudeDisplay.suffix}
+                  />
+                )
               : "—"
         }
         active={activeMetric === "altitude"}
@@ -193,11 +221,11 @@ function FlightTelemetryGrid({ speed, altitude, vs, track, onGround, hex }) {
       <SidebarMetricCard
         label={t("metrics.verticalSpeed")}
         value={
-          vs != null ? (
+          verticalSpeedDisplay ? (
             <MetricNumberFlow
-              value={Math.round(vs)}
-              format={{ signDisplay: "exceptZero" }}
-              suffix="fpm"
+              value={verticalSpeedDisplay.value}
+              format={verticalSpeedDisplay.format}
+              suffix={verticalSpeedDisplay.suffix}
             />
           ) : (
             "—"
@@ -210,11 +238,15 @@ function FlightTelemetryGrid({ speed, altitude, vs, track, onGround, hex }) {
         label={t("metrics.track")}
         value={
           track != null ? (
-            <MetricNumberFlow
-              value={Math.round(track)}
-              suffix="°"
-              suffixPosition="sup"
-            />
+            activeMetric === "track" ? (
+              trackDirection || "—"
+            ) : (
+              <MetricNumberFlow
+                value={Math.round(track)}
+                suffix="°"
+                suffixPosition="sup"
+              />
+            )
           ) : (
             "—"
           )

--- a/src/features/aircraft/tracking/flightTelemetryDisplayModel.js
+++ b/src/features/aircraft/tracking/flightTelemetryDisplayModel.js
@@ -1,0 +1,48 @@
+const KNOT_TO_KMH = 1.852;
+const FOOT_TO_METER = 0.3048;
+const TRACK_DIRECTIONS = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+
+function toFiniteTelemetryNumber(value) {
+  if (value == null || value === "") return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+export function resolveTrackDirection(track) {
+  const degrees = toFiniteTelemetryNumber(track);
+  if (degrees == null) return null;
+  const normalized = ((degrees % 360) + 360) % 360;
+  const index = Math.round(normalized / 45) % TRACK_DIRECTIONS.length;
+  return TRACK_DIRECTIONS[index];
+}
+
+export function formatFlightTelemetryMetric({
+  metric,
+  value,
+  alternate = false,
+} = {}) {
+  const numeric = toFiniteTelemetryNumber(value);
+  if (numeric == null) return null;
+
+  if (metric === "speed") {
+    return alternate
+      ? { value: Math.round(numeric * KNOT_TO_KMH), suffix: "km/h" }
+      : { value: Math.round(numeric), suffix: "kt" };
+  }
+
+  if (metric === "altitude") {
+    return alternate
+      ? { value: Math.round(numeric * FOOT_TO_METER), suffix: "m" }
+      : { value: Math.round(numeric), suffix: "ft" };
+  }
+
+  if (metric === "verticalSpeed") {
+    return {
+      value: Math.round(alternate ? numeric * FOOT_TO_METER : numeric),
+      suffix: alternate ? "m/min" : "fpm",
+      format: { signDisplay: "exceptZero" },
+    };
+  }
+
+  return null;
+}

--- a/src/features/aircraft/tracking/flightTelemetryDisplayModel.test.js
+++ b/src/features/aircraft/tracking/flightTelemetryDisplayModel.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+
+import {
+  formatFlightTelemetryMetric,
+  resolveTrackDirection,
+} from "./flightTelemetryDisplayModel.js";
+
+assert.deepEqual(
+  formatFlightTelemetryMetric({ metric: "speed", value: 250, alternate: false }),
+  { value: 250, suffix: "kt" },
+);
+
+assert.deepEqual(
+  formatFlightTelemetryMetric({ metric: "speed", value: 250, alternate: true }),
+  { value: 463, suffix: "km/h" },
+);
+
+assert.deepEqual(
+  formatFlightTelemetryMetric({ metric: "altitude", value: 12345, alternate: true }),
+  { value: 3763, suffix: "m" },
+);
+
+assert.deepEqual(
+  formatFlightTelemetryMetric({ metric: "verticalSpeed", value: -1200, alternate: true }),
+  { value: -366, suffix: "m/min", format: { signDisplay: "exceptZero" } },
+);
+
+assert.equal(resolveTrackDirection(0), "N");
+assert.equal(resolveTrackDirection(22), "N");
+assert.equal(resolveTrackDirection(23), "NE");
+assert.equal(resolveTrackDirection(91), "E");
+assert.equal(resolveTrackDirection(181), "S");
+assert.equal(resolveTrackDirection(270), "W");
+assert.equal(resolveTrackDirection(359), "N");
+assert.equal(resolveTrackDirection(null), null);
+
+console.log("flightTelemetryDisplayModel.test.js ok");


### PR DESCRIPTION
## Summary
- add click-to-toggle metric display for flight sidebar speed, altitude, and vertical speed
- convert active speed to km/h, altitude to meters, and vertical speed to m/min while preserving the existing active card styling
- show active track as one of eight compass directions, with a second click returning to degrees

## Verification
- `node src/features/aircraft/tracking/flightTelemetryDisplayModel.test.js`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- Mobile Playwright smoke on `http://localhost:3000/aircraft/JBU1323` with a fixture tracked aircraft: opened the sidebar, clicked Speed/Altitude/Vertical speed/Track, verified active card styling persisted and values toggled back on repeat click.
