### PR TITLE
Onboard TanStack Query: Provider + useAirportWiki pilot migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-three/postprocessing": "^3.0.4",
     "@sentry/nextjs": "^10.53.1",
     "@supabase/supabase-js": "^2.105.4",
+    "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-virtual": "^3.13.26",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",
+    "@tanstack/react-query-devtools": "^5.100.14",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.0.10",
     "tailwindcss": "^4.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.105.4
         version: 2.105.4
+      '@tanstack/react-query':
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.5)
       '@tanstack/react-virtual':
         specifier: ^3.13.26
         version: 3.13.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -105,6 +108,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
+      '@tanstack/react-query-devtools':
+        specifier: ^5.100.14
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.5))(react@19.2.5)
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@2.6.1)
@@ -1987,6 +1993,23 @@ packages:
 
   '@tanstack/query-core@5.100.11':
     resolution: {integrity: sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==}
+
+  '@tanstack/query-core@5.100.14':
+    resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
+
+  '@tanstack/query-devtools@5.100.14':
+    resolution: {integrity: sha512-g96SmSSQecYTYcyuAMRXr895GplJv01UGt7qttQWPOUyZ5EGz5tbRc589bMc2m5BsPFD6O0PCEAHdbDYNP6UBw==}
+
+  '@tanstack/react-query-devtools@5.100.14':
+    resolution: {integrity: sha512-JkP5VDgKOw3t/QSA1OABRHEqx8BuNs5MfvZRooNqdvN57SzTuGq3fKR1a2IH5rqa5HDLUm+FOXUEnB9ueHiLzg==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.100.14
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.100.14':
+    resolution: {integrity: sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-virtual@3.13.26':
     resolution: {integrity: sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ==}
@@ -5994,6 +6017,21 @@ snapshots:
       tailwindcss: 4.2.4
 
   '@tanstack/query-core@5.100.11': {}
+
+  '@tanstack/query-core@5.100.14': {}
+
+  '@tanstack/query-devtools@5.100.14': {}
+
+  '@tanstack/react-query-devtools@5.100.14(@tanstack/react-query@5.100.14(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-devtools': 5.100.14
+      '@tanstack/react-query': 5.100.14(react@19.2.5)
+      react: 19.2.5
+
+  '@tanstack/react-query@5.100.14(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.14
+      react: 19.2.5
 
   '@tanstack/react-virtual@3.13.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -5,6 +5,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import ThemedToaster from "@/components/app-shell/ThemedToaster.jsx";
 import { I18nProvider } from "@/features/app-shell/i18n/i18nProvider.jsx";
+import QueryProvider from "@/features/app-shell/queryProvider.jsx";
 import "leaflet/dist/leaflet.css";
 import "maplibre-gl/dist/maplibre-gl.css";
 import {
@@ -128,9 +129,11 @@ export default async function RootLayout({ children }) {
       </head>
       <body>
         <ClerkProvider>
-          <I18nProvider>
-            <div className="min-h-dvh bg-atc-bg text-atc-text">{children}</div>
-          </I18nProvider>
+          <QueryProvider>
+            <I18nProvider>
+              <div className="min-h-dvh bg-atc-bg text-atc-text">{children}</div>
+            </I18nProvider>
+          </QueryProvider>
           <ThemedToaster
             initialTheme={initialTheme}
             className="atc-toaster"

--- a/src/features/app-shell/queryProvider.jsx
+++ b/src/features/app-shell/queryProvider.jsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+// Single QueryClient per browser session. Sensible defaults that match how
+// this app talks to its upstreams:
+//   - staleTime 60s: aircraft / metar polls overwrite this with shorter
+//     intervals per-query; static lookups (wiki, airports) get a quiet
+//     baseline so the cache survives short navigations.
+//   - gcTime 5min: keeps results around long enough to feel snappy on tab
+//     re-entry without holding upstream bytes forever.
+//   - retry 1: most upstreams (adsbdb, wikipedia, AviationWeather) are best-
+//     effort. A single retry catches transient blips; more would mask real
+//     outages and slow the UI down.
+//   - refetchOnWindowFocus false: this app polls explicitly via the relevant
+//     hooks; focus-driven refetch on top of that would double-pull.
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000,
+        gcTime: 5 * 60_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
+
+export default function QueryProvider({ children }) {
+  // useState's lazy initializer guarantees a single client per provider
+  // instance — top-level `new QueryClient()` would share one client across
+  // every server-rendered request in dev.
+  const [client] = useState(createQueryClient);
+
+  return (
+    <QueryClientProvider client={client}>
+      {children}
+      {process.env.NODE_ENV === "development" ? (
+        <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
+      ) : null}
+    </QueryClientProvider>
+  );
+}

--- a/src/hooks/useAirportWiki.js
+++ b/src/hooks/useAirportWiki.js
@@ -1,36 +1,29 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { fetchAirportWikiSummary } from "../features/airport/wiki/airportWiki.js";
 import { useI18n } from "../features/app-shell/i18n/useI18n.js";
 
+// Wiki content barely changes during a session, so the 30-minute staleTime
+// avoids hammering Wikipedia when users hop between airports — the second
+// time they land on KBOS during the same session the summary paints
+// instantly from cache.
+const WIKI_STALE_TIME_MS = 30 * 60_000;
+
 export function useAirportWiki(airport) {
   const { locale } = useI18n();
-  const [summary, setSummary] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const airportKey = airport?.icao || airport?.iata || airport?.name || "";
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      setSummary(null);
-      setError(null);
-      if (!airport?.name && !airport?.icao && !airport?.iata) return;
-      setLoading(true);
-      try {
-        const next = await fetchAirportWikiSummary(airport, fetch, { locale });
-        if (!cancelled) setSummary(next);
-      } catch (err) {
-        if (!cancelled) setError(err?.message || "Airport summary unavailable");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [airport, airport?.name, airport?.icao, airport?.iata, locale]);
+  const query = useQuery({
+    queryKey: ["airport-wiki", airportKey, locale],
+    queryFn: () => fetchAirportWikiSummary(airport, fetch, { locale }),
+    enabled: Boolean(airportKey),
+    staleTime: WIKI_STALE_TIME_MS,
+  });
 
-  return { summary, loading, error };
+  return {
+    summary: query.data ?? null,
+    loading: query.isPending && query.fetchStatus !== "idle",
+    error: query.error ? query.error.message || "Airport summary unavailable" : null,
+  };
 }


### PR DESCRIPTION
## Summary
- Add `@tanstack/react-query` + `@tanstack/react-query-devtools` and a thin client-side `QueryProvider` mounted between `ClerkProvider` and `I18nProvider`
- Migrate `useAirportWiki` (the simplest data hook in the codebase: one-shot fetch, three-state return, single consumer) as a pilot — same public shape, so `WeatherBriefingStack` doesn't change
- DevTools panel is conditionally rendered only in `process.env.NODE_ENV === "development"`

## Why this hook first
Per the strategy discussion: TanStack Query is the right TanStack package for this app (poll-heavy, multiple upstreams with caching potential), but a big-bang migration risks regressing hooks with custom business logic (`useAircraftPositions` race-failover, `useTrackedAircraft` reconciliation, etc.). A pilot proves the integration without taking on that risk:
- `useAirportWiki` is 36 lines of textbook fetch state machine
- Single consumer (`WeatherBriefingStack`)
- Static content (Wikipedia summary) → 30-minute `staleTime` is honest, gives obvious cache-hit wins when revisiting an airport

## QueryClient defaults
```js
staleTime: 60_000        // baseline; static lookups can extend, polling hooks will shorten
gcTime:    5 * 60_000    // keeps recent results around for snappy back-nav
retry:     1             // best-effort upstreams (Wikipedia, adsbdb) — one retry catches blips, more masks outages
refetchOnWindowFocus: false  // app already polls; focus refetch would double-pull
```

## Public-shape preservation
`useAirportWiki` still returns `{ summary, loading, error }`. The mapping:
- `summary: query.data ?? null`
- `loading: query.isPending && query.fetchStatus !== "idle"` — true only during an actual fetch with no data yet, matches the prior semantics including the cache-hit case (instant render, `loading=false`)
- `error: query.error?.message ?? "Airport summary unavailable"`

## Follow-up plan (not in this PR)
- Migrate hooks opportunistically when they're touched for other reasons; do not refactor en masse
- `useFlightRoutes`, `useLocalWeather`, `useNearbyAirports`, `useAirportProcedures`, `useMetar` are good next candidates (one-shot fetches)
- `useAircraftPositions` / `useAircraftTrace` / `useTrackedAircraft` are tricky — they have multi-provider failover, audit logging, and race semantics that need careful queryFn design. Save until the integration is well understood.
- `apiLogger` audit instrumentation should keep working through `queryFn`; verify on each migration

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (94 test files)
- [ ] Vercel preview: open `/airport/KBOS` wiki panel, switch to another airport, switch back — second load should be near-instant from cache
- [ ] Toggle locale (zh-CN ↔ en) — locale changes the queryKey so summaries refetch in the right language
- [ ] React Query DevTools button visible in dev only, not in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)