### PR TITLE
Show ADSBao logo in sidebars

### DIFF
--- a/src/components/app-shell/DitherPageShell.jsx
+++ b/src/components/app-shell/DitherPageShell.jsx
@@ -1,8 +1,8 @@
 "use client";
 
-import BrandLogo from "@/components/brand/BrandLogo.jsx";
 import BrandingVideoBackground from "@/components/effects/BrandingVideoBackground.jsx";
 import PageNavigationDock from "@/components/navigation/PageNavigationDock.jsx";
+import SidebarBrandMark from "@/components/sidebar/SidebarBrandMark.jsx";
 import { SITE_DESCRIPTION } from "@/config/site.js";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 
@@ -26,7 +26,7 @@ export default function DitherPageShell({
       <div className="dither-page-panel relative isolate flex w-[var(--app-sidebar-width)] flex-none flex-col border-r border-[var(--atc-line-strong)] bg-atc-bg">
         <div className="dither-page-header flex-none px-6 pt-7 pb-6">
           <div className="flex items-center gap-3">
-            <BrandLogo height={40} className="dither-page-logo" />
+            <SidebarBrandMark className="dither-page-brand-mark" />
             <span
               aria-hidden="true"
               className="h-px flex-1 bg-[var(--atc-line-strong)]"

--- a/src/components/brand/BrandLogo.jsx
+++ b/src/components/brand/BrandLogo.jsx
@@ -1,6 +1,10 @@
 // Geometric ADSBao wordmark. Kept as SVG so the app does not need a
 // bitmap logo asset, but styled like the new consumer travel UI.
-export default function BrandLogo({ height = 44, className = "" }) {
+export default function BrandLogo({
+  height = 44,
+  className = "",
+  animated = false,
+}) {
   // Aspect ratio of the wordmark canvas; preserved as we scale by height.
   const width = Math.round(height * 4.4);
   return (
@@ -12,17 +16,27 @@ export default function BrandLogo({ height = 44, className = "" }) {
       viewBox="0 0 220 50"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}
+      className={`${className} ${animated ? "brand-logo--animated" : ""}`.trim()}
     >
-      <circle cx="19" cy="25" r="13" fill="var(--endf-yellow)" />
-      <path
-        d="M13 25h12m-5-5 5 5-5 5"
-        stroke="var(--endf-ink)"
-        strokeWidth="2.3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <g className="brand-logo__mark">
+        <circle
+          className="brand-logo__disc"
+          cx="19"
+          cy="25"
+          r="13"
+          fill="var(--endf-yellow)"
+        />
+        <path
+          className="brand-logo__arrow"
+          d="M13 25h12m-5-5 5 5-5 5"
+          stroke="var(--endf-ink)"
+          strokeWidth="2.3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </g>
       <text
+        className="brand-logo__word"
         x="44"
         y="34"
         fill="currentColor"
@@ -33,7 +47,15 @@ export default function BrandLogo({ height = 44, className = "" }) {
       >
         ADSBao
       </text>
-      <rect x="44" y="40" width="52" height="3" rx="1.5" fill="var(--endf-yellow)" />
+      <rect
+        className="brand-logo__underline"
+        x="44"
+        y="40"
+        width="82"
+        height="3"
+        rx="1.5"
+        fill="var(--endf-yellow)"
+      />
     </svg>
   );
 }

--- a/src/components/sidebar/SidebarBrandMark.jsx
+++ b/src/components/sidebar/SidebarBrandMark.jsx
@@ -1,0 +1,11 @@
+"use client";
+
+import BrandLogo from "@/components/brand/BrandLogo.jsx";
+
+export default function SidebarBrandMark({ className = "" }) {
+  return (
+    <div className={`sidebar-brand-mark ${className}`.trim()}>
+      <BrandLogo height={28} className="sidebar-brand-mark__logo" animated />
+    </div>
+  );
+}

--- a/src/components/sidebar/SidebarIdentityHero.jsx
+++ b/src/components/sidebar/SidebarIdentityHero.jsx
@@ -1,5 +1,7 @@
 "use client";
 
+import SidebarBrandMark from "./SidebarBrandMark.jsx";
+
 // Shared identity-hero pattern used at the top of every sidebar (airport
 // and flight). Renders:
 //   - A small uppercase label (e.g. "Airport", "Tracking").
@@ -18,6 +20,7 @@ export default function SidebarIdentityHero({
 }) {
   return (
     <div className="airport-sidebar-identity">
+      <SidebarBrandMark />
       <span className="endf-label">{label}</span>
       <div className="mt-3 flex items-baseline gap-3">
         <span

--- a/src/style.css
+++ b/src/style.css
@@ -4791,6 +4791,129 @@ body {
     vertical-align: baseline;
 }
 
+.sidebar-brand-mark {
+    align-items: center;
+    color: var(--atc-text);
+    display: flex;
+    margin-bottom: 18px;
+    min-height: 28px;
+}
+
+.sidebar-brand-mark__logo {
+    display: block;
+    height: 28px;
+    width: auto;
+}
+
+.dither-page-brand-mark {
+    margin-bottom: 0;
+}
+
+.brand-logo__mark {
+    transform-box: fill-box;
+    transform-origin: center;
+}
+
+.brand-logo__arrow,
+.brand-logo__disc,
+.brand-logo__underline,
+.brand-logo__word {
+    transform-box: fill-box;
+}
+
+.brand-logo__arrow {
+    transform-origin: 19px 25px;
+}
+
+.brand-logo__underline {
+    transform-origin: 44px 41.5px;
+}
+
+.brand-logo--animated .brand-logo__mark {
+    animation: brand-logo-mark-enter 720ms cubic-bezier(0.18, 0.78, 0.2, 1) both;
+}
+
+.brand-logo--animated .brand-logo__arrow {
+    animation:
+        brand-logo-arrow-enter 760ms cubic-bezier(0.18, 0.78, 0.2, 1) both,
+        brand-logo-arrow-orbit 6.8s ease-in-out 1.1s infinite;
+}
+
+.brand-logo--animated .brand-logo__word {
+    animation: brand-logo-word-enter 620ms ease-out 180ms both;
+}
+
+.brand-logo--animated .brand-logo__underline {
+    animation: brand-logo-underline-wipe 860ms cubic-bezier(0.16, 0.8, 0.2, 1) 320ms both;
+}
+
+@keyframes brand-logo-mark-enter {
+    from {
+        opacity: 0;
+        transform: rotate(-28deg) scale(0.72);
+    }
+    to {
+        opacity: 1;
+        transform: rotate(0deg) scale(1);
+    }
+}
+
+@keyframes brand-logo-arrow-enter {
+    from {
+        opacity: 0;
+        transform: rotate(-112deg) scale(0.68);
+    }
+    to {
+        opacity: 1;
+        transform: rotate(0deg) scale(1);
+    }
+}
+
+@keyframes brand-logo-arrow-orbit {
+    0%,
+    84%,
+    100% {
+        transform: rotate(0deg) scale(1);
+    }
+    90% {
+        transform: rotate(14deg) scale(1.02);
+    }
+    96% {
+        transform: rotate(-6deg) scale(1);
+    }
+}
+
+@keyframes brand-logo-word-enter {
+    from {
+        opacity: 0;
+        transform: translateX(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes brand-logo-underline-wipe {
+    from {
+        opacity: 0;
+        transform: scaleX(0);
+    }
+    to {
+        opacity: 1;
+        transform: scaleX(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .brand-logo--animated .brand-logo__arrow,
+    .brand-logo--animated .brand-logo__mark,
+    .brand-logo--animated .brand-logo__underline,
+    .brand-logo--animated .brand-logo__word {
+        animation: none;
+    }
+}
+
 .airport-sidebar-identity {
     background:
         linear-gradient(
@@ -7653,11 +7776,6 @@ body {
 
     .dither-page-header > .flex {
         gap: 10px;
-    }
-
-    .dither-page-logo {
-        height: 32px;
-        width: auto;
     }
 
     .dither-page-header .endf-page-title {


### PR DESCRIPTION
## Summary
- Add a shared SidebarBrandMark component for the ADSBao wordmark
- Render it through SidebarIdentityHero so airport and aircraft sidebars match
- Add compact sidebar logo spacing for the map kit layout

## Test Plan
- pnpm lint
- Browser check: /airport/KJFK and /aircraft/AAL1535 show the ADSBao wordmark in the sidebar