### PR TITLE
Refine sidebar dropdowns, badges, full-trace mode, and map layer safety

### DIFF
--- a/src/components/app-shell/LanguageSwitch.jsx
+++ b/src/components/app-shell/LanguageSwitch.jsx
@@ -56,8 +56,7 @@ export default function LanguageSwitch({
         <div
           role="menu"
           aria-label={t("language.menuLabel")}
-          className={`language-menu absolute ${placementClass} ${alignClass} z-[1300] w-28 overflow-hidden border border-[var(--atc-line-strong)] bg-atc-card shadow-xl`}
-          style={{ borderRadius: 12 }}
+          className={`language-menu absolute ${placementClass} ${alignClass}`}
         >
           {languageItems.map((item) => {
             const active = item.locale === locale;
@@ -67,12 +66,9 @@ export default function LanguageSwitch({
                 type="button"
                 role="menuitemradio"
                 aria-checked={active}
+                data-selected={active ? "true" : undefined}
                 onClick={() => handleSelect(item.locale)}
-                className={`font-nav flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.08em] transition-colors ${
-                  active
-                    ? "bg-[color-mix(in_oklab,var(--atc-accent)_14%,transparent)] text-atc-text"
-                    : "text-atc-faint hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] hover:text-atc-text"
-                }`}
+                className="language-menu__item"
               >
                 <span>{item.label}</span>
                 {active && <Check className="h-3.5 w-3.5" aria-hidden="true" />}

--- a/src/components/flight/explorer/FlightExplorer.jsx
+++ b/src/components/flight/explorer/FlightExplorer.jsx
@@ -61,6 +61,7 @@ import { useTrackedAircraft } from "@/hooks/useTrackedAircraft.js";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel.js";
 import { normalizeCallsign } from "@/utils/callsign.js";
 import { formatFlightRouteLabel } from "@/utils/flightRouteDisplay.js";
+import { getDistanceNm } from "@/utils/aircraftTrafficIntent.js";
 import { SelectedAircraftTraceProvider } from "@/components/aircraft/trace/SelectedAircraftTraceContext.jsx";
 import AircraftPreviewCard from "@/components/aircraft/preview/AircraftPreviewCard.jsx";
 import { resolveAircraftLoadingOverlayState } from "@/features/aircraft/positions/aircraftLoadingOverlayModel.js";
@@ -350,19 +351,58 @@ function FlightExplorerContent({ callsign }) {
       trackedAircraftForDisplay
     );
   }, [aircraft, trackedAircraftForDisplay]);
-  const mapAircraft = useMemo(
-    () =>
-      showNearbyMapContext
-        ? aircraft
-        : enrichedTrackedAircraft
-          ? [enrichedTrackedAircraft]
-          : [],
-    [aircraft, enrichedTrackedAircraft, showNearbyMapContext],
-  );
-  const mapNearbyAirports = useMemo(
-    () => (showNearbyMapContext ? nearbyAirports : []),
-    [nearbyAirports, showNearbyMapContext],
-  );
+  // Full-trace mode declutters the zoomed-out viewport: only the focal
+  // aircraft and the FlightAware route endpoints (if any) stay on the map.
+  const flightAwareRouteAirports = useMemo(() => {
+    const route = enrichedTrackedAircraft?.flightRoute;
+    if (route?.source !== "flightaware") return [];
+    const endpoints = [];
+    for (const point of [route.origin, route.destination]) {
+      if (!point) continue;
+      const pointLat = Number(point.lat);
+      const pointLon = Number(point.lon);
+      if (!Number.isFinite(pointLat) || !Number.isFinite(pointLon)) continue;
+      endpoints.push({
+        icao: point.icao || "",
+        iata: point.iata || "",
+        name: point.name || "",
+        municipality: point.municipality || "",
+        country: point.country || "",
+        lat: pointLat,
+        lon: pointLon,
+        distanceNm:
+          focalLat != null && focalLon != null
+            ? getDistanceNm(focalLat, focalLon, pointLat, pointLon)
+            : null,
+      });
+    }
+    return endpoints;
+  }, [enrichedTrackedAircraft?.flightRoute, focalLat, focalLon]);
+
+  const mapAircraft = useMemo(() => {
+    if (!mapFollowsAircraft) {
+      return enrichedTrackedAircraft ? [enrichedTrackedAircraft] : [];
+    }
+    return showNearbyMapContext
+      ? aircraft
+      : enrichedTrackedAircraft
+        ? [enrichedTrackedAircraft]
+        : [];
+  }, [
+    aircraft,
+    enrichedTrackedAircraft,
+    showNearbyMapContext,
+    mapFollowsAircraft,
+  ]);
+  const mapNearbyAirports = useMemo(() => {
+    if (!mapFollowsAircraft) return flightAwareRouteAirports;
+    return showNearbyMapContext ? nearbyAirports : [];
+  }, [
+    nearbyAirports,
+    showNearbyMapContext,
+    mapFollowsAircraft,
+    flightAwareRouteAirports,
+  ]);
   const trackedMetadataSignature = useMemo(
     () =>
       JSON.stringify({

--- a/src/components/map/NearbyAirportLayer.jsx
+++ b/src/components/map/NearbyAirportLayer.jsx
@@ -6,6 +6,10 @@ import { useMapInstance } from "./MapContext.js";
 import { AIRPORT_MAP_PANES } from "../../config/airportMap.js";
 import { ensureAirportMapPane } from "../../features/airport/map/mapPane.js";
 import {
+  safeAddToMap,
+  safeRemoveFromMap,
+} from "../../features/airport/map/leafletLayerSafety.js";
+import {
   buildRunwayCenterlineCollection,
   buildRunwayEndLabels,
 } from "../../features/airport/map/runwayAnnotationModel.js";
@@ -23,18 +27,27 @@ const airportLabel = (airport) => airport.iata || airport.icao || "";
 const markerHtml = (airport) => {
   const code = escapeHtml(airportLabel(airport));
   const distance = Number.isFinite(airport.distanceNm)
-    ? `${airport.distanceNm.toFixed(0)}NM`
-    : "";
-  // Two parts: the dot sits exactly on the airport position; the badge
-  // is positioned absolutely down-left so the runway / centerline at
-  // the airport stays visible underneath.
+    ? Math.round(airport.distanceNm)
+    : null;
+  // Two parts: the dot sits exactly on the airport position; the label
+  // stack (code pill + distance pill) is offset down-left so the runway
+  // / centerline at the airport stays visible underneath.
   return `
     <div class="nearby-airport-marker notranslate" translate="no">
       <span class="nearby-airport-marker-dot"></span>
-      <span class="nearby-airport-marker-label">
-        <strong>${code}</strong>
-        ${distance ? `<small>${escapeHtml(distance)}</small>` : ""}
-      </span>
+      <div class="airport-overlay-label nearby-airport-marker-label">
+        <span class="airport-overlay-label__code endf-tab endf-tab--code">
+          <span>${code}</span>
+        </span>
+        ${
+          distance != null
+            ? `<span class="airport-overlay-label__detail airport-overlay-label__detail--near">
+                <span class="airport-overlay-label__detail-value">${distance}</span>
+                <span class="airport-overlay-label__detail-label">NM</span>
+              </span>`
+            : ""
+        }
+      </div>
     </div>
   `;
 };
@@ -115,9 +128,9 @@ export default function NearbyAirportLayer({
   onSelectRef.current = onSelectAirport;
 
   useEffect(() => {
-    if (!map || !map.getContainer) return undefined;
+    if (!map || !map.getContainer || !map.getPane) return undefined;
 
-    layerRef.current?.removeFrom(map);
+    safeRemoveFromMap(layerRef.current, map);
     const layer = L.layerGroup();
 
     for (const airport of airports) {
@@ -148,11 +161,12 @@ export default function NearbyAirportLayer({
       marker.addTo(layer);
     }
 
-    layer.addTo(map);
+    const added = safeAddToMap(layer, map, { label: "NearbyAirportLayer" });
+    if (!added) return undefined;
     layerRef.current = layer;
 
     return () => {
-      layer.removeFrom(map);
+      safeRemoveFromMap(layer, map);
       layerRef.current = null;
     };
   }, [

--- a/src/components/map/controls/MapControlRail.jsx
+++ b/src/components/map/controls/MapControlRail.jsx
@@ -55,10 +55,11 @@ export default function MapControlRail({
         <Button
           variant="atcIcon"
           size="icon"
-          className="ctrl-btn ctrl-fit-trace"
+          className={`ctrl-btn ctrl-fit-trace ${!zoomActive && !zoomDisabled ? "active" : ""}`}
           title={t("map.fitTrace")}
           onClick={onFitToTrace}
           type="button"
+          aria-pressed={!zoomActive && !zoomDisabled}
         >
           <MapControlIcon iconKey="route" />
         </Button>

--- a/src/components/sidebar/SidebarMetric.jsx
+++ b/src/components/sidebar/SidebarMetric.jsx
@@ -4,12 +4,6 @@
 // of stat-card cells (label, value, unit). The airport sidebar uses it
 // as a tab strip (WEATHER / FLIGHTS, interactive); the flight sidebar
 // uses it to display the focal aircraft's telemetry as static cells.
-//
-// Divider lines are applied automatically:
-//   - Every "even" cell (the right column) gets a left border so the
-//     vertical seam between the two columns is consistent.
-//   - Cells past the first row get a top border so multi-row grids
-//     still read as a panel of cards.
 
 export function SidebarMetricGrid({ children, label = "Metrics" }) {
   return (

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -52,7 +52,7 @@ const SelectContent = React.forwardRef(({ className, children, position = "poppe
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-[1500] max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/src/style.css
+++ b/src/style.css
@@ -789,7 +789,51 @@ body {
 }
 
 .language-menu {
-    border-radius: 12px;
+    background: var(--atc-card);
+    border: 1px solid var(--atc-line);
+    border-radius: var(--atc-radius-card);
+    box-shadow:
+        0 12px 32px color-mix(in oklab, var(--atc-bg) 60%, transparent),
+        0 2px 6px color-mix(in oklab, var(--atc-bg) 40%, transparent);
+    color: var(--atc-text);
+    display: flex;
+    flex-direction: column;
+    font-family: var(--airport-sidebar-sans);
+    min-width: 160px;
+    padding: 6px;
+    z-index: 1300;
+}
+
+.language-menu__item {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    border-radius: 10px;
+    color: var(--atc-faint);
+    cursor: pointer;
+    display: flex;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    gap: 8px;
+    justify-content: space-between;
+    letter-spacing: 0;
+    line-height: 1.2;
+    padding: 8px 10px;
+    text-align: left;
+    width: 100%;
+    transition: background 0.18s ease, color 0.18s ease;
+}
+
+.language-menu__item:hover {
+    background: color-mix(in oklab, var(--atc-elev) 55%, transparent);
+    color: var(--atc-text);
+}
+
+.language-menu__item[data-selected="true"] {
+    background: color-mix(in oklab, var(--atc-accent) 12%, transparent);
+    color: var(--atc-text);
+    font-weight: 600;
 }
 
 .page-nav-dock__button,
@@ -2272,12 +2316,6 @@ body {
     padding: 18px;
 }
 
-.sidebar-metric-card:nth-child(2n),
-.sidebar-metric-card:nth-child(n + 3) {
-    border-left: 1px solid var(--atc-line);
-    border-top: 1px solid var(--atc-line);
-}
-
 .sidebar-metric-card__label,
 .sidebar-metric-card__unit,
 .aircraft-preview-stat__label,
@@ -3637,37 +3675,9 @@ body {
 }
 
 .nearby-airport-marker-label {
-    align-items: center;
-    background: var(--endf-yellow);
-    color: var(--endf-ink);
-    display: inline-flex;
-    font-family: var(--font-display);
-    gap: 6px;
-    left: 6px;
-    line-height: 1;
-    padding: 4px 9px;
+    left: 8px;
     position: absolute;
-    text-transform: uppercase;
     top: 6px;
-    transform: skewX(var(--endf-skew));
-}
-
-.nearby-airport-marker-label > * {
-    transform: skewX(calc(-1 * var(--endf-skew)));
-}
-
-.nearby-airport-marker-label strong {
-    font-size: 11px;
-    font-weight: 900;
-    letter-spacing: 0.04em;
-}
-
-.nearby-airport-marker-label small {
-    color: var(--endf-ink);
-    font-size: 8.5px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    opacity: 0.7;
 }
 
 .aircraft-table-route-cycle {
@@ -4351,13 +4361,13 @@ body {
 
 .airport-overlay-label__detail--near {
     align-items: center;
-    background: var(--atc-click-bg);
+    background: var(--endf-yellow);
     border: 0;
     border-radius: 999px;
     box-shadow:
         0 1px 3px color-mix(in oklab, var(--atc-text) 22%, transparent),
-        inset 0 1px 0 color-mix(in oklab, var(--atc-click-fg) 13%, transparent);
-    color: var(--atc-click-fg);
+        inset 0 1px 0 color-mix(in oklab, var(--endf-ink) 13%, transparent);
+    color: var(--endf-ink);
     display: inline-flex;
     font-family: var(--font-sans);
     font-size: 7.5px;
@@ -4369,12 +4379,12 @@ body {
 }
 
 .airport-overlay-label__detail-label {
-    color: var(--atc-click-muted);
+    color: color-mix(in oklab, var(--endf-ink) 65%, transparent);
     font-weight: 800;
 }
 
 .airport-overlay-label__detail-value {
-    color: var(--atc-click-fg);
+    color: var(--endf-ink);
     font-weight: 900;
     min-width: 1ch;
     text-align: right;
@@ -5029,16 +5039,6 @@ body {
     z-index: 1;
 }
 
-/* Vertical seam between the two columns. */
-.sidebar-metric-card:nth-child(2n) {
-    border-left: 1px solid var(--atc-line);
-}
-
-/* Horizontal seam between rows (anything past the first row). */
-.sidebar-metric-card:nth-child(n + 3) {
-    border-top: 1px solid var(--atc-line);
-}
-
 .sidebar-metric-card__label,
 .sidebar-metric-card__unit {
     color: var(--atc-faint);
@@ -5649,20 +5649,30 @@ body {
 }
 
 .aircraft-filter-card-content {
-    background: var(--atc-bg);
-    border-color: var(--atc-line);
-    border-radius: 0;
+    background: var(--atc-card);
+    border: 1px solid var(--atc-line);
+    border-radius: var(--atc-radius-card);
+    box-shadow:
+        0 12px 32px color-mix(in oklab, var(--atc-bg) 60%, transparent),
+        0 2px 6px color-mix(in oklab, var(--atc-bg) 40%, transparent);
     color: var(--atc-text);
     font-family: var(--airport-sidebar-sans);
     letter-spacing: 0;
-    text-transform: uppercase;
+    padding: 6px;
 }
 
 .aircraft-filter-card-item {
-    border-radius: 0;
+    border-radius: 10px;
     cursor: pointer;
-    font-size: 11px;
-    font-weight: 700;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0;
+    line-height: 1.2;
+    padding: 8px 10px;
+}
+
+.aircraft-filter-card-item[data-state="checked"] {
+    font-weight: 600;
 }
 
 .aircraft-filter-type {
@@ -5670,15 +5680,19 @@ body {
 }
 
 .aircraft-filter-type-panel {
-    background: var(--atc-bg);
+    background: var(--atc-card);
     border: 1px solid var(--atc-line);
+    border-radius: var(--atc-radius-card);
+    box-shadow:
+        0 12px 32px color-mix(in oklab, var(--atc-bg) 60%, transparent),
+        0 2px 6px color-mix(in oklab, var(--atc-bg) 40%, transparent);
     color: var(--atc-text);
     display: flex;
     flex-direction: column;
     font-family: var(--airport-sidebar-sans);
     max-height: 320px;
     overflow-y: auto;
-    padding: 4px 0;
+    padding: 6px;
     z-index: 1200;
 }
 
@@ -5686,11 +5700,13 @@ body {
     align-items: center;
     background: transparent;
     border: 0;
+    border-radius: 10px;
     cursor: pointer;
     display: grid;
     font-family: inherit;
+    gap: 4px;
     grid-template-columns: 16px minmax(0, 1fr) auto;
-    padding: 6px 10px;
+    padding: 8px 10px;
     text-align: left;
     width: 100%;
 }
@@ -5713,42 +5729,51 @@ body {
 }
 
 .aircraft-filter-type-row__label {
-    font-size: 11px;
-    font-weight: 700;
+    font-size: 13px;
+    font-weight: 600;
     letter-spacing: 0;
-    text-transform: uppercase;
+    line-height: 1.2;
 }
 
 .aircraft-filter-type-row--item .aircraft-filter-type-row__label {
-    font-weight: 600;
+    font-weight: 500;
     padding-left: 8px;
-    text-transform: none;
 }
 
 .aircraft-filter-type-row__count {
     color: var(--atc-faint);
-    font-size: 9px;
-    font-weight: 700;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0;
 }
 
 .aircraft-filter-type-row[data-selected="true"] {
-    background: color-mix(in oklab, var(--atc-accent) 9%, transparent);
+    background: color-mix(in oklab, var(--atc-accent) 12%, transparent);
 }
 
 .aircraft-filter-type-row[data-selected="true"] .aircraft-filter-type-row__label {
     color: var(--atc-text);
+    font-weight: 600;
 }
 
 .aircraft-filter-type-row--header {
-    background: color-mix(in oklab, var(--atc-line) 22%, transparent);
+    background: transparent;
+}
+
+.aircraft-filter-type-row--header .aircraft-filter-type-row__label {
+    color: var(--atc-faint);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 }
 
 .aircraft-filter-type-row--header:hover {
-    background: color-mix(in oklab, var(--atc-elev) 70%, transparent);
+    background: color-mix(in oklab, var(--atc-elev) 55%, transparent);
 }
 
 .aircraft-filter-type-group + .aircraft-filter-type-group {
-    border-top: 1px solid color-mix(in oklab, var(--atc-line) 60%, transparent);
+    margin-top: 4px;
 }
 
 /* Override carousel slide flex to fit narrower sidebar column */
@@ -8621,18 +8646,8 @@ body {
     }
 
     .airport-map-kit .nearby-airport-marker-label {
-        gap: 5px;
-        left: 5px;
-        padding: 3px 7px;
+        left: 6px;
         top: 5px;
-    }
-
-    .airport-map-kit .nearby-airport-marker-label strong {
-        font-size: 9px;
-    }
-
-    .airport-map-kit .nearby-airport-marker-label small {
-        font-size: 7px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Active sidebar metric card now paints all four borders uniformly (removed redundant nth-child border overrides).
- Radix Select content z-index bumped above the airport sidebar so the altitude and aircraft-type dropdowns are no longer occluded.
- Altitude, aircraft-type, and language dropdowns re-skinned to the impeccable rounded-panel + sentence-case item style.
- Nearby airport map labels now reuse the focal BOS pill markup (white pill code + NM sub-pill) and match the major badge colors in dark theme.
- Fit-to-trace toolbar button is now a visual toggle, mutually exclusive with the zoom-cycle button.
- Full-trace mode declutters the map to just the focal aircraft and any FlightAware route origin/destination endpoints.
- NearbyAirportLayer wraps addTo/removeFrom in safeAddToMap so a mid-mount Leaflet map cannot crash the useEffect with a missing pane (fixes the runtime TypeError reading 'appendChild').

## Test plan
- [ ] Active card on airport sidebar: top/right/bottom/left all share the bright border color.
- [ ] Altitude and aircraft-type dropdowns open above the sidebar and use rounded sentence-case items.
- [ ] Language menu uses the same rounded panel + item style.
- [ ] Nearby airport badges show white code pill + dark NM sub-pill in dark theme, matching the focal BOS pill.
- [ ] Fit-to-trace and zoom-cycle buttons toggle each other's active state.
- [ ] In full-trace mode with a FlightAware route, only the focal aircraft and origin/destination airports remain on the map.
- [ ] /aircraft/[callsign] no longer throws the appendChild TypeError on first render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)