### PR TITLE
[codex] Animate airspace overlay toggles

### DIFF
--- a/src/components/map/AirspaceLayer.tsx
+++ b/src/components/map/AirspaceLayer.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, type MutableRefObject } from "react";
 import L from "leaflet";
 import { AIRPORT_MAP_PANES } from "@/config/airportMap";
 import {
+  buildAirspaceOverlayAnimationPlan,
   buildAirspaceOverlayFeatures,
   resolveAirspaceOverlayFocusStyle,
   resolveAirspaceOverlayStyle,
@@ -38,32 +39,42 @@ export default function AirspaceLayer({
   onSelectAirspace?: ((airspaceId: string) => void) | null;
 }) {
   const map = useMapInstance();
-  const layerRef = useRef(null);
+  const layerRef = useRef<L.GeoJSON | null>(null);
+  const boundaryLabelsRef = useRef<SVGTextElement[]>([]);
+  const labelFrameRef = useRef(0);
+  const animationFrameRef = useRef(0);
+  const selectedAirspaceIdRef = useRef(selectedAirspaceId);
+  const visibleRef = useRef(visible);
   const onSelectRef = useRef(onSelectAirspace);
   onSelectRef.current = onSelectAirspace;
+  selectedAirspaceIdRef.current = selectedAirspaceId;
+  visibleRef.current = visible;
   const features = useMemo(
     () => buildAirspaceOverlayFeatures(airspaces),
     [airspaces],
   );
 
   useEffect(() => {
-    if (!map || !visible || features.length === 0) return undefined;
+    if (!map || features.length === 0) return undefined;
 
+    cancelAirspaceAnimation(animationFrameRef);
+    window.cancelAnimationFrame(labelFrameRef.current);
+    boundaryLabelsRef.current.forEach((label) => label.remove());
+    boundaryLabelsRef.current = [];
     safeRemoveFromMap(layerRef.current, map);
     const boundaryLabels: SVGTextElement[] = [];
-    let labelFrame = 0;
     const airspacePane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.airspace);
     const paneElement = map.getPane(airspacePane);
-    if (paneElement) paneElement.style.pointerEvents = "auto";
+    if (paneElement) paneElement.style.pointerEvents = visibleRef.current ? "auto" : "none";
     const polygonLayer = L.geoJSON(features as any, {
       interactive: Boolean(onSelectRef.current),
       pane: airspacePane,
       style(feature) {
-        const style = resolveAirspaceOverlayStyle(feature as any);
-        if (selectedAirspaceId && feature?.properties?.id === selectedAirspaceId) {
-          return resolveAirspaceOverlayFocusStyle(feature as any);
-        }
-        return style;
+        return resolveVisibleAirspaceStyle(
+          feature as any,
+          selectedAirspaceIdRef.current,
+          visibleRef.current ? 1 : 0,
+        );
       },
       onEachFeature(feature, featureLayer) {
         featureLayer.on("click", (event) => {
@@ -77,28 +88,222 @@ export default function AirspaceLayer({
     const added = safeAddToMap(polygonLayer, map, { label: "AirspaceLayer" });
     if (!added) return undefined;
     layerRef.current = polygonLayer;
-    labelFrame = window.requestAnimationFrame(() => {
-      boundaryLabels.push(...attachBoundaryLabels(polygonLayer, selectedAirspaceId));
+    applyAirspaceGroupOpacity(
+      polygonLayer,
+      boundaryLabels,
+      selectedAirspaceIdRef.current,
+      visibleRef.current ? 1 : 0,
+    );
+    labelFrameRef.current = window.requestAnimationFrame(() => {
+      boundaryLabels.push(
+        ...attachBoundaryLabels(
+          polygonLayer,
+          selectedAirspaceIdRef.current,
+          visibleRef.current ? 1 : 0,
+        ),
+      );
+      boundaryLabelsRef.current = boundaryLabels;
     });
 
     return () => {
-      window.cancelAnimationFrame(labelFrame);
+      cancelAirspaceAnimation(animationFrameRef);
+      window.cancelAnimationFrame(labelFrameRef.current);
       boundaryLabels.forEach((label) => label.remove());
+      boundaryLabelsRef.current = [];
       safeRemoveFromMap(polygonLayer, map);
       layerRef.current = null;
     };
-  }, [map, features, selectedAirspaceId, visible]);
+  }, [map, features]);
+
+  useEffect(() => {
+    const polygonLayer = layerRef.current;
+    if (!map || !polygonLayer) return;
+
+    const airspacePane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.airspace);
+    const paneElement = map.getPane(airspacePane);
+    if (paneElement) paneElement.style.pointerEvents = visible ? "auto" : "none";
+
+    animateAirspaceGroupOpacity({
+      layerGroup: polygonLayer,
+      labels: boundaryLabelsRef.current,
+      selectedAirspaceId,
+      visible,
+      animationFrameRef,
+    });
+  }, [map, selectedAirspaceId, visible]);
 
   return null;
+}
+
+function resolveVisibleAirspaceStyle(
+  feature: Record<string, any>,
+  selectedAirspaceId: string,
+  opacityScale: number,
+) {
+  const style =
+    selectedAirspaceId && feature?.properties?.id === selectedAirspaceId
+      ? resolveAirspaceOverlayFocusStyle(feature)
+      : resolveAirspaceOverlayStyle(feature);
+  return {
+    ...style,
+    fillOpacity: Number(style.fillOpacity || 0) * opacityScale,
+    opacity: Number(style.opacity || 0) * opacityScale,
+  };
+}
+
+function animateAirspaceGroupOpacity({
+  layerGroup,
+  labels,
+  selectedAirspaceId,
+  visible,
+  animationFrameRef,
+}: {
+  layerGroup: L.GeoJSON;
+  labels: SVGTextElement[];
+  selectedAirspaceId: string;
+  visible: boolean;
+  animationFrameRef: MutableRefObject<number>;
+}) {
+  cancelAirspaceAnimation(animationFrameRef);
+
+  const layers = getAirspaceFeatureLayers(layerGroup);
+  const reducedMotion = prefersReducedMotion();
+  const plan = buildAirspaceOverlayAnimationPlan(
+    layers,
+    visible ? "enter" : "exit",
+    { reducedMotion },
+  );
+
+  if (reducedMotion || plan.itemDurationMs === 0) {
+    applyAirspaceGroupOpacity(layerGroup, labels, selectedAirspaceId, visible ? 1 : 0);
+    return;
+  }
+
+  const labelGroups = groupLabelsByLayerIndex(labels);
+  const startedAt = window.performance.now();
+  const targetOpacity = visible ? 1 : 0;
+  const animations = plan.steps.map((step) => {
+    const layer = layers[step.index];
+    return {
+      layer,
+      labels: labelGroups.get(step.index) || [],
+      delayMs: step.delayMs,
+      fromOpacity: readAirspaceLayerOpacityScale(layer, visible ? 0 : 1),
+    };
+  });
+
+  const tick = (now: number) => {
+    let complete = true;
+    for (const animation of animations) {
+      const elapsed = now - startedAt - animation.delayMs;
+      if (elapsed < 0) {
+        complete = false;
+        continue;
+      }
+
+      const progress = Math.min(1, elapsed / plan.itemDurationMs);
+      const opacityScale =
+        animation.fromOpacity +
+        (targetOpacity - animation.fromOpacity) * easeOutQuart(progress);
+      applyAirspaceFeatureOpacity(
+        animation.layer,
+        animation.labels,
+        selectedAirspaceId,
+        opacityScale,
+      );
+      if (progress < 1) complete = false;
+    }
+
+    if (complete) {
+      applyAirspaceGroupOpacity(layerGroup, labels, selectedAirspaceId, targetOpacity);
+      animationFrameRef.current = 0;
+      return;
+    }
+
+    animationFrameRef.current = window.requestAnimationFrame(tick);
+  };
+
+  animationFrameRef.current = window.requestAnimationFrame(tick);
+}
+
+function applyAirspaceGroupOpacity(
+  layerGroup: L.GeoJSON,
+  labels: SVGTextElement[],
+  selectedAirspaceId: string,
+  opacityScale: number,
+) {
+  const labelGroups = groupLabelsByLayerIndex(labels);
+  getAirspaceFeatureLayers(layerGroup).forEach((layer, index) => {
+    applyAirspaceFeatureOpacity(
+      layer,
+      labelGroups.get(index) || [],
+      selectedAirspaceId,
+      opacityScale,
+    );
+  });
+}
+
+function applyAirspaceFeatureOpacity(
+  layer: any,
+  labels: SVGTextElement[],
+  selectedAirspaceId: string,
+  opacityScale: number,
+) {
+  if (typeof layer?.setStyle === "function") {
+    layer.setStyle(resolveVisibleAirspaceStyle(layer.feature, selectedAirspaceId, opacityScale));
+  }
+  layer.__airspaceOpacityScale = opacityScale;
+  labels.forEach((label) => setBoundaryLabelState(label, selectedAirspaceId, opacityScale));
+}
+
+function getAirspaceFeatureLayers(layerGroup: L.GeoJSON) {
+  const layers: any[] = [];
+  layerGroup.eachLayer((layer: any) => layers.push(layer));
+  return layers;
+}
+
+function groupLabelsByLayerIndex(labels: SVGTextElement[]) {
+  const groups = new Map<number, SVGTextElement[]>();
+  labels.forEach((label) => {
+    const index = Number(label.dataset.airspaceLayerIndex);
+    if (!Number.isInteger(index)) return;
+    const group = groups.get(index) || [];
+    group.push(label);
+    groups.set(index, group);
+  });
+  return groups;
+}
+
+function readAirspaceLayerOpacityScale(layer: any, fallback: number) {
+  const value = Number(layer?.__airspaceOpacityScale);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function cancelAirspaceAnimation(animationFrameRef: MutableRefObject<number>) {
+  if (!animationFrameRef.current) return;
+  window.cancelAnimationFrame(animationFrameRef.current);
+  animationFrameRef.current = 0;
+}
+
+function easeOutQuart(value: number) {
+  return 1 - Math.pow(1 - value, 4);
+}
+
+function prefersReducedMotion() {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
 }
 
 function attachBoundaryLabels(
   layerGroup: L.GeoJSON,
   selectedAirspaceId = "",
+  opacityScale = 1,
 ): SVGTextElement[] {
   const labels: SVGTextElement[] = [];
 
+  let layerIndex = 0;
   layerGroup.eachLayer((layer: any) => {
+    const currentLayerIndex = layerIndex;
+    layerIndex += 1;
     const path = typeof layer.getElement === "function"
       ? layer.getElement()
       : null;
@@ -112,10 +317,6 @@ function attachBoundaryLabels(
 
     const lines = boundaryLabelLines(layer.feature?.properties || {}, path, pathLength);
     if (lines.length === 0) return;
-    const isFocused =
-      Boolean(selectedAirspaceId) &&
-      String(layer.feature?.properties?.id || "") === selectedAirspaceId;
-
     const pathId = path.id || `airspace-boundary-${boundaryLabelSequence += 1}`;
     path.id = pathId;
 
@@ -124,9 +325,10 @@ function attachBoundaryLabels(
       BOUNDARY_LABEL_OFFSETS_BY_COUNT[4];
     lines.forEach((line, index) => {
       const label = document.createElementNS(SVG_NS, "text");
+      label.dataset.airspaceLayerIndex = String(currentLayerIndex);
+      label.dataset.airspaceFeatureId = String(layer.feature?.properties?.id || "");
       label.classList.add("airspace-boundary-label");
-      if (isFocused) label.classList.add("airspace-boundary-label--focused");
-      label.setAttribute("opacity", isFocused ? "1" : "0.5");
+      setBoundaryLabelState(label, selectedAirspaceId, opacityScale);
       label.setAttribute("dy", String(lineOffsets[index] || 0));
       const textPath = document.createElementNS(SVG_NS, "textPath");
       textPath.setAttribute("href", `#${pathId}`);
@@ -141,6 +343,18 @@ function attachBoundaryLabels(
   });
 
   return labels;
+}
+
+function setBoundaryLabelState(
+  label: SVGTextElement,
+  selectedAirspaceId: string,
+  opacityScale: number,
+) {
+  const isFocused =
+    Boolean(selectedAirspaceId) &&
+    label.dataset.airspaceFeatureId === selectedAirspaceId;
+  label.classList.toggle("airspace-boundary-label--focused", isFocused);
+  label.style.opacity = String((isFocused ? 1 : 0.5) * opacityScale);
 }
 
 function boundaryLabelLines(

--- a/src/features/airport/map/airspaceOverlayModel.test.ts
+++ b/src/features/airport/map/airspaceOverlayModel.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  buildAirspaceOverlayAnimationPlan,
   buildAirspaceOverlayFeatures,
   resolveAirspaceOverlayFocusStyle,
   resolveAirspaceOverlayStyle,
@@ -82,6 +83,40 @@ const polygon = {
 
   assert.equal(orderedFeatures[0].properties.id, "large");
   assert.equal(orderedFeatures[1].properties.id, "small");
+}
+
+{
+  const enterPlan = buildAirspaceOverlayAnimationPlan([{}, {}, {}], "enter");
+  assert.deepEqual(
+    enterPlan.steps.map((step) => [step.index, step.delayMs]),
+    [
+      [0, 0],
+      [1, 32],
+      [2, 64],
+    ],
+  );
+  assert.equal(enterPlan.itemDurationMs, 220);
+
+  const exitPlan = buildAirspaceOverlayAnimationPlan([{}, {}, {}], "exit");
+  assert.deepEqual(
+    exitPlan.steps.map((step) => [step.index, step.delayMs]),
+    [
+      [2, 0],
+      [1, 32],
+      [0, 64],
+    ],
+  );
+
+  const densePlan = buildAirspaceOverlayAnimationPlan(Array.from({ length: 80 }), "enter");
+  assert.equal(Math.max(...densePlan.steps.map((step) => step.delayMs)), 420);
+  assert.equal(densePlan.totalDurationMs, 640);
+
+  const reducedPlan = buildAirspaceOverlayAnimationPlan([{}, {}], "enter", {
+    reducedMotion: true,
+  });
+  assert.equal(reducedPlan.itemDurationMs, 0);
+  assert.equal(reducedPlan.totalDurationMs, 0);
+  assert.deepEqual(reducedPlan.steps.map((step) => step.delayMs), [0, 0]);
 }
 
 {

--- a/src/features/airport/map/airspaceOverlayModel.ts
+++ b/src/features/airport/map/airspaceOverlayModel.ts
@@ -1,4 +1,5 @@
 type AirspaceOverlayRecord = Record<string, any>;
+type AirspaceOverlayAnimationPhase = "enter" | "exit";
 
 type AirspaceOverlayFeature = {
   type: "Feature";
@@ -15,6 +16,12 @@ type AirspaceOverlayFeature = {
     verticalLimit: string;
     source: string;
   };
+};
+
+const AIRSPACE_OVERLAY_ANIMATION = {
+  itemDurationMs: 220,
+  staggerMs: 32,
+  maxDelayMs: 420,
 };
 
 const TOKEN_BY_LEVEL: Record<string, string> = {
@@ -71,6 +78,39 @@ export function buildAirspaceOverlayFeatures(
   }).sort(
     (a, b) => approximateGeometryBoundsArea(b.geometry) - approximateGeometryBoundsArea(a.geometry),
   );
+}
+
+export function buildAirspaceOverlayAnimationPlan(
+  items: readonly unknown[] = [],
+  phase: AirspaceOverlayAnimationPhase,
+  options: { reducedMotion?: boolean } = {},
+) {
+  const count = items.length;
+  const indexes = Array.from({ length: count }, (_, index) => index);
+  const orderedIndexes = phase === "exit" ? indexes.reverse() : indexes;
+
+  if (options.reducedMotion || count === 0) {
+    return {
+      itemDurationMs: 0,
+      totalDurationMs: 0,
+      steps: orderedIndexes.map((index) => ({ index, delayMs: 0 })),
+    };
+  }
+
+  const maxDelayMs = Math.min(
+    AIRSPACE_OVERLAY_ANIMATION.maxDelayMs,
+    Math.max(0, (count - 1) * AIRSPACE_OVERLAY_ANIMATION.staggerMs),
+  );
+  const staggerMs = count <= 1 ? 0 : maxDelayMs / (count - 1);
+
+  return {
+    itemDurationMs: AIRSPACE_OVERLAY_ANIMATION.itemDurationMs,
+    totalDurationMs: Math.round(maxDelayMs + AIRSPACE_OVERLAY_ANIMATION.itemDurationMs),
+    steps: orderedIndexes.map((index, order) => ({
+      index,
+      delayMs: Math.round(order * staggerMs),
+    })),
+  };
 }
 
 function approximateGeometryBoundsArea(geometry: AirspaceOverlayRecord = {}) {


### PR DESCRIPTION
## Summary
- Add a staggered fade plan for airspace overlay enter and exit states.
- Keep the Leaflet airspace layer mounted while toggling so polygons and boundary labels animate together.
- Respect reduced-motion and disable airspace pointer events after the fade-out completes.

## Test Plan
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm lint
- Browser verified on http://localhost:3000/airport/KSFO?locale=zh-CN that airspace polygons and boundary labels fade together.