### PR TITLE
Refine airport and navaid previews

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.airport.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewCard.airport.test.ts
@@ -5,11 +5,19 @@ import { fileURLToPath } from "node:url";
 const desktopCardPath = fileURLToPath(
   new URL("./AirportPreviewMetadataCard.tsx", import.meta.url),
 );
+const previewCardPath = fileURLToPath(
+  new URL("./AircraftPreviewCard.tsx", import.meta.url),
+);
 const mobileCardPath = fileURLToPath(
   new URL("./AirportPreviewMobileCard.tsx", import.meta.url),
 );
+const stylePath = fileURLToPath(new URL("../../../style.css", import.meta.url));
+const zhPath = fileURLToPath(new URL("../../../config/i18n/zh-CN.ts", import.meta.url));
 const desktopSource = readFileSync(desktopCardPath, "utf8");
+const previewSource = readFileSync(previewCardPath, "utf8");
 const mobileSource = readFileSync(mobileCardPath, "utf8");
+const styleSource = readFileSync(stylePath, "utf8");
+const zhSource = readFileSync(zhPath, "utf8");
 
 assert.match(
   desktopSource,
@@ -25,6 +33,16 @@ assert.match(
   desktopSource,
   /grid-cols-\[auto_minmax\(0,1fr\)\]/,
   "desktop airport preview detail rows should align labels and right-side values",
+);
+assert.match(
+  previewSource,
+  /isAirport \? "aircraft-preview-card--airport" : ""/,
+  "desktop airport preview should opt into an airport-specific card width",
+);
+assert.match(
+  styleSource,
+  /\.aircraft-preview-card--airport \{[\s\S]*?width: 320px;/,
+  "desktop airport preview card should be wider than the default preview card",
 );
 assert.match(
   desktopSource,
@@ -55,6 +73,11 @@ assert.doesNotMatch(
   mobileSource,
   /flex-col/,
   "mobile airport preview should not keep the old stacked two-line layout",
+);
+assert.match(
+  zhSource,
+  /openAirport: "追踪机场"/,
+  "Chinese airport preview CTA should use the shorter track-airport label",
 );
 
 console.log("AircraftPreviewCard.airport.test.ts ok");

--- a/src/components/aircraft/preview/AircraftPreviewCard.airport.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewCard.airport.test.ts
@@ -27,6 +27,26 @@ assert.match(
   "desktop airport preview detail rows should align labels and right-side values",
 );
 assert.match(
+  desktopSource,
+  /text-\[14px\][^"]*whitespace-normal[^"]*break-words/,
+  "desktop airport preview name should be one size smaller and wrap when long",
+);
+assert.match(
+  desktopSource,
+  /text-\[11px\][^"]*whitespace-normal[^"]*break-words/,
+  "desktop airport preview place should be one size smaller and wrap when long",
+);
+assert.doesNotMatch(
+  desktopSource,
+  /<dd className="mt-1 truncate text-\[15px\]/,
+  "desktop airport preview name should not truncate long airport names",
+);
+assert.doesNotMatch(
+  desktopSource,
+  /<dd className="mt-1 truncate text-\[12px\]/,
+  "desktop airport preview place should not truncate long location text",
+);
+assert.match(
   mobileSource,
   /airport-preview-mobile-card__summary/,
   "mobile airport preview should use a compact single-line summary",

--- a/src/components/aircraft/preview/AircraftPreviewCard.navaid.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewCard.navaid.test.ts
@@ -67,13 +67,23 @@ assert.match(
 );
 assert.match(
   desktopSource,
-  /className="min-w-0 flex-1"/,
-  "desktop navaid preview identity column should fill the header space before the icon",
+  /className="relative"/,
+  "desktop navaid preview header should let the identity rows use the full card width",
+);
+assert.match(
+  desktopSource,
+  /absolute right-0 top-0/,
+  "desktop navaid preview icon should not consume identity-row width",
 );
 assert.match(
   desktopSource,
   /w-full grid-cols-\[auto_minmax\(0,1fr\)\]/,
   "desktop navaid identity rows should use the same left-label/right-value alignment as metadata fields",
+);
+assert.doesNotMatch(
+  desktopSource,
+  /flex items-start justify-between gap-3/,
+  "desktop navaid identity rows should not be inside a header flex layout that shortens the value column",
 );
 assert.doesNotMatch(
   desktopSource,

--- a/src/components/aircraft/preview/AircraftPreviewCard.navaid.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewCard.navaid.test.ts
@@ -60,5 +60,25 @@ assert.match(
   /preview\.navaidName/,
   "desktop navaid preview should label the name value in the header",
 );
+assert.match(
+  desktopSource,
+  /identityRows/,
+  "desktop navaid preview should render name and type as identity rows",
+);
+assert.match(
+  desktopSource,
+  /grid-cols-\[auto_minmax\(0,1fr\)\]/,
+  "desktop navaid identity rows should use the same left-label/right-value alignment as metadata fields",
+);
+assert.doesNotMatch(
+  desktopSource,
+  /grid-cols-\[minmax\(0,1fr\)_auto\]/,
+  "desktop navaid identity rows should not split name and type into side-by-side blocks",
+);
+assert.doesNotMatch(
+  desktopSource,
+  /text-\[15px\] font-semibold/,
+  "desktop navaid identity values should not use a different title-style font from metadata values",
+);
 
 console.log("AircraftPreviewCard.navaid.test.ts ok");

--- a/src/components/aircraft/preview/AircraftPreviewCard.navaid.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewCard.navaid.test.ts
@@ -67,7 +67,12 @@ assert.match(
 );
 assert.match(
   desktopSource,
-  /grid-cols-\[auto_minmax\(0,1fr\)\]/,
+  /className="min-w-0 flex-1"/,
+  "desktop navaid preview identity column should fill the header space before the icon",
+);
+assert.match(
+  desktopSource,
+  /w-full grid-cols-\[auto_minmax\(0,1fr\)\]/,
   "desktop navaid identity rows should use the same left-label/right-value alignment as metadata fields",
 );
 assert.doesNotMatch(

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -127,7 +127,7 @@ export default function AircraftPreviewCard({
           key={identityKey}
           className={`aircraft-preview-card aircraft-preview-card--desktop-reveal ${
             !isAirport && !isNavaid && hasPhoto ? "aircraft-preview-card--has-photo" : ""
-          } aircraft-preview-card--photo-${photoTone}`}
+          } ${isAirport ? "aircraft-preview-card--airport" : ""} aircraft-preview-card--photo-${photoTone}`}
           aria-label={previewAriaLabel}
         >
           {!isAirport && !isNavaid && (

--- a/src/components/aircraft/preview/AirportPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/AirportPreviewMetadataCard.tsx
@@ -54,7 +54,7 @@ export default function AirportPreviewMetadataCard({ airport }) {
               <dt className="font-[var(--font-mono)] text-[7px] font-semibold uppercase leading-none tracking-normal text-atc-faint">
                 {t("preview.airportName")}
               </dt>
-              <dd className="mt-1 truncate text-[15px] font-semibold leading-tight text-atc-text">
+              <dd className="mt-1 text-[14px] font-semibold leading-snug whitespace-normal break-words text-atc-text">
                 {name}
               </dd>
             </div>
@@ -63,7 +63,7 @@ export default function AirportPreviewMetadataCard({ airport }) {
                 <dt className="font-[var(--font-mono)] text-[7px] font-semibold uppercase leading-none tracking-normal text-atc-faint">
                   {t("preview.airportPlace")}
                 </dt>
-                <dd className="mt-1 truncate text-[12px] leading-tight text-atc-dim">
+                <dd className="mt-1 text-[11px] leading-snug whitespace-normal break-words text-atc-dim">
                   {placeLine}
                 </dd>
               </div>

--- a/src/components/aircraft/preview/NavaidPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/NavaidPreviewMetadataCard.tsx
@@ -51,7 +51,7 @@ export default function NavaidPreviewMetadataCard({
   return (
     <div className="aircraft-preview-metadata-card">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <span className="endf-label">{t("preview.navaidPreview")}</span>
           <div className="mt-1 flex min-w-0 items-baseline gap-2">
             <span
@@ -62,7 +62,7 @@ export default function NavaidPreviewMetadataCard({
             </span>
           </div>
           {identityRows.length ? (
-            <dl className="mt-2 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
+            <dl className="mt-2 grid w-full grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
               {identityRows.map((row) => (
                 <div className="contents" key={row.label}>
                   <dt className="text-atc-faint uppercase tracking-[0.1em]">

--- a/src/components/aircraft/preview/NavaidPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/NavaidPreviewMetadataCard.tsx
@@ -50,8 +50,8 @@ export default function NavaidPreviewMetadataCard({
 
   return (
     <div className="aircraft-preview-metadata-card">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
+      <div className="relative">
+        <div className="min-w-0 pr-8">
           <span className="endf-label">{t("preview.navaidPreview")}</span>
           <div className="mt-1 flex min-w-0 items-baseline gap-2">
             <span
@@ -61,29 +61,29 @@ export default function NavaidPreviewMetadataCard({
               {ident}
             </span>
           </div>
-          {identityRows.length ? (
-            <dl className="mt-2 grid w-full grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
-              {identityRows.map((row) => (
-                <div className="contents" key={row.label}>
-                  <dt className="text-atc-faint uppercase tracking-[0.1em]">
-                    {row.label}
-                  </dt>
-                  <dd
-                    className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
-                    translate="no"
-                  >
-                    {row.value}
-                  </dd>
-                </div>
-              ))}
-            </dl>
-          ) : null}
         </div>
         <RadioTower
           aria-hidden="true"
-          className="mt-1 size-5 flex-none text-atc-dim"
+          className="absolute right-0 top-0 size-5 text-atc-dim"
           strokeWidth={1.8}
         />
+        {identityRows.length ? (
+          <dl className="mt-2 grid w-full grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
+            {identityRows.map((row) => (
+              <div className="contents" key={row.label}>
+                <dt className="text-atc-faint uppercase tracking-[0.1em]">
+                  {row.label}
+                </dt>
+                <dd
+                  className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
+                  translate="no"
+                >
+                  {row.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
       </div>
 
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />

--- a/src/components/aircraft/preview/NavaidPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/NavaidPreviewMetadataCard.tsx
@@ -32,6 +32,10 @@ export default function NavaidPreviewMetadataCard({
     formatNavaidVariation(navaid?.magneticVariationDeg) ||
     formatNavaidVariation(navaid?.slavedVariationDeg);
 
+  const identityRows = [
+    { label: t("preview.navaidName"), value: name },
+    { label: t("preview.navaidType"), value: type },
+  ].filter((row) => row.value);
   const detailRows = [
     { label: t("metrics.frequency"), value: frequency },
     {
@@ -57,31 +61,23 @@ export default function NavaidPreviewMetadataCard({
               {ident}
             </span>
           </div>
-          <dl className="mt-2 grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-3">
-            {name ? (
-              <div className="min-w-0">
-                <dt className="font-[var(--font-mono)] text-[7px] font-semibold uppercase leading-none tracking-normal text-atc-faint">
-                  {t("preview.navaidName")}
-                </dt>
-                <dd className="mt-1 truncate text-[15px] font-semibold leading-tight text-atc-text">
-                  {name}
-                </dd>
-              </div>
-            ) : null}
-            {type ? (
-              <div className="min-w-[42px] text-right">
-                <dt className="font-[var(--font-mono)] text-[7px] font-semibold uppercase leading-none tracking-normal text-atc-faint">
-                  {t("preview.navaidType")}
-                </dt>
-                <dd
-                  className="notranslate mt-1 font-[var(--font-mono)] text-[12px] font-bold uppercase leading-tight tracking-normal text-atc-dim"
-                  translate="no"
-                >
-                  {type}
-                </dd>
-              </div>
-            ) : null}
-          </dl>
+          {identityRows.length ? (
+            <dl className="mt-2 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
+              {identityRows.map((row) => (
+                <div className="contents" key={row.label}>
+                  <dt className="text-atc-faint uppercase tracking-[0.1em]">
+                    {row.label}
+                  </dt>
+                  <dd
+                    className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
+                    translate="no"
+                  >
+                    {row.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
         </div>
         <RadioTower
           aria-hidden="true"

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -172,7 +172,7 @@ const en = {
     trackTrace: "Track trace",
     trackingTrace: "Tracking trace",
     loadingTrace: "Loading trace...",
-    openAirport: "Open airport context",
+    openAirport: "Track airport",
     viewingAirport: "Viewing airport",
     creditPrefix: "credit@",
   },

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -168,7 +168,7 @@ const zhCN = {
     trackTrace: "追踪航迹",
     trackingTrace: "正在追踪航迹",
     loadingTrace: "正在加载航迹…",
-    openAirport: "查看机场上下文",
+    openAirport: "追踪机场",
     viewingAirport: "正在查看机场",
     creditPrefix: "图源@",
   },

--- a/src/style.css
+++ b/src/style.css
@@ -4638,6 +4638,10 @@ body {
     box-shadow: none;
 }
 
+.aircraft-preview-card--airport {
+    width: 320px;
+}
+
 .aircraft-preview-card--desktop-reveal {
     --endf-wipe-cover: var(--atc-card);
     isolation: isolate;


### PR DESCRIPTION
## Summary
- align navaid name/type values to the same right edge as the rest of the metadata fields
- make airport preview names/locations smaller and wrap instead of truncating
- widen desktop airport preview cards and shorten the airport action copy to track the airport

## Tests
- PATH=/opt/homebrew/bin:/Users/ruyyi/.cargo/bin:/Users/ruyyi/.codex/tmp/arg0/codex-arg0wCG7rY:/Users/ruyyi/.npm-global/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/bin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/pnpm test
- PATH=/opt/homebrew/bin:/Users/ruyyi/.cargo/bin:/Users/ruyyi/.codex/tmp/arg0/codex-arg0wCG7rY:/Users/ruyyi/.npm-global/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/bin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/pnpm lint
- PATH=/opt/homebrew/bin:/Users/ruyyi/.cargo/bin:/Users/ruyyi/.codex/tmp/arg0/codex-arg0wCG7rY:/Users/ruyyi/.npm-global/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/bin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/pnpm build