### PR TITLE
Improve FlightAware fallback tracking

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.jsx
+++ b/src/components/airport/explorer/AirportExplorer.jsx
@@ -56,8 +56,6 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     selectAircraft,
     setSelectedAircraftId,
     selectAirport,
-    pauseMapFollow,
-    resumeMapFollow,
     mapFollowsAircraft,
   } = useExplorerUi();
   const airportProfile = useMemo(
@@ -208,9 +206,6 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             runwayProcedures={null}
             procedureFixLabelRunwayProcedures={procedures.runwayProcedures}
             showProcedureFixLabels
-            mobileMapInteractionEnabled={isMobile}
-            onMapMoveFromCenter={pauseMapFollow}
-            onRecenterMap={resumeMapFollow}
           />
           <AircraftDataLoadingOverlay
             active={

--- a/src/components/explorer/ExplorerUiContext.jsx
+++ b/src/components/explorer/ExplorerUiContext.jsx
@@ -30,9 +30,8 @@ const initialUiState = {
   fitToTraceSignal: 0,
   // When true (default), the map re-centers on every aircraft position
   // poll. The user opts out by clicking "fit to trace" — the map then
-  // stays anchored on the trace bounds. A bounded mobile map gesture
-  // also pauses auto-follow until the user taps recenter. Clicking any
-  // preset zoom re-enables auto-follow.
+  // stays anchored on the trace bounds. Clicking any preset zoom
+  // re-enables auto-follow.
   mapFollowsAircraft: true,
 };
 
@@ -111,10 +110,6 @@ function airportExplorerUiReducer(state, action) {
         fitToTraceSignal: state.fitToTraceSignal + 1,
         mapFollowsAircraft: false,
       };
-    case "pauseMapFollow":
-      return { ...state, mapFollowsAircraft: false };
-    case "resumeMapFollow":
-      return { ...state, mapFollowsAircraft: true };
     default:
       return state;
   }
@@ -211,14 +206,6 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "fitToTrace" });
   }, []);
 
-  const pauseMapFollow = useCallback(() => {
-    dispatch({ type: "pauseMapFollow" });
-  }, []);
-
-  const resumeMapFollow = useCallback(() => {
-    dispatch({ type: "resumeMapFollow" });
-  }, []);
-
   const fitToTraceSignal = state.fitToTraceSignal;
   const mapFollowsAircraft = state.mapFollowsAircraft;
 
@@ -254,8 +241,6 @@ export function ExplorerUiProvider({ children }) {
       setSelectedAircraftId,
       selectAirport,
       fitToTrace,
-      pauseMapFollow,
-      resumeMapFollow,
     }),
     [
       sidebarMode,
@@ -287,8 +272,6 @@ export function ExplorerUiProvider({ children }) {
       setSelectedAircraftId,
       selectAirport,
       fitToTrace,
-      pauseMapFollow,
-      resumeMapFollow,
     ],
   );
 

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -15,6 +15,10 @@ import {
   getTrackedFlightTraceRefreshKey,
 } from "@/features/aircraft/tracking/lostSignalTrackingModel.js";
 import {
+  getFlightAwareFallbackTraceStartAtMs,
+  shouldLockMapViewportForTrackingState,
+} from "@/features/aircraft/tracking/flightAwareFallbackTrackingModel.js";
+import {
   getFlightTrackingContextPosition,
   shouldShowFlightTrackingLoadingOverlay,
 } from "@/features/aircraft/tracking/flightTrackingContextModel.js";
@@ -84,8 +88,6 @@ function FlightExplorerContent({ callsign }) {
     selectAircraft,
     setSelectedAircraftId,
     selectAirport,
-    pauseMapFollow,
-    resumeMapFollow,
     toggleMapLabels,
     fitToTrace,
     mapFollowsAircraft,
@@ -113,6 +115,7 @@ function FlightExplorerContent({ callsign }) {
     lostSignal,
     pollVersion: trackedPollVersion,
     visibilityRefreshVersion: trackedVisibilityRefreshVersion,
+    trackingState,
   } = useTrackedAircraft(callsign);
 
   // Anchor the tracking session as soon as we have a callsign so the
@@ -132,9 +135,14 @@ function FlightExplorerContent({ callsign }) {
     if (session) setTrackingSession(session);
   }, [callsign, trackedAircraft?.icao24]);
   const focalTraceStartAtMs = useMemo(
-    () => getTraceCutoffMs(trackingSession),
-    [trackingSession],
+    () =>
+      getFlightAwareFallbackTraceStartAtMs({
+        trackingState,
+        defaultTraceStartAtMs: getTraceCutoffMs(trackingSession),
+      }),
+    [trackingSession, trackingState],
   );
