### PR TITLE
Virtualize the nearby list and animate row entry / value changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-three/postprocessing": "^3.0.4",
     "@sentry/nextjs": "^10.53.1",
     "@supabase/supabase-js": "^2.105.4",
+    "@tanstack/react-virtual": "^3.13.26",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
@@ -55,8 +56,14 @@
       "@sentry/cli"
     ],
     "supportedArchitectures": {
-      "os": ["darwin", "linux"],
-      "cpu": ["x64", "arm64"]
+      "os": [
+        "darwin",
+        "linux"
+      ],
+      "cpu": [
+        "x64",
+        "arm64"
+      ]
     }
   },
   "license": "MIT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.105.4
         version: 2.105.4
+      '@tanstack/react-virtual':
+        specifier: ^3.13.26
+        version: 3.13.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -1984,6 +1987,15 @@ packages:
 
   '@tanstack/query-core@5.100.11':
     resolution: {integrity: sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==}
+
+  '@tanstack/react-virtual@3.13.26':
+    resolution: {integrity: sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.16.0':
+    resolution: {integrity: sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==}
 
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
@@ -5982,6 +5994,14 @@ snapshots:
       tailwindcss: 4.2.4
 
   '@tanstack/query-core@5.100.11': {}
+
+  '@tanstack/react-virtual@3.13.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/virtual-core': 3.16.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/virtual-core@3.16.0': {}
 
   '@tweenjs/tween.js@23.1.3': {}
 

--- a/src/components/sidebar/AircraftRow.jsx
+++ b/src/components/sidebar/AircraftRow.jsx
@@ -3,11 +3,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Plane } from "lucide-react";
+import NumberFlow from "@number-flow/react";
 import {
   formatFlightRouteMunicipalityLabel,
   getFlightRouteAirlineIconUrl,
 } from "../../utils/flightRouteDisplay.js";
-import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap.jsx";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 
 // Tiny self-contained <img> that hides itself if the URL 404s. Avoids
@@ -169,31 +169,25 @@ function AircraftIdentityCell({
   );
 }
 
-// Plain-text formatter for list rows. NumberFlow's animated digits look
-// great on a couple of metric cards, but rendering ~290 instances (145
-// aircraft × 2 columns) every poll tick costs framerate. Static text
-// via Intl.NumberFormat keeps locale-correct separators without the
-// per-row custom-element overhead. The compact value group uses the same
-// Endfield content-swap hook as row replacement, so the old numeric value
-// is erased before the refreshed value is injected.
+// Animated numeric cell. NumberFlow handles digit-level animation natively,
+// replacing the older static-text + EndfieldValueSwap cross-fade. Cost is
+// bounded by virtualization: only the rows in the visible window mount, so
+// the previous ~290-instance worst case becomes ~24 (12 rows × 2 cells).
 function NumberWithUnit({ value, unit, format }) {
-  const formatted = new Intl.NumberFormat(undefined, format).format(value);
   return (
-    <EndfieldValueSwap
-      identityKey={`${formatted}:${unit}`}
-      value={(
-        <>
-          <span className="aircraft-table-number-value">{formatted}</span>
-          <sub
-            className="aircraft-table-unit notranslate relative top-[0.22em] text-[7px] font-semibold leading-none text-atc-dim"
-            translate="no"
-          >
-            {unit}
-          </sub>
-        </>
-      )}
-      className="aircraft-table-number inline-flex items-baseline justify-end gap-0.5 tabular-nums"
-    />
+    <span className="grid w-full grid-cols-[minmax(0,1fr)_var(--aircraft-table-unit-width,14px)] items-baseline gap-x-0.5 tabular-nums">
+      <NumberFlow
+        value={value}
+        format={format}
+        className="block min-w-0 text-right"
+      />
+      <sub
+        className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] font-semibold leading-none text-atc-dim"
+        translate="no"
+      >
+        {unit}
+      </sub>
+    </span>
   );
 }
 

--- a/src/components/sidebar/AircraftTable.jsx
+++ b/src/components/sidebar/AircraftTable.jsx
@@ -39,6 +39,7 @@ import { getDistanceNm } from "../../utils/aircraftTrafficIntent.js";
 import AircraftList from "./AircraftList.jsx";
 import AircraftSlot from "./AircraftSlot.jsx";
 import AirportSlot from "./AirportSlot.jsx";
