### PR TITLE
[codex] Polish loading status UI

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.jsx
@@ -150,8 +150,13 @@ export default function AircraftPreviewCard({
           )}
           {trackHref && (
             <>
-              {!isAirport && traceLoading && (
-                <div className="aircraft-preview-mobile-card__trace-status">
+              {!isAirport && (
+                <div
+                  className={`aircraft-preview-mobile-card__trace-status ${
+                    traceLoading ? "is-active" : ""
+                  }`}
+                  aria-hidden={!traceLoading}
+                >
                   {t("preview.loadingTrace")}
                 </div>
               )}

--- a/src/components/aircraft/preview/AircraftPreviewMetadataCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewMetadataCard.jsx
@@ -34,8 +34,13 @@ export default function AircraftPreviewMetadataCard({
       <AircraftPreviewTelemetry aircraft={aircraft} />
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
       <AircraftPreviewMetadata aircraft={aircraft} />
-      {trackHref && traceLoading && (
-        <div className="aircraft-preview-card__trace-status">
+      {trackHref && (
+        <div
+          className={`aircraft-preview-card__trace-status ${
+            traceLoading ? "is-active" : ""
+          }`}
+          aria-hidden={!traceLoading}
+        >
           {t("preview.loadingTrace")}
         </div>
       )}

--- a/src/components/airport/explorer/AirportExplorer.jsx
+++ b/src/components/airport/explorer/AirportExplorer.jsx
@@ -4,7 +4,10 @@ import dynamic from "next/dynamic";
 import { useEffect, useMemo } from "react";
 import AirportSidebar from "@/components/sidebar/AirportSidebar";
 import AirportExplorerDesktopSidebar from "./AirportExplorerDesktopSidebar.jsx";
-import { MapLoadingFallback } from "@/components/map/MapLoadingOverlay.jsx";
+import {
+  MapLoadingFallback,
+  useMapLoadingOverlayText,
+} from "@/components/map/MapLoadingOverlay.jsx";
 import {
   ExplorerUiProvider,
   useExplorerUi,
@@ -19,7 +22,10 @@ import { useAirportProcedures } from "@/hooks/useAirportProcedures.js";
 import { useNearbyAirports } from "@/hooks/useNearbyAirports.js";
 import { SelectedAircraftTraceProvider } from "../../aircraft/trace/SelectedAircraftTraceContext.jsx";
 import AircraftPreviewCard from "../../aircraft/preview/AircraftPreviewCard.jsx";
-import { areCriticalLoadingRequestsSettled } from "@/features/aircraft/positions/aircraftLoadingOverlayModel.js";
+import {
+  areCriticalLoadingRequestsSettled,
+  resolveAircraftLoadingOverlayState,
+} from "@/features/aircraft/positions/aircraftLoadingOverlayModel.js";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -112,6 +118,36 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     };
   }, [isMobile]);
 
+  const criticalLoadingSettled = areCriticalLoadingRequestsSettled({
+    aircraftPositionsSettled: traffic.aircraftPositionsSettled,
+    metarSettled: weather.metarSettled,
+    nearbyAirportsSettled: nearbyAirports.settled,
+    proceduresSettled: procedures.settled,
+  });
+  const loadingOverlayActive =
+    !criticalLoadingSettled || traffic.aircraftLoadingOverlayActive;
+  const loadingOverlaySources = {
+    trafficLoading:
+      traffic.aircraftLoadingOverlayActive || !traffic.aircraftPositionsSettled,
+    weatherLoading: weather.metarLoading || !weather.metarSettled,
+    nearbyAirportsLoading: nearbyAirports.loading || !nearbyAirports.settled,
+    proceduresLoading: procedures.loading || !procedures.settled,
+    routeLoadingCount: traffic.routeLoadingCount,
+  };
+  const sourceLoadingState = resolveAircraftLoadingOverlayState({
+    mapReady: true,
+    variant: "airport",
+    feedLoading: false,
+    ...loadingOverlaySources,
+  });
+  const sourceLoadingCopy = useMapLoadingOverlayText({
+    mode: sourceLoadingState.mode,
+    reason: sourceLoadingState.reason,
+    variant: "airport",
+  });
+  const sourceLoadingStatus = sourceLoadingState.active
+    ? sourceLoadingCopy.status
+    : "";
   const sidebarProps = {
     icao: airportProfile.icao,
     iata: airportProfile.iata,
@@ -133,16 +169,11 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     lastUpdated: traffic.lastUpdated,
     feedStatus: traffic.feedStatus,
     feedSource: traffic.feedSource,
+    loadingStatus: sourceLoadingStatus,
     onSelectAircraft: selectAircraft,
     onSelectAirport: selectAirport,
     onBack,
   };
-  const criticalLoadingSettled = areCriticalLoadingRequestsSettled({
-    aircraftPositionsSettled: traffic.aircraftPositionsSettled,
-    metarSettled: weather.metarSettled,
-    nearbyAirportsSettled: nearbyAirports.settled,
-    proceduresSettled: procedures.settled,
-  });
 
   return (
     <SelectedAircraftTraceProvider selectedAircraft={selection.selectedAircraft}>
@@ -176,6 +207,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
               feedStatus={traffic.feedStatus}
               lastUpdated={traffic.lastUpdated}
               routeProvider={traffic.routeProvider}
+              loadingStatus={sourceLoadingStatus}
             />
           )}
 
@@ -202,19 +234,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             runwayProcedures={null}
             procedureFixLabelRunwayProcedures={procedures.runwayProcedures}
             showProcedureFixLabels
-            loadingOverlayActive={
-              !criticalLoadingSettled || traffic.aircraftLoadingOverlayActive
-            }
-            loadingOverlaySources={{
-              trafficLoading:
-                traffic.aircraftLoadingOverlayActive ||
-                !traffic.aircraftPositionsSettled,
-              weatherLoading: weather.metarLoading || !weather.metarSettled,
-              nearbyAirportsLoading:
-                nearbyAirports.loading || !nearbyAirports.settled,
-              proceduresLoading: procedures.loading || !procedures.settled,
-              routeLoadingCount: traffic.routeLoadingCount,
-            }}
+            loadingOverlayActive={loadingOverlayActive}
+            loadingOverlaySources={loadingOverlaySources}
           />
 
           {isMobile && sidebarOpen && (

--- a/src/components/explorer/ExplorerMapMenu.jsx
+++ b/src/components/explorer/ExplorerMapMenu.jsx
@@ -11,6 +11,7 @@ export default function ExplorerMapMenu({
   feedStatus = "live",
   lastUpdated = null,
   routeProvider = "",
+  loadingStatus = "",
   onFitToTrace = null,
   zoomDisabled = false,
 } = {}) {
@@ -64,6 +65,7 @@ export default function ExplorerMapMenu({
           feedStatus={feedStatus}
           lastUpdated={lastUpdated}
           routeProvider={routeProvider}
+          loadingStatus={loadingStatus}
         />
       ) : null}
     </div>

--- a/src/components/explorer/MobileMapSourceStatus.jsx
+++ b/src/components/explorer/MobileMapSourceStatus.jsx
@@ -12,10 +12,13 @@ export default function MobileMapSourceStatus({
   feedStatus = "live",
   lastUpdated = null,
   routeProvider = ROUTE_PROVIDER.ADSBDB,
+  loadingStatus = "",
 }) {
   const status = buildMobileMapSourceStatus({ feedSource, routeProvider });
   const updatedLabel = formatUpdated(lastUpdated);
-  if (!status.feedSource && !updatedLabel && !status.routeProvider) return null;
+  if (!status.feedSource && !updatedLabel && !status.routeProvider && !loadingStatus) {
+    return null;
+  }
 
   return (
     <div
@@ -60,6 +63,15 @@ export default function MobileMapSourceStatus({
                 {status.routeProvider}
               </span>
             )}
+            direction="reverse"
+          />
+        </span>
+      ) : null}
+      {loadingStatus ? (
+        <span className="airport-map-source-status__loading">
+          <EndfieldValueSwap
+            identityKey={`loading:${loadingStatus}`}
+            value={<span>{loadingStatus}</span>}
             direction="reverse"
           />
         </span>

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -5,7 +5,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import FlightSidebar from "@/components/sidebar/FlightSidebar";
 import ExplorerMapMenu from "@/components/explorer/ExplorerMapMenu.jsx";
-import { MapLoadingFallback } from "@/components/map/MapLoadingOverlay.jsx";
+import {
+  MapLoadingFallback,
+  useMapLoadingOverlayText,
+} from "@/components/map/MapLoadingOverlay.jsx";
 import LostSignalToast from "@/components/aircraft/tracking/LostSignalToast.jsx";
 import {
   getOrCreateTrackedFlight,
@@ -60,6 +63,7 @@ import { normalizeCallsign } from "@/utils/callsign.js";
 import { formatFlightRouteLabel } from "@/utils/flightRouteDisplay.js";
 import { SelectedAircraftTraceProvider } from "@/components/aircraft/trace/SelectedAircraftTraceContext.jsx";
 import AircraftPreviewCard from "@/components/aircraft/preview/AircraftPreviewCard.jsx";
+import { resolveAircraftLoadingOverlayState } from "@/features/aircraft/positions/aircraftLoadingOverlayModel.js";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -413,6 +417,37 @@ function FlightExplorerContent({ callsign }) {
 
   const handleBack = () => router.push("/");
 
+  const flightTrackingLoadingActive = shouldShowFlightTrackingLoadingOverlay({
+    hasActiveFlight: Boolean(callsign),
+    trackedAircraftSettled,
+    trackedLoadingOverlayActive,
+  });
+  const loadingOverlaySources = {
+    trackedAircraftLoading: flightTrackingLoadingActive,
+    trafficLoading:
+      showNearbyContext &&
+      (fetchedNearbyAircraftLoading || !fetchedNearbyAircraftSettled),
+    nearbyAirportsLoading:
+      showNearbyContext &&
+      (fetchedNearbyAirportsLoading || !fetchedNearbyAirportsSettled),
+    routeLoadingCount,
+  };
+  const sourceLoadingState = resolveAircraftLoadingOverlayState({
+    mapReady: true,
+    variant: "flight",
+    feedLoading: false,
+    ...loadingOverlaySources,
+  });
+  const sourceLoadingCopy = useMapLoadingOverlayText({
+    mode: sourceLoadingState.mode,
+    reason: sourceLoadingState.reason,
+    variant: "flight",
+    callsign,
+  });
+  const sourceLoadingStatus = sourceLoadingState.active
+    ? sourceLoadingCopy.status
+    : "";
+
   const sidebarProps = {
     callsign,
     aircraft: enrichedTrackedAircraft,
@@ -427,13 +462,9 @@ function FlightExplorerContent({ callsign }) {
     showNearbyList: showNearbyContext,
     feedSource,
     lastUpdated,
+    loadingStatus: sourceLoadingStatus,
     onBack: handleBack,
   };
-  const flightTrackingLoadingActive = shouldShowFlightTrackingLoadingOverlay({
-    hasActiveFlight: Boolean(callsign),
-    trackedAircraftSettled,
-    trackedLoadingOverlayActive,
-  });
 
   return (
     <SelectedAircraftTraceProvider
@@ -476,6 +507,7 @@ function FlightExplorerContent({ callsign }) {
               feedStatus="live"
               lastUpdated={lastUpdated}
               routeProvider={routeProvider}
+              loadingStatus={sourceLoadingStatus}
               onFitToTrace={fitToTrace}
               zoomDisabled={flightDisplayContext.zoomDisabled}
             />
@@ -510,16 +542,7 @@ function FlightExplorerContent({ callsign }) {
             loadingOverlayActive={flightTrackingLoadingActive}
             loadingOverlayVariant="flight"
             loadingOverlayCallsign={callsign}
-            loadingOverlaySources={{
-              trackedAircraftLoading: flightTrackingLoadingActive,
-              trafficLoading:
-                showNearbyContext &&
-                (fetchedNearbyAircraftLoading || !fetchedNearbyAircraftSettled),
-              nearbyAirportsLoading:
-                showNearbyContext &&
-                (fetchedNearbyAirportsLoading || !fetchedNearbyAirportsSettled),
-              routeLoadingCount,
-            }}
+            loadingOverlaySources={loadingOverlaySources}
           >
             <FlightAwareRouteArc path={focalFlightAwareRoutePath} />
             <MapFitToTraceController

--- a/src/components/map/AirportMap.jsx
+++ b/src/components/map/AirportMap.jsx
@@ -28,6 +28,7 @@ import {
   resolveAirportMapFocalCenter,
   resolveDocumentTheme,
 } from "../../features/airport/map/airportMapModel.js";
+import { resolveMapLoadingPresentation } from "../../features/aircraft/positions/aircraftLoadingOverlayModel.js";
 
 const resolveCurrentTheme = () =>
   typeof document !== "undefined"
@@ -226,6 +227,8 @@ export default function AirportMap({
     active: loadingOverlayActive,
     sources: loadingOverlaySources,
   });
+  const loadingPresentation =
+    resolveMapLoadingPresentation(loadingOverlayState);
   const loadingOverlayCopy = useMapLoadingOverlayText({
     mode: loadingOverlayState.mode,
     reason: loadingOverlayState.reason,
@@ -328,7 +331,7 @@ export default function AirportMap({
       )}
 
       <MapLoadingOverlay
-        active={loadingOverlayState.active}
+        active={loadingPresentation.overlayActive}
         variant={loadingOverlayVariant}
         {...loadingOverlayCopy}
       />

--- a/src/components/sidebar/AirportSidebar.jsx
+++ b/src/components/sidebar/AirportSidebar.jsx
@@ -28,6 +28,7 @@ export default function AirportSidebar({
   lastUpdated = null,
   feedStatus = "live",
   feedSource = "",
+  loadingStatus = "",
   onSelectAircraft,
   onSelectAirport,
   onBack,
@@ -62,6 +63,7 @@ export default function AirportSidebar({
       feedStatus={feedStatus}
       feedSource={feedSource}
       lastUpdated={lastUpdated}
+      loadingStatus={loadingStatus}
       onBack={onBack}
       onClose={onClose}
       header={header}

--- a/src/components/sidebar/FlightSidebar.jsx
+++ b/src/components/sidebar/FlightSidebar.jsx
@@ -37,6 +37,7 @@ export default function FlightSidebar({
   showNearbyList = true,
   feedSource = "",
   lastUpdated = null,
+  loadingStatus = "",
   onBack,
   onClose = null,
 }) {
@@ -83,6 +84,7 @@ export default function FlightSidebar({
       variant="flight"
       feedSource={feedSource}
       lastUpdated={lastUpdated}
+      loadingStatus={loadingStatus}
       onBack={onBack}
       onClose={onClose}
       header={header}

--- a/src/components/sidebar/SidebarShell.jsx
+++ b/src/components/sidebar/SidebarShell.jsx
@@ -26,6 +26,7 @@ export default function SidebarShell({
   header,
   children,
   variant = "airport",
+  loadingStatus = "",
 }) {
   const { t } = useI18n();
   const flightAwareEnabled = useFlightAwareEnabled();
@@ -104,6 +105,15 @@ export default function SidebarShell({
                 direction="reverse"
               />
             </span>
+            {loadingStatus ? (
+              <span className="airport-feed-loading-status">
+                <EndfieldValueSwap
+                  identityKey={`loading:${loadingStatus}`}
+                  value={<span>{loadingStatus}</span>}
+                  direction="reverse"
+                />
+              </span>
+            ) : null}
           </div>
         )}
       </div>

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.js
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.js
@@ -61,6 +61,18 @@ export function resolveAircraftLoadingOverlayState({
   return { active: true, mode: "feed", reason: activeSource[0] };
 }
 
+export function resolveMapLoadingPresentation({
+  active = false,
+  mode = "idle",
+  reason = "",
+} = {}) {
+  const overlayActive = Boolean(active && mode === "map");
+  return {
+    overlayActive,
+    sourceStatusActive: Boolean(active && reason && !overlayActive),
+  };
+}
+
 export function shouldTriggerVisibilityRefreshOverlay({
   wasActive = false,
   hiddenSince = 0,

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js
@@ -6,6 +6,7 @@ import {
   getLoadingOverlayExitDelay,
   resolveAircraftLoadingOverlayMode,
   resolveAircraftLoadingOverlayState,
+  resolveMapLoadingPresentation,
   scheduleAfterOverlayPaint,
   shouldShowAircraftLoadingOverlay,
   shouldTriggerVisibilityRefreshOverlay,
@@ -210,6 +211,33 @@ assert.deepEqual(
     mapReady: true,
   }),
   { active: false, mode: "idle", reason: "" },
+);
+
+assert.deepEqual(
+  resolveMapLoadingPresentation({
+    active: true,
+    mode: "map",
+    reason: "map",
+  }),
+  { overlayActive: true, sourceStatusActive: false },
+);
+
+assert.deepEqual(
+  resolveMapLoadingPresentation({
+    active: true,
+    mode: "feed",
+    reason: "routes",
+  }),
+  { overlayActive: false, sourceStatusActive: true },
+);
+
+assert.deepEqual(
+  resolveMapLoadingPresentation({
+    active: false,
+    mode: "idle",
+    reason: "",
+  }),
+  { overlayActive: false, sourceStatusActive: false },
 );
 
 {

--- a/src/style.css
+++ b/src/style.css
@@ -2308,7 +2308,8 @@ body {
 }
 
 .airport-map-source-status__line,
-.airport-map-source-status__route {
+.airport-map-source-status__route,
+.airport-map-source-status__loading {
     align-items: center;
     display: flex;
     justify-content: flex-end;
@@ -2328,6 +2329,20 @@ body {
     gap: 6px;
     letter-spacing: 0.24em;
     line-height: 1;
+}
+
+.airport-map-source-status__loading {
+    color: var(--atc-dim);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    line-height: 1.1;
+    max-width: min(280px, calc(100vw - 132px));
+    overflow-wrap: anywhere;
+    text-align: right;
+    text-transform: uppercase;
+    white-space: normal;
 }
 
 .airport-map-source-status__source,
@@ -4101,6 +4116,19 @@ body {
     font-family: var(--font-display);
 }
 
+.airport-feed-loading-status {
+    color: var(--atc-dim);
+    font-family: var(--font-mono);
+    font-size: 8px;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    line-height: 1.15;
+    max-width: 220px;
+    overflow-wrap: anywhere;
+    text-align: right;
+    text-transform: uppercase;
+}
+
 .airport-feed-status--infer {
     color: var(--atc-faint);
 }
@@ -5704,20 +5732,36 @@ body {
 }
 
 .aircraft-preview-card__trace-status {
-    margin-top: 12px;
     color: var(--atc-dim);
     font-family: var(--font-mono);
     font-size: 10px;
     font-weight: 600;
     letter-spacing: 0.08em;
     line-height: 1.35;
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
     overflow-wrap: anywhere;
     text-align: center;
     text-transform: uppercase;
+    transform: translateY(-4px);
+    transition:
+        max-height 0.28s ease,
+        margin-top 0.28s ease,
+        opacity 0.18s ease,
+        transform 0.28s ease;
     white-space: normal;
 }
 
-.aircraft-preview-card__trace-status + .aircraft-preview-card__track-btn {
+.aircraft-preview-card__trace-status.is-active {
+    margin-top: 12px;
+    max-height: 44px;
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.aircraft-preview-card__trace-status.is-active + .aircraft-preview-card__track-btn {
     margin-top: 8px;
 }
 
@@ -6082,18 +6126,34 @@ body {
 
 .aircraft-preview-mobile-card__trace-status {
     align-self: stretch;
-    margin: 4px 14px 0;
     color: var(--atc-dim);
     font-family: var(--font-mono);
     font-size: 10px;
     font-weight: 600;
     letter-spacing: 0.08em;
     line-height: 1.35;
+    margin: 0 14px;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
     overflow-wrap: anywhere;
     pointer-events: none;
     text-align: center;
     text-transform: uppercase;
+    transform: translateY(-4px);
+    transition:
+        max-height 0.28s ease,
+        margin-top 0.28s ease,
+        opacity 0.18s ease,
+        transform 0.28s ease;
     white-space: normal;
+}
+
+.aircraft-preview-mobile-card__trace-status.is-active {
+    margin-top: 4px;
+    max-height: 44px;
+    opacity: 1;
+    transform: translateY(0);
 }
 
 /* Centered route-feedback modal. Mounted via Radix Dialog so focus trap,
@@ -6738,6 +6798,8 @@ body {
     .aircraft-preview-card__media-slot,
     .aircraft-preview-mobile-card__inner > *,
     .aircraft-preview-mobile-card__track,
+    .aircraft-preview-card__trace-status,
+    .aircraft-preview-mobile-card__trace-status,
     .aircraft-table-route-cycle--alternate::before,
     .endf-underline::after {
         transition: none;


### PR DESCRIPTION
## Summary
- Smooth the preview-card trace loading status on desktop and mobile by keeping the status row mounted and animating height, opacity, and offset.
- Move post-map loading details out of the full-map overlay and into the existing source / route-provider status area.
- Keep the full-screen loading overlay for the map renderer phase only, with model coverage for the presentation split.

## Verification
- `node src/features/aircraft/positions/aircraftLoadingOverlayModel.test.js`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- Local headless Chrome smoke on `/airport/KBOS` and `/aircraft/BAW242`: no console errors and no 5xx network responses; CSS rules for preview trace transitions and source loading status were present.
