### PR TITLE
Release v1.6.0: nearby virtualization and data-layer onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/changelog/ChangelogPanel.jsx
+++ b/src/components/changelog/ChangelogPanel.jsx
@@ -10,15 +10,18 @@ import { CHANGELOG } from "@/config/changelog.js";
 // optional current marker, summary, then short highlights.
 
 const CHINESE_RELEASE_COPY = {
-  "v1.5.1": {
-    title: "FlightAware 兜底焦点模式",
+  "v1.6.0": {
+    title: "附近列表虚拟化与数据层接入",
     summary:
-      "FlightAware 兜底现在会把飞行地图锁定到焦点航班的完整航迹视图,并保留已缓存的机型与航路信息。",
+      "侧栏附近列表改为窗口化滚动,距离与高度采用数字滚动呈现;页面层 z-index 统一为命名 token;TanStack Query 开始接管客户端数据获取。",
     highlights: [
-      "FlightAware 兜底会禁用缩放预设,并自动适配焦点航班完整航迹",
-      "完整航迹兜底视图会隐藏地图和侧栏里的附近飞机与附近机场",
-      "跟踪航班的机型与航路上下文会缓存 6 小时",
-      "FlightAware 航迹刷新节奏限制为 60 秒一次",
+      "附近列表(飞机 + 机场)用 TanStack Virtual 实现窗口化,距离与高度每次轮询通过 NumberFlow 数字滚动",
+      "新行有细微淡入动画,尊重 prefers-reduced-motion",
+      "置顶飞机槽位采用 metric tile 选中风格(深色底 + 由下至上的边缘辉光)",
+      "首页与详情页的工具栏 / sidebar 几何对齐,都以内容区域居中",
+      "页面层 z-index 改成命名 tier token,修复了桌面端与移动端的 Leaflet pane 冲突",
+      "TanStack Query + DevTools 接入应用骨架,useAirportWiki 作为样板迁移,后续数据 hook 按需替换",
+      "小型叶子组件迁移到 inline Tailwind,style.css 体积减少约 15%",
     ],
   },
   "v1.5.0": {

--- a/src/config/changelog.js
+++ b/src/config/changelog.js
@@ -6,16 +6,19 @@
 
 export const CHANGELOG = [
   {
-    version: "v1.5.1",
-    kind: "patch",
-    title: "FlightAware fallback focus mode",
+    version: "v1.6.0",
+    kind: "feat",
+    title: "Nearby list virtualization and data-layer onboarding",
     summary:
-      "FlightAware fallback now locks the flight map into a focused full-trace view while preserving cached aircraft type and route metadata.",
+      "Sidebar nearby list windows through a virtualizer with animated digit metrics, page-level UI gets unified token-based stacking, and TanStack Query starts handling client-side data fetching.",
     highlights: [
-      "FlightAware fallback disables zoom presets and auto-fits the complete focal trace",
-      "Full-trace fallback hides nearby aircraft and airports from the map and sidebar",
-      "Tracked-flight metadata caches aircraft type and route context for 6 hours",
-      "FlightAware trace refreshes are throttled to a 60-second cadence",
+      "Nearby list (aircraft + airports) windows through TanStack Virtual; distance and altitude animate via NumberFlow on every poll tick",
+      "Subtle fade-up enter animation for genuinely-new rows; honours prefers-reduced-motion",
+      "Pinned aircraft slot styled as a peer of the metric tiles — ink surface with a bottom-up edge glow",
+      "Toolbar and sidebar geometry unified across home and detail pages; both center over the content area",
+      "Page-level z-index ladder replaced by named tier tokens; Leaflet pane collisions fixed in both desktop and mobile layouts",
+      "TanStack Query and DevTools mounted in the app shell; useAirportWiki migrated as the pilot for future data-hook adoption",
+      "~15% style.css reduction by migrating small leaf components to inline Tailwind utilities and dropping dead CSS",
     ],
   },
   {

--- a/src/config/siteMeta.js
+++ b/src/config/siteMeta.js
@@ -1,5 +1,5 @@
 export const ADSBAO_PRODUCT_NAME = "ADSBao";
-export const ADSBAO_SITE_VERSION = "1.5.1";
+export const ADSBAO_SITE_VERSION = "1.6.0";
 export const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
 
 export function buildAdsbaoUserAgent(suffix = "") {

--- a/src/config/siteMeta.test.js
+++ b/src/config/siteMeta.test.js
@@ -7,14 +7,14 @@ import {
 } from "./siteMeta.js";
 
 assert.equal(ADSBAO_PRODUCT_NAME, "ADSBao");
-assert.equal(ADSBAO_SITE_VERSION, "1.5.1");
+assert.equal(ADSBAO_SITE_VERSION, "1.6.0");
 assert.equal(
   buildAdsbaoUserAgent("adsbdb/v0"),
-  "ADSBao/1.5.1 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+  "ADSBao/1.6.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
 );
 assert.equal(
   buildAdsbaoUserAgent(),
-  "ADSBao/1.5.1 (+https://github.com/orriduck/ADSBao)",
+  "ADSBao/1.6.0 (+https://github.com/orriduck/ADSBao)",
 );
 
 console.log("siteMeta.test.js ok");


### PR DESCRIPTION
## Summary
Roll v1.5.1 → v1.6.0. The v1.5.1 FlightAware-fallback changelog entry is dropped per product direction; the new v1.6.0 entry covers the recent sidebar + data-layer + visual work merged across PRs #297–#301.

## Files touched
- `package.json` → `1.6.0`
- `src/config/siteMeta.js` → `ADSBAO_SITE_VERSION = "1.6.0"`
- `src/config/siteMeta.test.js` → assertions bumped
- `src/config/changelog.js` → drop v1.5.1 FlightAware entry, prepend v1.6.0
- `src/components/changelog/ChangelogPanel.jsx` → matching zh-CN release copy

## v1.6.0 highlights (in changelog)
- Nearby list (aircraft + airports) windows through TanStack Virtual; distance and altitude animate via NumberFlow on every poll tick
- Subtle fade-up enter animation for genuinely-new rows; honours `prefers-reduced-motion`
- Pinned aircraft slot styled as a peer of the metric tiles — ink surface with a bottom-up edge glow
- Toolbar and sidebar geometry unified across home and detail pages; both center over the content area
- Page-level z-index ladder replaced by named tier tokens; Leaflet pane collisions fixed in both desktop and mobile layouts
- TanStack Query and DevTools mounted in the app shell; `useAirportWiki` migrated as the pilot
- ~15% style.css reduction by migrating small leaf components to inline Tailwind utilities and dropping dead CSS

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (94 test files; siteMeta assertions cover the version bump)
- [ ] Vercel preview: `/changelog` renders v1.6.0 on top, no FlightAware mention in the latest entry; About page shows v1.6.0
- [ ] After merge, tag annotated release per CLAUDE.md:
  ```
  git tag -a v1.6.0 -m "v1.6.0 - Nearby virtualization and data-layer onboarding"
  git push origin v1.6.0
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)