+import VirtualNearbyList from "./VirtualNearbyList.jsx";
 
 export default function AircraftTable({
   aircraft = [],
@@ -132,6 +133,26 @@ export default function AircraftTable({
       (item) => getAircraftIdentity(item) !== selectedAircraftId,
     );
   }, [pinnedAircraft, filteredAircraft, selectedAircraftId]);
+  const combinedRows = useMemo(() => {
+    const out = [];
+    for (const aircraftItem of listRows) {
+      const id = getAircraftIdentity(aircraftItem);
+      out.push({
+        type: "aircraft",
+        id: id || `aircraft-idx:${out.length}`,
+        data: aircraftItem,
+      });
+    }
+    for (const airport of filteredAirports) {
+      out.push({
+        type: "airport",
+        id: `airport:${airport.icao}`,
+        data: airport,
+      });
+    }
+    return out;
+  }, [filteredAirports, listRows]);
+
   const aircraftListResetKey = useMemo(
     () =>
       [
@@ -263,7 +284,7 @@ export default function AircraftTable({
         )}
       </div>
 
-      <div className={fill ? "flex-1 overflow-y-auto" : "overflow-visible"}>
+      <div className={fill ? "flex-1 min-h-0" : "overflow-visible"}>
         {listRows.length === 0 &&
         filteredAirports.length === 0 &&
         !pinnedAircraft ? (
@@ -272,6 +293,15 @@ export default function AircraftTable({
               ? t("sidebar.noMatches")
               : t("sidebar.nothingInRange")}
           </div>
+        ) : fill ? (
+          <VirtualNearbyList
+            items={combinedRows}
+            selectedAircraftId={selectedAircraftId}
+            selectedAirportIcao={selectedAirportIcao}
+            onSelectAircraft={onSelectAircraft}
+            onSelectAirport={onSelectAirport}
+            resetSignal={aircraftListResetKey}
+          />
         ) : (
           <>
             {listRows.length > 0 && (
@@ -283,11 +313,11 @@ export default function AircraftTable({
               />
             )}
             {filteredAirports.length > 0 && (
-              <ul className="aircraft-table-list">
+              <ul className="divide-y divide-atc-line">
                 {filteredAirports.map((airport) => (
                   <li
                     key={`airport:${airport.icao}`}
-                    className="aircraft-table-list__item"
+                    className="relative list-none [perspective:800px]"
                   >
                     <AirportSlot
                       airport={airport}

--- a/src/components/sidebar/AirportRow.jsx
+++ b/src/components/sidebar/AirportRow.jsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { TowerControl } from "lucide-react";
+import NumberFlow from "@number-flow/react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
 import { airportCityName, airportDisplayName } from "@/utils/airport.js";
 import { countryName } from "@/utils/flag.js";
-import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap.jsx";
 
 // Airport equivalent of AircraftRow — same column rhythm so an
 // "airports & aircraft" mixed list reads as one coherent table.
@@ -73,26 +73,23 @@ export default function AirportRow({
   );
 }
 
-// See AircraftRow.NumberWithUnit — same reasoning: static text to keep
-// the long nearby list from costing framerate on every poll.
+// Mirrors AircraftRow.NumberWithUnit — virtualization bounds the instance
+// count, so NumberFlow's digit-level animation is affordable here too.
 function NumberWithUnit({ value, unit, format }) {
-  const formatted = new Intl.NumberFormat(undefined, format).format(value);
   return (
-    <EndfieldValueSwap
-      identityKey={`${formatted}:${unit}`}
-      value={(
-        <>
-          <span className="aircraft-table-number-value">{formatted}</span>
-          <sub
-            className="aircraft-table-unit notranslate relative top-[0.22em] text-[7px] font-semibold leading-none text-atc-dim"
-            translate="no"
-          >
-            {unit}
-          </sub>
-        </>
-      )}
-      className="aircraft-table-number inline-flex items-baseline justify-end gap-0.5 tabular-nums"
-    />
+    <span className="grid w-full grid-cols-[minmax(0,1fr)_var(--aircraft-table-unit-width,14px)] items-baseline gap-x-0.5 tabular-nums">
+      <NumberFlow
+        value={value}
+        format={format}
+        className="block min-w-0 text-right"
+      />
+      <sub
+        className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] font-semibold leading-none text-atc-dim"
+        translate="no"
+      >
+        {unit}
+      </sub>
+    </span>
   );
 }
 

--- a/src/components/sidebar/VirtualNearbyList.jsx
+++ b/src/components/sidebar/VirtualNearbyList.jsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+import AircraftRow from "./AircraftRow.jsx";
+import AirportRow from "./AirportRow.jsx";
+
+const ROW_HEIGHT_PX = 64;
+const OVERSCAN_ROWS = 6;
+const ENTER_ANIMATION_MS = 260;
+
+// Windowed render for the nearby list. Both aircraft and airport rows live in
+// a single scroll container so the virtualizer can manage them as one stream.
+// Stable per-item keys (icao for airports, callsign/icao24 for aircraft) let
+// React preserve component identity across scrolls so NumberFlow inside each
+// row keeps its animation state instead of remounting.
+export default function VirtualNearbyList({
+  items,
+  selectedAircraftId = "",
+  selectedAirportIcao = "",
+  onSelectAircraft,
+  onSelectAirport,
+  resetSignal,
+}) {
+  const parentRef = useRef(null);
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT_PX,
+    overscan: OVERSCAN_ROWS,
+    getItemKey: (index) => items[index]?.id ?? index,
+  });
+
+  // Track which item ids were present in the previous render so we can mark
+  // genuinely-new rows for the enter animation. Rows that scroll back into the
+  // virtual window are already in this set and stay static — only data-driven
+  // additions (a new aircraft, a filter change, a fresh resetSignal) animate.
+  // Tracking the previously-rendered ids in a ref keeps the enter animation
+  // scoped to genuine data changes — scrolling a known id back into the
+  // virtual window leaves it untouched. resetSignal (filter / selection
+  // change) wipes the ref before flags are computed, so the post-reset list
+  // animates in as a unit instead of flickering only the rare new identity.
+  const seenIdsRef = useRef(new Set());
+  const lastResetRef = useRef(resetSignal);
+  const enterFlags = useMemo(() => {
+    if (lastResetRef.current !== resetSignal) {
+      seenIdsRef.current = new Set();
+      lastResetRef.current = resetSignal;
+    }
+    const flags = new Map();
+    for (const item of items) {
+      flags.set(item.id, !seenIdsRef.current.has(item.id));
+    }
+    return flags;
+  }, [items, resetSignal]);
+
+  useEffect(() => {
+    seenIdsRef.current = new Set(items.map((item) => item.id));
+  }, [items]);
+
+  useEffect(() => {
+    parentRef.current?.scrollTo({ top: 0 });
+  }, [resetSignal]);
+
+  const virtualRows = virtualizer.getVirtualItems();
+  const totalSize = virtualizer.getTotalSize();
+
+  return (
+    <div ref={parentRef} className="h-full overflow-y-auto">
+      <div
+        style={{ height: `${totalSize}px`, position: "relative", width: "100%" }}
+      >
+        {virtualRows.map((virtualRow) => {
+          const item = items[virtualRow.index];
+          if (!item) return null;
+          const isFirst = virtualRow.index === 0;
+          return (
+            <NearbyVirtualRow
+              key={virtualRow.key}
+              index={virtualRow.index}
+              start={virtualRow.start}
+              size={virtualRow.size}
+              isFirst={isFirst}
+              shouldAnimateEnter={enterFlags.get(item.id) === true}
+              item={item}
+              selectedAircraftId={selectedAircraftId}
+              selectedAirportIcao={selectedAirportIcao}
+              onSelectAircraft={onSelectAircraft}
+              onSelectAirport={onSelectAirport}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function NearbyVirtualRow({
+  index,
+  start,
+  size,
+  isFirst,
+  shouldAnimateEnter,
+  item,
+  selectedAircraftId,
+  selectedAirportIcao,
+  onSelectAircraft,
+  onSelectAirport,
+}) {
+  // `entering` toggles the keyframes class. It's initialised from the parent's
+  // flag at mount, but rows can also be reused across filter changes (same key,
+  // new shouldAnimateEnter prop) — the second effect re-triggers the animation
+  // in that case. The first effect times the class off after the keyframes
+  // have run their full course.
+  const [entering, setEntering] = useState(shouldAnimateEnter);
+  useEffect(() => {
+    if (shouldAnimateEnter) setEntering(true);
+  }, [shouldAnimateEnter]);
+  useEffect(() => {
+    if (!entering) return undefined;
+    const timer = window.setTimeout(
+      () => setEntering(false),
+      ENTER_ANIMATION_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [entering]);
+
+  return (
+    <div
+      data-index={index}
+      className={`absolute left-0 top-0 w-full ${
+        isFirst ? "" : "border-t border-atc-line"
+      } [perspective:800px]`}
+      style={{
+        height: `${size}px`,
+        transform: `translateY(${start}px)`,
+      }}
+    >
+      <div className={entering ? "nearby-row-enter" : ""}>
+        {item.type === "aircraft" ? (
+          <AircraftRow
+            aircraft={item.data}
+            aircraftId={item.id}
+            selected={item.id === selectedAircraftId}
+            onSelectAircraft={onSelectAircraft}
+          />
+        ) : (
+          <AirportRow
+            airport={item.data}
+            airportId={item.data?.icao}
+            selected={item.data?.icao === selectedAirportIcao}
+            onSelectAirport={onSelectAirport}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -127,6 +127,27 @@
     }
 }
 
+@keyframes nearby-row-enter {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.nearby-row-enter {
+    animation: nearby-row-enter 240ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .nearby-row-enter {
+        animation: none;
+    }
+}
+
 @font-face {
     font-family: "HarmonyOS Sans ADSBao";
     src: url("/fonts/harmonyos/HarmonyOS_Sans_Medium.ttf") format("truetype");
@@ -3678,34 +3699,6 @@ body {
     display: flex;
     justify-content: flex-end;
     min-width: 0;
-}
-
-.aircraft-table-number {
-    display: block;
-    min-width: 100%;
-    width: 100%;
-}
-
-.aircraft-table-number .endf-value-swap__content {
-    align-items: baseline;
-    column-gap: 2px;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) var(--aircraft-table-unit-width, 14px);
-    width: 100%;
-}
-
-.aircraft-table-number-value {
-    display: block;
-    font-variant-numeric: tabular-nums;
-    min-width: 0;
-    text-align: right;
-}
-
-.aircraft-table-unit {
-    display: inline-block;
-    min-width: 0;
-    text-align: left;
-    width: var(--aircraft-table-unit-width, 14px);
 }
 
 .aircraft-table-cell--distance {


### PR DESCRIPTION
## Summary
- Replace the always-mounted aircraft + airport rows with a single TanStack Virtual stream — only the rows that fit in the visible window (~11) mount at a time
- With instance count bounded, the per-row distance / altitude / elevation cells switch from plain `Intl.NumberFormat` text to `@number-flow/react` and animate digit changes
- Add a 240ms fade-up enter animation for genuinely-new ids; rows scrolling back into the virtual window stay static; `resetSignal` (filter cycle, selection swap) re-animates the refreshed list as a unit; respects `prefers-reduced-motion`
- Non-virtualized mobile-overlay path (`fill=false`) keeps the existing layout and now uses Tailwind `divide-y` for inter-row borders since the old `.aircraft-table-list` rules are dead

## Why
The previous code carried a deliberate comment in `AircraftRow.NumberWithUnit` explaining why NumberFlow was avoided for the in-row numbers: ~290 animated custom-elements per poll tick (≈145 aircraft × 2 numeric cells) was too expensive. Virtualization fixes the root cause — mounted instance count is now constant regardless of list size — so NumberFlow becomes affordable in-row.

## Implementation notes
- `VirtualNearbyList.jsx` owns the scroll viewport and computes a combined items array (`{ type: "aircraft" | "airport", id, data }`) from `listRows` + `filteredAirports`. Stable per-item keys (`callsign`/`icao24`, `icao:<code>`) let React preserve component identity across scroll-driven re-renders so NumberFlow keeps its animation state.
- Enter animation is gated by a `seenIdsRef` set + a `resetSignal` watcher. On `resetSignal` change the set is wiped synchronously inside the `useMemo`, so the same render that swaps `items` also flags every row as new. A second effect inside `NearbyVirtualRow` re-triggers the keyframes when a reused row instance receives a fresh `shouldAnimateEnter=true` prop (filter swaps keep IDs around and reuse mounts).
- Now-orphaned CSS rules (`.aircraft-table-number`, `.aircraft-table-number .endf-value-swap__content`, `.aircraft-table-number-value`, the standalone `.aircraft-table-unit` base — the responsive `.airport-map-kit .aircraft-table-unit` override is preserved by keeping the class on the `<sub>`).

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (94 test files)
- [x] Dev-server smoke: `/airport/KBOS`, `/aircraft/DAL2043` both 200
- [x] DOM timeline confirms 11 rows pick up `.nearby-row-enter` on initial mount AND on entity-filter cycle, both for ~240ms
- [x] NumberFlow shadow DOM renders digits (verified via Chrome devtools shadow-root inspection)
- [ ] Visual review on Vercel preview: sidebar scroll, filter cycling, ground / `-` fallback states, mobile overlay (`fill=false`) still works without virtualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)