### PR TITLE
Sidebar: Departures + Arrivals metric cards when FlightAware on

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.jsx
+++ b/src/components/airport/explorer/AirportExplorer.jsx
@@ -169,6 +169,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     lastUpdated: traffic.lastUpdated,
     feedStatus: traffic.feedStatus,
     feedSource: traffic.feedSource,
+    routeProvider: traffic.routeProvider,
     loadingStatus: sourceLoadingStatus,
     onSelectAircraft: selectAircraft,
     onSelectAirport: selectAirport,

--- a/src/components/sidebar/AirportSidebar.jsx
+++ b/src/components/sidebar/AirportSidebar.jsx
@@ -28,6 +28,7 @@ export default function AirportSidebar({
   lastUpdated = null,
   feedStatus = "live",
   feedSource = "",
+  routeProvider = "",
   loadingStatus = "",
   onSelectAircraft,
   onSelectAirport,
@@ -53,7 +54,8 @@ export default function AirportSidebar({
         activeView={activeView}
         onViewChange={setActiveView}
         metar={metar}
-        aircraftCount={aircraft.length}
+        aircraft={aircraft}
+        routeProvider={routeProvider}
       />
     </>
   );

--- a/src/components/sidebar/SidebarViewSwitch.jsx
+++ b/src/components/sidebar/SidebarViewSwitch.jsx
@@ -1,18 +1,37 @@
 "use client";
 
+import { useMemo } from "react";
 import NumberFlow from "@number-flow/react";
 import { SidebarMetricCard, SidebarMetricGrid } from "./SidebarMetric";
 import { useI18n } from "@/features/app-shell/i18n/useI18n.js";
+import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel.js";
+import { ARRIVAL, DEPARTURE } from "@/utils/aircraftMovement.js";
 
 export default function SidebarViewSwitch({
   activeView = "briefing",
   onViewChange,
   metar = null,
-  aircraftCount = 0,
+  aircraft = [],
+  routeProvider = "",
 }) {
   const { t } = useI18n();
   const temperature = formatTemperature(metar);
   const rule = metar?.flightCategory?.toUpperCase() || "WX";
+  const showMovementCards = routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
+
+  // Pre-compute departure / arrival counts only when FlightAware is on.
+  // The aircraft.movement field is already resolved upstream by
+  // enrichAircraftWithRoutes, so this is just two filters.
+  const { departureCount, arrivalCount } = useMemo(() => {
+    if (!showMovementCards) return { departureCount: 0, arrivalCount: 0 };
+    let dep = 0;
+    let arr = 0;
+    for (const item of aircraft) {
+      if (item?.movement === DEPARTURE) dep += 1;
+      else if (item?.movement === ARRIVAL) arr += 1;
+    }
+    return { departureCount: dep, arrivalCount: arr };
+  }, [aircraft, showMovementCards]);
 
   return (
     <SidebarMetricGrid label={t("sidebar.airportViews")}>
@@ -25,11 +44,25 @@ export default function SidebarViewSwitch({
       />
       <SidebarMetricCard
         label={t("sidebar.flights")}
-        value={<NumberFlow value={aircraftCount} />}
+        value={<NumberFlow value={aircraft.length} />}
         unit={`${rule} / ADS-B`}
         active={activeView === "traffic"}
         onClick={() => onViewChange?.("traffic")}
       />
+      {showMovementCards && (
+        <>
+          <SidebarMetricCard
+            label={t("sidebar.departures")}
+            value={<NumberFlow value={departureCount} />}
+            unit="OUT"
+          />
+          <SidebarMetricCard
+            label={t("sidebar.arrivals")}
+            value={<NumberFlow value={arrivalCount} />}
+            unit="IN"
+          />
+        </>
+      )}
     </SidebarMetricGrid>
   );
 }

--- a/src/config/i18n/en.js
+++ b/src/config/i18n/en.js
@@ -123,6 +123,8 @@ const en = {
     airportViews: "Airport sidebar views",
     weatherViews: "Weather views",
     unknownAirport: "Unknown airport",
+    departures: "Departures",
+    arrivals: "Arrivals",
   },
   metrics: {
     speed: "Speed",

--- a/src/config/i18n/zh-CN.js
+++ b/src/config/i18n/zh-CN.js
@@ -118,6 +118,8 @@ const zhCN = {
     airportViews: "机场侧栏视图",
     weatherViews: "天气视图",
     unknownAirport: "未知机场",
+    departures: "起飞",
+    arrivals: "到达",
   },
   metrics: {
     speed: "速度",


### PR DESCRIPTION
## Summary

- Airport sidebar gains two metric cards under Weather + Flights when the signed-in user has the FlightAware route provider enabled.
- Counts come from `aircraft.movement` (already resolved by `enrichAircraftWithRoutes`), filtered against `DEPARTURE` / `ARRIVAL`.
- Cards are informational (no click). With `routeProvider=adsbdb` the layout is unchanged.

## Test plan

- [ ] Sign in with a FlightAware-enabled email → open `/airport/KBOS` → expect 4 cards (Weather, Flights, Departures, Arrivals) in a 2×2 grid.
- [ ] Sign out (or use adsbdb account) → expect only Weather + Flights.
- [ ] Pick a quiet airport → expect both counts at 0.
- [ ] Departure/arrival counts update as route data resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)