### PR TITLE
Fix flight tracking initial state and trace UX

### DIFF
--- a/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
+++ b/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
@@ -49,7 +49,13 @@ export function SelectedAircraftTraceProvider({
   focalTraceRefreshKey = "",
   children,
 }) {
-  const primaryHook = useAircraftTrace(selectedAircraft);
+  const primaryMatchesFocal =
+    selectedAircraft &&
+    focalAircraft &&
+    getAircraftIdentity(selectedAircraft) === getAircraftIdentity(focalAircraft);
+  const primaryHook = useAircraftTrace(selectedAircraft, {
+    notifyInitialFetch: !primaryMatchesFocal,
+  });
   // Focal trace uses adsb.lol's trace_full endpoint on the aircraft
   // detail page so the user sees the whole flight on load — not just
   // the rolling tail. The optional cutoff clips the historical points
@@ -62,6 +68,7 @@ export function SelectedAircraftTraceProvider({
     traceStartAtMs: focalTraceStartAtMs,
     persistKey: focalPersistKey,
     traceRefreshKey: focalTraceRefreshKey,
+    notifyInitialFetch: false,
   });
 
   const primary = useMemo(

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -360,7 +360,6 @@ function FlightExplorerContent({ callsign }) {
         isMobile={isMobile}
         sidebarOpen={sidebarOpen}
         onApplyTemporaryRoute={applyTemporaryRoute}
-        suppressMobileWhenAlreadyTracking
       />
       <div
         className={`font-sans text-atc-text ${
@@ -417,6 +416,7 @@ function FlightExplorerContent({ callsign }) {
             showProcedureFixLabels={false}
             focalRangeRings={false}
             nearbyRangeRings={flightDisplayContext.nearbyRangeRings}
+            deferUntilFocal
           >
             <FlightAwareRouteArc path={focalFlightAwareRoutePath} />
             <MapFitToTraceController

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -20,6 +20,7 @@ import { useI18n } from "../../features/app-shell/i18n/useI18n.js";
 import { aircraftMatchesFilters } from "../../features/aircraft/filters/aircraftFilters.js";
 import {
   getMapOverlayTheme,
+  resolveAirportMapInitialCenter,
   getVisibleAircraft,
   resolveAirportMapFocalCenter,
   resolveDocumentTheme,
@@ -56,6 +57,8 @@ export default function AirportMap({
   showProcedureFixLabels = false,
   focalRangeRings = null,
   nearbyRangeRings = null,
+  fallbackCenter = AIRPORT_MAP_FALLBACK_CENTER,
+  deferUntilFocal = false,
   children = null,
 }) {
   const { locale } = useI18n();
@@ -81,6 +84,16 @@ export default function AirportMap({
     () => resolveAirportMapFocalCenter({ lat, lon }),
     [lat, lon],
   );
+  const initialCenter = useMemo(
+    () =>
+      resolveAirportMapInitialCenter({
+        focalCenter,
+        fallbackCenter,
+        deferUntilFocal,
+      }),
+    [deferUntilFocal, fallbackCenter, focalCenter],
+  );
+  const canInitializeMap = Boolean(initialCenter);
 
   useEffect(() => {
     setCurrentTheme(resolveCurrentTheme());
@@ -96,12 +109,9 @@ export default function AirportMap({
   }, []);
 
   useEffect(() => {
-    if (!mapEl.current || mapRef.current) return undefined;
+    if (!mapEl.current || mapRef.current || !initialCenter) return undefined;
     const map = L.map(mapEl.current, {
-      center: [
-        focalCenter?.lat ?? AIRPORT_MAP_FALLBACK_CENTER.lat,
-        focalCenter?.lon ?? AIRPORT_MAP_FALLBACK_CENTER.lon,
-      ],
+      center: [initialCenter.lat, initialCenter.lon],
       zoom,
       zoomControl: false,
       attributionControl: false,
@@ -129,7 +139,7 @@ export default function AirportMap({
       setMapInstance(null);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [canInitializeMap]);
 
   // followsCenter controls whether the map re-centers on every poll.
   // After "fit to trace" the caller flips this to false so the map

--- a/src/components/map/MapTileLayers.jsx
+++ b/src/components/map/MapTileLayers.jsx
@@ -4,6 +4,10 @@ import { useEffect, useRef } from "react";
 import L from "leaflet";
 import "@maplibre/maplibre-gl-leaflet";
 import { useMapInstance } from "./MapContext.js";
+import {
+  shouldAttemptMapLibreTiles,
+  shouldLogMapTileLayerFailure,
+} from "@/features/airport/map/mapTileLayerModel.js";
 
 export default function MapTileLayers({
   theme = "dark",
@@ -21,6 +25,14 @@ export default function MapTileLayers({
 
   useEffect(() => {
     if (!hasTilePane(map)) return undefined;
+    if (
+      !shouldAttemptMapLibreTiles({
+        userAgent: navigator.userAgent,
+        webGlAvailable: hasWebGlContext(),
+      })
+    ) {
+      return undefined;
+    }
     const abort = new AbortController();
     let cancelled = false;
 
@@ -28,14 +40,25 @@ export default function MapTileLayers({
       .then((style) => {
         if (cancelled || !hasTilePane(map)) return;
         removeLayer(layerRef.current, map);
-        layerRef.current = L.maplibreGL({
-          style,
-          interactive: false,
-          attributionControl: false,
-          className: "atc-maplibre-base",
-        }).addTo(map);
-        layerRef.current.getContainer()?.classList.add("atc-tile-base");
-        setSelectionOpacity(layerRef.current, theme, selectionActiveRef.current);
+        let nextLayer = null;
+        try {
+          nextLayer = L.maplibreGL({
+            style,
+            interactive: false,
+            attributionControl: false,
+            className: "atc-maplibre-base",
+          });
+          nextLayer.addTo(map);
+          layerRef.current = nextLayer;
+          layerRef.current.getContainer()?.classList.add("atc-tile-base");
+          setSelectionOpacity(layerRef.current, theme, selectionActiveRef.current);
+        } catch (error) {
+          removeLayer(nextLayer, map);
+          layerRef.current = null;
+          if (shouldLogMapTileLayerFailure(error)) {
+            console.error("[airport-map] failed to initialize map tiles", error);
+          }
+        }
       })
       .catch((error) => {
         if (error?.name === "AbortError") return;
@@ -109,7 +132,13 @@ function hasTilePane(map) {
 function removeLayer(layer, map) {
   if (!layer || !map || typeof layer.removeFrom !== "function") return;
   if (!map._panes) return;
-  layer.removeFrom(map);
+  try {
+    layer.removeFrom(map);
+  } catch (error) {
+    if (shouldLogMapTileLayerFailure(error)) {
+      console.error("[airport-map] failed to remove map tiles", error);
+    }
+  }
 }
 
 function setSelectionOpacity(layer, theme, selectionActive) {
@@ -120,4 +149,13 @@ function setSelectionOpacity(layer, theme, selectionActive) {
     return;
   }
   container.style.opacity = "1";
+}
+
+function hasWebGlContext() {
+  const canvas = document.createElement("canvas");
+  const context =
+    canvas.getContext("webgl2") ||
+    canvas.getContext("webgl") ||
+    canvas.getContext("experimental-webgl");
+  return Boolean(context);
 }

--- a/src/features/aircraft/trace/aircraftTraceNotificationModel.js
+++ b/src/features/aircraft/trace/aircraftTraceNotificationModel.js
@@ -1,0 +1,5 @@
+export function resolveAircraftTraceNotificationMode({
+  notifyInitialFetch = true,
+} = {}) {
+  return notifyInitialFetch !== false;
+}

--- a/src/features/aircraft/trace/aircraftTraceNotificationModel.test.js
+++ b/src/features/aircraft/trace/aircraftTraceNotificationModel.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+
+import {
+  resolveAircraftTraceNotificationMode,
+} from "./aircraftTraceNotificationModel.js";
+
+assert.equal(resolveAircraftTraceNotificationMode(), true);
+assert.equal(
+  resolveAircraftTraceNotificationMode({ notifyInitialFetch: false }),
+  false,
+);
+assert.equal(
+  resolveAircraftTraceNotificationMode({ notifyInitialFetch: true }),
+  true,
+);
+
+console.log("aircraftTraceNotificationModel.test.js ok");

--- a/src/features/airport/map/airportMapModel.js
+++ b/src/features/airport/map/airportMapModel.js
@@ -33,6 +33,19 @@ export const resolveAirportMapFocalCenter = ({ lat, lon } = {}) => {
   return { lat: focalLat, lon: focalLon };
 };
 
+export const resolveAirportMapInitialCenter = ({
+  focalCenter = null,
+  fallbackCenter = null,
+  deferUntilFocal = false,
+} = {}) => {
+  if (focalCenter) return focalCenter;
+  if (deferUntilFocal) return null;
+  return resolveAirportMapFocalCenter({
+    lat: fallbackCenter?.lat,
+    lon: fallbackCenter?.lon,
+  });
+};
+
 export const formatCoordinateLabel = (value, axis) => {
   if (!value) return "";
   const positiveSuffix = axis === "lat" ? "N" : "E";

--- a/src/features/airport/map/airportMapModel.test.js
+++ b/src/features/airport/map/airportMapModel.test.js
@@ -5,6 +5,7 @@ import {
   formatCoordinateLabel,
   getMapOverlayTheme,
   getVisibleAircraft,
+  resolveAirportMapInitialCenter,
   resolveAirportMapFocalCenter,
   resolveDocumentTheme,
 } from "./airportMapModel.js";
@@ -30,6 +31,30 @@ assert.deepEqual(resolveAirportMapFocalCenter({ lat: "0", lon: "0" }), {
   lat: 0,
   lon: 0,
 });
+assert.deepEqual(
+  resolveAirportMapInitialCenter({
+    focalCenter: null,
+    fallbackCenter: { lat: 33.9416, lon: -118.4085 },
+    deferUntilFocal: false,
+  }),
+  { lat: 33.9416, lon: -118.4085 },
+);
+assert.equal(
+  resolveAirportMapInitialCenter({
+    focalCenter: null,
+    fallbackCenter: { lat: 33.9416, lon: -118.4085 },
+    deferUntilFocal: true,
+  }),
+  null,
+);
+assert.deepEqual(
+  resolveAirportMapInitialCenter({
+    focalCenter: { lat: 42.36, lon: -71.01 },
+    fallbackCenter: { lat: 33.9416, lon: -118.4085 },
+    deferUntilFocal: true,
+  }),
+  { lat: 42.36, lon: -71.01 },
+);
 
 assert.deepEqual(
   getVisibleAircraft({ aircraft, airportLat: 42.3656, airportLon: -71.0096, zoom: ZOOM_AIRPORT })

--- a/src/features/airport/map/mapFitTraceModel.js
+++ b/src/features/airport/map/mapFitTraceModel.js
@@ -14,11 +14,13 @@ export function buildTraceFitPoints({ traces = [], routePath = [] } = {}) {
     }
   }
 
-  for (const point of routePath || []) {
-    if (Array.isArray(point)) {
-      pushFiniteLatLon(points, point[0], point[1]);
-    } else {
-      pushFiniteLatLon(points, point?.lat, point?.lon);
+  if (points.length > 0) {
+    for (const point of routePath || []) {
+      if (Array.isArray(point)) {
+        pushFiniteLatLon(points, point[0], point[1]);
+      } else {
+        pushFiniteLatLon(points, point?.lat, point?.lon);
+      }
     }
   }
 

--- a/src/features/airport/map/mapFitTraceModel.test.js
+++ b/src/features/airport/map/mapFitTraceModel.test.js
@@ -54,4 +54,20 @@ import { buildTraceFitPoints } from "./mapFitTraceModel.js";
   );
 }
 
+{
+  const points = buildTraceFitPoints({
+    traces: [],
+    routePath: [
+      [49.19, -123.18],
+      [-33.94, 151.18],
+    ],
+  });
+
+  assert.deepEqual(
+    points,
+    [],
+    "route-only geometry should not trigger flight-page trace fitting",
+  );
+}
+
 console.log("mapFitTraceModel.test.js ok");

--- a/src/features/airport/map/mapTileLayerModel.js
+++ b/src/features/airport/map/mapTileLayerModel.js
@@ -1,0 +1,19 @@
+const RECOVERABLE_FAILURE_PATTERNS = [
+  /webgl/i,
+  /context creation/i,
+  /maplibre/i,
+];
+
+export function shouldAttemptMapLibreTiles({
+  userAgent = "",
+  webGlAvailable = true,
+} = {}) {
+  if (!webGlAvailable) return false;
+  if (/HeadlessChrome/i.test(String(userAgent || ""))) return false;
+  return true;
+}
+
+export function shouldLogMapTileLayerFailure(error) {
+  const message = error?.message || String(error || "");
+  return !RECOVERABLE_FAILURE_PATTERNS.some((pattern) => pattern.test(message));
+}

--- a/src/features/airport/map/mapTileLayerModel.test.js
+++ b/src/features/airport/map/mapTileLayerModel.test.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+
+import {
+  shouldAttemptMapLibreTiles,
+  shouldLogMapTileLayerFailure,
+} from "./mapTileLayerModel.js";
+
+assert.equal(
+  shouldAttemptMapLibreTiles({
+    userAgent:
+      "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+    webGlAvailable: true,
+  }),
+  false,
+);
+assert.equal(
+  shouldAttemptMapLibreTiles({
+    userAgent:
+      "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+    webGlAvailable: false,
+  }),
+  false,
+);
+assert.equal(
+  shouldAttemptMapLibreTiles({
+    userAgent:
+      "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+    webGlAvailable: true,
+  }),
+  true,
+);
+
+assert.equal(
+  shouldLogMapTileLayerFailure(new Error("WebGL context creation failed")),
+  false,
+);
+assert.equal(
+  shouldLogMapTileLayerFailure(new Error("OpenFreeMap style request failed: 503")),
+  true,
+);
+
+console.log("mapTileLayerModel.test.js ok");

--- a/src/features/airport/nearby/nearbyAirports.mechanism.js
+++ b/src/features/airport/nearby/nearbyAirports.mechanism.js
@@ -114,6 +114,9 @@ const getNearbyAirportsFromOurAirports = async ({ query, queries }) => {
 };
 
 const logSupabaseCacheWarning = (action, error) => {
+  if (action === "write") {
+    return;
+  }
   console.warn(`[airports/nearby] Supabase cache ${action} failed`, error);
 };
 

--- a/src/features/airport/nearby/nearbyAirports.mechanism.test.js
+++ b/src/features/airport/nearby/nearbyAirports.mechanism.test.js
@@ -85,4 +85,57 @@ assert.deepEqual(calls[0].options, {
   excludeIdent: "",
 });
 
+{
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args);
+  try {
+    const quietPayload = await getNearbyAirports({
+      query: {
+        lat: 43.73,
+        lon: -79.45,
+        icao: "",
+        radiusNm: 40,
+        limit: 12,
+        country: "US",
+        minRunwayLength: 5000,
+      },
+      airportCache: {
+        async read() {
+          return null;
+        },
+        async write() {
+          throw new Error(
+            'Supabase nearby airport cache write failed (new row violates row-level security policy for table "nearby_airport_cache")',
+          );
+        },
+      },
+      ourAirportsQueries: {
+        async getNearbyAirportsByPosition() {
+          return [
+            {
+              ident: "CYYZ",
+              icao: "CYYZ",
+              iata: "YYZ",
+              name: "Toronto Pearson International Airport",
+              country: "CA",
+              lat: 43.6772,
+              lon: -79.6306,
+              distanceNm: 8.7,
+            },
+          ];
+        },
+        async getRunwaysByAirport() {
+          return [];
+        },
+      },
+    });
+
+    assert.equal(quietPayload.source, "ourairports");
+    assert.deepEqual(warnings, []);
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 console.log("nearbyAirports.mechanism.test.js ok");

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.js
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.js
@@ -99,7 +99,6 @@ const EARTH_RADIUS_NM = 3440.065;
 const ROUTE_LOOKUP_SUPPRESSED_TRACKING_STATUSES = new Set([
   "flightaware_terminal",
   "missing",
-  "stale",
 ]);
 
 const haversineNm = (lat1, lon1, lat2, lon2) => {

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.test.js
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.test.js
@@ -3,10 +3,12 @@ import assert from "node:assert/strict";
 import {
   buildRouteCacheKey,
   buildRoutesByCallsign,
+  getLookupCallsigns,
   getRouteLookupStats,
   getFreshRouteCacheEntry,
   rankCandidatesByDistance,
   resolvePendingRouteLookups,
+  shouldSuppressRouteLookup,
 } from "./flightRouteLookupModel.js";
 
 const now = 1_700_000_000_000;
@@ -266,4 +268,28 @@ const route = {
     source: "aircraft-metadata",
     confidence: "position-metadata",
   });
+}
+
+{
+  const aircraft = [
+    {
+      callsign: "SQ26",
+      lat: 45.1,
+      lon: -42.2,
+      trackingState: { status: "stale" },
+    },
+    {
+      callsign: "DAL123",
+      trackingState: { status: "missing" },
+    },
+    {
+      callsign: "AAL100",
+      trackingState: { status: "flightaware_terminal" },
+    },
+  ];
+
+  assert.equal(shouldSuppressRouteLookup(aircraft[0]), false);
+  assert.equal(shouldSuppressRouteLookup(aircraft[1]), true);
+  assert.equal(shouldSuppressRouteLookup(aircraft[2]), true);
+  assert.deepEqual(getLookupCallsigns(aircraft), ["SQ26"]);
 }

--- a/src/hooks/useAircraftTrace.js
+++ b/src/hooks/useAircraftTrace.js
@@ -14,6 +14,9 @@ import {
   readTrackedTrace,
   writeTrackedTrace,
 } from "../features/aircraft/tracking/trackedTraceStorage.js";
+import {
+  resolveAircraftTraceNotificationMode,
+} from "../features/aircraft/trace/aircraftTraceNotificationModel.js";
 
 // How long to wait after the last merged-trace change before writing to
 // localStorage. Live polls land every 3s, so a short debounce lets a
@@ -123,6 +126,9 @@ export function useAircraftTrace(selectedAircraft = null, options = {}) {
     typeof options?.traceRefreshKey === "string"
       ? options.traceRefreshKey
       : "";
+  const notifyInitialFetch = resolveAircraftTraceNotificationMode({
+    notifyInitialFetch: options?.notifyInitialFetch,
+  });
   const traceLabel = formatTraceFetchLabel(selectedAircraft, hex);
 
   const [fullPoints, setFullPoints] = useState([]);
@@ -155,7 +161,13 @@ export function useAircraftTrace(selectedAircraft = null, options = {}) {
     setRecentPoints([]);
     setRecentLoading(true);
 
-    fetchTraceSource({ hex, label, source: "recent", full: false })
+    fetchTraceSource({
+      hex,
+      label,
+      source: "recent",
+      full: false,
+      notify: notifyInitialFetch,
+    })
       .then(({ points }) => {
         if (disposed) return;
         setRecentPoints(points);
@@ -173,7 +185,13 @@ export function useAircraftTrace(selectedAircraft = null, options = {}) {
       setFullPoints([]);
       setFullLoading(true);
 
-      fetchTraceSource({ hex, label, source: "full", full: true })
+      fetchTraceSource({
+        hex,
+        label,
+        source: "full",
+        full: true,
+        notify: notifyInitialFetch,
+      })
         .then(({ points }) => {
           if (disposed) return;
           setFullPoints(points);
@@ -194,7 +212,7 @@ export function useAircraftTrace(selectedAircraft = null, options = {}) {
     return () => {
       disposed = true;
     };
-  }, [hex, fullTrace, traceLabel]);
+  }, [hex, fullTrace, notifyInitialFetch, traceLabel]);
 
   // While the tracked-flight page is resuming from a background tab (or
   // keeping the lost-signal overlay alive), silently refresh the upstream


### PR DESCRIPTION
## Summary
- defer flight-map initialization until the tracked aircraft has focal coordinates, avoiding the temporary LAX-centered view
- keep mobile flight identity visible on /aircraft/[callsign] and make automatic focal trace fetches silent
- allow stale oceanic tracked positions to keep static route lookup and avoid route-only auto-fit
- harden MapLibre/WebGL fallback and quiet non-fatal nearby-airport cache write failures

## Verification
- pnpm test
- pnpm lint
- pnpm build
- Headless desktop /aircraft/DAL479 screenshot: no Application error, no MapLibre uncaught WebGL errors, no trace toast text
- Headless mobile /aircraft/DAL479 screenshot: mobile first viewport shows DAL479, BOS -> LAX, B752, telemetry, and trace action
- curl /api/proxy/aircraft/callsign/SQ26 confirmed current stale tracking state; curl /api/proxy/flight-routes/callsign/SQ26 returned FRA -> JFK

Closes #278