### PR TITLE
Use normal weight for source status

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2348,7 +2348,7 @@ body {
     gap: 7px;
     color: var(--atc-dim);
     font-size: 11px;
-    font-weight: 900;
+    font-weight: 400;
     letter-spacing: 0.035em;
     line-height: 1;
     text-transform: uppercase;
@@ -2357,7 +2357,7 @@ body {
 .map-source-status__route {
     color: var(--atc-orange);
     font-size: 10px;
-    font-weight: 900;
+    font-weight: 400;
     gap: 5px;
     letter-spacing: 0.2em;
     line-height: 1;
@@ -2382,7 +2382,7 @@ body {
     color: var(--atc-dim);
     font-family: var(--font-mono);
     font-size: 9px;
-    font-weight: 800;
+    font-weight: 400;
     letter-spacing: 0.08em;
     line-height: 1;
     max-width: min(280px, calc(100vw - 132px));


### PR DESCRIPTION
## Summary
- Set map source status feed, route, and loading text to normal font weight

## Test Plan
- Not run per request

Co-authored-by: Codex <codex@openai.com>