### PR TITLE
[codex] Localize flight sidebar direction toggle

### DIFF
--- a/src/components/sidebar/FlightSidebar.jsx
+++ b/src/components/sidebar/FlightSidebar.jsx
@@ -14,7 +14,7 @@ import {
 import { getAircraftPositionSourceBadge } from "@/features/aviation/sourceDisplayModel.js";
 import {
   formatFlightTelemetryMetric,
-  resolveTrackDirection,
+  resolveTrackDirectionTranslationKey,
 } from "@/features/aircraft/tracking/flightTelemetryDisplayModel.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 import { toFiniteNumber } from "@/utils/math.js";
@@ -182,7 +182,7 @@ function FlightTelemetryGrid({ speed, altitude, vs, track, onGround, hex }) {
     value: vs,
     alternate: activeMetric === "vs",
   });
-  const trackDirection = resolveTrackDirection(track);
+  const trackDirectionKey = resolveTrackDirectionTranslationKey(track);
 
   return (
     <SidebarMetricGrid label={t("sidebar.flightTelemetry")}>
@@ -239,7 +239,7 @@ function FlightTelemetryGrid({ speed, altitude, vs, track, onGround, hex }) {
         value={
           track != null ? (
             activeMetric === "track" ? (
-              trackDirection || "—"
+              trackDirectionKey ? t(trackDirectionKey) : "—"
             ) : (
               <MetricNumberFlow
                 value={Math.round(track)}
@@ -253,6 +253,7 @@ function FlightTelemetryGrid({ speed, altitude, vs, track, onGround, hex }) {
         }
         active={activeMetric === "track"}
         onClick={() => toggle("track")}
+        valueTranslate={activeMetric === "track"}
       />
       {hex && (
         <>

--- a/src/config/i18n/en.js
+++ b/src/config/i18n/en.js
@@ -139,6 +139,16 @@ const en = {
     rule: "Rule",
     elevation: "Elevation",
   },
+  directions: {
+    n: "N",
+    ne: "NE",
+    e: "E",
+    se: "SE",
+    s: "S",
+    sw: "SW",
+    w: "W",
+    nw: "NW",
+  },
   aircraft: {
     noRoute: "No route",
     airborne: "Airborne",

--- a/src/config/i18n/zh-CN.js
+++ b/src/config/i18n/zh-CN.js
@@ -134,6 +134,16 @@ const zhCN = {
     rule: "目视 / 仪表",
     elevation: "海拔",
   },
+  directions: {
+    n: "北",
+    ne: "东北",
+    e: "东",
+    se: "东南",
+    s: "南",
+    sw: "西南",
+    w: "西",
+    nw: "西北",
+  },
   aircraft: {
     noRoute: "无航路",
     airborne: "空中",

--- a/src/features/aircraft/tracking/flightTelemetryDisplayModel.js
+++ b/src/features/aircraft/tracking/flightTelemetryDisplayModel.js
@@ -1,6 +1,7 @@
 const KNOT_TO_KMH = 1.852;
 const FOOT_TO_METER = 0.3048;
 const TRACK_DIRECTIONS = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+const TRACK_DIRECTION_KEYS = ["n", "ne", "e", "se", "s", "sw", "w", "nw"];
 
 function toFiniteTelemetryNumber(value) {
   if (value == null || value === "") return null;
@@ -9,11 +10,20 @@ function toFiniteTelemetryNumber(value) {
 }
 
 export function resolveTrackDirection(track) {
+  const index = resolveTrackDirectionIndex(track);
+  return index == null ? null : TRACK_DIRECTIONS[index];
+}
+
+export function resolveTrackDirectionTranslationKey(track) {
+  const index = resolveTrackDirectionIndex(track);
+  return index == null ? null : `directions.${TRACK_DIRECTION_KEYS[index]}`;
+}
+
+function resolveTrackDirectionIndex(track) {
   const degrees = toFiniteTelemetryNumber(track);
   if (degrees == null) return null;
   const normalized = ((degrees % 360) + 360) % 360;
-  const index = Math.round(normalized / 45) % TRACK_DIRECTIONS.length;
-  return TRACK_DIRECTIONS[index];
+  return Math.round(normalized / 45) % TRACK_DIRECTIONS.length;
 }
 
 export function formatFlightTelemetryMetric({

--- a/src/features/aircraft/tracking/flightTelemetryDisplayModel.test.js
+++ b/src/features/aircraft/tracking/flightTelemetryDisplayModel.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   formatFlightTelemetryMetric,
   resolveTrackDirection,
+  resolveTrackDirectionTranslationKey,
 } from "./flightTelemetryDisplayModel.js";
 
 assert.deepEqual(
@@ -33,5 +34,10 @@ assert.equal(resolveTrackDirection(181), "S");
 assert.equal(resolveTrackDirection(270), "W");
 assert.equal(resolveTrackDirection(359), "N");
 assert.equal(resolveTrackDirection(null), null);
+
+assert.equal(resolveTrackDirectionTranslationKey(0), "directions.n");
+assert.equal(resolveTrackDirectionTranslationKey(23), "directions.ne");
+assert.equal(resolveTrackDirectionTranslationKey(91), "directions.e");
+assert.equal(resolveTrackDirectionTranslationKey(null), null);
 
 console.log("flightTelemetryDisplayModel.test.js ok");

--- a/src/features/app-shell/i18n/i18nModel.test.js
+++ b/src/features/app-shell/i18n/i18nModel.test.js
@@ -49,10 +49,12 @@ assert.equal(normalizeLocaleSelection(null, "en"), "en");
 // English rather than leaking raw "sidebar.flights" into the layout.
 {
   const en = {
+    directions: { ne: "NE" },
     sidebar: { flights: "Flights", nearby: "Nearby" },
     lostSignal: { title: "{callsign} stopped reporting" },
   };
   const zh = {
+    directions: { ne: "东北" },
     sidebar: { flights: "航班" },
     lostSignal: { title: "{callsign} 已停止报告" },
   };
@@ -68,6 +70,15 @@ assert.equal(normalizeLocaleSelection(null, "en"), "en");
       fallbackDictionary: en,
     }),
     "Nearby",
+  );
+
+  assert.equal(
+    resolveTranslation({
+      key: "directions.ne",
+      dictionary: zh,
+      fallbackDictionary: en,
+    }),
+    "东北",
   );
   assert.equal(
     resolveTranslation({


### PR DESCRIPTION
## Summary
- localize the flight sidebar 8-way track direction values through the app i18n dictionaries
- keep the numeric direction fallback helper for tests while adding translation keys for UI rendering
- mark translated direction values as translatable sidebar metric content

## Verification
- `node src/features/aircraft/tracking/flightTelemetryDisplayModel.test.js`
- `node src/features/app-shell/i18n/i18nModel.test.js`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- Mobile Playwright smoke on `http://localhost:3000/aircraft/JBU1323` with zh-CN persisted locale and a changing fixture callsign response: speed stayed active across 3 aircraft-status refreshes, and active track rendered `东`.
