### PR TITLE
Polish sidebar and mobile flight status UI

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.jsx
@@ -148,36 +148,44 @@ export default function AircraftPreviewCard({
           ) : (
             <AircraftPreviewMobileCard aircraft={aircraft} />
           )}
-          {trackHref && (
-            <>
-              {!isAirport && (
-                <div
-                  className={`aircraft-preview-mobile-card__trace-status ${
-                    traceLoading ? "is-active" : ""
-                  }`}
-                  aria-hidden={!traceLoading}
-                >
-                  {t("preview.loadingTrace")}
-                </div>
-              )}
-              <button
-                type="button"
-                className="aircraft-preview-mobile-card__track"
-                onClick={handleMobileTap}
-                disabled={alreadyTracking}
-              >
-                {mobileTrackLabel}
-              </button>
-            </>
-          )}
-          {showMobileFeedbackTrigger && (
-            <button
-              type="button"
-              className="aircraft-preview-mobile-card__feedback-link"
-              onClick={() => setFeedbackModalOpen(true)}
+          {trackHref && !isAirport && (
+            <div
+              className={`aircraft-preview-mobile-card__trace-status ${
+                traceLoading ? "is-active" : ""
+              }`}
+              aria-hidden={!traceLoading}
             >
-              {mobileFeedbackLabel}
-            </button>
+              {t("preview.loadingTrace")}
+            </div>
+          )}
+          {(trackHref || showMobileFeedbackTrigger) && (
+            <div
+              className={`aircraft-preview-mobile-card__actions ${
+                !showMobileFeedbackTrigger
+                  ? "aircraft-preview-mobile-card__actions--single"
+                  : ""
+              }`}
+            >
+              {trackHref && (
+                <button
+                  type="button"
+                  className="aircraft-preview-mobile-card__track"
+                  onClick={handleMobileTap}
+                  disabled={alreadyTracking}
+                >
+                  {mobileTrackLabel}
+                </button>
+              )}
+              {showMobileFeedbackTrigger && (
+                <button
+                  type="button"
+                  className="aircraft-preview-mobile-card__feedback-link"
+                  onClick={() => setFeedbackModalOpen(true)}
+                >
+                  {mobileFeedbackLabel}
+                </button>
+              )}
+            </div>
           )}
         </aside>
       )}

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.jsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.jsx
@@ -38,6 +38,7 @@ export default function AircraftPreviewMobileCard({ aircraft }) {
   const onGround = Boolean(aircraft?.onGround);
 
   const hasStats = speed != null || altitude != null || vs != null || onGround;
+  const hasRouteStats = Boolean(route) || hasStats;
 
   return (
     <div className="aircraft-preview-mobile-card__inner">
@@ -49,83 +50,96 @@ export default function AircraftPreviewMobileCard({ aircraft }) {
           {callsign}
         </span>
         {type && (
-          <>
-            <span className="aircraft-preview-mobile-card__sep">/</span>
-            <span
-              className="aircraft-preview-mobile-card__type notranslate"
-              translate="no"
-            >
-              {type}
-            </span>
-          </>
+          <span
+            className="aircraft-preview-mobile-card__type notranslate"
+            translate="no"
+          >
+            {type}
+          </span>
         )}
       </div>
-      {route && (
-        <div
-          className="aircraft-preview-mobile-card__route notranslate"
-          translate="no"
-        >
-          <AirlineLogo
-            src={airlineIconUrl}
-            className="aircraft-preview-mobile-card__airline-logo"
-          />
-          <span className="aircraft-preview-mobile-card__route-text">
-            {route}
-          </span>
-        </div>
-      )}
-      {hasStats && (
-        <div className="aircraft-preview-mobile-card__row2">
-          {speed != null && (
-            <span className="aircraft-preview-mobile-card__stat">
-              <NumberFlow value={Math.round(speed)} className="aircraft-preview-mobile-card__num" />
-              <span
-                className="aircraft-preview-mobile-card__unit notranslate"
-                translate="no"
-              >
-                kt
+      {hasRouteStats && (
+        <div className="aircraft-preview-mobile-card__route-stats">
+          {route ? (
+            <div
+              className="aircraft-preview-mobile-card__route notranslate"
+              translate="no"
+            >
+              <AirlineLogo
+                src={airlineIconUrl}
+                className="aircraft-preview-mobile-card__airline-logo"
+              />
+              <span className="aircraft-preview-mobile-card__route-text">
+                {route}
               </span>
-            </span>
+            </div>
+          ) : (
+            <span aria-hidden="true" />
           )}
-          {(altitude != null || onGround) && (
-            <>
-              <span className="aircraft-preview-mobile-card__dot">·</span>
-              <span className="aircraft-preview-mobile-card__stat">
-                {onGround ? (
-                  <span className="aircraft-preview-mobile-card__num">
-                    {t("aircraft.gnd")}
-                  </span>
-                ) : (
-                  <NumberFlow value={Math.round(altitude)} className="aircraft-preview-mobile-card__num" />
-                )}
-                {!onGround && (
+          {hasStats && (
+            <div className="aircraft-preview-mobile-card__row2">
+              {speed != null && (
+                <span className="aircraft-preview-mobile-card__stat">
+                  <NumberFlow
+                    value={Math.round(speed)}
+                    className="aircraft-preview-mobile-card__num"
+                  />
                   <span
                     className="aircraft-preview-mobile-card__unit notranslate"
                     translate="no"
                   >
-                    ft
+                    kt
                   </span>
-                )}
-              </span>
-            </>
-          )}
-          {vs != null && (
-            <>
-              <span className="aircraft-preview-mobile-card__dot">·</span>
-              <span className="aircraft-preview-mobile-card__stat">
-                <NumberFlow
-                  value={Math.round(vs)}
-                  format={{ signDisplay: "exceptZero" }}
-                  className="aircraft-preview-mobile-card__num"
-                />
-                <span
-                  className="aircraft-preview-mobile-card__unit notranslate"
-                  translate="no"
-                >
-                  fpm
                 </span>
-              </span>
-            </>
+              )}
+              {(altitude != null || onGround) && (
+                <>
+                  {speed != null && (
+                    <span className="aircraft-preview-mobile-card__dot">·</span>
+                  )}
+                  <span className="aircraft-preview-mobile-card__stat">
+                    {onGround ? (
+                      <span className="aircraft-preview-mobile-card__num">
+                        {t("aircraft.gnd")}
+                      </span>
+                    ) : (
+                      <NumberFlow
+                        value={Math.round(altitude)}
+                        className="aircraft-preview-mobile-card__num"
+                      />
+                    )}
+                    {!onGround && (
+                      <span
+                        className="aircraft-preview-mobile-card__unit notranslate"
+                        translate="no"
+                      >
+                        ft
+                      </span>
+                    )}
+                  </span>
+                </>
+              )}
+              {vs != null && (
+                <>
+                  {(speed != null || altitude != null || onGround) && (
+                    <span className="aircraft-preview-mobile-card__dot">·</span>
+                  )}
+                  <span className="aircraft-preview-mobile-card__stat">
+                    <NumberFlow
+                      value={Math.round(vs)}
+                      format={{ signDisplay: "exceptZero" }}
+                      className="aircraft-preview-mobile-card__num"
+                    />
+                    <span
+                      className="aircraft-preview-mobile-card__unit notranslate"
+                      translate="no"
+                    >
+                      fpm
+                    </span>
+                  </span>
+                </>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/src/components/aircraft/preview/aircraftPreviewMobileCompactContract.test.js
+++ b/src/components/aircraft/preview/aircraftPreviewMobileCompactContract.test.js
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const mobileCard = readFileSync(
+  new URL("./AircraftPreviewMobileCard.jsx", import.meta.url),
+  "utf8",
+);
+const previewCard = readFileSync(
+  new URL("./AircraftPreviewCard.jsx", import.meta.url),
+  "utf8",
+);
+const style = readFileSync(new URL("../../../style.css", import.meta.url), "utf8");
+
+assert.match(mobileCard, /aircraft-preview-mobile-card__route-stats/);
+assert.doesNotMatch(mobileCard, /aircraft-preview-mobile-card__sep/);
+assert.match(previewCard, /aircraft-preview-mobile-card__actions/);
+assert.match(previewCard, /aircraft-preview-mobile-card__feedback-link/);
+assert.match(previewCard, /aircraft-preview-mobile-card__track/);
+
+const cardBlock = style.slice(
+  style.indexOf(".aircraft-preview-mobile-card {"),
+  style.indexOf(".aircraft-preview-mobile-card::before"),
+);
+assert.match(cardBlock, /repeating-linear-gradient/);
+assert.match(cardBlock, /0 0 \/ 46px 100% no-repeat/);
+
+const routeStatsBlock = style.slice(
+  style.indexOf(".aircraft-preview-mobile-card__route-stats"),
+  style.indexOf(
+    ".aircraft-preview-mobile-card__route {",
+    style.indexOf(".aircraft-preview-mobile-card__route-stats"),
+  ),
+);
+assert.match(routeStatsBlock, /display:\s*flex/);
+assert.match(routeStatsBlock, /justify-content:\s*space-between/);
+
+const actionsBlock = style.slice(
+  style.indexOf(".aircraft-preview-mobile-card__actions"),
+  style.indexOf(".aircraft-preview-mobile-card__track", style.indexOf(".aircraft-preview-mobile-card__actions")),
+);
+assert.match(actionsBlock, /display:\s*grid/);
+assert.match(actionsBlock, /grid-template-columns:\s*minmax\(0,\s*1fr\)\s+minmax\(0,\s*1fr\)/);
+assert.match(actionsBlock, /margin:\s*0\s+12px\s+0\s+56px/);
+
+const row1Block = style.slice(
+  style.indexOf(".aircraft-preview-mobile-card__row1"),
+  style.indexOf(
+    ".aircraft-preview-mobile-card__callsign,",
+    style.indexOf(".aircraft-preview-mobile-card__row1"),
+  ),
+);
+assert.match(row1Block, /display:\s*grid/);
+assert.match(row1Block, /grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto/);
+assert.match(row1Block, /width:\s*100%/);
+
+const trackBlock = style.slice(
+  style.indexOf(".aircraft-preview-mobile-card__track"),
+  style.indexOf(".aircraft-preview-mobile-card__track:hover"),
+);
+const feedbackBlock = style.slice(
+  style.indexOf(".aircraft-preview-mobile-card__feedback-link"),
+  style.indexOf(".aircraft-preview-mobile-card__feedback-link:active"),
+);
+assert.match(trackBlock, /background:/);
+assert.match(feedbackBlock, /background:/);
+assert.notEqual(trackBlock, feedbackBlock);
+
+console.log("aircraftPreviewMobileCompactContract.test.js ok");

--- a/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
+++ b/src/components/aircraft/trace/SelectedAircraftTraceContext.jsx
@@ -45,6 +45,7 @@ export function SelectedAircraftTraceProvider({
   selectedAircraft = null,
   focalAircraft = null,
   fullTraceForFocal = false,
+  showSelectedTrace = true,
   focalTraceStartAtMs = null,
   focalPersistKey = null,
   focalTraceRefreshKey = "",
@@ -86,6 +87,7 @@ export function SelectedAircraftTraceProvider({
       out.push({ ...focal, opacity: 1 });
     }
     if (
+      showSelectedTrace &&
       primary.aircraftHex &&
       primary.aircraftHex !== focal.aircraftHex
     ) {
@@ -96,7 +98,7 @@ export function SelectedAircraftTraceProvider({
       out.push({ ...primary, opacity: dim ? 0.4 : 1 });
     }
     return out;
-  }, [primary, focal]);
+  }, [primary, focal, showSelectedTrace]);
 
   const value = useMemo(
     () => ({

--- a/src/components/explorer/MobileMapSourceStatus.jsx
+++ b/src/components/explorer/MobileMapSourceStatus.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap.jsx";
 import RequestPulseDots from "@/components/ui/RequestPulseDots";
 import {
@@ -16,13 +17,38 @@ export default function MobileMapSourceStatus({
 }) {
   const status = buildMobileMapSourceStatus({ feedSource, routeProvider });
   const updatedLabel = formatUpdated(lastUpdated);
-  if (!status.feedSource && !updatedLabel && !status.routeProvider && !loadingStatus) {
+  const loadingActive = Boolean(loadingStatus);
+  const [displayedLoadingStatus, setDisplayedLoadingStatus] = useState(
+    loadingStatus,
+  );
+
+  useEffect(() => {
+    if (loadingStatus) {
+      setDisplayedLoadingStatus(loadingStatus);
+      return undefined;
+    }
+
+    const clearTimer = window.setTimeout(() => {
+      setDisplayedLoadingStatus("");
+    }, 220);
+    return () => window.clearTimeout(clearTimer);
+  }, [loadingStatus]);
+
+  if (
+    !status.feedSource &&
+    !updatedLabel &&
+    !status.routeProvider &&
+    !loadingStatus &&
+    !displayedLoadingStatus
+  ) {
     return null;
   }
 
   return (
     <div
-      className={`airport-map-source-status airport-map-source-status--${feedStatus}`}
+      className={`airport-map-source-status airport-map-source-status--${feedStatus} ${
+        loadingActive ? "airport-map-source-status--loading-active" : ""
+      }`}
       aria-label="Map data sources"
     >
       {status.feedSource || updatedLabel ? (
@@ -67,15 +93,18 @@ export default function MobileMapSourceStatus({
           />
         </span>
       ) : null}
-      {loadingStatus ? (
-        <span className="airport-map-source-status__loading">
-          <EndfieldValueSwap
-            identityKey={`loading:${loadingStatus}`}
-            value={<span>{loadingStatus}</span>}
-            direction="reverse"
-          />
-        </span>
-      ) : null}
+      <span
+        className={`airport-map-source-status__loading ${
+          loadingActive ? "is-active" : ""
+        }`}
+        aria-hidden={!loadingActive}
+      >
+        <EndfieldValueSwap
+          identityKey={`loading:${displayedLoadingStatus || "idle"}`}
+          value={<span>{displayedLoadingStatus}</span>}
+          direction="reverse"
+        />
+      </span>
     </div>
   );
 }

--- a/src/components/explorer/mobileMapSourceStatusMotionContract.test.js
+++ b/src/components/explorer/mobileMapSourceStatusMotionContract.test.js
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const component = readFileSync(
+  new URL("./MobileMapSourceStatus.jsx", import.meta.url),
+  "utf8",
+);
+const style = readFileSync(new URL("../../style.css", import.meta.url), "utf8");
+
+assert.match(component, /useState\(\s*loadingStatus,\s*\)/);
+assert.match(component, /window\.setTimeout\(\(\) => \{/);
+assert.match(component, /setDisplayedLoadingStatus\(""\);/);
+assert.match(component, /\}, 220\);/);
+assert.match(component, /airport-map-source-status--loading-active/);
+assert.match(component, /loadingActive \? "is-active" : ""/);
+assert.match(component, /aria-hidden=\{!loadingActive\}/);
+assert.match(component, /identityKey=\{`loading:\$\{displayedLoadingStatus \|\| "idle"\}`\}/);
+
+const statusBlock = style.slice(
+  style.indexOf(".airport-map-source-status__line,"),
+  style.indexOf(".airport-map-source-status__source,", style.indexOf(".airport-map-source-status__line,")),
+);
+
+assert.match(statusBlock, /transition:\s*transform 220ms cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\)/);
+assert.match(statusBlock, /airport-map-source-status--loading-active/);
+assert.match(statusBlock, /transform:\s*translateY\(-3px\)/);
+assert.match(statusBlock, /opacity:\s*0/);
+assert.match(statusBlock, /transform:\s*translateY\(-5px\)/);
+assert.match(statusBlock, /opacity 180ms ease-out/);
+assert.match(statusBlock, /\.airport-map-source-status__loading\.is-active/);
+assert.match(statusBlock, /opacity:\s*1/);
+assert.match(statusBlock, /transform:\s*translateY\(0\)/);
+
+const reducedMotionBlock = style.slice(
+  style.lastIndexOf("@media (prefers-reduced-motion: reduce)"),
+);
+assert.match(reducedMotionBlock, /airport-map-source-status__line/);
+assert.match(reducedMotionBlock, /airport-map-source-status__route/);
+assert.match(reducedMotionBlock, /airport-map-source-status__loading/);
+
+console.log("mobileMapSourceStatusMotionContract.test.js ok");

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -235,6 +235,8 @@ function FlightExplorerContent({ callsign }) {
     [isMobile, trackingState],
   );
   const showNearbyContext = flightDisplayContext.showNearbyContext !== false;
+  const showNearbyMapContext =
+    flightDisplayContext.showNearbyMapContext !== false;
   const nearbyQueryLat = showNearbyContext ? contextLat : null;
   const nearbyQueryLon = showNearbyContext ? contextLon : null;
 
@@ -348,6 +350,19 @@ function FlightExplorerContent({ callsign }) {
       trackedAircraftForDisplay
     );
   }, [aircraft, trackedAircraftForDisplay]);
+  const mapAircraft = useMemo(
+    () =>
+      showNearbyMapContext
+        ? aircraft
+        : enrichedTrackedAircraft
+          ? [enrichedTrackedAircraft]
+          : [],
+    [aircraft, enrichedTrackedAircraft, showNearbyMapContext],
+  );
+  const mapNearbyAirports = useMemo(
+    () => (showNearbyMapContext ? nearbyAirports : []),
+    [nearbyAirports, showNearbyMapContext],
+  );
   const trackedMetadataSignature = useMemo(
     () =>
       JSON.stringify({
@@ -471,6 +486,7 @@ function FlightExplorerContent({ callsign }) {
       selectedAircraft={selectedAircraft}
       focalAircraft={enrichedTrackedAircraft}
       fullTraceForFocal={flightDisplayContext.fullTraceForFocal}
+      showSelectedTrace={showNearbyMapContext}
       focalTraceStartAtMs={focalTraceStartAtMs}
       focalPersistKey={callsign || null}
       focalTraceRefreshKey={focalTraceRefreshKey}
@@ -517,8 +533,8 @@ function FlightExplorerContent({ callsign }) {
             lat={focalLat}
             lon={focalLon}
             zoom={mapZoom}
-            aircraft={aircraft}
-            nearbyAirports={nearbyAirports}
+            aircraft={mapAircraft}
+            nearbyAirports={mapNearbyAirports}
             airport={null}
             showMapLabels={showMapLabels}
             showRunwayBeams={false}

--- a/src/components/flight/explorer/flightAwareFullTraceMapContextContract.test.js
+++ b/src/components/flight/explorer/flightAwareFullTraceMapContextContract.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const explorer = readFileSync(
+  new URL("./FlightExplorer.jsx", import.meta.url),
+  "utf8",
+);
+const traceProvider = readFileSync(
+  new URL("../../aircraft/trace/SelectedAircraftTraceContext.jsx", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  explorer,
+  /const showNearbyContext = flightDisplayContext\.showNearbyContext !== false;/,
+);
+assert.match(
+  explorer,
+  /const showNearbyMapContext =\s+flightDisplayContext\.showNearbyMapContext !== false;/,
+);
+assert.match(explorer, /const mapAircraft = useMemo\(/);
+assert.match(explorer, /showNearbyMapContext\s+\? aircraft\s+:/);
+assert.match(explorer, /const mapNearbyAirports = useMemo\(/);
+assert.match(explorer, /showNearbyMapContext \? nearbyAirports : \[\]/);
+assert.match(explorer, /showNearbyList: showNearbyContext/);
+assert.match(explorer, /aircraft=\{mapAircraft\}/);
+assert.match(explorer, /nearbyAirports=\{mapNearbyAirports\}/);
+assert.match(explorer, /showSelectedTrace=\{showNearbyMapContext\}/);
+
+assert.match(traceProvider, /showSelectedTrace = true/);
+assert.match(traceProvider, /showSelectedTrace &&\s+primary\.aircraftHex/);
+
+console.log("flightAwareFullTraceMapContextContract.test.js ok");

--- a/src/components/sidebar/AircraftList.jsx
+++ b/src/components/sidebar/AircraftList.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { getAircraftIdentity } from "../../features/airport/context/airportContextUiModel.js";
+import { getAircraftListAnimationState } from "./aircraftListAnimationModel.js";
 import AircraftSlot from "./AircraftSlot.jsx";
 
 export default function AircraftList({
@@ -19,14 +20,10 @@ export default function AircraftList({
   const resetKeyRef = useRef(resetKey);
   const currentKeys = aircraft.map(getAircraftIdentity);
   const prevKeys = prevKeysRef.current;
-  const structureChanged =
-    resetKeyRef.current !== resetKey ||
-    didListStructureChange(prevKeys, currentKeys);
-  let cascadeCursor = 0;
-  const cascadeOrders = currentKeys.map((cur, i) => {
-    const prev = prevKeys[i];
-    if (structureChanged) return -1;
-    return prev !== undefined && prev !== cur ? cascadeCursor++ : -1;
+  const { cascadeOrders, disableSwap } = getAircraftListAnimationState({
+    prevKeys,
+    currentKeys,
+    resetKeyChanged: resetKeyRef.current !== resetKey,
   });
   useEffect(() => {
     prevKeysRef.current = currentKeys;
@@ -41,7 +38,7 @@ export default function AircraftList({
             aircraft={item}
             cascadeOrder={cascadeOrders[index]}
             flipStaggerStep={flipStaggerStep}
-            disableSwap={structureChanged}
+            disableSwap={disableSwap}
             selectedAircraftId={selectedAircraftId}
             onSelectAircraft={onSelectAircraft}
           />
@@ -49,17 +46,4 @@ export default function AircraftList({
       ))}
     </ul>
   );
-}
-
-function didListStructureChange(prevKeys, currentKeys) {
-  if (prevKeys.length === 0) return false;
-  if (prevKeys.length !== currentKeys.length) return true;
-
-  const previousSet = new Set(prevKeys);
-  const currentSet = new Set(currentKeys);
-  return currentKeys.some((key, index) => {
-    const prev = prevKeys[index];
-    if (prev === key) return false;
-    return previousSet.has(key) || currentSet.has(prev);
-  });
 }

--- a/src/components/sidebar/aircraftListAnimationModel.js
+++ b/src/components/sidebar/aircraftListAnimationModel.js
@@ -1,0 +1,28 @@
+export function getAircraftListAnimationState({
+  prevKeys = [],
+  currentKeys = [],
+  resetKeyChanged = false,
+} = {}) {
+  const disableSwap =
+    resetKeyChanged || didListMembershipChange(prevKeys, currentKeys);
+  let cascadeCursor = 0;
+  const cascadeOrders = currentKeys.map((cur, index) => {
+    const prev = prevKeys[index];
+    if (disableSwap) return -1;
+    return prev !== undefined && prev !== cur ? cascadeCursor++ : -1;
+  });
+
+  return { cascadeOrders, disableSwap };
+}
+
+function didListMembershipChange(prevKeys, currentKeys) {
+  if (prevKeys.length === 0) return false;
+  if (prevKeys.length !== currentKeys.length) return true;
+
+  const previousSet = new Set(prevKeys);
+  const currentSet = new Set(currentKeys);
+  return (
+    currentKeys.some((key) => !previousSet.has(key)) ||
+    prevKeys.some((key) => !currentSet.has(key))
+  );
+}

--- a/src/components/sidebar/aircraftListAnimationModel.test.js
+++ b/src/components/sidebar/aircraftListAnimationModel.test.js
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+
+import { getAircraftListAnimationState } from "./aircraftListAnimationModel.js";
+
+{
+  const state = getAircraftListAnimationState({
+    prevKeys: ["AAL100", "DAL200", "UAL300"],
+    currentKeys: ["DAL200", "AAL100", "UAL300"],
+    resetKeyChanged: false,
+  });
+
+  assert.equal(state.disableSwap, false);
+  assert.deepEqual(state.cascadeOrders, [0, 1, -1]);
+}
+
+{
+  const state = getAircraftListAnimationState({
+    prevKeys: ["AAL100", "DAL200"],
+    currentKeys: ["AAL100", "DAL200", "UAL300"],
+    resetKeyChanged: false,
+  });
+
+  assert.equal(state.disableSwap, true);
+  assert.deepEqual(state.cascadeOrders, [-1, -1, -1]);
+}
+
+{
+  const state = getAircraftListAnimationState({
+    prevKeys: ["AAL100", "DAL200"],
+    currentKeys: ["DAL200", "AAL100"],
+    resetKeyChanged: true,
+  });
+
+  assert.equal(state.disableSwap, true);
+  assert.deepEqual(state.cascadeOrders, [-1, -1]);
+}
+
+console.log("aircraftListAnimationModel.test.js ok");

--- a/src/components/sidebar/sidebarAnimationStyleContract.test.js
+++ b/src/components/sidebar/sidebarAnimationStyleContract.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const aircraftRow = readFileSync(
+  new URL("./AircraftRow.jsx", import.meta.url),
+  "utf8",
+);
+const style = readFileSync(new URL("../../style.css", import.meta.url), "utf8");
+
+const routeAlternateBlock = style.slice(
+  style.indexOf(".aircraft-table-route-cycle--alternate .aircraft-table-route-face--flight"),
+  style.indexOf("@keyframes aircraft-table-flight-fade"),
+);
+
+assert.match(routeAlternateBlock, /aircraft-table-flight-fade/);
+assert.match(routeAlternateBlock, /aircraft-table-route-fade/);
+assert.doesNotMatch(routeAlternateBlock, /aircraft-table-route-text-decode/);
+assert.doesNotMatch(routeAlternateBlock, /aircraft-table-route-cursor-wipe/);
+assert.doesNotMatch(routeAlternateBlock, /::before/);
+
+assert.match(aircraftRow, /function NumberWithUnit/);
+assert.match(aircraftRow, /<EndfieldValueSwap/);
+assert.match(aircraftRow, /value=\{distValue\}/);
+assert.match(aircraftRow, /value=\{Math\.round\(altValue\)\}/);
+
+console.log("sidebarAnimationStyleContract.test.js ok");

--- a/src/features/aircraft/tracking/flightTrackingDisplayModel.js
+++ b/src/features/aircraft/tracking/flightTrackingDisplayModel.js
@@ -8,6 +8,7 @@ const DEFAULT_CONTEXT = Object.freeze({
   airportLimit: 12,
   fullTraceForFocal: false,
   showNearbyContext: true,
+  showNearbyMapContext: true,
   zoomDisabled: false,
   nearbyRangeRings: Object.freeze({
     intervalNm: 5,
@@ -26,7 +27,8 @@ const FLIGHTAWARE_DESKTOP_CONTEXT = Object.freeze({
   airportRadiusNm: 250,
   airportLimit: 12,
   fullTraceForFocal: true,
-  showNearbyContext: false,
+  showNearbyContext: true,
+  showNearbyMapContext: false,
   zoomDisabled: true,
   nearbyRangeRings: null,
   mapFitOptions: Object.freeze({

--- a/src/features/aircraft/tracking/flightTrackingDisplayModel.test.js
+++ b/src/features/aircraft/tracking/flightTrackingDisplayModel.test.js
@@ -15,6 +15,7 @@ import {
   assert.equal(context.airportLimit, 12);
   assert.equal(context.fullTraceForFocal, false);
   assert.equal(context.showNearbyContext, true);
+  assert.equal(context.showNearbyMapContext, true);
   assert.equal(context.zoomDisabled, false);
   assert.deepEqual(context.nearbyRangeRings, {
     intervalNm: 5,
@@ -38,7 +39,8 @@ import {
   assert.equal(context.airportRadiusNm, 250);
   assert.equal(context.airportLimit, 12);
   assert.equal(context.fullTraceForFocal, true);
-  assert.equal(context.showNearbyContext, false);
+  assert.equal(context.showNearbyContext, true);
+  assert.equal(context.showNearbyMapContext, false);
   assert.equal(context.zoomDisabled, true);
   assert.equal(context.nearbyRangeRings, null);
   assert.deepEqual(context.mapFitOptions, {

--- a/src/style.css
+++ b/src/style.css
@@ -2318,6 +2318,16 @@ body {
     width: 100%;
 }
 
+.airport-map-source-status__line,
+.airport-map-source-status__route {
+    transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.airport-map-source-status--loading-active .airport-map-source-status__line,
+.airport-map-source-status--loading-active .airport-map-source-status__route {
+    transform: translateY(-3px);
+}
+
 .airport-map-source-status__line {
     gap: 8px;
 }
@@ -2339,10 +2349,22 @@ body {
     letter-spacing: 0.08em;
     line-height: 1.1;
     max-width: min(280px, calc(100vw - 132px));
+    min-height: 10px;
+    opacity: 0;
     overflow-wrap: anywhere;
     text-align: right;
     text-transform: uppercase;
+    transform: translateY(-5px);
+    transition:
+        opacity 180ms ease-out,
+        transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
     white-space: normal;
+    will-change: opacity, transform;
+}
+
+.airport-map-source-status__loading.is-active {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .airport-map-source-status__source,
@@ -3608,36 +3630,11 @@ body {
 }
 
 .aircraft-table-route-cycle--alternate .aircraft-table-route-face--flight {
-    animation:
-        aircraft-table-flight-fade 12s infinite,
-        aircraft-table-route-text-decode 12s steps(3, end) infinite;
+    animation: aircraft-table-flight-fade 12s infinite;
 }
 
 .aircraft-table-route-cycle--alternate .aircraft-table-route-face--route {
-    animation:
-        aircraft-table-route-fade 12s infinite,
-        aircraft-table-route-text-decode 12s steps(3, end) infinite;
-}
-
-.aircraft-table-route-cycle--alternate::before {
-    animation: aircraft-table-route-cursor-wipe 12s cubic-bezier(1, 0, 0.7, 1)
-        infinite;
-    background:
-        linear-gradient(
-            90deg,
-            transparent 0,
-            transparent 1px,
-            var(--endf-yellow) 1px 5px,
-            color-mix(in oklab, var(--endf-yellow) 18%, var(--sidebar)) 5px 10px,
-            var(--sidebar) 10px 100%
-        );
-    content: "";
-    inset: 0;
-    opacity: 0;
-    pointer-events: none;
-    position: absolute;
-    transform: translateX(0);
-    z-index: 3;
+    animation: aircraft-table-route-fade 12s infinite;
 }
 
 @keyframes aircraft-table-flight-fade {
@@ -3673,74 +3670,6 @@ body {
         visibility: visible;
     }
 }
-
-@keyframes aircraft-table-route-cursor-wipe {
-    0%,
-    58%,
-    100% {
-        opacity: 0;
-        transform: translateX(0);
-    }
-    60%,
-    61.5%,
-    63% {
-        opacity: 1;
-        transform: translateX(0);
-    }
-    60.75%,
-    62.25% {
-        opacity: 0.2;
-        transform: translateX(0);
-    }
-    65%,
-    91% {
-        opacity: 1;
-        transform: translateX(100%);
-    }
-    68%,
-    83%,
-    94% {
-        opacity: 0;
-        transform: translateX(100%);
-    }
-    85%,
-    86.5%,
-    88% {
-        opacity: 1;
-        transform: translateX(0);
-    }
-    85.75%,
-    87.25% {
-        opacity: 0.2;
-        transform: translateX(0);
-    }
-}
-
-@keyframes aircraft-table-route-text-decode {
-    0%,
-    58%,
-    68%,
-    83%,
-    94%,
-    100% {
-        text-shadow: none;
-    }
-    60%,
-    63%,
-    85%,
-    88% {
-        text-shadow:
-            0.08em 0 color-mix(in oklab, var(--endf-yellow) 70%, transparent),
-            -0.08em 0 color-mix(in oklab, var(--atc-text) 28%, transparent);
-    }
-    64%,
-    89% {
-        text-shadow:
-            -0.05em 0 color-mix(in oklab, var(--endf-yellow) 58%, transparent),
-            0.05em 0 color-mix(in oklab, var(--atc-text) 20%, transparent);
-    }
-}
-
 
 @keyframes aircraft-table-callsign-lift {
     0% {
@@ -5716,7 +5645,8 @@ body {
 }
 
 .aircraft-preview-card__track-btn:focus-visible,
-.aircraft-preview-mobile-card__track:focus-visible {
+.aircraft-preview-mobile-card__track:focus-visible,
+.aircraft-preview-mobile-card__feedback-link:focus-visible {
     outline: 2px solid color-mix(in oklab, var(--primary-bright) 72%, white);
     outline-offset: 3px;
 }
@@ -5989,13 +5919,26 @@ body {
     bottom: calc(64px + env(safe-area-inset-bottom));
     left: 50%;
     z-index: 1200;
-    width: min(340px, calc(100vw - 28px));
-    max-width: calc(100vw - 28px);
+    width: min(326px, calc(100vw - 24px));
+    max-width: calc(100vw - 24px);
     background:
+        repeating-linear-gradient(
+                135deg,
+                color-mix(in oklab, var(--endf-yellow) 24%, transparent) 0 3px,
+                transparent 3px 9px
+            )
+            0 0 / 46px 100% no-repeat,
+        linear-gradient(
+                135deg,
+                transparent 0 16px,
+                color-mix(in oklab, var(--endf-yellow) 22%, var(--atc-card)) 16px 31px,
+                transparent 31px 100%
+            )
+            0 0 / 46px 100% no-repeat,
         linear-gradient(
             90deg,
-            color-mix(in oklab, var(--endf-yellow) 14%, transparent) 0 52px,
-            transparent 52px
+            color-mix(in oklab, var(--endf-yellow) 16%, var(--atc-card)) 0 46px,
+            transparent 46px
         ),
         var(--atc-card);
     border: 1px solid var(--tone-border-firm);
@@ -6010,14 +5953,19 @@ body {
 }
 
 .aircraft-preview-mobile-card::before {
-    background: var(--endf-yellow);
+    background:
+        linear-gradient(
+            135deg,
+            color-mix(in oklab, var(--endf-yellow) 96%, oklch(0.96 0.006 190) 4%),
+            color-mix(in oklab, var(--endf-yellow) 58%, var(--atc-card))
+        );
     clip-path: polygon(0 0, 100% 0, 76% 100%, 0 100%);
     content: "";
-    height: 20px;
+    height: 18px;
     left: 0;
     position: absolute;
     top: 0;
-    width: 52px;
+    width: 46px;
     z-index: 0;
 }
 
@@ -6026,9 +5974,9 @@ body {
     border-right: 2px solid var(--endf-ink);
     content: "";
     height: 10px;
-    left: 22px;
+    left: 19px;
     position: absolute;
-    top: 5px;
+    top: 4px;
     transform: rotate(-45deg);
     width: 10px;
     z-index: 1;
@@ -6040,14 +5988,25 @@ body {
 .aircraft-preview-mobile-card--stacked {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    padding-bottom: 8px;
+    gap: 4px;
+    padding-bottom: 7px;
+}
+
+.aircraft-preview-mobile-card__actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 6px;
+    margin: 0 12px 0 56px;
+    pointer-events: auto;
+}
+
+.aircraft-preview-mobile-card__actions--single {
+    grid-template-columns: minmax(0, 1fr);
 }
 
 .aircraft-preview-mobile-card__track {
-    margin: 2px 12px 0;
-    min-height: 44px;
-    padding: 0 16px;
+    min-height: 36px;
+    padding: 0 10px;
     border: 1px solid color-mix(in oklab, var(--primary-bright) 88%, var(--primary-ink));
     border-radius: 2px;
     background:
@@ -6061,17 +6020,16 @@ body {
         inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 28%, transparent);
     color: var(--primary-ink);
     font-family: var(--font-display);
-    font-size: 13px;
+    font-size: 11px;
     font-weight: 800;
     font-style: normal;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.07em;
     line-height: 1.15;
     overflow-wrap: anywhere;
     text-align: center;
     text-transform: uppercase;
     white-space: normal;
     cursor: pointer;
-    pointer-events: auto;
     -webkit-tap-highlight-color: transparent;
     transition:
         box-shadow 0.15s ease-out,
@@ -6098,30 +6056,43 @@ body {
    doesn't compete with Track for taps. The card surface has pointer-events
    disabled by default; this re-enables them like the Track button does. */
 .aircraft-preview-mobile-card__feedback-link {
-    align-self: center;
-    margin: 4px 12px 0;
-    padding: 6px 10px;
-    border: none;
-    background: transparent;
+    min-height: 36px;
+    padding: 0 9px;
+    border: 1px dashed color-mix(in oklab, var(--atc-dim) 54%, transparent);
+    border-radius: 2px;
+    background:
+        linear-gradient(
+            180deg,
+            color-mix(in oklab, var(--atc-elev) 58%, transparent),
+            color-mix(in oklab, var(--atc-card) 88%, transparent)
+        );
     color: var(--atc-dim);
-    font-family: var(--font-sans);
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    line-height: 1;
-    text-decoration: underline;
-    text-decoration-color: color-mix(in oklab, var(--atc-dim) 50%, transparent);
-    text-underline-offset: 3px;
-    text-transform: none;
+    font-family: var(--font-display);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.07em;
+    line-height: 1.1;
+    overflow-wrap: anywhere;
+    text-align: center;
+    text-transform: uppercase;
     cursor: pointer;
-    pointer-events: auto;
     -webkit-tap-highlight-color: transparent;
-    transition: color 0.15s ease-out;
+    transition:
+        background 0.15s ease-out,
+        border-color 0.15s ease-out,
+        color 0.15s ease-out,
+        transform 0.12s ease-out;
 }
 
 .aircraft-preview-mobile-card__feedback-link:active,
 .aircraft-preview-mobile-card__feedback-link:hover {
+    border-color: color-mix(in oklab, var(--atc-text) 42%, transparent);
+    background: color-mix(in oklab, var(--atc-text) 9%, var(--atc-card));
     color: var(--atc-text);
+}
+
+.aircraft-preview-mobile-card__feedback-link:active {
+    transform: scale(0.97);
 }
 
 .aircraft-preview-mobile-card__trace-status {
@@ -6261,8 +6232,8 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 6px;
-    padding: 14px 16px 10px 64px;
+    gap: 5px;
+    padding: 11px 12px 7px 56px;
     position: relative;
     width: 100%;
     z-index: 2;
@@ -6302,53 +6273,65 @@ body {
     z-index: 1;
 }
 
-.aircraft-preview-mobile-card__track {
+.aircraft-preview-mobile-card__actions {
     animation:
         endf-content-reveal 430ms steps(1, end) both,
         endf-text-decode 430ms steps(3, end) both;
 }
 
 .aircraft-preview-mobile-card__row1 {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: baseline;
     gap: 10px;
     max-width: 100%;
+    width: 100%;
     white-space: nowrap;
 }
 
 .aircraft-preview-mobile-card__callsign,
 .aircraft-preview-mobile-card__type {
     font-family: var(--font-display);
-    font-size: 22px;
+    font-size: 19px;
     font-weight: 800;
     letter-spacing: 0;
     line-height: 0.9;
     color: var(--atc-text);
 }
 
-.aircraft-preview-mobile-card__sep {
-    font-family: var(--font-mono);
-    font-size: 13px;
-    font-weight: 400;
-    color: var(--atc-faint);
-    line-height: 1;
+.aircraft-preview-mobile-card__callsign {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-/* Route line on the mobile preview card — sits between the identity
-   row (callsign · type) and the telemetry row. Airline logo + parsed
-   route ("KLAX → KSEA"). Hidden entirely when no flight route is
-   available so the card stays compact. */
+.aircraft-preview-mobile-card__type {
+    justify-self: end;
+    text-align: right;
+}
+
+.aircraft-preview-mobile-card__route-stats {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+    justify-content: space-between;
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
+}
+
 .aircraft-preview-mobile-card__route {
     align-items: center;
     color: var(--atc-dim);
     display: flex;
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 600;
     gap: 8px;
     letter-spacing: 0.02em;
     line-height: 1;
-    max-width: 100%;
+    max-width: 56%;
+    min-width: 0;
     white-space: nowrap;
 }
 
@@ -6373,7 +6356,11 @@ body {
     align-items: center;
     justify-content: flex-start;
     gap: 0;
-    max-width: 100%;
+    flex: 0 1 auto;
+    max-width: 44%;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
 }
 
@@ -6385,7 +6372,7 @@ body {
 
 .aircraft-preview-mobile-card__num {
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 500;
     letter-spacing: 0.04em;
     color: var(--atc-dim);
@@ -6394,7 +6381,7 @@ body {
 
 .aircraft-preview-mobile-card__unit {
     font-family: var(--font-mono);
-    font-size: 9px;
+    font-size: 8px;
     font-weight: 500;
     letter-spacing: 0.06em;
     color: var(--atc-faint);
@@ -6800,7 +6787,9 @@ body {
     .aircraft-preview-mobile-card__track,
     .aircraft-preview-card__trace-status,
     .aircraft-preview-mobile-card__trace-status,
-    .aircraft-table-route-cycle--alternate::before,
+    .airport-map-source-status__line,
+    .airport-map-source-status__route,
+    .airport-map-source-status__loading,
     .endf-underline::after {
         transition: none;
         animation: none;


### PR DESCRIPTION
## Summary
- restore sidebar aircraft list reorder motion while keeping route fade transitions and value wipe/flash effects
- compact the mobile aircraft preview card with aligned identity, route/stats, actions, and textured rail treatment
- keep FlightAware full-trace nearby data visible in lists while hiding nearby aircraft/airports from the map, and smooth mobile source-status loading motion

## Test Plan
- pnpm test
- pnpm lint
- pnpm build
- git diff --check
