### PR TITLE
[codex] Use position time for map watermark

### DIFF
--- a/src/features/aircraft/positions/aircraftPositionsModel.js
+++ b/src/features/aircraft/positions/aircraftPositionsModel.js
@@ -1,5 +1,23 @@
 import { parseAdsbPositionTime } from "../../../utils/aircraftMotion.js";
 
+function parseTimestampMs(value) {
+  if (value == null || value === "") return null;
+  const number = Number(value);
+  if (Number.isFinite(number)) {
+    return number < 10_000_000_000 ? Math.round(number * 1000) : Math.round(number);
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolvePositionTimestampMs(aircraft) {
+  const sourceUpdatedAt = parseTimestampMs(
+    aircraft?.positionQuality?.sourceUpdatedAt,
+  );
+  if (sourceUpdatedAt != null) return sourceUpdatedAt;
+  return parseTimestampMs(aircraft?.positionTime);
+}
+
 export function normalizeAdsbAircraft(
   aircraft,
   { responseNow, receiveTime = Date.now() } = {},
@@ -42,6 +60,16 @@ export function normalizeAircraftSnapshot({ json, receiveTime = Date.now() }) {
         receiveTime,
       }),
     );
+}
+
+export function resolveLastSuccessfulPositionDate(aircraft) {
+  const entries = Array.isArray(aircraft) ? aircraft : [aircraft];
+  const latest = entries.reduce((max, item) => {
+    const timestamp = resolvePositionTimestampMs(item);
+    return timestamp != null && timestamp > max ? timestamp : max;
+  }, 0);
+
+  return latest > 0 ? new Date(latest) : null;
 }
 
 export function isHttp4xxOr5xx(error) {

--- a/src/features/aircraft/positions/aircraftPositionsModel.test.js
+++ b/src/features/aircraft/positions/aircraftPositionsModel.test.js
@@ -4,6 +4,7 @@ import {
   isHttp4xxOr5xx,
   normalizeAdsbAircraft,
   normalizeAircraftSnapshot,
+  resolveLastSuccessfulPositionDate,
 } from "./aircraftPositionsModel.js";
 
 const receiveTime = 1_700_000_003_200;
@@ -78,3 +79,31 @@ assert.equal(isHttp4xxOr5xx({ status: 500 }), true);
 assert.equal(isHttp4xxOr5xx({ statusCode: 404 }), true);
 assert.equal(isHttp4xxOr5xx(new Error("HTTP 429")), true);
 assert.equal(isHttp4xxOr5xx(new Error("network timeout")), false);
+
+{
+  const result = resolveLastSuccessfulPositionDate([
+    { positionTime: 1_700_000_001_000, receiveTime: 1_700_000_010_000 },
+    { positionTime: 1_700_000_004_000, receiveTime: 1_700_000_011_000 },
+  ]);
+
+  assert.equal(result?.getTime(), 1_700_000_004_000);
+}
+
+{
+  const result = resolveLastSuccessfulPositionDate({
+    positionTime: 1_700_000_004_000,
+    receiveTime: 1_700_000_020_000,
+    positionQuality: {
+      source: "flightaware",
+      sourceUpdatedAt: "2026-05-25T15:00:12.000Z",
+      fetchedAt: "2026-05-25T15:01:40.000Z",
+    },
+  });
+
+  assert.equal(result?.toISOString(), "2026-05-25T15:00:12.000Z");
+}
+
+{
+  assert.equal(resolveLastSuccessfulPositionDate([]), null);
+  assert.equal(resolveLastSuccessfulPositionDate({ receiveTime }), null);
+}

--- a/src/hooks/useAircraftPositions.js
+++ b/src/hooks/useAircraftPositions.js
@@ -11,6 +11,7 @@ import {
   describeAircraftFetchError,
   isHttp4xxOr5xx,
   normalizeAircraftSnapshot,
+  resolveLastSuccessfulPositionDate,
 } from "../features/aircraft/positions/aircraftPositionsModel.js";
 import { createAircraftTraceTracker } from "../features/aircraft/trace/aircraftTraceModel.js";
 import {
@@ -101,7 +102,6 @@ export function useAircraftPositions(icao, lat, lon, options = {}) {
           json: aircraftJson,
           receiveTime,
         });
-        const staleAgeMs = Number(aircraftJson?.staleAgeMs ?? 0);
         const isStale = aircraftJson?.stale === true;
         const nextAircraft = traceTrackerRef.current.update(
           snapshot,
@@ -115,7 +115,8 @@ export function useAircraftPositions(icao, lat, lon, options = {}) {
         setFeedSource(
           typeof aircraftJson?.source === "string" ? aircraftJson.source : "",
         );
-        setLastUpdated(new Date(receiveTime - Math.max(0, staleAgeMs)));
+        const positionDate = resolveLastSuccessfulPositionDate(nextAircraft);
+        if (positionDate) setLastUpdated(positionDate);
         setSettled(true);
         setInitialLoading(false);
         setVisibilityRefreshLoading(false);

--- a/src/hooks/useTrackedAircraft.js
+++ b/src/hooks/useTrackedAircraft.js
@@ -5,6 +5,7 @@ import { aircraftCallsignClient } from "../features/aviation/aviationData.js";
 import { AIRCRAFT_TRAFFIC_CONFIG } from "../config/aviation.js";
 import {
   normalizeAdsbAircraft,
+  resolveLastSuccessfulPositionDate,
 } from "../features/aircraft/positions/aircraftPositionsModel.js";
 import {
   getActiveAdsbMatchesLength,
@@ -144,13 +145,14 @@ export function useTrackedAircraft(callsign) {
             ...normalized,
             trackingState: nextTrackingState,
           });
+          const positionDate = resolveLastSuccessfulPositionDate(normalized);
+          if (positionDate) setLastUpdated(positionDate);
           missesRef.current = signalState.misses;
           setLostSignal(signalState.lostSignal);
         }
         setFeedSource(
           typeof payload?.source === "string" ? payload.source : "",
         );
-        setLastUpdated(new Date(receiveTime));
         setError(null);
       } catch (err) {
         if (disposedRef.current) return;


### PR DESCRIPTION
## Summary
- Change the map/source watermark timestamp to use the latest successful aircraft position time instead of response receive time.
- Prefer provider `positionQuality.sourceUpdatedAt` when available, falling back to normalized ADS-B `positionTime`.
- Stop advancing tracked-flight watermark time on empty callsign responses.

## Verification
- `node src/features/aircraft/positions/aircraftPositionsModel.test.js`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
