### PR TITLE
Fix FlightAware fallback map controls

### DIFF
--- a/src/components/explorer/ExplorerMapMenu.jsx
+++ b/src/components/explorer/ExplorerMapMenu.jsx
@@ -12,6 +12,7 @@ export default function ExplorerMapMenu({
   lastUpdated = null,
   routeProvider = "",
   onFitToTrace = null,
+  zoomDisabled = false,
 } = {}) {
   const { t } = useI18n();
   const {
@@ -46,6 +47,7 @@ export default function ExplorerMapMenu({
       <MapControlBar
         activeZoom={mapZoom}
         zoomActive={mapFollowsAircraft}
+        zoomDisabled={zoomDisabled}
         showMapLabels={showMapLabels}
         showRunwayBeams={showRunwayBeams}
         showRoutingPointBadges={showRoutingPointBadges}

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -367,6 +367,7 @@ function FlightExplorerContent({ callsign }) {
               lastUpdated={lastUpdated}
               routeProvider={routeProvider}
               onFitToTrace={fitToTrace}
+              zoomDisabled={mapViewportLocked}
             />
           )}
           <AirportMap
@@ -399,7 +400,6 @@ function FlightExplorerContent({ callsign }) {
             <FlightAwareRouteArc path={focalFlightAwareRoutePath} />
             <MapFitToTraceController
               routePath={focalFlightAwareRoutePath}
-              disabled={mapViewportLocked}
             />
           </AirportMap>
           <AircraftDataLoadingOverlay

--- a/src/components/map/MapFitToTraceController.jsx
+++ b/src/components/map/MapFitToTraceController.jsx
@@ -20,7 +20,7 @@ import { buildTraceFitPoints } from "@/features/airport/map/mapFitTraceModel.js"
 // mapFollowsAircraft (the fitToTrace action already turns that off),
 // so even when the resolved Leaflet zoom lands on a preset value the
 // map stays anchored on the bounds we just computed.
-export default function MapFitToTraceController({ routePath = [], disabled = false }) {
+export default function MapFitToTraceController({ routePath = [] }) {
   const map = useMapInstance();
   const { fitToTraceSignal } = useExplorerUi();
   const { traces } = useSelectedAircraftTrace();
@@ -29,7 +29,7 @@ export default function MapFitToTraceController({ routePath = [], disabled = fal
   useEffect(() => {
     if (!map || fitToTraceSignal === lastSignalRef.current) return;
     lastSignalRef.current = fitToTraceSignal;
-    if (fitToTraceSignal === 0 || disabled) return;
+    if (fitToTraceSignal === 0) return;
 
     const points = buildTraceFitPoints({ traces, routePath });
 
@@ -37,7 +37,7 @@ export default function MapFitToTraceController({ routePath = [], disabled = fal
 
     const bounds = L.latLngBounds(points);
     map.fitBounds(bounds, { padding: [60, 60], maxZoom: 14 });
-  }, [disabled, fitToTraceSignal, map, traces, routePath]);
+  }, [fitToTraceSignal, map, traces, routePath]);
 
   return null;
 }

--- a/src/components/map/controls/MapControlRail.jsx
+++ b/src/components/map/controls/MapControlRail.jsx
@@ -12,6 +12,7 @@ const LAYERS_ICON_KEY = "layers";
 export default function MapControlRail({
   currentZoomOption,
   zoomActive = true,
+  zoomDisabled = false,
   currentTheme,
   themeTitle,
   layerDrawerOpen,
@@ -24,6 +25,9 @@ export default function MapControlRail({
   const { t } = useI18n();
   const { isLoaded, isSignedIn } = useUser();
   const showSignedIn = isLoaded && isSignedIn;
+  const zoomTitle = zoomDisabled
+    ? t("map.zoomLockedFlightAware")
+    : `${currentZoomOption.title} (click to cycle)`;
   return (
     <div className="map-ctrl-bar">
       {onFitToTrace && (
@@ -42,9 +46,11 @@ export default function MapControlRail({
       <Button
         variant="atcIcon"
         size="icon"
-        className={`ctrl-btn ctrl-view ${zoomActive ? "active" : ""}`}
-        title={`${currentZoomOption.title} (click to cycle)`}
+        className={`ctrl-btn ctrl-view ${zoomActive && !zoomDisabled ? "active" : ""}`}
+        title={zoomTitle}
         onClick={onCycleZoom}
+        disabled={zoomDisabled}
+        aria-disabled={zoomDisabled}
         type="button"
       >
         <MapControlIcon iconKey={currentZoomOption.iconKey} />

--- a/src/components/ui/MapControlBar.jsx
+++ b/src/components/ui/MapControlBar.jsx
@@ -17,6 +17,7 @@ const LAYER_DRAWER_ID = "map-layer-drawer";
 export default function MapControlBar({
   activeZoom = ZOOM_AIRPORT,
   zoomActive = true,
+  zoomDisabled = false,
   showMapLabels = false,
   showRunwayBeams = true,
   showRoutingPointBadges = true,
@@ -46,6 +47,7 @@ export default function MapControlBar({
   });
 
   const cycleZoom = () => {
+    if (zoomDisabled) return;
     // If the button is currently inactive (auto-follow is off because the
     // user clicked fit-to-trace), the first click should resume tracking
     // at the SAME preset zoom they were on — not skip to the next one.
@@ -77,6 +79,7 @@ export default function MapControlBar({
       <MapControlRail
         currentZoomOption={currentZoomOption}
         zoomActive={zoomActive}
+        zoomDisabled={zoomDisabled}
         currentTheme={themePreference}
         themeTitle={themeTitle}
         layerDrawerOpen={layerDrawerOpen}

--- a/src/config/i18n/en.js
+++ b/src/config/i18n/en.js
@@ -222,6 +222,7 @@ const en = {
     layerOverlaysAria: "Map layer overlays",
     toggleSidebar: "Toggle sidebar",
     fitTrace: "Fit map to trace",
+    zoomLockedFlightAware: "Zoom is locked while using FlightAware fallback",
     approachingView: "Approaching view (click to cycle)",
     themeButtonAria: "Theme: {label} (click to switch)",
     themeLight: "Light",

--- a/src/config/i18n/zh-CN.js
+++ b/src/config/i18n/zh-CN.js
@@ -217,6 +217,7 @@ const zhCN = {
     layerOverlaysAria: "地图图层叠加",
     toggleSidebar: "切换侧栏",
     fitTrace: "适配航迹",
+    zoomLockedFlightAware: "FlightAware 兜底时锁定缩放",
     approachingView: "进近视图(点击循环)",
     themeButtonAria: "主题:{label}(点击切换)",
     themeLight: "明亮",

--- a/src/features/aircraft/tracking/trackedFlightPositionResolver.js
+++ b/src/features/aircraft/tracking/trackedFlightPositionResolver.js
@@ -125,10 +125,10 @@ function pickStalePrimary(candidates, now) {
     .sort((a, b) => a.ageSeconds - b.ageSeconds)[0] || null;
 }
 
-function normalizeFlightAwarePosition(position) {
+function normalizeFlightAwarePosition(position, { fallbackHex = "" } = {}) {
   if (!position || !hasUsableLatLon(position)) return null;
   return {
-    hex: position.hex || "",
+    hex: position.hex || fallbackHex || "",
     flight: position.callsign || "",
     callsign: position.callsign || "",
     lat: position.lat,
@@ -177,6 +177,7 @@ export async function resolveTrackedFlightPosition({
     };
   }
 
+  const stale = pickStalePrimary(candidates, now);
   let fallback = flightAwareFallback;
   if (!fallback && featureEnabled && typeof getFlightAwareFallback === "function") {
     fallback = await getFlightAwareFallback(callsign);
@@ -194,7 +195,9 @@ export async function resolveTrackedFlightPosition({
       : null;
 
   if (!fallbackTerminal && fallback?.ok && fallback.hasPosition) {
-    const position = normalizeFlightAwarePosition(fallback.position);
+    const position = normalizeFlightAwarePosition(fallback.position, {
+      fallbackHex: stale?.position?.hex || lastKnown?.hex || "",
+    });
     if (position) {
       return {
         source: "flightaware",
@@ -230,7 +233,6 @@ export async function resolveTrackedFlightPosition({
     };
   }
 
-  const stale = pickStalePrimary(candidates, now);
   const fallbackPosition = stale?.position || lastKnown;
   if (fallbackPosition && hasUsableLatLon(fallbackPosition)) {
     const staleStatus = stale

--- a/src/features/aircraft/tracking/trackedFlightPositionResolver.test.js
+++ b/src/features/aircraft/tracking/trackedFlightPositionResolver.test.js
@@ -72,6 +72,21 @@ assert.equal(ADSB_FRESH_MAX_AGE_SECONDS, 60);
 }
 
 {
+  const resolved = await resolveTrackedFlightPosition({
+    adsbLolPosition: primary("adsb.lol", 120, { hex: "A1F1A0" }),
+    airplanesLivePosition: null,
+    getFlightAwareFallback: async () => flightAware,
+    callsign: "AAL100",
+    featureEnabled: true,
+    now,
+  });
+
+  assert.equal(resolved.source, "flightaware");
+  assert.equal(resolved.position.hex, "A1F1A0");
+  assert.equal(resolved.trackingState.status, "flightaware_active");
+}
+
+{
   let flightAwareCalls = 0;
   const lastKnown = primary("adsb.lol", 300, { lat: 40, lon: -70 });
   const resolved = await resolveTrackedFlightPosition({


### PR DESCRIPTION
## Summary
- disable the zoom-cycle control while FlightAware fallback owns the tracked position
- keep the full-trace / fit-trace control responsive instead of swallowing clicks during fallback
- preserve the most recent ADS-B hex when FlightAware fallback has no hex so trace_full can still fetch the aircraft trace

## Verification
- pnpm test
- pnpm lint
- pnpm build