### PR TITLE
Batch sidebar route refresh updates

### DIFF
--- a/src/features/aviation/flight-routes/flightRouteDisplayBatchModel.js
+++ b/src/features/aviation/flight-routes/flightRouteDisplayBatchModel.js
@@ -1,0 +1,37 @@
+export const ROUTE_DISPLAY_BATCH_MS = 180;
+
+export function createRouteDisplayBatcher({
+  publish,
+  delayMs = ROUTE_DISPLAY_BATCH_MS,
+  schedule = setTimeout,
+  clearSchedule = clearTimeout,
+} = {}) {
+  let publishedVersion = 0;
+  let pendingVersion = 0;
+  let timer = null;
+
+  const flush = () => {
+    timer = null;
+    if (pendingVersion <= publishedVersion) return;
+    publishedVersion = pendingVersion;
+    publish?.(publishedVersion);
+  };
+
+  return {
+    syncRouteVersion(routeVersion) {
+      const nextVersion = Number(routeVersion);
+      if (!Number.isFinite(nextVersion) || nextVersion <= publishedVersion) {
+        return;
+      }
+      pendingVersion = Math.max(pendingVersion, nextVersion);
+      if (timer) return;
+      timer = schedule(flush, Math.max(0, delayMs));
+    },
+
+    dispose() {
+      if (!timer) return;
+      clearSchedule(timer);
+      timer = null;
+    },
+  };
+}

--- a/src/features/aviation/flight-routes/flightRouteDisplayBatchModel.test.js
+++ b/src/features/aviation/flight-routes/flightRouteDisplayBatchModel.test.js
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+
+import { createRouteDisplayBatcher } from "./flightRouteDisplayBatchModel.js";
+
+function createManualTimer() {
+  const callbacks = [];
+  return {
+    callbacks,
+    schedule(callback) {
+      callbacks.push(callback);
+      return callback;
+    },
+    clear(callback) {
+      const index = callbacks.indexOf(callback);
+      if (index >= 0) callbacks.splice(index, 1);
+    },
+    runNext() {
+      const callback = callbacks.shift();
+      if (callback) callback();
+    },
+  };
+}
+
+{
+  const timer = createManualTimer();
+  const published = [];
+  const batcher = createRouteDisplayBatcher({
+    publish: (routeVersion) => published.push(routeVersion),
+    schedule: timer.schedule,
+    clearSchedule: timer.clear,
+    delayMs: 180,
+  });
+
+  batcher.syncRouteVersion(1);
+  batcher.syncRouteVersion(2);
+  batcher.syncRouteVersion(3);
+
+  assert.deepEqual(published, []);
+  assert.equal(timer.callbacks.length, 1);
+
+  timer.runNext();
+
+  assert.deepEqual(published, [3]);
+
+  batcher.syncRouteVersion(3);
+  assert.equal(timer.callbacks.length, 0);
+
+  batcher.dispose();
+}
+
+{
+  const timer = createManualTimer();
+  const published = [];
+  const batcher = createRouteDisplayBatcher({
+    publish: (routeVersion) => published.push(routeVersion),
+    schedule: timer.schedule,
+    clearSchedule: timer.clear,
+    delayMs: 180,
+  });
+
+  batcher.syncRouteVersion(1);
+  batcher.dispose();
+
+  assert.equal(timer.callbacks.length, 0);
+  assert.deepEqual(published, []);
+}
+
+console.log("flightRouteDisplayBatchModel.test.js ok");