+  const mapViewportLocked = shouldLockMapViewportForTrackingState(trackingState);
   const focalTraceRefreshKey = useMemo(
     () =>
       getTrackedFlightTraceRefreshKey({
@@ -377,7 +385,7 @@ function FlightExplorerContent({ callsign }) {
             selectedAircraftId={selectedAircraftId}
             selectedAirportIcao={selectedAirportIcao}
             focalAircraftId={focalKey}
-            followsCenter={mapFollowsAircraft}
+            followsCenter={mapFollowsAircraft && !mapViewportLocked}
             onSelectAircraft={selectAircraft}
             onSelectAirport={selectAirport}
             runwayMap={null}
@@ -386,13 +394,11 @@ function FlightExplorerContent({ callsign }) {
             showProcedureFixLabels={false}
             focalRangeRings={false}
             nearbyRangeRings={{ intervalNm: 5, maxNm: 5, prominent: true }}
-            mobileMapInteractionEnabled={isMobile}
-            onMapMoveFromCenter={pauseMapFollow}
-            onRecenterMap={resumeMapFollow}
           >
             <FlightAwareRouteArc path={focalFlightAwareRoutePath} />
             <MapFitToTraceController
               routePath={focalFlightAwareRoutePath}
+              disabled={mapViewportLocked}
             />
           </AirportMap>
           <AircraftDataLoadingOverlay

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import L from "leaflet";
-import { Crosshair } from "lucide-react";
 import { MapContext } from "./MapContext.js";
 import MapTileLayers from "./MapTileLayers.jsx";
 import AreaMarker from "./AreaMarker.jsx";
@@ -20,15 +19,11 @@ import { getAircraftIdentity } from "../../features/airport/context/airportConte
 import { useI18n } from "../../features/app-shell/i18n/useI18n.js";
 import { aircraftMatchesFilters } from "../../features/aircraft/filters/aircraftFilters.js";
 import {
-  clampMapCenterToRadius,
   getMapOverlayTheme,
   getVisibleAircraft,
   resolveAirportMapFocalCenter,
   resolveDocumentTheme,
 } from "../../features/airport/map/airportMapModel.js";
-
-const MOBILE_MAP_GESTURE_RADIUS_NM = 20;
-const MAP_CENTER_DEADZONE_NM = 0.05;
 
 const resolveCurrentTheme = () =>
   typeof document !== "undefined"
@@ -61,12 +56,9 @@ export default function AirportMap({
   showProcedureFixLabels = false,
   focalRangeRings = null,
   nearbyRangeRings = null,
-  mobileMapInteractionEnabled = false,
-  onMapMoveFromCenter = null,
-  onRecenterMap = null,
   children = null,
 }) {
-  const { locale, t } = useI18n();
+  const { locale } = useI18n();
   // Single source of truth for the ring bands so the inline labels
   // (AreaMarker), per-airport rings (NearbyAirportLayer), and the
   // bottom-left legend all agree on what to render. Pass `false` to
@@ -83,22 +75,12 @@ export default function AirportMap({
   const mapEl = useRef(null);
   const mapRef = useRef(null);
   const sizeObs = useRef(null);
-  const programmaticMoveRef = useRef(false);
   const [mapInstance, setMapInstance] = useState(null);
   const [currentTheme, setCurrentTheme] = useState(() => resolveCurrentTheme());
   const focalCenter = useMemo(
     () => resolveAirportMapFocalCenter({ lat, lon }),
     [lat, lon],
   );
-  const boundedMobileInteraction =
-    mobileMapInteractionEnabled && Boolean(focalCenter);
-  const runProgrammaticMapMove = useCallback((move) => {
-    programmaticMoveRef.current = true;
-    move();
-    window.setTimeout(() => {
-      programmaticMoveRef.current = false;
-    }, 0);
-  }, []);
 
   useEffect(() => {
     setCurrentTheme(resolveCurrentTheme());
@@ -149,87 +131,17 @@ export default function AirportMap({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    if (!mapInstance) return;
-
-    mapInstance.dragging.disable();
-    if (boundedMobileInteraction) {
-      mapInstance.touchZoom?.enable();
-      return;
-    }
-
-    mapInstance.touchZoom?.disable();
-  }, [boundedMobileInteraction, mapInstance]);
-
   // followsCenter controls whether the map re-centers on every poll.
   // After "fit to trace" the caller flips this to false so the map
   // stays anchored to the trace bounds even though the aircraft keeps
   // moving; clicking a preset zoom flips it back to true upstream.
   useEffect(() => {
     if (mapRef.current && focalCenter && followsCenter) {
-      runProgrammaticMapMove(() => {
-        mapRef.current.setView([focalCenter.lat, focalCenter.lon], zoom, {
-          animate: false,
-        });
+      mapRef.current.setView([focalCenter.lat, focalCenter.lon], zoom, {
+        animate: false,
       });
     }
-  }, [focalCenter, followsCenter, runProgrammaticMapMove, zoom]);
-
-  useEffect(() => {
-    if (!mapInstance || !boundedMobileInteraction || !focalCenter) {
-      return undefined;
-    }
-
-    const getCenterDistanceNm = () =>
-      mapInstance.distance(
-        [focalCenter.lat, focalCenter.lon],
-        mapInstance.getCenter(),
-      ) / 1852;
-
-    const clampToMobileRadius = () => {
-      const center = mapInstance.getCenter();
-      const clamped = clampMapCenterToRadius({
-        center: { lat: center.lat, lon: center.lng },
-        focalCenter,
-        radiusNm: MOBILE_MAP_GESTURE_RADIUS_NM,
-      });
-      if (
-        !clamped ||
-        (Math.abs(clamped.lat - center.lat) < 0.000001 &&
-          Math.abs(clamped.lon - center.lng) < 0.000001)
-      ) {
-        return;
-      }
-
-      runProgrammaticMapMove(() => {
-        mapInstance.setView([clamped.lat, clamped.lon], mapInstance.getZoom(), {
-          animate: false,
-        });
-      });
-    };
-
-    const handleMoveEnd = () => {
-      const wasProgrammatic = programmaticMoveRef.current;
-      clampToMobileRadius();
-
-      if (!wasProgrammatic && getCenterDistanceNm() > MAP_CENTER_DEADZONE_NM) {
-        onMapMoveFromCenter?.();
-      }
-    };
-
-    mapInstance.on("moveend", handleMoveEnd);
-    clampToMobileRadius();
-
-    return () => {
-      mapInstance.off("moveend", handleMoveEnd);
-    };
-  }, [
-    boundedMobileInteraction,
-    focalCenter,
-    mapInstance,
-    onMapMoveFromCenter,
-    runProgrammaticMapMove,
-  ]);
+  }, [focalCenter, followsCenter, zoom]);
 
   // Clicks on the map background (not on an aircraft marker) clear the
   // selection so the user can drop "trace mode" without targeting an
@@ -291,21 +203,6 @@ export default function AirportMap({
   const selectionActive = Boolean(selectedAircraftId && selectedAircraft);
 
   const overlayTheme = getMapOverlayTheme(currentTheme);
-
-  const handleRecenter = () => {
-    if (!mapRef.current || !focalCenter) return;
-
-    onRecenterMap?.();
-    runProgrammaticMapMove(() => {
-      mapRef.current.setView(
-        [focalCenter.lat, focalCenter.lon],
-        mapRef.current.getZoom(),
-        {
-          animate: false,
-        },
-      );
-    });
-  };
 
   return (
     <div className="relative h-full w-full bg-atc-bg">
@@ -399,18 +296,6 @@ export default function AirportMap({
           color={overlayTheme.attributionColor}
           shadowColor={overlayTheme.labelShadowColor}
         />
-      )}
-
-      {mapInstance && boundedMobileInteraction && (
-        <button
-          type="button"
-          className="ctrl-btn map-recenter-btn"
-          aria-label={t("map.recenter")}
-          title={t("map.recenter")}
-          onClick={handleRecenter}
-        >
-          <Crosshair aria-hidden="true" />
-        </button>
       )}
 
       {!mapInstance && <MapLoadingState />}

--- a/src/components/map/MapFitToTraceController.jsx
+++ b/src/components/map/MapFitToTraceController.jsx
@@ -20,7 +20,7 @@ import { buildTraceFitPoints } from "@/features/airport/map/mapFitTraceModel.js"
 // mapFollowsAircraft (the fitToTrace action already turns that off),
 // so even when the resolved Leaflet zoom lands on a preset value the
 // map stays anchored on the bounds we just computed.
-export default function MapFitToTraceController({ routePath = [] }) {
+export default function MapFitToTraceController({ routePath = [], disabled = false }) {
   const map = useMapInstance();
   const { fitToTraceSignal } = useExplorerUi();
   const { traces } = useSelectedAircraftTrace();
@@ -29,7 +29,7 @@ export default function MapFitToTraceController({ routePath = [] }) {
   useEffect(() => {
     if (!map || fitToTraceSignal === lastSignalRef.current) return;
     lastSignalRef.current = fitToTraceSignal;
-    if (fitToTraceSignal === 0) return;
+    if (fitToTraceSignal === 0 || disabled) return;
 
     const points = buildTraceFitPoints({ traces, routePath });
 
@@ -37,7 +37,7 @@ export default function MapFitToTraceController({ routePath = [] }) {
 
     const bounds = L.latLngBounds(points);
     map.fitBounds(bounds, { padding: [60, 60], maxZoom: 14 });
-  }, [fitToTraceSignal, map, traces, routePath]);
+  }, [disabled, fitToTraceSignal, map, traces, routePath]);
 
   return null;
 }

--- a/src/config/i18n/en.js
+++ b/src/config/i18n/en.js
@@ -222,7 +222,6 @@ const en = {
     layerOverlaysAria: "Map layer overlays",
     toggleSidebar: "Toggle sidebar",
     fitTrace: "Fit map to trace",
-    recenter: "Return to center",
     approachingView: "Approaching view (click to cycle)",
     themeButtonAria: "Theme: {label} (click to switch)",
     themeLight: "Light",

--- a/src/config/i18n/zh-CN.js
+++ b/src/config/i18n/zh-CN.js
@@ -217,7 +217,6 @@ const zhCN = {
     layerOverlaysAria: "地图图层叠加",
     toggleSidebar: "切换侧栏",
     fitTrace: "适配航迹",
-    recenter: "回到中心点",
     approachingView: "进近视图(点击循环)",
     themeButtonAria: "主题:{label}(点击切换)",
     themeLight: "明亮",

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.js
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.js
@@ -34,14 +34,22 @@ const htmlDecode = (value) =>
 const escapeRegExp = (value) =>
   String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-function errorResult(errorType, { message = "", fetchedAt } = {}) {
+function errorResult(errorType, { message = "", fetchedAt, upstreamStatus } = {}) {
   return {
     ok: false,
     hasPosition: false,
     errorType,
     message,
+    upstreamStatus,
     fetchedAt: fetchedAt || new Date().toISOString(),
   };
+}
+
+function cacheFallbackResult(cacheStore, callsign, result, nowMs) {
+  cacheStore.set(callsign, {
+    result,
+    expiresAt: nowMs + FLIGHTAWARE_FALLBACK_CACHE_TTL_MS,
+  });
 }
 
 function extractMetaContent(html, key) {
@@ -390,9 +398,19 @@ export async function getFlightAwareFallbackByCallsign(callsign, {
     if (response.status === 429) {
       return errorResult("rate_limited", { fetchedAt });
     }
+    if (response.status === 402) {
+      const result = errorResult("payment_required", {
+        message: "HTTP 402",
+        upstreamStatus: 402,
+        fetchedAt,
+      });
+      cacheFallbackResult(cacheStore, normalizedCallsign, result, nowMs);
+      return result;
+    }
     if (!response.ok) {
       return errorResult("network_failed", {
         message: `HTTP ${response.status}`,
+        upstreamStatus: response.status,
         fetchedAt,
       });
     }
@@ -406,10 +424,7 @@ export async function getFlightAwareFallbackByCallsign(callsign, {
       html,
       fetchedAt,
     });
-    cacheStore.set(normalizedCallsign, {
-      result,
-      expiresAt: nowMs + FLIGHTAWARE_FALLBACK_CACHE_TTL_MS,
-    });
+    cacheFallbackResult(cacheStore, normalizedCallsign, result, nowMs);
     return result;
   } catch (error) {
     const isTimeout =

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.js
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.js
@@ -3,7 +3,7 @@ import { buildAdsbaoUserAgent } from "../../../config/siteMeta.js";
 import { normalizeRouteCallsign } from "../../aviation/flight-routes/flightRouteCallsign.js";
 
 export const FLIGHTAWARE_FALLBACK_BASE = "https://www.flightaware.com/live/flight";
-export const FLIGHTAWARE_FALLBACK_CACHE_TTL_MS = 45_000;
+export const FLIGHTAWARE_FALLBACK_CACHE_TTL_MS = 60_000;
 export const FLIGHTAWARE_FALLBACK_TIMEOUT_MS = 7_000;
 export const FLIGHTAWARE_FALLBACK_USER_AGENT =
   buildAdsbaoUserAgent("flightaware/fallback-html");

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js
@@ -253,4 +253,32 @@ assert.equal(buildFlightAwareFallbackUrl("bad-call"), "");
   assert.equal(failed.errorType, "network_failed");
 }
 
+{
+  clearFlightAwareFallbackCache();
+  let fetchCalls = 0;
+  const first = await getFlightAwareFallbackByCallsign("AAL100", {
+    env: { FLIGHTAWARE_FALLBACK_ENABLED: "true" },
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response("payment required", { status: 402 });
+    },
+    now: () => Date.parse(fetchedAt),
+  });
+  const second = await getFlightAwareFallbackByCallsign("AAL100", {
+    env: { FLIGHTAWARE_FALLBACK_ENABLED: "true" },
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response("payment required", { status: 402 });
+    },
+    now: () => Date.parse(fetchedAt) + 30_000,
+  });
+
+  assert.equal(first.ok, false);
+  assert.equal(first.errorType, "payment_required");
+  assert.equal(first.upstreamStatus, 402);
+  assert.equal(first.message, "HTTP 402");
+  assert.equal(second.errorType, "payment_required");
+  assert.equal(fetchCalls, 1);
+}
+
 console.log("flightAwareFallbackProvider.test.js ok");

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  FLIGHTAWARE_FALLBACK_CACHE_TTL_MS,
   buildFlightAwareFallbackUrl,
   clearFlightAwareFallbackCache,
   getFlightAwareFallbackByCallsign,
@@ -98,6 +99,7 @@ assert.equal(
   "https://www.flightaware.com/live/flight/AAL100",
 );
 assert.equal(buildFlightAwareFallbackUrl("bad-call"), "");
+assert.equal(FLIGHTAWARE_FALLBACK_CACHE_TTL_MS, 60_000);
 
 {
   const result = parseFlightAwareFallbackPage({
@@ -185,10 +187,22 @@ assert.equal(buildFlightAwareFallbackUrl("bad-call"), "");
     fetchImpl,
     now: () => Date.parse(fetchedAt) + 30_000,
   });
+  const third = await getFlightAwareFallbackByCallsign("AAL100", {
+    env,
+    fetchImpl,
+    now: () => Date.parse(fetchedAt) + 59_000,
+  });
+  const fourth = await getFlightAwareFallbackByCallsign("AAL100", {
+    env,
+    fetchImpl,
+    now: () => Date.parse(fetchedAt) + 61_000,
+  });
 
-  assert.equal(fetchCalls, 1);
+  assert.equal(fetchCalls, 2);
   assert.equal(first.hasPosition, true);
   assert.equal(second.hasPosition, true);
+  assert.equal(third.hasPosition, true);
+  assert.equal(fourth.hasPosition, true);
 }
 
 {

--- a/src/features/aircraft/tracking/flightAwareFallbackTrackingModel.js
+++ b/src/features/aircraft/tracking/flightAwareFallbackTrackingModel.js
@@ -1,0 +1,15 @@
+export function isFlightAwareFallbackTracking(trackingState) {
+  return String(trackingState?.status || "").trim() === "flightaware_active";
+}
+
+export function getFlightAwareFallbackTraceStartAtMs({
+  trackingState = null,
+  defaultTraceStartAtMs = null,
+} = {}) {
+  if (isFlightAwareFallbackTracking(trackingState)) return null;
+  return defaultTraceStartAtMs;
+}
+
+export function shouldLockMapViewportForTrackingState(trackingState) {
+  return isFlightAwareFallbackTracking(trackingState);
+}

--- a/src/features/aircraft/tracking/flightAwareFallbackTrackingModel.test.js
+++ b/src/features/aircraft/tracking/flightAwareFallbackTrackingModel.test.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+
+import {
+  getFlightAwareFallbackTraceStartAtMs,
+  isFlightAwareFallbackTracking,
+  shouldLockMapViewportForTrackingState,
+} from "./flightAwareFallbackTrackingModel.js";
+
+const cutoff = Date.parse("2026-05-25T03:00:00.000Z");
+
+assert.equal(
+  isFlightAwareFallbackTracking({ status: "flightaware_active" }),
+  true,
+);
+assert.equal(
+  isFlightAwareFallbackTracking({ status: "adsb_live" }),
+  false,
+);
+assert.equal(
+  isFlightAwareFallbackTracking({ status: "flightaware_terminal" }),
+  false,
+);
+
+assert.equal(
+  getFlightAwareFallbackTraceStartAtMs({
+    trackingState: { status: "flightaware_active" },
+    defaultTraceStartAtMs: cutoff,
+  }),
+  null,
+);
+assert.equal(
+  getFlightAwareFallbackTraceStartAtMs({
+    trackingState: { status: "adsb_live" },
+    defaultTraceStartAtMs: cutoff,
+  }),
+  cutoff,
+);
+
+assert.equal(
+  shouldLockMapViewportForTrackingState({ status: "flightaware_active" }),
+  true,
+);
+assert.equal(
+  shouldLockMapViewportForTrackingState({ status: "missing" }),
+  false,
+);
+
+console.log("flightAwareFallbackTrackingModel.test.js ok");

--- a/src/features/airport/map/airportMapModel.js
+++ b/src/features/airport/map/airportMapModel.js
@@ -5,9 +5,6 @@ import { getDistanceNm } from "../../../utils/aircraftTrafficIntent.js";
 // Matches the focal-airport's default first-ring interval so the
 // ground filter aligns with the visual layer.
 const DEFAULT_GROUND_AREA_RADIUS_NM = 3;
-const EARTH_RADIUS_NM = 3440.065;
-const DEG_TO_RAD = Math.PI / 180;
-const RAD_TO_DEG = 180 / Math.PI;
 
 export const resolveDocumentTheme = (documentElement) =>
   documentElement?.getAttribute("data-theme") === "light" ? "light" : "dark";
@@ -34,71 +31,6 @@ export const resolveAirportMapFocalCenter = ({ lat, lon } = {}) => {
   const focalLon = toFiniteCoordinate(lon);
   if (focalLat == null || focalLon == null) return null;
   return { lat: focalLat, lon: focalLon };
-};
-
-const normalizeLongitude = (lon) => ((((lon + 180) % 360) + 360) % 360) - 180;
-
-const getBearingRad = (from, to) => {
-  const fromLat = from.lat * DEG_TO_RAD;
-  const toLat = to.lat * DEG_TO_RAD;
-  const deltaLon = (to.lon - from.lon) * DEG_TO_RAD;
-  const y = Math.sin(deltaLon) * Math.cos(toLat);
-  const x =
-    Math.cos(fromLat) * Math.sin(toLat) -
-    Math.sin(fromLat) * Math.cos(toLat) * Math.cos(deltaLon);
-  return Math.atan2(y, x);
-};
-
-const destinationPoint = (origin, bearingRad, distanceNm) => {
-  const angularDistance = distanceNm / EARTH_RADIUS_NM;
-  const originLat = origin.lat * DEG_TO_RAD;
-  const originLon = origin.lon * DEG_TO_RAD;
-  const destinationLat = Math.asin(
-    Math.sin(originLat) * Math.cos(angularDistance) +
-      Math.cos(originLat) * Math.sin(angularDistance) * Math.cos(bearingRad),
-  );
-  const destinationLon =
-    originLon +
-    Math.atan2(
-      Math.sin(bearingRad) * Math.sin(angularDistance) * Math.cos(originLat),
-      Math.cos(angularDistance) - Math.sin(originLat) * Math.sin(destinationLat),
-    );
-
-  return {
-    lat: destinationLat * RAD_TO_DEG,
-    lon: normalizeLongitude(destinationLon * RAD_TO_DEG),
-  };
-};
-
-export const clampMapCenterToRadius = ({ center, focalCenter, radiusNm }) => {
-  const centerLat = toFiniteCoordinate(center?.lat);
-  const centerLon = toFiniteCoordinate(center?.lon);
-  const focalLat = toFiniteCoordinate(focalCenter?.lat);
-  const focalLon = toFiniteCoordinate(focalCenter?.lon);
-  const limitNm = toFiniteCoordinate(radiusNm);
-
-  if (
-    centerLat == null ||
-    centerLon == null ||
-    focalLat == null ||
-    focalLon == null ||
-    limitNm == null ||
-    limitNm <= 0
-  ) {
-    return null;
-  }
-
-  const currentCenter = { lat: centerLat, lon: centerLon };
-  const focal = { lat: focalLat, lon: focalLon };
-  const distanceNm = getDistanceNm(
-    focal.lat,
-    focal.lon,
-    currentCenter.lat,
-    currentCenter.lon,
-  );
-  if (distanceNm == null || distanceNm <= limitNm) return currentCenter;
-
-  return destinationPoint(focal, getBearingRad(focal, currentCenter), limitNm);
 };
 
 export const formatCoordinateLabel = (value, axis) => {

--- a/src/features/airport/map/airportMapModel.test.js
+++ b/src/features/airport/map/airportMapModel.test.js
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 
 import { ZOOM_AIRPORT, ZOOM_APPROACH } from "../../../utils/airportMapDisplay.js";
 import {
-  clampMapCenterToRadius,
   formatCoordinateLabel,
   getMapOverlayTheme,
   getVisibleAircraft,
@@ -62,31 +61,4 @@ assert.equal(
 assert.equal(getMapOverlayTheme("dark").attributionColor, "var(--map-attribution)");
 
 const focalCenter = { lat: 42.3656, lon: -71.0096 };
-
-assert.deepEqual(
-  clampMapCenterToRadius({
-    center: { lat: 42.45, lon: -71.0096 },
-    focalCenter,
-    radiusNm: 20,
-  }),
-  { lat: 42.45, lon: -71.0096 },
-);
-
-const clampedNorth = clampMapCenterToRadius({
-  center: { lat: 42.8656, lon: -71.0096 },
-  focalCenter,
-  radiusNm: 20,
-});
-assert.ok(clampedNorth);
-assert.ok(clampedNorth.lat > focalCenter.lat);
-assert.ok(clampedNorth.lat < 42.8656);
-assert.ok(Math.abs(clampedNorth.lon - focalCenter.lon) < 0.000001);
-
-const clampedEast = clampMapCenterToRadius({
-  center: { lat: 42.3656, lon: -70.4096 },
-  focalCenter,
-  radiusNm: 20,
-});
-assert.ok(clampedEast);
-assert.ok(clampedEast.lon > focalCenter.lon);
-assert.ok(clampedEast.lon < -70.4096);
+assert.ok(focalCenter);

--- a/src/style.css
+++ b/src/style.css
@@ -2740,16 +2740,6 @@ body {
     box-shadow: inset 0 -2px 0 var(--endf-yellow);
 }
 
-.map-recenter-btn {
-    bottom: max(18px, env(safe-area-inset-bottom));
-    box-shadow:
-        0 12px 26px color-mix(in oklab, var(--atc-bg) 58%, transparent),
-        inset 0 -2px 0 color-mix(in oklab, var(--atc-orange) 60%, transparent);
-    position: absolute;
-    right: max(12px, env(safe-area-inset-right));
-    z-index: 900;
-}
-
 .ctrl-sep {
     background: linear-gradient(
         180deg,


### PR DESCRIPTION
## Summary
- classify FlightAware HTTP 402 responses as payment_required with upstream status for diagnostics
- keep full tracked-flight trace visible and lock map viewport while FlightAware fallback is active
- cache FlightAware fallback requests for 60 seconds and revert the mobile 20nm map pan/recenter behavior

## Verification
- pnpm test
- pnpm lint
- pnpm build