### PR TITLE
Scope Supabase feature flags by environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ NEXT_PUBLIC_SUPABASE_URL=https://vqjvtpqryblqwrbsaxwb.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_ieVPDaMnd4swiHGoJ66OOA_77ZOpwfr
 # Server-only. Required for Supabase-managed feature flags.
 SUPABASE_SERVICE_ROLE_KEY=
+# Optional server-side feature flag scope override: local, preview, or production.
+FEATURE_FLAGS_ENV=
 AERODATABOX_RAPIDAPI_KEY=
 AERODATABOX_RAPIDAPI_HOST=aerodatabox.p.rapidapi.com
 

--- a/scripts/feature-flags.js
+++ b/scripts/feature-flags.js
@@ -36,15 +36,16 @@ function buildScriptEnv() {
 
 function printUsage() {
   console.log(`Usage:
-  pnpm ff get <email>
-  pnpm ff set <email> <flag> <on|off>
-  pnpm ff merge <email> '<json-flags>'
-  pnpm ff clear <email> [flag]
+  pnpm ff [--env local|preview|production] get <email>
+  pnpm ff [--env local|preview|production] set <email> <flag> <on|off>
+  pnpm ff [--env local|preview|production] merge <email> '<json-flags>'
+  pnpm ff [--env local|preview|production] clear <email> [flag]
 
 Examples:
   pnpm ff set you@example.com flightAwareEnabled on
-  pnpm ff set you@example.com flightAwareEnabled off
-  pnpm ff merge you@example.com '{"flightAwareEnabled":true}'
+  pnpm ff --env preview set you@example.com flightAwareEnabled on
+  pnpm ff --env production set you@example.com flightAwareEnabled off
+  pnpm ff --env preview merge you@example.com '{"flightAwareEnabled":true}'
   pnpm ff clear you@example.com`);
 }
 

--- a/scripts/feature-flags.model.js
+++ b/scripts/feature-flags.model.js
@@ -1,5 +1,6 @@
 import {
   normalizeFeatureFlags,
+  normalizeFeatureFlagEnvironment,
   normalizeUserEmail,
 } from "../src/features/app-shell/feature-flags/userFeatureFlagsModel.js";
 
@@ -13,16 +14,44 @@ export function parseBooleanFlagValue(value) {
   throw new Error(`Expected boolean value, got "${value}"`);
 }
 
+function extractEnvironmentOption(args = []) {
+  const nextArgs = [];
+  let environment = "local";
+
+  for (let index = 0; index < args.length; index++) {
+    const value = String(args[index] || "");
+    if (value === "--env" || value === "-e") {
+      environment = args[index + 1];
+      index++;
+      continue;
+    }
+    if (value.startsWith("--env=")) {
+      environment = value.slice("--env=".length);
+      continue;
+    }
+    nextArgs.push(args[index]);
+  }
+
+  return {
+    args: nextArgs,
+    environment: normalizeFeatureFlagEnvironment(environment),
+  };
+}
+
 export function parseFeatureFlagCommand(args = []) {
-  const [rawAction, rawEmail, rawFlagKey, rawValue] = args;
+  const {
+    args: positionalArgs,
+    environment,
+  } = extractEnvironmentOption(args);
+  const [rawAction, rawEmail, rawFlagKey, rawValue] = positionalArgs;
   const action = String(rawAction || "").trim().toLowerCase();
   const email = normalizeUserEmail(rawEmail);
   if (!action || !email) {
-    throw new Error("Usage: pnpm ff <get|set|merge|clear> <email> ...");
+    throw new Error("Usage: pnpm ff [--env local|preview|production] <get|set|merge|clear> <email> ...");
   }
 
   if (action === "get") {
-    return { action: "get", email };
+    return { action: "get", email, environment };
   }
 
   if (action === "set") {
@@ -33,6 +62,7 @@ export function parseFeatureFlagCommand(args = []) {
     return {
       action: "set",
       email,
+      environment,
       flagKey,
       flagValue: parseBooleanFlagValue(rawValue),
     };
@@ -45,14 +75,15 @@ export function parseFeatureFlagCommand(args = []) {
     return {
       action: "merge",
       email,
+      environment,
       flags: normalizeFeatureFlags(JSON.parse(rawFlagKey)),
     };
   }
 
   if (action === "clear") {
     const flagKey = String(rawFlagKey || "").trim();
-    if (flagKey) return { action: "clear-flag", email, flagKey };
-    return { action: "clear-user", email };
+    if (flagKey) return { action: "clear-flag", email, environment, flagKey };
+    return { action: "clear-user", email, environment };
   }
 
   throw new Error(`Unknown feature flag command "${rawAction}"`);
@@ -64,42 +95,70 @@ export async function applyFeatureFlagCommand({ command, repository } = {}) {
   }
 
   if (command.action === "get") {
-    const row = await repository.readFlagsByEmail(command.email);
-    return { email: command.email, flags: normalizeFeatureFlags(row?.flags) };
+    const row = await repository.readFlagsByEmail(command.email, {
+      environment: command.environment,
+    });
+    return {
+      email: command.email,
+      environment: command.environment,
+      flags: normalizeFeatureFlags(row?.flags),
+    };
   }
 
   if (command.action === "set") {
-    const row = await repository.readFlagsByEmail(command.email);
+    const row = await repository.readFlagsByEmail(command.email, {
+      environment: command.environment,
+    });
     const flags = {
       ...normalizeFeatureFlags(row?.flags),
       [command.flagKey]: command.flagValue,
     };
-    return repository.upsertFlagsByEmail({ email: command.email, flags });
+    return repository.upsertFlagsByEmail({
+      email: command.email,
+      environment: command.environment,
+      flags,
+    });
   }
 
   if (command.action === "merge") {
-    const row = await repository.readFlagsByEmail(command.email);
+    const row = await repository.readFlagsByEmail(command.email, {
+      environment: command.environment,
+    });
     const flags = {
       ...normalizeFeatureFlags(row?.flags),
       ...normalizeFeatureFlags(command.flags),
     };
-    return repository.upsertFlagsByEmail({ email: command.email, flags });
+    return repository.upsertFlagsByEmail({
+      email: command.email,
+      environment: command.environment,
+      flags,
+    });
   }
 
   if (command.action === "clear-flag") {
-    const row = await repository.readFlagsByEmail(command.email);
+    const row = await repository.readFlagsByEmail(command.email, {
+      environment: command.environment,
+    });
     const flags = { ...normalizeFeatureFlags(row?.flags) };
     delete flags[command.flagKey];
     if (Object.keys(flags).length === 0) {
-      await repository.deleteFlagsByEmail(command.email);
-      return { email: command.email, flags: {} };
+      await repository.deleteFlagsByEmail(command.email, {
+        environment: command.environment,
+      });
+      return { email: command.email, environment: command.environment, flags: {} };
     }
-    return repository.upsertFlagsByEmail({ email: command.email, flags });
+    return repository.upsertFlagsByEmail({
+      email: command.email,
+      environment: command.environment,
+      flags,
+    });
   }
 
   if (command.action === "clear-user") {
-    await repository.deleteFlagsByEmail(command.email);
-    return { email: command.email, flags: {} };
+    await repository.deleteFlagsByEmail(command.email, {
+      environment: command.environment,
+    });
+    return { email: command.email, environment: command.environment, flags: {} };
   }
 
   throw new Error(`Unsupported feature flag action "${command.action}"`);

--- a/scripts/feature-flags.model.test.js
+++ b/scripts/feature-flags.model.test.js
@@ -6,10 +6,11 @@ import {
 } from "./feature-flags.model.js";
 
 assert.deepEqual(
-  parseFeatureFlagCommand(["set", " Owner@Example.COM ", "flightAwareEnabled", "on"]),
+  parseFeatureFlagCommand(["--env", "preview", "set", " Owner@Example.COM ", "flightAwareEnabled", "on"]),
   {
     action: "set",
     email: "owner@example.com",
+    environment: "preview",
     flagKey: "flightAwareEnabled",
     flagValue: true,
   },
@@ -20,16 +21,18 @@ assert.deepEqual(
   {
     action: "set",
     email: "owner@example.com",
+    environment: "local",
     flagKey: "flightAwareEnabled",
     flagValue: false,
   },
 );
 
 assert.deepEqual(
-  parseFeatureFlagCommand(["merge", "owner@example.com", '{"flightAwareEnabled":true,"other":"true"}']),
+  parseFeatureFlagCommand(["merge", "--env=production", "owner@example.com", '{"flightAwareEnabled":true,"other":"true"}']),
   {
     action: "merge",
     email: "owner@example.com",
+    environment: "production",
     flags: {
       flightAwareEnabled: true,
       other: false,
@@ -42,6 +45,7 @@ assert.deepEqual(
   {
     action: "clear-flag",
     email: "owner@example.com",
+    environment: "local",
     flagKey: "flightAwareEnabled",
   },
 );
@@ -51,7 +55,13 @@ assert.deepEqual(
   {
     action: "clear-user",
     email: "owner@example.com",
+    environment: "local",
   },
+);
+
+assert.throws(
+  () => parseFeatureFlagCommand(["--env", "staging", "get", "owner@example.com"]),
+  /Expected feature flag environment/,
 );
 
 assert.throws(
@@ -64,13 +74,13 @@ assert.throws(
   const result = await applyFeatureFlagCommand({
     command: parseFeatureFlagCommand(["set", "owner@example.com", "flightAwareEnabled", "on"]),
     repository: {
-      async readFlagsByEmail(email) {
-        calls.push(["read", email]);
+      async readFlagsByEmail(email, options) {
+        calls.push(["read", email, options]);
         return { flags: { existingFlag: true } };
       },
-      async upsertFlagsByEmail({ email, flags }) {
-        calls.push(["upsert", email, flags]);
-        return { email, flags };
+      async upsertFlagsByEmail({ email, environment, flags }) {
+        calls.push(["upsert", email, environment, flags]);
+        return { email, environment, flags };
       },
     },
   });
@@ -80,8 +90,8 @@ assert.throws(
     flightAwareEnabled: true,
   });
   assert.deepEqual(calls, [
-    ["read", "owner@example.com"],
-    ["upsert", "owner@example.com", { existingFlag: true, flightAwareEnabled: true }],
+    ["read", "owner@example.com", { environment: "local" }],
+    ["upsert", "owner@example.com", "local", { existingFlag: true, flightAwareEnabled: true }],
   ]);
 }
 
@@ -90,21 +100,21 @@ assert.throws(
   const result = await applyFeatureFlagCommand({
     command: parseFeatureFlagCommand(["clear", "owner@example.com", "flightAwareEnabled"]),
     repository: {
-      async readFlagsByEmail(email) {
-        calls.push(["read", email]);
+      async readFlagsByEmail(email, options) {
+        calls.push(["read", email, options]);
         return { flags: { flightAwareEnabled: true, otherFlag: true } };
       },
-      async upsertFlagsByEmail({ email, flags }) {
-        calls.push(["upsert", email, flags]);
-        return { email, flags };
+      async upsertFlagsByEmail({ email, environment, flags }) {
+        calls.push(["upsert", email, environment, flags]);
+        return { email, environment, flags };
       },
     },
   });
 
   assert.deepEqual(result.flags, { otherFlag: true });
   assert.deepEqual(calls, [
-    ["read", "owner@example.com"],
-    ["upsert", "owner@example.com", { otherFlag: true }],
+    ["read", "owner@example.com", { environment: "local" }],
+    ["upsert", "owner@example.com", "local", { otherFlag: true }],
   ]);
 }
 
@@ -113,15 +123,15 @@ assert.throws(
   const result = await applyFeatureFlagCommand({
     command: parseFeatureFlagCommand(["clear", "owner@example.com"]),
     repository: {
-      async deleteFlagsByEmail(email) {
-        calls.push(["delete", email]);
-        return { email };
+      async deleteFlagsByEmail(email, options) {
+        calls.push(["delete", email, options]);
+        return { email, environment: options.environment };
       },
     },
   });
 
-  assert.deepEqual(result, { email: "owner@example.com", flags: {} });
-  assert.deepEqual(calls, [["delete", "owner@example.com"]]);
+  assert.deepEqual(result, { email: "owner@example.com", environment: "local", flags: {} });
+  assert.deepEqual(calls, [["delete", "owner@example.com", { environment: "local" }]]);
 }
 
 console.log("feature-flags.model.test.js ok");

--- a/src/app/api/dao/userFeatureFlags.dao.js
+++ b/src/app/api/dao/userFeatureFlags.dao.js
@@ -1,15 +1,18 @@
 import { createServerSupabaseClient } from "./supabaseClient.js";
 import {
   normalizeFeatureFlags,
+  normalizeFeatureFlagEnvironment,
   normalizeUserEmail,
+  resolveFeatureFlagEnvironment,
 } from "../../../features/app-shell/feature-flags/userFeatureFlagsModel.js";
 
 export const USER_FEATURE_FLAGS_TABLE = "user_feature_flags";
-const SELECT_COLUMNS = "email,flags,updated_at";
+const SELECT_COLUMNS = "email,environment,flags,updated_at";
 
 export function createUserFeatureFlagsRepository({
   supabaseUrl,
   supabaseKey,
+  environment,
   createClientImpl,
 } = {}) {
   const client = createServerSupabaseClient({
@@ -18,16 +21,21 @@ export function createUserFeatureFlagsRepository({
     createClientImpl,
   });
   if (!client) return null;
+  const defaultEnvironment = normalizeFeatureFlagEnvironment(environment);
 
   return {
-    async readFlagsByEmail(email) {
+    async readFlagsByEmail(email, options = {}) {
       const normalizedEmail = normalizeUserEmail(email);
       if (!normalizedEmail) return null;
+      const normalizedEnvironment = normalizeFeatureFlagEnvironment(
+        options.environment || defaultEnvironment,
+      );
 
       const { data, error } = await client
         .from(USER_FEATURE_FLAGS_TABLE)
         .select(SELECT_COLUMNS)
         .eq("email", normalizedEmail)
+        .eq("environment", normalizedEnvironment)
         .maybeSingle();
 
       if (error && error.code !== "PGRST116") {
@@ -39,24 +47,29 @@ export function createUserFeatureFlagsRepository({
       if (!data) return null;
       return {
         email: normalizeUserEmail(data.email),
+        environment: normalizeFeatureFlagEnvironment(data.environment),
         flags: normalizeFeatureFlags(data.flags),
         updatedAt: data.updated_at || "",
       };
     },
 
-    async upsertFlagsByEmail({ email, flags } = {}) {
+    async upsertFlagsByEmail({ email, environment, flags } = {}) {
       const normalizedEmail = normalizeUserEmail(email);
       if (!normalizedEmail) return null;
+      const normalizedEnvironment = normalizeFeatureFlagEnvironment(
+        environment || defaultEnvironment,
+      );
 
       const { data, error } = await client
         .from(USER_FEATURE_FLAGS_TABLE)
         .upsert(
           {
             email: normalizedEmail,
+            environment: normalizedEnvironment,
             flags: normalizeFeatureFlags(flags),
             updated_at: new Date().toISOString(),
           },
-          { onConflict: "email" },
+          { onConflict: "email,environment" },
         )
         .select(SELECT_COLUMNS)
         .single();
@@ -69,19 +82,24 @@ export function createUserFeatureFlagsRepository({
 
       return {
         email: normalizeUserEmail(data.email),
+        environment: normalizeFeatureFlagEnvironment(data.environment),
         flags: normalizeFeatureFlags(data.flags),
         updatedAt: data.updated_at || "",
       };
     },
 
-    async deleteFlagsByEmail(email) {
+    async deleteFlagsByEmail(email, options = {}) {
       const normalizedEmail = normalizeUserEmail(email);
       if (!normalizedEmail) return null;
+      const normalizedEnvironment = normalizeFeatureFlagEnvironment(
+        options.environment || defaultEnvironment,
+      );
 
       const { error } = await client
         .from(USER_FEATURE_FLAGS_TABLE)
         .delete()
-        .eq("email", normalizedEmail);
+        .eq("email", normalizedEmail)
+        .eq("environment", normalizedEnvironment);
 
       if (error) {
         throw new Error(
@@ -89,7 +107,7 @@ export function createUserFeatureFlagsRepository({
         );
       }
 
-      return { email: normalizedEmail };
+      return { email: normalizedEmail, environment: normalizedEnvironment };
     },
   };
 }
@@ -101,6 +119,7 @@ export function createUserFeatureFlagsRepositoryFromEnv({
   return createUserFeatureFlagsRepository({
     supabaseUrl: env.NEXT_PUBLIC_SUPABASE_URL || env.SUPABASE_URL,
     supabaseKey: env.SUPABASE_SERVICE_ROLE_KEY || env.SUPABASE_SECRET_KEY,
+    environment: resolveFeatureFlagEnvironment(env),
     createClientImpl,
   });
 }

--- a/src/app/api/dao/userFeatureFlags.dao.test.js
+++ b/src/app/api/dao/userFeatureFlags.dao.test.js
@@ -66,6 +66,7 @@ function createFakeSupabaseClient({
   const { calls, createClientImpl } = createFakeSupabaseClient({
     writeData: {
       email: "owner@example.com",
+      environment: "preview",
       flags: { flightAwareEnabled: true, otherFlag: "true" },
       updated_at: "2026-05-26T12:00:00.000Z",
     },
@@ -73,6 +74,7 @@ function createFakeSupabaseClient({
   const repository = createUserFeatureFlagsRepository({
     supabaseUrl: "https://example.supabase.co",
     supabaseKey: "sb_secret_test",
+    environment: "preview",
     createClientImpl,
   });
 
@@ -84,13 +86,15 @@ function createFakeSupabaseClient({
   assert.equal(calls[1].type, "from");
   assert.equal(calls[2].type, "upsert");
   assert.equal(calls[2].row.email, "owner@example.com");
+  assert.equal(calls[2].row.environment, "preview");
   assert.deepEqual(calls[2].row.flags, {
     flightAwareEnabled: true,
     otherFlag: false,
   });
-  assert.deepEqual(calls[2].options, { onConflict: "email" });
+  assert.deepEqual(calls[2].options, { onConflict: "email,environment" });
   assert.deepEqual(row, {
     email: "owner@example.com",
+    environment: "preview",
     flags: { flightAwareEnabled: true, otherFlag: false },
     updatedAt: "2026-05-26T12:00:00.000Z",
   });
@@ -101,16 +105,18 @@ function createFakeSupabaseClient({
   const repository = createUserFeatureFlagsRepository({
     supabaseUrl: "https://example.supabase.co",
     supabaseKey: "sb_secret_test",
+    environment: "preview",
     createClientImpl,
   });
 
   const result = await repository.deleteFlagsByEmail(" Owner@Example.COM ");
 
-  assert.deepEqual(result, { email: "owner@example.com" });
+  assert.deepEqual(result, { email: "owner@example.com", environment: "preview" });
   assert.deepEqual(calls.slice(1), [
     { type: "from", table: USER_FEATURE_FLAGS_TABLE },
     { type: "delete" },
     { type: "eq", column: "email", value: "owner@example.com" },
+    { type: "eq", column: "environment", value: "preview" },
   ]);
 }
 
@@ -118,6 +124,7 @@ function createFakeSupabaseClient({
   const { calls, createClientImpl } = createFakeSupabaseClient({
     readData: {
       email: "owner@example.com",
+      environment: "preview",
       flags: { flightAwareEnabled: true, otherFlag: "true" },
       updated_at: "2026-05-26T12:00:00.000Z",
     },
@@ -125,6 +132,7 @@ function createFakeSupabaseClient({
   const repository = createUserFeatureFlagsRepository({
     supabaseUrl: "https://example.supabase.co",
     supabaseKey: "sb_secret_test",
+    environment: "preview",
     createClientImpl,
   });
 
@@ -133,12 +141,14 @@ function createFakeSupabaseClient({
   assert.equal(calls[0].supabaseKey, "sb_secret_test");
   assert.deepEqual(calls.slice(1), [
     { type: "from", table: USER_FEATURE_FLAGS_TABLE },
-    { type: "select", columns: "email,flags,updated_at" },
+    { type: "select", columns: "email,environment,flags,updated_at" },
     { type: "eq", column: "email", value: "owner@example.com" },
+    { type: "eq", column: "environment", value: "preview" },
     { type: "maybeSingle" },
   ]);
   assert.deepEqual(row, {
     email: "owner@example.com",
+    environment: "preview",
     flags: { flightAwareEnabled: true, otherFlag: false },
     updatedAt: "2026-05-26T12:00:00.000Z",
   });
@@ -179,12 +189,21 @@ function createFakeSupabaseClient({
       NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_test",
       SUPABASE_SERVICE_ROLE_KEY: "sb_service_role_test",
+      VERCEL_ENV: "preview",
     },
     createClientImpl,
   });
 
   assert.ok(repository);
   assert.equal(calls[0].supabaseKey, "sb_service_role_test");
+  await repository.readFlagsByEmail("owner@example.com");
+  assert.deepEqual(calls.slice(1), [
+    { type: "from", table: USER_FEATURE_FLAGS_TABLE },
+    { type: "select", columns: "email,environment,flags,updated_at" },
+    { type: "eq", column: "email", value: "owner@example.com" },
+    { type: "eq", column: "environment", value: "preview" },
+    { type: "maybeSingle" },
+  ]);
 }
 
 assert.equal(

--- a/src/features/app-shell/feature-flags/userFeatureFlags.server.js
+++ b/src/features/app-shell/feature-flags/userFeatureFlags.server.js
@@ -3,6 +3,7 @@ import {
   getClerkUserPrimaryEmail,
   isFeatureFlagEnabled,
   normalizeFeatureFlags,
+  resolveFeatureFlagEnvironment,
 } from "./userFeatureFlagsModel.js";
 import {
   createUserFeatureFlagsRepositoryFromEnv,
@@ -10,13 +11,15 @@ import {
 
 export async function resolveFeatureFlagsForUser({
   user,
+  env = process.env,
   repository = createUserFeatureFlagsRepositoryFromEnv(),
 } = {}) {
   const email = getClerkUserPrimaryEmail(user);
   if (!email || !repository) return {};
+  const environment = resolveFeatureFlagEnvironment(env);
 
   try {
-    const row = await repository.readFlagsByEmail(email);
+    const row = await repository.readFlagsByEmail(email, { environment });
     return normalizeFeatureFlags(row?.flags);
   } catch (error) {
     console.warn(

--- a/src/features/app-shell/feature-flags/userFeatureFlags.server.test.js
+++ b/src/features/app-shell/feature-flags/userFeatureFlags.server.test.js
@@ -12,14 +12,15 @@ import {
       primaryEmailAddress: { emailAddress: "Owner@Example.COM" },
     },
     repository: {
-      async readFlagsByEmail(email) {
-        calls.push(email);
+      async readFlagsByEmail(email, options) {
+        calls.push({ email, environment: options.environment });
         return { flags: { flightAwareEnabled: true } };
       },
     },
+    env: { VERCEL_ENV: "preview" },
   });
 
-  assert.deepEqual(calls, ["owner@example.com"]);
+  assert.deepEqual(calls, [{ email: "owner@example.com", environment: "preview" }]);
   assert.deepEqual(flags, { flightAwareEnabled: true });
 }
 

--- a/src/features/app-shell/feature-flags/userFeatureFlagsModel.js
+++ b/src/features/app-shell/feature-flags/userFeatureFlagsModel.js
@@ -2,8 +2,37 @@ export const FEATURE_FLAGS = Object.freeze({
   FLIGHTAWARE_ENABLED: "flightAwareEnabled",
 });
 
+export const FEATURE_FLAG_ENVIRONMENTS = Object.freeze({
+  LOCAL: "local",
+  PREVIEW: "preview",
+  PRODUCTION: "production",
+});
+
+const ENVIRONMENT_ALIASES = Object.freeze({
+  development: FEATURE_FLAG_ENVIRONMENTS.LOCAL,
+  local: FEATURE_FLAG_ENVIRONMENTS.LOCAL,
+  preview: FEATURE_FLAG_ENVIRONMENTS.PREVIEW,
+  production: FEATURE_FLAG_ENVIRONMENTS.PRODUCTION,
+});
+
 export function normalizeUserEmail(email) {
   return String(email || "").trim().toLowerCase();
+}
+
+export function normalizeFeatureFlagEnvironment(environment) {
+  const normalized = String(environment || "").trim().toLowerCase();
+  if (!normalized) return FEATURE_FLAG_ENVIRONMENTS.LOCAL;
+  const mapped = ENVIRONMENT_ALIASES[normalized];
+  if (mapped) return mapped;
+  throw new Error(
+    `Expected feature flag environment to be one of: ${Object.values(FEATURE_FLAG_ENVIRONMENTS).join(", ")}`,
+  );
+}
+
+export function resolveFeatureFlagEnvironment(env = process.env) {
+  return normalizeFeatureFlagEnvironment(
+    env.FEATURE_FLAGS_ENV || env.VERCEL_ENV || FEATURE_FLAG_ENVIRONMENTS.LOCAL,
+  );
 }
 
 export function getClerkUserPrimaryEmail(user) {

--- a/src/features/app-shell/feature-flags/userFeatureFlagsModel.test.js
+++ b/src/features/app-shell/feature-flags/userFeatureFlagsModel.test.js
@@ -6,12 +6,30 @@ import {
   getClerkUserPrimaryEmail,
   isFeatureFlagEnabled,
   normalizeFeatureFlags,
+  normalizeFeatureFlagEnvironment,
   normalizeUserEmail,
+  resolveFeatureFlagEnvironment,
 } from "./userFeatureFlagsModel.js";
 
 assert.equal(normalizeUserEmail(" OWNER@Example.COM "), "owner@example.com");
 assert.equal(normalizeUserEmail(""), "");
 assert.equal(normalizeUserEmail(null), "");
+assert.equal(normalizeFeatureFlagEnvironment("preview"), "preview");
+assert.equal(normalizeFeatureFlagEnvironment("development"), "local");
+assert.equal(normalizeFeatureFlagEnvironment(""), "local");
+assert.throws(
+  () => normalizeFeatureFlagEnvironment("staging"),
+  /Expected feature flag environment/,
+);
+assert.equal(
+  resolveFeatureFlagEnvironment({ FEATURE_FLAGS_ENV: "preview" }),
+  "preview",
+);
+assert.equal(
+  resolveFeatureFlagEnvironment({ VERCEL_ENV: "production" }),
+  "production",
+);
+assert.equal(resolveFeatureFlagEnvironment({}), "local");
 
 assert.equal(
   getClerkUserPrimaryEmail({

--- a/supabase/migrations/20260526102052_scope_user_feature_flags_by_environment.sql
+++ b/supabase/migrations/20260526102052_scope_user_feature_flags_by_environment.sql
@@ -1,0 +1,22 @@
+alter table public.user_feature_flags
+  add column if not exists environment text not null default 'production';
+
+alter table public.user_feature_flags
+  drop constraint if exists user_feature_flags_environment_check;
+
+alter table public.user_feature_flags
+  add constraint user_feature_flags_environment_check
+  check (environment in ('local', 'preview', 'production'));
+
+alter table public.user_feature_flags
+  drop constraint if exists user_feature_flags_pkey;
+
+alter table public.user_feature_flags
+  add constraint user_feature_flags_pkey
+  primary key (email, environment);
+
+comment on column public.user_feature_flags.environment is
+  'Feature flag scope. Local and preview flags are isolated from production.';
+
+comment on table public.user_feature_flags is
+  'Server-read feature flags keyed by Clerk primary email and environment. Example flags: {"flightAwareEnabled": true}.';


### PR DESCRIPTION
## Summary

- Scope Supabase-backed user feature flags by `email + environment` instead of only email.
- Add `local`, `preview`, and `production` environment normalization.
- Make local CLI commands default to `local`; add `--env local|preview|production` for explicit control.
- Have server-side reads resolve environment from `FEATURE_FLAGS_ENV` or `VERCEL_ENV`.
- Add a Supabase migration that preserves existing rows as `production` and changes the primary key to `(email, environment)`.

## Verification

- `git diff --check`
- `pnpm test` (93 test files passed)
- `pnpm lint`
- `pnpm build`
- `supabase db push --linked --yes --include-all`
- `supabase migration list --linked`
- `pnpm ff --env production get ruyyi0323@gmail.com` returned production `flightAwareEnabled: true`
- `pnpm ff get ruyyi0323@gmail.com` returned local empty flags
- `pnpm ff --env preview set/get codex-scope@adsbao.local flightAwareEnabled on`
- `pnpm ff --env production get codex-scope@adsbao.local` returned empty flags
- `pnpm ff --env local get codex-scope@adsbao.local` returned empty flags
- `pnpm ff --env preview clear/get codex-scope@adsbao.local` cleared preview smoke row