--- a/src/features/aviation/flight-routes/flightRouteScheduler.js
+++ b/src/features/aviation/flight-routes/flightRouteScheduler.js
@@ -48,9 +48,13 @@ export function createFlightRouteScheduler({
   let lastAuditSnapshot = "";
   let latestAircraft = [];
   let latestRouteContext = {};
+  let routeVersion = 0;
 
   const notify = () => {
-    const state = { loadingCount: inFlightKeys.size + queuedKeys.size };
+    const state = {
+      loadingCount: inFlightKeys.size + queuedKeys.size,
+      routeVersion,
+    };
     for (const listener of listeners) listener(state);
   };
 
@@ -107,6 +111,7 @@ export function createFlightRouteScheduler({
       } else {
         cache.set(cacheKey, { route: null, time: timestamp });
       }
+      routeVersion += 1;
       auditRouteQueue();
     } catch (error) {
       logger.warn?.(
@@ -114,6 +119,7 @@ export function createFlightRouteScheduler({
         error?.message || error,
       );
       cache.set(cacheKey, { route: null, time: now() });
+      routeVersion += 1;
       auditRouteQueue();
     } finally {
       inFlightKeys.delete(cacheKey);
@@ -151,7 +157,10 @@ export function createFlightRouteScheduler({
   return {
     subscribe(listener) {
       listeners.add(listener);
-      listener({ loadingCount: inFlightKeys.size + queuedKeys.size });
+      listener({
+        loadingCount: inFlightKeys.size + queuedKeys.size,
+        routeVersion,
+      });
       return () => listeners.delete(listener);
     },
 
@@ -209,6 +218,7 @@ export function createFlightRouteScheduler({
         route,
         time: now(),
       });
+      routeVersion += 1;
       notify();
     },
 

--- a/src/features/aviation/flight-routes/flightRouteScheduler.test.js
+++ b/src/features/aviation/flight-routes/flightRouteScheduler.test.js
@@ -54,8 +54,12 @@ function createManualTimer() {
   });
 
   let notificationCount = 0;
+  const notifications = [];
   scheduler.subscribe(() => {
     notificationCount += 1;
+  });
+  scheduler.subscribe((state) => {
+    notifications.push(state);
   });
 
   const routeContext = {
@@ -77,6 +81,7 @@ function createManualTimer() {
 
   assert.deepEqual(fetched, [{ callsign: "DAL123", routeContext }]);
   assert.equal(scheduler.getLoadingCount(), 0);
+  assert.equal(notifications.at(-1).routeVersion, 1);
   assert.deepEqual(
     scheduler.getRoutesByCallsign({
       aircraft: [{ callsign: "dal123" }],
@@ -93,6 +98,48 @@ function createManualTimer() {
   assert.equal(timer.callbacks.length, 0);
   await flushPromises();
   assert.equal(fetched.length, 1);
+  scheduler.dispose();
+}
+
+{
+  const timer = createManualTimer();
+  const scheduler = createFlightRouteScheduler({
+    client: {
+      async fetchFlightRoute() {
+        throw new Error("network should not run");
+      },
+    },
+    config: {
+      maxConcurrentLookups: 1,
+      maxLookupsPerPass: 2,
+      maxQueueSize: 10,
+      queueIntervalMs: 0,
+      auditLogIntervalMs: 0,
+      hitCacheMs: 60_000,
+      missCacheMs: 10_000,
+    },
+    logger: { info() {}, warn() {} },
+    schedule: timer.schedule,
+    clearSchedule: timer.clear,
+    now: () => 1_700_000_000_000,
+  });
+
+  const notifications = [];
+  scheduler.subscribe((state) => notifications.push(state));
+  scheduler.applyTemporaryRoute(
+    " aal456 ",
+    {
+      callsign: "AAL456",
+      origin: { icao: "KLAX" },
+      destination: { icao: "KJFK" },
+    },
+    { icao: "KJFK", iata: "JFK" },
+  );
+
+  assert.deepEqual(
+    notifications.map((state) => state.routeVersion),
+    [0, 1],
+  );
   scheduler.dispose();
 }
 

--- a/src/hooks/useFlightRoutes.js
+++ b/src/hooks/useFlightRoutes.js
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { normalizeCallsign } from "../utils/callsign.js";
 import { flightRouteScheduler } from "../features/aviation/flight-routes/flightRouteScheduler.js";
+import { createRouteDisplayBatcher } from "../features/aviation/flight-routes/flightRouteDisplayBatchModel.js";
 
 export { formatFlightRouteQueueAudit } from "../features/aviation/flight-routes/flightRouteScheduler.js";
 
@@ -10,6 +11,7 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
   const [version, setVersion] = useState(0);
   const [loadingCount, setLoadingCount] = useState(0);
   const mountedRef = useRef(true);
+  const routeDisplayBatcherRef = useRef(null);
   const routeContext = useMemo(
     () => ({
       icao: routeContextInput?.icao || "",
@@ -31,8 +33,18 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
   );
 
   useEffect(() => {
+    mountedRef.current = true;
+    routeDisplayBatcherRef.current = createRouteDisplayBatcher({
+      publish: (routeVersion) => {
+        if (!mountedRef.current) return;
+        setVersion(routeVersion);
+      },
+    });
+
     return () => {
       mountedRef.current = false;
+      routeDisplayBatcherRef.current?.dispose();
+      routeDisplayBatcherRef.current = null;
     };
   }, []);
 
@@ -45,12 +57,13 @@ export function useFlightRoutes(aircraft, routeContextInput = {}) {
 
   useEffect(
     () =>
-      flightRouteScheduler.subscribe(({ loadingCount: nextLoadingCount }) => {
+      flightRouteScheduler.subscribe((state) => {
         if (!mountedRef.current) return;
-        setLoadingCount(nextLoadingCount);
-        // Always bump so the color updates the moment the route lands,
-        // even if the aircraft list has refreshed since this fetch started.
-        setVersion((value) => value + 1);
+        setLoadingCount(state.loadingCount);
+        // Route fetches complete independently. Publish route-cache changes
+        // to the list in a small batch so route labels and their reveal
+        // animations enter together instead of rippling row by row.
+        routeDisplayBatcherRef.current?.syncRouteVersion(state.routeVersion);
       }),
     [],
   );


### PR DESCRIPTION
## Summary
- Batch route-cache publish events before recomputing sidebar route labels.
- Keep route loading count immediate while synchronizing origin/destination reveal animations.
- Add focused scheduler and route display batcher coverage.

## Test Plan
- pnpm test
- pnpm lint
- pnpm build