### PR TITLE
[codex] Default navaid markers off

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -48,7 +48,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     mapZoom,
     showMapLabels,
     showRunwayBeams,
-    showRoutingPointBadges,
+    showNavaidMarkers,
     trafficFilter,
     typeFilter,
     altitudeLevel,
@@ -244,7 +244,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             airport={airport}
             showMapLabels={showMapLabels}
             showRunwayBeams={showRunwayBeams}
-            showRoutingPointBadges={showRoutingPointBadges}
+            showNavaidMarkers={showNavaidMarkers}
             trafficFilter={trafficFilter}
             typeFilter={typeFilter}
             altitudeLevel={altitudeLevel}

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -19,12 +19,12 @@ export default function ExplorerMapMenu({
     mapFollowsAircraft,
     showMapLabels,
     showRunwayBeams,
-    showRoutingPointBadges,
+    showNavaidMarkers,
     setMapZoom,
     toggleSidebar,
     toggleMapLabels,
     toggleRunwayBeams,
-    toggleRoutingPointBadges,
+    toggleNavaidMarkers,
   } = useExplorerUi();
 
   return (
@@ -39,12 +39,12 @@ export default function ExplorerMapMenu({
         zoomDisabled={zoomDisabled}
         showMapLabels={showMapLabels}
         showRunwayBeams={showRunwayBeams}
-        showRoutingPointBadges={showRoutingPointBadges}
+        showNavaidMarkers={showNavaidMarkers}
         showSidebarToggle={isMobile}
         onZoom={setMapZoom}
         onToggleMapLabels={toggleMapLabels}
         onToggleRunwayBeams={toggleRunwayBeams}
-        onToggleRoutingPointBadges={toggleRoutingPointBadges}
+        onToggleNavaidMarkers={toggleNavaidMarkers}
         onToggleSidebar={toggleSidebar}
         onFitToTrace={onFitToTrace}
       />

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -68,10 +68,10 @@ function airportExplorerUiReducer(state, action) {
       return { ...state, showMapLabels: toggleValue(state.showMapLabels) };
     case "toggleRunwayBeams":
       return { ...state, showRunwayBeams: toggleValue(state.showRunwayBeams) };
-    case "toggleRoutingPointBadges":
+    case "toggleNavaidMarkers":
       return {
         ...state,
-        showRoutingPointBadges: toggleValue(state.showRoutingPointBadges),
+        showNavaidMarkers: toggleValue(state.showNavaidMarkers),
       };
     case "setTrafficFilter":
       return { ...state, trafficFilter: action.trafficFilter };
@@ -151,7 +151,7 @@ export function ExplorerUiProvider({ children }) {
     mapZoom,
     showMapLabels,
     showRunwayBeams,
-    showRoutingPointBadges,
+    showNavaidMarkers,
     trafficFilter,
     typeFilter,
     altitudeLevel,
@@ -196,8 +196,8 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "toggleRunwayBeams" });
   }, []);
 
-  const toggleRoutingPointBadges = useCallback(() => {
-    dispatch({ type: "toggleRoutingPointBadges" });
+  const toggleNavaidMarkers = useCallback(() => {
+    dispatch({ type: "toggleNavaidMarkers" });
   }, []);
 
   const setTrafficFilter = useCallback((trafficFilter) => {
@@ -257,7 +257,7 @@ export function ExplorerUiProvider({ children }) {
       mapFollowsAircraft,
       showMapLabels,
       showRunwayBeams,
-      showRoutingPointBadges,
+      showNavaidMarkers,
       trafficFilter,
       typeFilter,
       altitudeLevel,
@@ -275,7 +275,7 @@ export function ExplorerUiProvider({ children }) {
       closeSidebar,
       toggleMapLabels,
       toggleRunwayBeams,
-      toggleRoutingPointBadges,
+      toggleNavaidMarkers,
       selectAircraft,
       setSelectedAircraftId,
       selectAirport,
@@ -292,7 +292,7 @@ export function ExplorerUiProvider({ children }) {
       mapFollowsAircraft,
       showMapLabels,
       showRunwayBeams,
-      showRoutingPointBadges,
+      showNavaidMarkers,
       trafficFilter,
       typeFilter,
       altitudeLevel,
@@ -310,7 +310,7 @@ export function ExplorerUiProvider({ children }) {
       closeSidebar,
       toggleMapLabels,
       toggleRunwayBeams,
-      toggleRoutingPointBadges,
+      toggleNavaidMarkers,
       selectAircraft,
       setSelectedAircraftId,
       selectAirport,

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -581,7 +581,7 @@ function FlightExplorerContent({ callsign }) {
             airport={null}
             showMapLabels={showMapLabels}
             showRunwayBeams={false}
-            showRoutingPointBadges={false}
+            showNavaidMarkers={false}
             trafficFilter={trafficFilter}
             typeFilter={typeFilter}
             altitudeLevel={altitudeLevel}

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -54,7 +54,7 @@ export default function AirportMap({
   airport = null,
   showMapLabels = false,
   showRunwayBeams = true,
-  showRoutingPointBadges = true,
+  showNavaidMarkers = false,
   trafficFilter = "all",
   typeFilter = "all",
   altitudeLevel = "all",
@@ -305,7 +305,7 @@ export default function AirportMap({
           <NavaidLabelLayer
             navaids={nearbyNavaids}
             theme={currentTheme}
-            visible={showRoutingPointBadges}
+            visible={showNavaidMarkers}
             selectedNavaidKey={selectedNavaidKey}
             onSelectNavaid={onSelectNavaid}
           />

--- a/src/components/map/controls/MapLayerDrawer.tsx
+++ b/src/components/map/controls/MapLayerDrawer.tsx
@@ -24,11 +24,11 @@ const LAYER_TOGGLES = [
   },
   {
     iconKey: "mapPinned",
-    labelKey: "mapLayers.routingPointBadges",
-    activeKey: "mapLayers.hideRoutingPointBadges",
-    inactiveKey: "mapLayers.showRoutingPointBadges",
-    prop: "showBadges",
-    handler: "onToggleBadges",
+    labelKey: "mapLayers.navaidMarkers",
+    activeKey: "mapLayers.hideNavaidMarkers",
+    inactiveKey: "mapLayers.showNavaidMarkers",
+    prop: "showNavaidMarkers",
+    handler: "onToggleNavaidMarkers",
   },
 ];
 
@@ -41,19 +41,19 @@ export default function MapLayerDrawer({
   open,
   showMapLabels,
   showBeams,
-  showBadges,
+  showNavaidMarkers,
   onToggleMapLabels,
   onToggleBeams,
-  onToggleBadges,
+  onToggleNavaidMarkers,
 }) {
   const { t } = useI18n();
   const state = {
     showMapLabels,
     showBeams,
-    showBadges,
+    showNavaidMarkers,
     onToggleMapLabels,
     onToggleBeams,
-    onToggleBadges,
+    onToggleNavaidMarkers,
   };
 
   return (

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -20,12 +20,12 @@ export default function MapControlBar({
   zoomDisabled = false,
   showMapLabels = false,
   showRunwayBeams = true,
-  showRoutingPointBadges = true,
+  showNavaidMarkers = false,
   showSidebarToggle = true,
   onZoom,
   onToggleMapLabels,
   onToggleRunwayBeams,
-  onToggleRoutingPointBadges,
+  onToggleNavaidMarkers,
   onToggleSidebar,
   onFitToTrace = null,
 }) {
@@ -72,10 +72,10 @@ export default function MapControlBar({
         open={layerDrawerOpen}
         showMapLabels={showMapLabels}
         showBeams={showRunwayBeams}
-        showBadges={showRoutingPointBadges}
+        showNavaidMarkers={showNavaidMarkers}
         onToggleMapLabels={onToggleMapLabels}
         onToggleBeams={onToggleRunwayBeams}
-        onToggleBadges={onToggleRoutingPointBadges}
+        onToggleNavaidMarkers={onToggleNavaidMarkers}
       />
 
       <MapControlRail

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -294,9 +294,9 @@ const en = {
     approachBeams: "Approach beams",
     showApproachBeams: "Show approach beams",
     hideApproachBeams: "Hide approach beams",
-    routingPointBadges: "Navaid labels",
-    showRoutingPointBadges: "Show navaid labels",
-    hideRoutingPointBadges: "Hide navaid labels",
+    navaidMarkers: "Navaid markers",
+    showNavaidMarkers: "Show navaid markers",
+    hideNavaidMarkers: "Hide navaid markers",
   },
   lostSignal: {
     subtitle: "Signal lost",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -290,9 +290,9 @@ const zhCN = {
     approachBeams: "进近光束",
     showApproachBeams: "显示进近光束",
     hideApproachBeams: "隐藏进近光束",
-    routingPointBadges: "导航台标签",
-    showRoutingPointBadges: "显示导航台标签",
-    hideRoutingPointBadges: "隐藏导航台标签",
+    navaidMarkers: "导航台标记",
+    showNavaidMarkers: "显示导航台标记",
+    hideNavaidMarkers: "隐藏导航台标记",
   },
   lostSignal: {
     subtitle: "信号丢失",

--- a/src/features/airport/explorer/airportExplorerUiModel.test.ts
+++ b/src/features/airport/explorer/airportExplorerUiModel.test.ts
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import { DEFAULT_AIRPORT_EXPLORER_UI_STATE } from "./airportExplorerUiModel";
 
 assert.equal(
-  DEFAULT_AIRPORT_EXPLORER_UI_STATE.showRoutingPointBadges,
-  true,
+  DEFAULT_AIRPORT_EXPLORER_UI_STATE.showNavaidMarkers,
+  false,
 );
 
 console.log("airportExplorerUiModel.test.ts ok");

--- a/src/features/airport/explorer/airportExplorerUiModel.ts
+++ b/src/features/airport/explorer/airportExplorerUiModel.ts
@@ -5,6 +5,6 @@ export const DEFAULT_AIRPORT_EXPLORER_UI_STATE = {
   mapZoom: ZOOM_APPROACH,
   showMapLabels: false,
   showRunwayBeams: true,
-  showRoutingPointBadges: true,
+  showNavaidMarkers: false,
   ...DEFAULT_AIRCRAFT_FILTERS,
 };


### PR DESCRIPTION
## Summary
- Defaults airport navaid markers to off.
- Renames the map layer control copy to navaid markers in English and Chinese.
- Renames the internal UI state/props/actions from routing point badges to navaid markers.

## Validation
- `pnpm test`
- `pnpm lint` (passes with the existing TanStack Virtual warning in `VirtualNearbyList.tsx`)
- `pnpm build`
- Local KBOS smoke: default `.navaid-label` count is `0`; toggle title/aria is `显示导航台标记` with `aria-pressed=false`.