### PR TITLE
Auto fit FlightAware fallback trace

### DIFF
--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -15,6 +15,7 @@ import {
   getTrackedFlightTraceRefreshKey,
 } from "@/features/aircraft/tracking/lostSignalTrackingModel.js";
 import {
+  getFlightAwareFallbackAutoFitKey,
   getFlightAwareFallbackTraceStartAtMs,
   shouldLockMapViewportForTrackingState,
 } from "@/features/aircraft/tracking/flightAwareFallbackTrackingModel.js";
@@ -143,6 +144,15 @@ function FlightExplorerContent({ callsign }) {
     [trackingSession, trackingState],
   );
   const mapViewportLocked = shouldLockMapViewportForTrackingState(trackingState);
+  const flightAwareAutoFitKey = useMemo(
+    () =>
+      getFlightAwareFallbackAutoFitKey({
+        trackingState,
+        callsign,
+        aircraftHex: trackedAircraft?.icao24,
+      }),
+    [callsign, trackedAircraft?.icao24, trackingState],
+  );
   const focalTraceRefreshKey = useMemo(
     () =>
       getTrackedFlightTraceRefreshKey({
@@ -400,6 +410,7 @@ function FlightExplorerContent({ callsign }) {
             <FlightAwareRouteArc path={focalFlightAwareRoutePath} />
             <MapFitToTraceController
               routePath={focalFlightAwareRoutePath}
+              autoFitKey={flightAwareAutoFitKey}
             />
           </AirportMap>
           <AircraftDataLoadingOverlay

--- a/src/components/map/MapFitToTraceController.jsx
+++ b/src/components/map/MapFitToTraceController.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext.js";
 import { useExplorerUi } from "@/components/explorer/ExplorerUiContext.jsx";
@@ -9,7 +9,8 @@ import { buildTraceFitPoints } from "@/features/airport/map/mapFitTraceModel.js"
 
 // Listens for the `fitToTrace` signal from the UI reducer and pans/zooms
 // the map so the full trace of every currently-visible aircraft fits in
-// the viewport.
+// the viewport. When `autoFitKey` is provided, it waits until trace
+// points exist and then performs the same fit once for that key.
 //
 // When the optional `routePath` prop is supplied, it is folded into the
 // bounds. The flight page passes this only for FlightAware-sourced focal
@@ -20,24 +21,48 @@ import { buildTraceFitPoints } from "@/features/airport/map/mapFitTraceModel.js"
 // mapFollowsAircraft (the fitToTrace action already turns that off),
 // so even when the resolved Leaflet zoom lands on a preset value the
 // map stays anchored on the bounds we just computed.
-export default function MapFitToTraceController({ routePath = [] }) {
+export default function MapFitToTraceController({
+  routePath = [],
+  autoFitKey = "",
+}) {
   const map = useMapInstance();
   const { fitToTraceSignal } = useExplorerUi();
   const { traces } = useSelectedAircraftTrace();
   const lastSignalRef = useRef(0);
+  const lastAutoFitKeyRef = useRef("");
+  const fitPoints = useMemo(
+    () => buildTraceFitPoints({ traces, routePath }),
+    [traces, routePath],
+  );
+  const fitMapToPoints = useCallback(
+    (points) => {
+      if (!map || points.length === 0) return;
+      const bounds = L.latLngBounds(points);
+      map.fitBounds(bounds, { padding: [60, 60], maxZoom: 14 });
+    },
+    [map],
+  );
 
   useEffect(() => {
     if (!map || fitToTraceSignal === lastSignalRef.current) return;
     lastSignalRef.current = fitToTraceSignal;
     if (fitToTraceSignal === 0) return;
 
-    const points = buildTraceFitPoints({ traces, routePath });
+    fitMapToPoints(fitPoints);
+  }, [fitMapToPoints, fitToTraceSignal, fitPoints, map]);
 
-    if (points.length === 0) return;
-
-    const bounds = L.latLngBounds(points);
-    map.fitBounds(bounds, { padding: [60, 60], maxZoom: 14 });
-  }, [fitToTraceSignal, map, traces, routePath]);
+  useEffect(() => {
+    const key = String(autoFitKey || "").trim();
+    if (!key) {
+      lastAutoFitKeyRef.current = "";
+      return;
+    }
+    if (!map || key === lastAutoFitKeyRef.current || fitPoints.length === 0) {
+      return;
+    }
+    lastAutoFitKeyRef.current = key;
+    fitMapToPoints(fitPoints);
+  }, [autoFitKey, fitMapToPoints, fitPoints, map]);
 
   return null;
 }

--- a/src/features/aircraft/tracking/flightAwareFallbackTrackingModel.js
+++ b/src/features/aircraft/tracking/flightAwareFallbackTrackingModel.js
@@ -13,3 +13,17 @@ export function getFlightAwareFallbackTraceStartAtMs({
 export function shouldLockMapViewportForTrackingState(trackingState) {
   return isFlightAwareFallbackTracking(trackingState);
 }
+
+export function getFlightAwareFallbackAutoFitKey({
+  trackingState = null,
+  callsign = "",
+  aircraftHex = "",
+} = {}) {
+  if (!isFlightAwareFallbackTracking(trackingState)) return "";
+  const normalizedCallsign = String(callsign || "").trim().toUpperCase();
+  const normalizedHex = String(aircraftHex || "").trim().toUpperCase();
+  if (!normalizedCallsign) return "";
+  return ["flightaware", normalizedCallsign, normalizedHex]
+    .filter(Boolean)
+    .join(":");
+}

--- a/src/features/aircraft/tracking/flightAwareFallbackTrackingModel.test.js
+++ b/src/features/aircraft/tracking/flightAwareFallbackTrackingModel.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  getFlightAwareFallbackAutoFitKey,
   getFlightAwareFallbackTraceStartAtMs,
   isFlightAwareFallbackTracking,
   shouldLockMapViewportForTrackingState,
@@ -43,6 +44,30 @@ assert.equal(
 assert.equal(
   shouldLockMapViewportForTrackingState({ status: "missing" }),
   false,
+);
+
+assert.equal(
+  getFlightAwareFallbackAutoFitKey({
+    trackingState: { status: "flightaware_active" },
+    callsign: "ual23",
+    aircraftHex: "A1F1A0",
+  }),
+  "flightaware:UAL23:A1F1A0",
+);
+assert.equal(
+  getFlightAwareFallbackAutoFitKey({
+    trackingState: { status: "flightaware_active" },
+    callsign: "ual23",
+  }),
+  "flightaware:UAL23",
+);
+assert.equal(
+  getFlightAwareFallbackAutoFitKey({
+    trackingState: { status: "adsb_live" },
+    callsign: "ual23",
+    aircraftHex: "A1F1A0",
+  }),
+  "",
 );
 
 console.log("flightAwareFallbackTrackingModel.test.js ok");


### PR DESCRIPTION
## Summary
- auto-fit the map once when a tracked flight initially enters FlightAware fallback
- wait until full/recent trace points exist before fitting so first-load FA pages do not no-op
- keep the auto-fit keyed by callsign/hex so returning to ADS-B resets normal behavior

## Verification
- pnpm test
- pnpm lint
- pnpm build