### PR TITLE
Refine mobile preview cards

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.airport.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewCard.airport.test.ts
@@ -11,11 +11,15 @@ const previewCardPath = fileURLToPath(
 const mobileCardPath = fileURLToPath(
   new URL("./AirportPreviewMobileCard.tsx", import.meta.url),
 );
+const mobileBaseCardPath = fileURLToPath(
+  new URL("./MobilePreviewCard.tsx", import.meta.url),
+);
 const stylePath = fileURLToPath(new URL("../../../style.css", import.meta.url));
 const zhPath = fileURLToPath(new URL("../../../config/i18n/zh-CN.ts", import.meta.url));
 const desktopSource = readFileSync(desktopCardPath, "utf8");
 const previewSource = readFileSync(previewCardPath, "utf8");
 const mobileSource = readFileSync(mobileCardPath, "utf8");
+const mobileBaseSource = readFileSync(mobileBaseCardPath, "utf8");
 const styleSource = readFileSync(stylePath, "utf8");
 const zhSource = readFileSync(zhPath, "utf8");
 
@@ -66,13 +70,38 @@ assert.doesNotMatch(
 );
 assert.match(
   mobileSource,
-  /airport-preview-mobile-card__summary/,
-  "mobile airport preview should use a compact single-line summary",
+  /MobilePreviewIdentity[\s\S]*?icon=\{TowerControl\}[\s\S]*?label=\{t\("preview\.airportPreview"\)\}/,
+  "mobile airport preview should place the airport icon with the primary identity",
+);
+assert.match(
+  mobileSource,
+  /MobilePreviewIdentity[\s\S]*?secondary=\{/,
+  "mobile airport preview should place short airport stats on the primary identity row",
 );
 assert.doesNotMatch(
   mobileSource,
-  /flex-col/,
-  "mobile airport preview should not keep the old stacked two-line layout",
+  /MobilePreviewDetailRow label=/,
+  "mobile airport preview should not show field labels on mobile",
+);
+assert.doesNotMatch(
+  mobileSource,
+  /MobilePreviewRuleRow/,
+  "mobile airport preview should not spend a separate row on regular stats",
+);
+assert.match(
+  mobileBaseSource,
+  /mobile-preview-card-enter/,
+  "base mobile preview card should own the enter animation class",
+);
+assert.match(
+  styleSource,
+  /@keyframes mobile-preview-card-enter/,
+  "base mobile preview card should define a fade-up enter animation",
+);
+assert.match(
+  styleSource,
+  /prefers-reduced-motion[\s\S]*?\.mobile-preview-card-enter/,
+  "base mobile preview card enter animation should respect reduced motion",
 );
 assert.match(
   zhSource,

--- a/src/components/aircraft/preview/AircraftPreviewCard.navaid.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewCard.navaid.test.ts
@@ -32,13 +32,38 @@ assert.match(
 );
 assert.match(
   mobileSource,
-  /navaid-preview-mobile-card__summary/,
-  "mobile navaid preview should use a compact single-line summary instead of a staggered two-row identity",
+  /MobilePreviewIdentity[\s\S]*?icon=\{RadioTower\}[\s\S]*?label=\{t\("preview\.navaidPreview"\)\}/,
+  "mobile navaid preview should place the navaid icon with the primary identity",
 );
 assert.match(
   mobileSource,
-  /\{type \? <Stat plain=\{type\} \/> : null\}/,
-  "mobile navaid preview should put the navaid type in the right-side metadata row",
+  /secondary=\{type\}/,
+  "mobile navaid preview should put the navaid type on the right side of the identity row",
+);
+assert.doesNotMatch(
+  mobileSource,
+  /MobilePreviewDetailRow wrap/,
+  "mobile navaid preview should not spend a separate row on the navaid name",
+);
+assert.doesNotMatch(
+  mobileSource,
+  /MobilePreviewDetailRow label=/,
+  "mobile navaid preview should not show field labels on mobile",
+);
+assert.match(
+  mobileSource,
+  /MobilePreviewRuleRow/,
+  "mobile navaid preview should keep navaid name and regular data in one compact rule row",
+);
+assert.match(
+  mobileSource,
+  /left=\{name \? <span className="block min-w-0 truncate whitespace-nowrap">/,
+  "mobile navaid preview should truncate long navaid names inside the compact rule row",
+);
+assert.match(
+  mobileSource,
+  /frequency \? \([\s\S]*?<MobilePreviewMetaChip>/,
+  "mobile navaid preview should put frequency with the right-side stats group",
 );
 assert.doesNotMatch(
   mobileSource,

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -4,9 +4,18 @@
 import { useState } from "react";
 import type { ComponentProps, ReactElement } from "react";
 import NumberFlow from "@number-flow/react";
+import { Plane } from "lucide-react";
 import { toFiniteNumber } from "@/utils/math";
 import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import {
+  MobilePreviewContent,
+  MobilePreviewDetailRow,
+  MobilePreviewIdentity,
+  MobilePreviewMetaChip,
+  MobilePreviewMetaChips,
+  MobilePreviewRuleRow,
+} from "./MobilePreviewCard";
 
 type NumberFlowFormat = ComponentProps<typeof NumberFlow>["format"];
 
@@ -69,9 +78,6 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
 
   const hasStats = speed != null || altitude != null || vs != null || onGround;
 
-  // Stat row separator dot. Kept as a tiny render-prop so the comma /
-  // dot rhythm is consistent across kt · ft · fpm without hand-placing
-  // every conditional.
   const stats: ReactElement[] = [];
   if (speed != null) {
     stats.push(
@@ -99,86 +105,61 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
   }
 
   return (
-    <div className="relative z-[2] box-border flex w-full flex-col items-stretch gap-[6px] px-[14px] pt-[12px] pb-[8px]">
-      <div className="grid w-full max-w-full grid-cols-[minmax(0,1fr)_auto] items-baseline gap-[10px] whitespace-nowrap">
-        <span
-          translate="no"
-          className="notranslate min-w-0 overflow-hidden text-ellipsis font-[var(--font-display)] text-[19px] font-extrabold leading-[0.9] tracking-normal text-atc-text"
-        >
-          {callsign}
-        </span>
-        {type && (
-          <span
-            translate="no"
-            className="notranslate justify-self-end text-right font-[var(--font-display)] text-[19px] font-extrabold leading-[0.9] tracking-normal text-atc-text"
-          >
-            {type}
-          </span>
-        )}
-      </div>
-      {(route || hasStats) && (
-        <div className="grid w-full max-w-full min-w-0 grid-cols-[minmax(0,1fr)_max-content] items-center gap-2">
-          {route ? (
-            <div
-              translate="no"
-              className="notranslate flex min-w-0 max-w-full items-center gap-2 whitespace-nowrap font-[var(--font-mono)] text-[10px] font-semibold leading-none tracking-[0.02em] text-atc-dim"
-            >
-              <AirlineLogo src={airlineIconUrl} />
-              <span className="overflow-hidden text-ellipsis text-atc-text">
-                {route}
+    <MobilePreviewContent>
+      <MobilePreviewIdentity
+        icon={Plane}
+        label={t("preview.aircraftPreview")}
+        primary={callsign}
+        secondary={type}
+        secondaryClassName="text-[20px] font-extrabold text-atc-text"
+      />
+      {(route || hasStats) ? (
+        <MobilePreviewRuleRow
+          left={
+            route ? (
+              <span className="inline-flex min-w-0 max-w-full items-center gap-[6px] align-baseline">
+                <AirlineLogo src={airlineIconUrl} />
+                <span className="min-w-0 truncate whitespace-nowrap">{route}</span>
               </span>
-            </div>
-          ) : (
-            <span aria-hidden="true" />
-          )}
-          {hasStats && (
-            <div className="flex min-w-0 max-w-full items-center justify-end overflow-visible whitespace-nowrap">
-              {stats.map((stat, i) => (
-                <span key={stat.key || i} className="flex items-baseline">
-                  {i > 0 && (
-                    <span
-                      aria-hidden="true"
-                      className="mx-[5px] font-[var(--font-mono)] text-[10px] text-atc-faint"
-                    >
-                      ·
-                    </span>
-                  )}
-                  {stat}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+            ) : null
+          }
+          right={
+            hasStats ? (
+              <MobilePreviewMetaChips>
+                {stats.map((stat, i) => (
+                  <MobilePreviewMetaChip key={stat.key || i}>
+                    {stat}
+                  </MobilePreviewMetaChip>
+                ))}
+              </MobilePreviewMetaChips>
+            ) : null
+          }
+        />
+      ) : null}
+    </MobilePreviewContent>
   );
 }
 
-// Single stat token — either a numeric NumberFlow + unit pair, or a
-// plain text token like "GND". Used by the parent's stats[] list so the
-// kt / ft / fpm rhythm renders the same way every time.
 function Stat({ value = 0, unit, plain, format }: StatProps) {
   return (
-    <span className="flex items-baseline gap-[2px]">
+    <>
       {plain != null ? (
-        <span className="font-[var(--font-mono)] text-[10px] font-medium tabular-nums text-atc-dim">
-          {plain}
-        </span>
+        <span className="tabular-nums">{plain}</span>
       ) : (
         <NumberFlow
           value={value}
           format={format}
-          className="font-[var(--font-mono)] text-[10px] font-medium tabular-nums text-atc-dim"
+          className="tabular-nums"
         />
       )}
       {unit && (
         <span
           translate="no"
-          className="notranslate font-[var(--font-mono)] text-[8px] font-medium lowercase text-atc-faint"
+          className="notranslate text-[8px] font-medium lowercase text-atc-faint"
         >
           {unit}
         </span>
       )}
-    </span>
+    </>
   );
 }

--- a/src/components/aircraft/preview/AirportPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AirportPreviewMobileCard.tsx
@@ -2,9 +2,16 @@
 
 import type { ComponentProps } from "react";
 import NumberFlow from "@number-flow/react";
-import { airportDisplayName } from "@/utils/airport";
+import { TowerControl } from "lucide-react";
+import { airportCityName, airportDisplayName } from "@/utils/airport";
+import { countryName, flagEmoji } from "@/utils/flag";
 import { toFiniteNumber } from "@/utils/math";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import {
+  MobilePreviewContent,
+  MobilePreviewDetailRow,
+  MobilePreviewIdentity,
+} from "./MobilePreviewCard";
 
 type NumberFlowFormat = ComponentProps<typeof NumberFlow>["format"];
 
@@ -29,79 +36,75 @@ type StatProps = {
   format?: NumberFlowFormat;
 };
 
-// Airport variant of the bottom-of-screen mobile preview card. The code stays
-// prominent, while the airport name and stats sit on one compact row so the
-// card keeps the same silhouette as other preview types.
+// Airport variant of the bottom-of-screen mobile preview card. The airport
+// type marker, code, long name, and location share the same mobile preview
+// structure used by aircraft and navaids.
 export default function AirportPreviewMobileCard({ airport }: AirportPreviewMobileCardProps) {
-  const { locale } = useI18n();
+  const { locale, t } = useI18n();
   const icao = (airport?.icao || "").trim().toUpperCase();
   const iata = (airport?.iata || "").trim().toUpperCase();
   const codeLine = iata && iata !== icao ? `${iata} · ${icao}` : icao || "—";
   const name = airportDisplayName(airport, locale);
+  const flag = flagEmoji(airport?.country);
+  const country = countryName(airport?.country, locale) || airport?.country || "";
+  const city = airportCityName(airport?.city, locale);
+  const placeText = [city, country].filter(Boolean).join(", ");
+  const placeLine = flag && placeText ? `${flag} ${placeText}` : placeText;
   const distance = toFiniteNumber(airport?.distanceNm);
   const elevation = toFiniteNumber(airport?.elevationFt);
   const hasStats = distance != null || elevation != null;
 
   return (
-    <div className="relative z-[2] box-border flex w-full items-baseline justify-between gap-[12px] px-[14px] pb-[8px] pt-[12px]">
-      <div className="airport-preview-mobile-card__summary flex min-w-0 max-w-full items-baseline gap-[8px] whitespace-nowrap">
-        <span
-          translate="no"
-          className="notranslate flex-none font-[var(--font-display)] text-[19px] font-extrabold leading-[0.9] tracking-normal text-atc-text"
-        >
-          {codeLine}
-        </span>
-        {name ? (
-          <span
-            translate="no"
-            className="notranslate min-w-0 overflow-hidden text-ellipsis font-[var(--font-mono)] text-[11px] font-semibold leading-none tracking-normal text-atc-dim"
-          >
-            {name}
-          </span>
-        ) : null}
-      </div>
-      {hasStats && (
-        <div className="airport-preview-mobile-card__stats flex flex-none items-baseline justify-end overflow-visible whitespace-nowrap">
-          {distance != null && (
-            <Stat
-              value={distance}
-              unit="NM"
-              format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
-            />
-          )}
-          {elevation != null && (
-            <>
-              {distance != null && (
-                <span
-                  aria-hidden="true"
-                  className="mx-[5px] font-[var(--font-mono)] text-[10px] text-atc-faint"
-                >
-                  ·
-                </span>
-              )}
-              <Stat value={Math.round(elevation)} unit="ft" />
-            </>
-          )}
-        </div>
-      )}
-    </div>
+    <MobilePreviewContent>
+      <MobilePreviewIdentity
+        icon={TowerControl}
+        label={t("preview.airportPreview")}
+        primary={codeLine}
+        secondary={
+          hasStats ? (
+            <span className="flex items-baseline justify-end gap-[10px]">
+              {distance != null ? (
+                <Stat
+                  value={distance}
+                  unit="NM"
+                  format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
+                />
+              ) : null}
+              {elevation != null ? (
+                <Stat value={Math.round(elevation)} unit="ft" />
+              ) : null}
+            </span>
+          ) : null
+        }
+      />
+      {name ? (
+        <MobilePreviewDetailRow wrap>
+          {name}
+        </MobilePreviewDetailRow>
+      ) : null}
+      {placeLine ? (
+        <MobilePreviewDetailRow wrap>
+          {placeLine}
+        </MobilePreviewDetailRow>
+      ) : null}
+    </MobilePreviewContent>
   );
 }
 
 function Stat({ value, unit, format }: StatProps) {
   return (
-    <span className="flex items-baseline gap-[2px]">
+    <>
       <NumberFlow
         value={value}
         format={format}
-        className="font-[var(--font-mono)] text-[10px] font-medium tabular-nums text-atc-dim"
+        className="tabular-nums"
       />
       <span
         translate="no"
-        className="notranslate font-[var(--font-mono)] text-[8px] font-medium lowercase text-atc-faint"
+        className="notranslate text-[8px] font-medium uppercase text-atc-faint"
       >
         {unit}
       </span>
-    </span>
+    </>
   );
 }

--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // Shared shell for the bottom-of-screen mobile preview card. Both the
@@ -29,10 +30,11 @@ export default function MobilePreviewCard({
       aria-label={ariaLabel}
       data-ui="mobile-preview-card"
       className={cn(
-        "fixed left-1/2 -translate-x-1/2 z-popover",
+        "fixed left-1/2 z-popover",
         "bottom-[calc(64px+env(safe-area-inset-bottom))]",
         "w-[min(342px,calc(100vw-24px))] max-w-[calc(100vw-24px)]",
         "isolate overflow-hidden select-none pointer-events-none",
+        "mobile-preview-card-enter",
         "rounded-[var(--atc-radius-card)] border border-atc-line-strong/85 text-atc-text",
         // Solid card under a warm top-left gradient layer (same 135deg
         // language as the sidebar identity surface). Use background +
@@ -82,6 +84,154 @@ export function MobilePreviewActions({ children }: Record<string, any>) {
     <div className="pointer-events-auto mx-[14px] flex flex-col items-stretch gap-1">
       {children}
     </div>
+  );
+}
+
+export function MobilePreviewContent({ children }: React.PropsWithChildren) {
+  return (
+    <div className="relative z-[2] box-border flex w-full flex-col items-stretch gap-[6px] px-[14px] pb-[7px] pt-[10px]">
+      {children}
+    </div>
+  );
+}
+
+export function MobilePreviewEntityHeader({
+  icon: Icon,
+  label,
+  children,
+}: React.PropsWithChildren<{ icon: LucideIcon; label: string }>) {
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-3">
+      <span
+        aria-label={label}
+        title={label}
+        className="grid size-[18px] flex-none place-items-center text-atc-dim"
+      >
+        <Icon aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+      </span>
+      {children ? (
+        <div className="flex min-w-0 max-w-[62%] items-center justify-end">
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function MobilePreviewIdentity({
+  icon: Icon,
+  label,
+  primary,
+  secondary = null,
+  secondaryClassName,
+}: {
+  icon: LucideIcon;
+  label: string;
+  primary: React.ReactNode;
+  secondary?: React.ReactNode;
+  secondaryClassName?: string;
+}) {
+  return (
+    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-end gap-2">
+      <div className="flex min-w-0 items-end gap-[6px]">
+        <span
+          aria-label={label}
+          title={label}
+          className="mb-[1px] grid size-[18px] flex-none place-items-center text-atc-dim"
+        >
+          <Icon aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+        </span>
+        <span
+          translate="no"
+          className="notranslate min-w-0 truncate whitespace-nowrap font-[var(--font-mono)] text-[20px] font-extrabold leading-none tracking-normal text-atc-text"
+        >
+          {primary}
+        </span>
+      </div>
+      {secondary ? (
+        <span
+          translate="no"
+          className={cn(
+            "notranslate max-w-[122px] truncate whitespace-nowrap text-right font-[var(--font-mono)] text-[10px] font-semibold leading-none tracking-normal text-atc-dim",
+            secondaryClassName,
+          )}
+        >
+          {secondary}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function MobilePreviewDetailRow({
+  wrap = false,
+  children,
+}: React.PropsWithChildren<{ wrap?: boolean }>) {
+  return (
+    <div className="flex min-w-0 items-baseline justify-end font-[var(--font-mono)]">
+      <span
+        translate="no"
+        className={cn(
+          "notranslate min-w-0 text-right text-[10px] font-medium leading-tight tracking-normal text-atc-dim",
+          wrap ? "whitespace-normal break-words" : "truncate whitespace-nowrap",
+        )}
+      >
+        {children}
+      </span>
+    </div>
+  );
+}
+
+export function MobilePreviewRuleRow({
+  left = null,
+  right = null,
+}: {
+  left?: React.ReactNode;
+  right?: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 items-baseline justify-between gap-3 border-t border-atc-line pt-[5px] font-[var(--font-mono)]">
+      <div className="min-w-0 flex-1 overflow-hidden whitespace-nowrap text-left text-[11px] font-semibold leading-none tracking-normal text-atc-text">
+        {left}
+      </div>
+      <div className="flex min-w-0 shrink-0 items-baseline justify-end gap-[10px] overflow-hidden whitespace-nowrap text-right text-[11px] font-semibold leading-none tracking-normal text-atc-text">
+        {right}
+      </div>
+    </div>
+  );
+}
+
+export function MobilePreviewMetaChips({ children }: React.PropsWithChildren) {
+  return (
+    <dl className="flex min-w-0 items-baseline gap-[10px]">
+      {children}
+    </dl>
+  );
+}
+
+export function MobilePreviewMetaChip({
+  children,
+}: React.PropsWithChildren) {
+  return (
+    <div className="flex min-w-0">
+      <dd
+        translate="no"
+        className="notranslate flex min-w-0 items-baseline gap-[2px] overflow-hidden whitespace-nowrap"
+      >
+        {children}
+      </dd>
+    </div>
+  );
+}
+
+export function MobilePreviewHeaderValue({ children }: React.PropsWithChildren) {
+  return (
+    <span
+      translate="no"
+      className="notranslate min-w-0 truncate whitespace-nowrap text-right font-[var(--font-mono)] text-[10px] font-semibold leading-none tracking-normal text-atc-dim"
+    >
+      {children}
+    </span>
   );
 }
 

--- a/src/components/aircraft/preview/NavaidPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/NavaidPreviewMobileCard.tsx
@@ -1,8 +1,17 @@
 "use client";
 
 import NumberFlow from "@number-flow/react";
+import { RadioTower } from "lucide-react";
 import { toFiniteNumber } from "@/utils/math";
 import { formatNavaidFrequency } from "./navaidPreviewFormat";
+import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import {
+  MobilePreviewContent,
+  MobilePreviewIdentity,
+  MobilePreviewMetaChip,
+  MobilePreviewMetaChips,
+  MobilePreviewRuleRow,
+} from "./MobilePreviewCard";
 
 type NavaidPreviewMobileCardProps = {
   navaid?: Record<string, any> | null;
@@ -11,71 +20,52 @@ type NavaidPreviewMobileCardProps = {
 export default function NavaidPreviewMobileCard({
   navaid,
 }: NavaidPreviewMobileCardProps) {
+  const { t } = useI18n();
   const ident = String(navaid?.ident || "").trim().toUpperCase() || "—";
   const type = String(navaid?.type || "").trim().toUpperCase();
   const name = String(navaid?.name || ident).trim();
   const distance = toFiniteNumber(navaid?.distanceNm);
   const frequency = formatNavaidFrequency(navaid?.frequencyKhz);
   const dmeChannel = String(navaid?.dme?.channel || "").trim();
-  const hasStats = Boolean(type || distance != null || frequency || dmeChannel);
+  const hasStats = Boolean(distance != null || frequency || dmeChannel);
 
   return (
-    <div className="relative z-[2] box-border flex w-full items-baseline justify-between gap-[12px] px-[14px] pb-[8px] pt-[12px]">
-      <div className="navaid-preview-mobile-card__summary flex min-w-0 max-w-full items-baseline gap-[8px] whitespace-nowrap">
-        <span
-          translate="no"
-          className="notranslate flex-none font-[var(--font-display)] text-[19px] font-extrabold leading-[0.9] tracking-normal text-atc-text"
-        >
-          {ident}
-        </span>
-        {name ? (
-          <span
-            translate="no"
-            className="notranslate min-w-0 overflow-hidden text-ellipsis font-[var(--font-mono)] text-[11px] font-semibold leading-none tracking-normal text-atc-dim"
-          >
-            {name}
-          </span>
-        ) : null}
-      </div>
-      {hasStats ? (
-        <div className="navaid-preview-mobile-card__stats flex flex-none items-baseline justify-end overflow-visible whitespace-nowrap">
-          {type ? <Stat plain={type} /> : null}
-          {distance != null ? (
-            <>
-              {type ? <Separator /> : null}
-              <Stat
-                value={distance}
-                unit="NM"
-                format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
-              />
-            </>
-          ) : null}
-          {frequency ? (
-            <>
-              {type || distance != null ? <Separator /> : null}
-              <Stat plain={frequency} />
-            </>
-          ) : null}
-          {dmeChannel ? (
-            <>
-              {type || distance != null || frequency ? <Separator /> : null}
-              <Stat plain={dmeChannel} />
-            </>
-          ) : null}
-        </div>
+    <MobilePreviewContent>
+      <MobilePreviewIdentity
+        icon={RadioTower}
+        label={t("preview.navaidPreview")}
+        primary={ident}
+        secondary={type}
+      />
+      {(name || hasStats) ? (
+        <MobilePreviewRuleRow
+          left={name ? <span className="block min-w-0 truncate whitespace-nowrap">{name}</span> : null}
+          right={
+            <MobilePreviewMetaChips>
+              {frequency ? (
+                <MobilePreviewMetaChip>
+                  <Stat plain={frequency} />
+                </MobilePreviewMetaChip>
+              ) : null}
+              {distance != null ? (
+                <MobilePreviewMetaChip>
+                  <Stat
+                    value={distance}
+                    unit="NM"
+                    format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
+                  />
+                </MobilePreviewMetaChip>
+              ) : null}
+              {dmeChannel ? (
+                <MobilePreviewMetaChip>
+                  <Stat plain={dmeChannel} />
+                </MobilePreviewMetaChip>
+              ) : null}
+            </MobilePreviewMetaChips>
+          }
+        />
       ) : null}
-    </div>
-  );
-}
-
-function Separator() {
-  return (
-    <span
-      aria-hidden="true"
-      className="mx-[5px] font-[var(--font-mono)] text-[10px] text-atc-faint"
-    >
-      ·
-    </span>
+    </MobilePreviewContent>
   );
 }
 
@@ -87,25 +77,25 @@ function Stat({
 }: Record<string, any>) {
   if (plain) {
     return (
-      <span className="notranslate font-[var(--font-mono)] text-[10px] font-medium tabular-nums text-atc-dim">
+      <span className="notranslate tabular-nums">
         {plain}
       </span>
     );
   }
 
   return (
-    <span className="flex items-baseline gap-[2px]">
+    <>
       <NumberFlow
         value={value}
         format={format}
-        className="font-[var(--font-mono)] text-[10px] font-medium tabular-nums text-atc-dim"
+        className="tabular-nums"
       />
       <span
         translate="no"
-        className="notranslate font-[var(--font-mono)] text-[8px] font-medium uppercase text-atc-faint"
+        className="notranslate text-[8px] font-medium uppercase text-atc-faint"
       >
         {unit}
       </span>
-    </span>
+    </>
   );
 }

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -165,6 +165,7 @@ const en = {
     aircraftPreview: "Aircraft",
     airportPreview: "Airport",
     navaidPreview: "Navaid",
+    aircraftRoute: "Route",
     navaidType: "Type",
     navaidName: "Name",
     airportName: "Name",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -161,6 +161,7 @@ const zhCN = {
     aircraftPreview: "飞机",
     airportPreview: "机场",
     navaidPreview: "导航台",
+    aircraftRoute: "航路",
     navaidType: "类型",
     navaidName: "名称",
     airportName: "名称",

--- a/src/style.css
+++ b/src/style.css
@@ -101,8 +101,25 @@
     animation: nearby-row-enter 240ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
 }
 
+@keyframes mobile-preview-card-enter {
+    from {
+        opacity: 0;
+        transform: translate(-50%, 10px);
+    }
+    to {
+        opacity: 1;
+        transform: translate(-50%, 0);
+    }
+}
+
+.mobile-preview-card-enter {
+    transform: translate(-50%, 0);
+    animation: mobile-preview-card-enter 260ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
 @media (prefers-reduced-motion: reduce) {
-    .nearby-row-enter {
+    .nearby-row-enter,
+    .mobile-preview-card-enter {
         animation: none;
     }
 }


### PR DESCRIPTION
## Summary
- align mobile airport, aircraft, and navaid preview cards with the desktop preview-card visual language
- use icon-only entity cues, tighter labels, compact single-line metric values, and wrapping only for long name/place fields
- update source-level preview-card assertions and add the route label translation

## Verification
- pnpm test
- pnpm lint (passes with existing TanStack Virtual React Compiler warning)
- pnpm build
- in-app browser mobile checks on localhost: KBOS airport, selected aircraft, and navaid preview cards