### PR TITLE
Normalize aircraft type displays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/aircraft/preview/AircraftPreviewIdentity.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewIdentity.tsx
@@ -3,6 +3,7 @@
 import AirlineLogo from "./AirlineLogo";
 import AircraftPreviewType from "./AircraftPreviewType";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { getAircraftPreviewTypeDisplay } from "@/features/aircraft/preview/aircraftPreviewTypeModel";
 import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay";
 
 // Callsign + parsed route. Mirrors the sidebar row's identity cell so the
@@ -13,34 +14,54 @@ export default function AircraftPreviewIdentity({ aircraft }) {
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
   const route = aircraft?.flightRouteLabel || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
-
-  const routeBase =
-    "inline-flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-atc-dim md:gap-[5px] md:text-[9px]";
+  const typeDisplay = getAircraftPreviewTypeDisplay(aircraft);
 
   return (
     <div className="mb-2.5 flex flex-col gap-1 md:mb-2 md:gap-[3px]">
       <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_max-content] items-start gap-x-[14px] md:gap-x-[11px]">
         <span
-          className="notranslate min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[22px] font-extrabold italic leading-none text-atc-text md:text-[18px]"
+          className="notranslate min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[22px] font-extrabold leading-none text-atc-text md:text-[18px]"
           translate="no"
+          title={callsign}
         >
           {callsign}
         </span>
         <AircraftPreviewType aircraft={aircraft} />
       </div>
-      {route ? (
-        <span className={`notranslate tracking-[0.04em] ${routeBase}`} translate="no">
-          <AirlineLogo
-            src={airlineIconUrl}
-            className="h-4 w-[26px] flex-none rounded-[2px] bg-[#f5f3ee] object-contain px-[2px] py-[1px] md:h-[13px] md:w-[21px]"
-          />
-          {route}
+      <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_minmax(84px,156px)] items-center gap-x-[14px] md:grid-cols-[minmax(0,1fr)_minmax(74px,132px)] md:gap-x-[11px]">
+        {route ? (
+          <span
+            className="notranslate inline-flex min-w-0 items-center gap-1.5 overflow-hidden font-mono text-[11px] tracking-[0.04em] text-atc-dim md:gap-[5px] md:text-[9px]"
+            translate="no"
+            title={route}
+          >
+            <AirlineLogo
+              src={airlineIconUrl}
+              className="h-4 w-[26px] flex-none rounded-[2px] bg-[#f5f3ee] object-contain px-[2px] py-[1px] md:h-[13px] md:w-[21px]"
+            />
+            <span className="min-w-0 truncate">{route}</span>
+          </span>
+        ) : (
+          <span className="min-w-0 truncate font-mono text-[11px] italic tracking-[0.02em] text-atc-faint md:text-[9px]">
+            {t("aircraft.noRoute")}
+          </span>
+        )}
+        <span className="notranslate flex min-w-0 items-center justify-end gap-1.5 text-right font-mono text-[10px] font-semibold uppercase tracking-normal text-atc-faint md:text-[8px]" translate="no">
+          {typeDisplay.secondary ? (
+            <span className="min-w-0 truncate" title={typeDisplay.secondary}>
+              {typeDisplay.secondary}
+            </span>
+          ) : null}
+          {typeDisplay.category ? (
+            <span
+              className="flex-none rounded-[3px] border border-atc-line px-1 py-[1px] text-[9px] leading-none text-atc-dim md:text-[7px]"
+              title={typeDisplay.category}
+            >
+              {typeDisplay.category}
+            </span>
+          ) : null}
         </span>
-      ) : (
-        <span className={`italic tracking-[0.02em] text-atc-faint ${routeBase}`}>
-          {t("aircraft.noRoute")}
-        </span>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -8,6 +8,7 @@ import { Plane } from "lucide-react";
 import { toFiniteNumber } from "@/utils/math";
 import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { resolveAircraftDisplayModel } from "@/features/aircraft/aircraftTypeDisplayModel";
 import {
   MobilePreviewContent,
   MobilePreviewDetailRow,
@@ -23,6 +24,8 @@ type AircraftPreviewMobileCardAircraft = {
   callsign?: string | null;
   icao24?: string | null;
   type?: string | null;
+  desc?: string | null;
+  category?: string | null;
   flightRouteLabel?: string | null;
   flightRoute?: unknown;
   velocity?: unknown;
@@ -67,7 +70,20 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
   const { t } = useI18n();
   const callsign =
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
-  const type = (aircraft?.type || "").trim().toUpperCase();
+  const typeDisplay = resolveAircraftDisplayModel(aircraft || {});
+  const secondary =
+    typeDisplay.displayName === "N/A"
+      ? null
+      : (
+          <span className="inline-flex min-w-0 max-w-full items-center justify-end gap-1.5">
+            <span className="min-w-0 truncate">{typeDisplay.displayName}</span>
+            {typeDisplay.category ? (
+              <span className="flex-none rounded-[3px] border border-atc-line px-1 py-[1px] text-[9px] font-semibold leading-none text-atc-dim">
+                {typeDisplay.category}
+              </span>
+            ) : null}
+          </span>
+        );
   const route = aircraft?.flightRouteLabel || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
 
@@ -110,8 +126,8 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
         icon={Plane}
         label={t("preview.aircraftPreview")}
         primary={callsign}
-        secondary={type}
-        secondaryClassName="text-[20px] font-extrabold text-atc-text"
+        secondary={secondary}
+        secondaryClassName="max-w-[min(50vw,220px)] text-[15px] font-extrabold text-atc-text"
       />
       {(route || hasStats) ? (
         <MobilePreviewRuleRow

--- a/src/components/aircraft/preview/AircraftPreviewType.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewType.tsx
@@ -6,24 +6,15 @@ import { getAircraftPreviewTypeDisplay } from "@/features/aircraft/preview/aircr
 // silhouette in the card header. Falls back gracefully when one or both
 // fields are missing — the row stays the same height either way.
 export default function AircraftPreviewType({ aircraft }) {
-  const { primary, secondary } = getAircraftPreviewTypeDisplay(aircraft);
+  const { primary } = getAircraftPreviewTypeDisplay(aircraft);
 
   return (
-    <div className="flex w-max min-w-0 flex-col items-end gap-0.5 text-right">
-      <div
-        className="notranslate whitespace-nowrap font-mono text-[22px] font-extrabold italic leading-none text-atc-text md:text-[18px]"
-        translate="no"
-      >
-        {primary}
-      </div>
-      {secondary && (
-        <div
-          className="notranslate font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-atc-faint md:text-[8px]"
-          translate="no"
-        >
-          {secondary}
-        </div>
-      )}
+    <div
+      className="notranslate min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-right font-mono text-[18px] font-extrabold leading-none text-atc-text md:text-[15px]"
+      translate="no"
+      title={primary}
+    >
+      {primary}
     </div>
   );
 }

--- a/src/components/changelog/ChangelogPanel.tsx
+++ b/src/components/changelog/ChangelogPanel.tsx
@@ -10,6 +10,17 @@ import { CHANGELOG } from "@/config/changelog";
 // optional current marker, summary, then short highlights.
 
 const CHINESE_RELEASE_COPY = {
+  "v1.8.1": {
+    title: "机型名称与空域初始动画",
+    summary:
+      "飞机预览和筛选现在优先显示更容易识别的机型名称,默认开启的空域图层也会在首次加载时依次淡入。",
+    highlights: [
+      "飞机预览卡显示友好的机型名称,ICAO 机型码降为辅助信息",
+      "机型筛选共用同一套机型解析逻辑,搜索同时匹配友好名称和 ICAO 码",
+      "只有 A1/A2/A3 分类、没有具体机型的数据会显示为 Unknown,筛选中归为 All Unclassified",
+      "默认开启空域图层时,首次加载完成也会播放分层淡入动画",
+    ],
+  },
   "v1.8.0": {
     title: "机场空域图层",
     summary:

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -407,6 +407,7 @@ function FlightExplorerContent({ callsign }) {
     () =>
       JSON.stringify({
         type: enrichedTrackedAircraft?.type || "",
+        desc: enrichedTrackedAircraft?.desc || "",
         category: enrichedTrackedAircraft?.category || "",
         origin: enrichedTrackedAircraft?.origin || "",
         destination: enrichedTrackedAircraft?.destination || "",
@@ -415,6 +416,7 @@ function FlightExplorerContent({ callsign }) {
       }),
     [
       enrichedTrackedAircraft?.type,
+      enrichedTrackedAircraft?.desc,
       enrichedTrackedAircraft?.category,
       enrichedTrackedAircraft?.origin,
       enrichedTrackedAircraft?.destination,

--- a/src/components/map/AirspaceLayer.tsx
+++ b/src/components/map/AirspaceLayer.tsx
@@ -6,6 +6,7 @@ import { AIRPORT_MAP_PANES } from "@/config/airportMap";
 import {
   buildAirspaceOverlayAnimationPlan,
   buildAirspaceOverlayFeatures,
+  resolveAirspaceInitialOpacity,
   resolveAirspaceOverlayFocusStyle,
   resolveAirspaceOverlayStyle,
 } from "@/features/airport/map/airspaceOverlayModel";
@@ -43,6 +44,8 @@ export default function AirspaceLayer({
   const boundaryLabelsRef = useRef<SVGTextElement[]>([]);
   const labelFrameRef = useRef(0);
   const animationFrameRef = useRef(0);
+  const hasAnimatedInitialEnterRef = useRef(false);
+  const skipNextVisibilityAnimationRef = useRef(false);
   const selectedAirspaceIdRef = useRef(selectedAirspaceId);
   const visibleRef = useRef(visible);
   const onSelectRef = useRef(onSelectAirspace);
@@ -63,6 +66,16 @@ export default function AirspaceLayer({
     boundaryLabelsRef.current = [];
     safeRemoveFromMap(layerRef.current, map);
     const boundaryLabels: SVGTextElement[] = [];
+    const animateInitialEnter =
+      visibleRef.current && !hasAnimatedInitialEnterRef.current;
+    const initialOpacity = resolveAirspaceInitialOpacity({
+      visible: visibleRef.current,
+      animateInitialEnter,
+    });
+    if (animateInitialEnter) {
+      hasAnimatedInitialEnterRef.current = true;
+      skipNextVisibilityAnimationRef.current = true;
+    }
     const airspacePane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.airspace);
     const paneElement = map.getPane(airspacePane);
     if (paneElement) paneElement.style.pointerEvents = visibleRef.current ? "auto" : "none";
@@ -73,7 +86,7 @@ export default function AirspaceLayer({
         return resolveVisibleAirspaceStyle(
           feature as any,
           selectedAirspaceIdRef.current,
-          visibleRef.current ? 1 : 0,
+          initialOpacity,
         );
       },
       onEachFeature(feature, featureLayer) {
@@ -92,17 +105,26 @@ export default function AirspaceLayer({
       polygonLayer,
       boundaryLabels,
       selectedAirspaceIdRef.current,
-      visibleRef.current ? 1 : 0,
+      initialOpacity,
     );
     labelFrameRef.current = window.requestAnimationFrame(() => {
       boundaryLabels.push(
         ...attachBoundaryLabels(
           polygonLayer,
           selectedAirspaceIdRef.current,
-          visibleRef.current ? 1 : 0,
+          initialOpacity,
         ),
       );
       boundaryLabelsRef.current = boundaryLabels;
+      if (animateInitialEnter) {
+        animateAirspaceGroupOpacity({
+          layerGroup: polygonLayer,
+          labels: boundaryLabels,
+          selectedAirspaceId: selectedAirspaceIdRef.current,
+          visible: true,
+          animationFrameRef,
+        });
+      }
     });
 
     return () => {
@@ -122,6 +144,11 @@ export default function AirspaceLayer({
     const airspacePane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.airspace);
     const paneElement = map.getPane(airspacePane);
     if (paneElement) paneElement.style.pointerEvents = visible ? "auto" : "none";
+
+    if (skipNextVisibilityAnimationRef.current) {
+      skipNextVisibilityAnimationRef.current = false;
+      return;
+    }
 
     animateAirspaceGroupOpacity({
       layerGroup: polygonLayer,

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -36,6 +36,10 @@ import { cn } from "@/lib/utils";
 import { useExplorerUi } from "@/components/explorer/ExplorerUiContext";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import {
+  aircraftTypeSearchText,
+  resolveAircraftDisplayModel,
+} from "@/features/aircraft/aircraftTypeDisplayModel";
+import {
   ALTITUDE_LEVEL_OPTIONS,
   ENTITY_FILTER_OPTIONS,
   aircraftMatchesFilters,
@@ -417,7 +421,9 @@ function AircraftTypeFilterCard({ groups, selectedTypes, onChange }) {
   const selectedSet = useMemo(() => new Set(selectedTypes), [selectedTypes]);
   const displayValue = useMemo(() => {
     if (!isMultiSelect) return t("sidebar.all");
-    if (selectedTypes.length === 1) return selectedTypes[0];
+    if (selectedTypes.length === 1) {
+      return resolveAircraftDisplayModel({ type: selectedTypes[0] }).displayName;
+    }
     return t("sidebar.typesCount", { count: selectedTypes.length });
   }, [isMultiSelect, selectedTypes, t]);
 
@@ -437,10 +443,11 @@ function AircraftTypeFilterCard({ groups, selectedTypes, onChange }) {
   };
 
   const toggleGroup = (group) => {
-    const allSelected = group.types.every((t) => selectedSet.has(t));
+    const groupValues = group.types.map((type) => type.value);
+    const allSelected = groupValues.every((value) => selectedSet.has(value));
     const next = allSelected
-      ? selectedTypes.filter((t) => !group.types.includes(t))
-      : [...new Set([...selectedTypes, ...group.types])];
+      ? selectedTypes.filter((type) => !groupValues.includes(type))
+      : [...new Set([...selectedTypes, ...groupValues])];
     commit(next);
   };
 
@@ -478,8 +485,8 @@ function AircraftTypeFilterCard({ groups, selectedTypes, onChange }) {
             <MenuItemLabel>{t("sidebar.all")}</MenuItemLabel>
           </MenuItem>
           {groups.map((group) => {
-            const groupSelectedCount = group.types.filter((t) =>
-              selectedSet.has(t),
+            const groupSelectedCount = group.types.filter((type) =>
+              selectedSet.has(type.value),
             ).length;
             const allSelected = groupSelectedCount === group.types.length;
             const partialSelected =
@@ -509,18 +516,31 @@ function AircraftTypeFilterCard({ groups, selectedTypes, onChange }) {
                 </MenuItem>
                 {group.types.map((type) => (
                   <MenuItem
-                    key={type}
-                    selected={selectedSet.has(type)}
-                    onClick={() => toggleType(type)}
+                    key={type.value}
+                    selected={selectedSet.has(type.value)}
+                    onClick={() => toggleType(type.value)}
                     // Indent type rows under their group header.
                     className="[&_[data-ui=menu-label]]:pl-2"
                   >
                     <MenuItemCheck>
-                      {selectedSet.has(type) ? (
+                      {selectedSet.has(type.value) ? (
                         <Check size={11} aria-hidden="true" />
                       ) : null}
                     </MenuItemCheck>
-                    <MenuItemLabel data-ui="menu-label">{type}</MenuItemLabel>
+                    <MenuItemLabel
+                      data-ui="menu-label"
+                      className="flex min-w-0 flex-col gap-0.5"
+                    >
+                      <span className="min-w-0 truncate">{type.label}</span>
+                      {type.icaoType && type.icaoType !== type.label ? (
+                        <span
+                          className="notranslate min-w-0 truncate font-mono text-[9px] font-medium uppercase tracking-normal text-atc-faint"
+                          translate="no"
+                        >
+                          {type.icaoType}
+                        </span>
+                      ) : null}
+                    </MenuItemLabel>
                   </MenuItem>
                 ))}
               </div>
@@ -649,7 +669,7 @@ function aircraftSearchText(aircraft: AircraftLike = {}) {
     aircraft.callsign,
     aircraft.icao24,
     aircraft.registration,
-    aircraftTypeLabel(aircraft),
+    aircraftTypeSearchText(aircraft),
     aircraft.flightRouteLabel,
     routeMunicipalities,
     getAircraftContextGroup(aircraft),

--- a/src/components/sidebar/FlightSidebar.tsx
+++ b/src/components/sidebar/FlightSidebar.tsx
@@ -12,6 +12,7 @@ import {
   getFlightRouteAirlineIconUrl,
 } from "@/utils/flightRouteDisplay";
 import { getAircraftPositionSourceBadge } from "@/features/aviation/sourceDisplayModel";
+import { resolveAircraftDisplayModel } from "@/features/aircraft/aircraftTypeDisplayModel";
 import {
   formatFlightTelemetryMetric,
   resolveTrackDirectionTranslationKey,
@@ -48,8 +49,7 @@ export default function FlightSidebar({
   const displayCallsign =
     (aircraft?.callsign || callsign || "").trim() || "—";
   const hex = aircraft?.icao24 ? aircraft.icao24.toUpperCase() : "";
-  const type = (aircraft?.type || "").trim().toUpperCase();
-  const category = (aircraft?.category || "").trim().toUpperCase();
+  const typeDisplay = resolveAircraftDisplayModel(aircraft || {});
   const route = formatFlightRouteLabel(aircraft?.flightRoute) || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
   const speed = toFiniteNumber(aircraft?.velocity);
@@ -65,8 +65,7 @@ export default function FlightSidebar({
     <>
       <FlightIdentity
         callsign={displayCallsign}
-        type={type}
-        category={category}
+        typeDisplay={typeDisplay}
         route={route}
         airlineIconUrl={airlineIconUrl}
         positionSourceBadge={positionSourceBadge}
@@ -112,31 +111,35 @@ export default function FlightSidebar({
 
 function FlightIdentity({
   callsign,
-  type,
-  category,
+  typeDisplay,
   route,
   airlineIconUrl,
   positionSourceBadge,
 }) {
   const { t } = useI18n();
+  const hasTypeDisplay =
+    typeDisplay?.displayName && typeDisplay.displayName !== "N/A";
+  const secondary = [typeDisplay?.icaoType, typeDisplay?.category]
+    .filter(Boolean)
+    .join(" / ");
   return (
     <SidebarIdentityHero label={t("sidebar.tracking")} code={callsign}>
-      {(type || category) && (
-        <div className="mt-2 flex items-baseline gap-2">
-          {type && (
+      {hasTypeDisplay && (
+        <div className="mt-2 flex min-w-0 items-baseline gap-2">
+          <span
+            className="notranslate min-w-0 truncate font-mono text-[13px] font-semibold italic text-atc-text"
+            translate="no"
+            title={typeDisplay.displayName}
+          >
+            {typeDisplay.displayName}
+          </span>
+          {secondary && (
             <span
-              className="notranslate font-mono text-[13px] font-semibold italic text-atc-text"
+              className="notranslate endf-chip flex-none"
               translate="no"
+              title={secondary}
             >
-              {type}
-            </span>
-          )}
-          {category && (
-            <span
-              className="notranslate endf-chip"
-              translate="no"
-            >
-              <span>{category}</span>
+              <span>{secondary}</span>
             </span>
           )}
         </div>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -6,6 +6,19 @@
 
 export const CHANGELOG = [
   {
+    version: "v1.8.1",
+    kind: "patch",
+    title: "Aircraft type labels and airspace entry polish",
+    summary:
+      "Aircraft previews and filters now prefer friendly type names while the default airspace layer animates in on first load.",
+    highlights: [
+      "Aircraft preview cards show friendly aircraft names with ICAO codes demoted to secondary metadata",
+      "Aircraft type filters use the shared aircraft type resolver and match friendly names plus ICAO codes",
+      "Category-only aircraft display as Unknown while the filter groups them as All Unclassified",
+      "Airspace overlays now stagger-fade in during the initial default load",
+    ],
+  },
+  {
     version: "v1.8.0",
     kind: "feat",
     title: "Airport airspace overlays",

--- a/src/config/siteMeta.test.ts
+++ b/src/config/siteMeta.test.ts
@@ -7,14 +7,14 @@ import {
 } from "./siteMeta";
 
 assert.equal(ADSBAO_PRODUCT_NAME, "ADSBao");
-assert.equal(ADSBAO_SITE_VERSION, "1.8.0");
+assert.equal(ADSBAO_SITE_VERSION, "1.8.1");
 assert.equal(
   buildAdsbaoUserAgent("adsbdb/v0"),
-  "ADSBao/1.8.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+  "ADSBao/1.8.1 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
 );
 assert.equal(
   buildAdsbaoUserAgent(),
-  "ADSBao/1.8.0 (+https://github.com/orriduck/ADSBao)",
+  "ADSBao/1.8.1 (+https://github.com/orriduck/ADSBao)",
 );
 
 console.log("siteMeta.test.ts ok");

--- a/src/config/siteMeta.ts
+++ b/src/config/siteMeta.ts
@@ -1,5 +1,5 @@
 export const ADSBAO_PRODUCT_NAME = "ADSBao";
-export const ADSBAO_SITE_VERSION = "1.8.0";
+export const ADSBAO_SITE_VERSION = "1.8.1";
 export const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
 
 export function buildAdsbaoUserAgent(suffix = "") {

--- a/src/features/aircraft/aircraftTypeDisplayModel.test.ts
+++ b/src/features/aircraft/aircraftTypeDisplayModel.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+
+import { resolveAircraftDisplayModel } from "./aircraftTypeDisplayModel";
+
+assert.deepEqual(
+  resolveAircraftDisplayModel({
+    type: " e75l ",
+    category: " a3 ",
+    desc: "EMBRAER ERJ-170-200 (long wing)",
+  }),
+  {
+    displayName: "Embraer 175",
+    shortName: "E175",
+    icaoType: "E75L",
+    category: "A3",
+    source: "desc",
+  },
+);
+
+assert.deepEqual(
+  resolveAircraftDisplayModel({
+    type: "b38m",
+    category: "a3",
+  }),
+  {
+    displayName: "Boeing 737 MAX 8",
+    shortName: "737 MAX 8",
+    icaoType: "B38M",
+    category: "A3",
+    source: "fallback",
+  },
+);
+
+assert.deepEqual(
+  resolveAircraftDisplayModel({
+    type: "a21n",
+    desc: "AIRBUS A-321neo",
+  }),
+  {
+    displayName: "Airbus A321neo",
+    shortName: "A321neo",
+    icaoType: "A21N",
+    category: "",
+    source: "desc",
+  },
+);
+
+assert.deepEqual(resolveAircraftDisplayModel({ type: "zzzz" }), {
+  displayName: "ZZZZ",
+  shortName: "ZZZZ",
+  icaoType: "ZZZZ",
+  category: "",
+  source: "icao",
+});
+
+assert.deepEqual(resolveAircraftDisplayModel({ category: "a1" }), {
+  displayName: "Unknown",
+  shortName: "Unknown",
+  icaoType: "",
+  category: "A1",
+  source: "category",
+});

--- a/src/features/aircraft/aircraftTypeDisplayModel.ts
+++ b/src/features/aircraft/aircraftTypeDisplayModel.ts
@@ -1,0 +1,169 @@
+type AircraftTypeDisplaySource = "desc" | "fallback" | "icao" | "category";
+
+type AircraftTypeDisplayRecord = {
+  type?: unknown;
+  t?: unknown;
+  icaoType?: unknown;
+  category?: unknown;
+  desc?: unknown;
+  description?: unknown;
+  [key: string]: unknown;
+};
+
+type AircraftTypeFallback = {
+  displayName: string;
+  shortName: string;
+};
+
+const AIRCRAFT_TYPE_FALLBACKS: Record<string, AircraftTypeFallback> = Object.freeze({
+  A318: { displayName: "Airbus A318", shortName: "A318" },
+  A319: { displayName: "Airbus A319", shortName: "A319" },
+  A320: { displayName: "Airbus A320", shortName: "A320" },
+  A321: { displayName: "Airbus A321", shortName: "A321" },
+  A19N: { displayName: "Airbus A319neo", shortName: "A319neo" },
+  A20N: { displayName: "Airbus A320neo", shortName: "A320neo" },
+  A21N: { displayName: "Airbus A321neo", shortName: "A321neo" },
+  A332: { displayName: "Airbus A330-200", shortName: "A330-200" },
+  A333: { displayName: "Airbus A330-300", shortName: "A330-300" },
+  A339: { displayName: "Airbus A330-900neo", shortName: "A330-900neo" },
+  A359: { displayName: "Airbus A350-900", shortName: "A350-900" },
+  A35K: { displayName: "Airbus A350-1000", shortName: "A350-1000" },
+  A388: { displayName: "Airbus A380-800", shortName: "A380-800" },
+  BCS1: { displayName: "Airbus A220-100", shortName: "A220-100" },
+  BCS3: { displayName: "Airbus A220-300", shortName: "A220-300" },
+  B737: { displayName: "Boeing 737-700", shortName: "737-700" },
+  B738: { displayName: "Boeing 737-800", shortName: "737-800" },
+  B739: { displayName: "Boeing 737-900", shortName: "737-900" },
+  B37M: { displayName: "Boeing 737 MAX 7", shortName: "737 MAX 7" },
+  B38M: { displayName: "Boeing 737 MAX 8", shortName: "737 MAX 8" },
+  B39M: { displayName: "Boeing 737 MAX 9", shortName: "737 MAX 9" },
+  B3XM: { displayName: "Boeing 737 MAX 10", shortName: "737 MAX 10" },
+  B752: { displayName: "Boeing 757-200", shortName: "757-200" },
+  B763: { displayName: "Boeing 767-300", shortName: "767-300" },
+  B772: { displayName: "Boeing 777-200", shortName: "777-200" },
+  B77W: { displayName: "Boeing 777-300ER", shortName: "777-300ER" },
+  B788: { displayName: "Boeing 787-8", shortName: "787-8" },
+  B789: { displayName: "Boeing 787-9", shortName: "787-9" },
+  B78X: { displayName: "Boeing 787-10", shortName: "787-10" },
+  B748: { displayName: "Boeing 747-8", shortName: "747-8" },
+  BE30: { displayName: "Beechcraft King Air 300", shortName: "King Air 300" },
+  C172: { displayName: "Cessna 172 Skyhawk", shortName: "C172" },
+  CRJ2: { displayName: "CRJ200", shortName: "CRJ200" },
+  CRJ7: { displayName: "CRJ700", shortName: "CRJ700" },
+  CRJ9: { displayName: "CRJ900", shortName: "CRJ900" },
+  CRJX: { displayName: "CRJ1000", shortName: "CRJ1000" },
+  E170: { displayName: "Embraer 170", shortName: "E170" },
+  E75L: { displayName: "Embraer 175", shortName: "E175" },
+  E75S: { displayName: "Embraer 175", shortName: "E175" },
+  E190: { displayName: "Embraer 190", shortName: "E190" },
+  E195: { displayName: "Embraer 195", shortName: "E195" },
+  E290: { displayName: "Embraer E190-E2", shortName: "E190-E2" },
+  E295: { displayName: "Embraer E195-E2", shortName: "E195-E2" },
+  PA34: { displayName: "Piper Seneca", shortName: "Seneca" },
+  P28A: { displayName: "Piper PA-28", shortName: "PA-28" },
+  P46T: { displayName: "Piper Malibu Mirage", shortName: "Malibu Mirage" },
+  SR20: { displayName: "Cirrus SR20", shortName: "SR20" },
+  SR22: { displayName: "Cirrus SR22", shortName: "SR22" },
+});
+
+const UNKNOWN_AIRCRAFT_TYPE: AircraftTypeFallback = Object.freeze({
+  displayName: "Unknown",
+  shortName: "Unknown",
+});
+
+function cleanUpper(value: unknown) {
+  return String(value || "").trim().toUpperCase();
+}
+
+function cleanDescription(value: unknown) {
+  return String(value || "").trim().replace(/\s+/g, " ");
+}
+
+function titleCaseDescription(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/\b([a-z])/g, (match) => match.toUpperCase())
+    .replace(/\bA-(\d)/g, "A$1")
+    .replace(/\bCrj-(\d)/g, "CRJ$1")
+    .replace(/\bErj-/g, "ERJ-")
+    .replace(/\bMax\b/g, "MAX")
+    .replace(/\bNeo\b/g, "neo")
+    .replace(/\bEr\b/g, "ER")
+    .replace(/\bDc\b/g, "DC")
+    .replace(/\bMd\b/g, "MD");
+}
+
+function compactDisplayName(displayName: string, icaoType: string) {
+  if (/^Airbus A\d{3}neo$/i.test(displayName)) {
+    return displayName.replace(/^Airbus /i, "");
+  }
+  if (/^Airbus A\d{3}(?:-\d{3,4})?$/i.test(displayName)) {
+    return displayName.replace(/^Airbus /i, "");
+  }
+  if (/^Boeing \d{3}/i.test(displayName)) {
+    return displayName.replace(/^Boeing /i, "");
+  }
+  if (/^Embraer 1\d{2}$/i.test(displayName)) {
+    return `E${displayName.slice(-3)}`;
+  }
+  return AIRCRAFT_TYPE_FALLBACKS[icaoType]?.shortName || displayName;
+}
+
+function normalizeDescription(desc: string, icaoType: string) {
+  const fallback = AIRCRAFT_TYPE_FALLBACKS[icaoType];
+  if (fallback) return fallback;
+  const displayName = titleCaseDescription(desc)
+    .replace(/^Bombardier Regional Jet CRJ-?(\d{3,4})$/i, "CRJ$1")
+    .replace(/^Canadair Regional Jet CRJ-?(\d{3,4})$/i, "CRJ$1")
+    .replace(/^Embraer ERJ-170-200 \(Long Wing\)$/i, "Embraer 175")
+    .replace(/^Embraer ERJ 170-200 \(Long Wing\)$/i, "Embraer 175");
+
+  return {
+    displayName,
+    shortName: compactDisplayName(displayName, icaoType),
+  };
+}
+
+export function resolveAircraftDisplayModel(aircraft: AircraftTypeDisplayRecord = {}) {
+  const icaoType = cleanUpper(aircraft.type || aircraft.icaoType || aircraft.t);
+  const category = cleanUpper(aircraft.category);
+  const desc = cleanDescription(aircraft.desc || aircraft.description);
+  let source: AircraftTypeDisplaySource = "icao";
+  let resolved: AircraftTypeFallback | null = null;
+
+  if (desc) {
+    resolved = normalizeDescription(desc, icaoType);
+    source = "desc";
+  } else if (icaoType && AIRCRAFT_TYPE_FALLBACKS[icaoType]) {
+    resolved = AIRCRAFT_TYPE_FALLBACKS[icaoType];
+    source = "fallback";
+  }
+
+  if (!resolved && !icaoType && category) {
+    resolved = UNKNOWN_AIRCRAFT_TYPE;
+    source = "category";
+  }
+
+  const displayName = resolved?.displayName || icaoType || "N/A";
+  const shortName = resolved?.shortName || displayName;
+
+  return {
+    displayName,
+    shortName,
+    icaoType,
+    category,
+    source: resolved || icaoType ? source : "category",
+  };
+}
+
+export function aircraftTypeSearchText(aircraft: AircraftTypeDisplayRecord = {}) {
+  const display = resolveAircraftDisplayModel(aircraft);
+  return [
+    display.displayName,
+    display.shortName,
+    display.icaoType,
+    display.category,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}

--- a/src/features/aircraft/filters/aircraftFilters.test.ts
+++ b/src/features/aircraft/filters/aircraftFilters.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import {
   aircraftMatchesFilters,
+  aircraftTypeLabel,
+  getAircraftTypeGroups,
   getNextEntityFilter,
 } from "./aircraftFilters";
 
@@ -40,5 +42,61 @@ test("filters aircraft by airport movement", () => {
   assert.equal(
     aircraftMatchesFilters(unknown, { movementFilter: "all" }),
     true,
+  );
+});
+
+test("groups aircraft type filters by raw ICAO value while displaying friendly names", () => {
+  const groups = getAircraftTypeGroups([
+    { type: " b38m ", category: " a3 " },
+    {
+      type: " e75l ",
+      category: " a3 ",
+      desc: "EMBRAER ERJ-170-200 (long wing)",
+    },
+  ]);
+
+  assert.deepEqual(
+    groups.find((group) => group.category === "A3")?.types,
+    [
+      {
+        value: "B38M",
+        label: "Boeing 737 MAX 8",
+        shortLabel: "737 MAX 8",
+        icaoType: "B38M",
+      },
+      {
+        value: "E75L",
+        label: "Embraer 175",
+        shortLabel: "E175",
+        icaoType: "E75L",
+      },
+    ],
+  );
+});
+
+test("keeps aircraft type filter values as ICAO codes", () => {
+  assert.equal(
+    aircraftTypeLabel({
+      type: " e75l ",
+      category: " a3 ",
+      desc: "EMBRAER ERJ-170-200 (long wing)",
+    }),
+    "E75L",
+  );
+});
+
+test("labels category-only aircraft as unclassified in type filters", () => {
+  const groups = getAircraftTypeGroups([{ category: " a3 " }]);
+
+  assert.deepEqual(
+    groups.find((group) => group.category === "A3")?.types,
+    [
+      {
+        value: "A3",
+        label: "All Unclassified",
+        shortLabel: "All Unclassified",
+        icaoType: "",
+      },
+    ],
   );
 });

--- a/src/features/aircraft/filters/aircraftFilters.ts
+++ b/src/features/aircraft/filters/aircraftFilters.ts
@@ -2,6 +2,8 @@
 // option.labelKey through t(...) so the dropdown switches with the locale.
 // `label` is kept as a default English fallback for any consumer that
 // reads it directly.
+import { resolveAircraftDisplayModel } from "../aircraftTypeDisplayModel";
+
 export const TRAFFIC_FILTER_OPTIONS = [
   { value: "all", labelKey: "sidebar.all", label: "All" },
   { value: "routed", labelKey: "filters.routesOnly", label: "Routes only" },
@@ -59,6 +61,7 @@ const CATEGORY_LABELS = Object.freeze({
 
 const CATEGORY_ORDER = ["A1", "A2", "A3", "A4", "A5", "A6", "A7", "OTHER"];
 const OTHER_LABEL = { key: "filters.categoryOther", default: "Other" };
+const UNCLASSIFIED_TYPE_LABEL = "All Unclassified";
 
 type AircraftFilterRecord = {
   type?: unknown;
@@ -79,7 +82,8 @@ type AircraftFilterOptions = {
 };
 
 export function aircraftTypeLabel(aircraft: AircraftFilterRecord = {}) {
-  return String(aircraft.type || aircraft.category || "").trim();
+  const display = resolveAircraftDisplayModel(aircraft);
+  return display.icaoType || display.category;
 }
 
 export function getAircraftCategoryCode(aircraft: AircraftFilterRecord = {}) {
@@ -93,6 +97,10 @@ export function getCategoryLabel(categoryCode: string) {
 
 export function getCategoryLabelKey(categoryCode: string) {
   return (CATEGORY_LABELS[categoryCode] || OTHER_LABEL).key;
+}
+
+function getAircraftTypeFilterLabel(display: ReturnType<typeof resolveAircraftDisplayModel>) {
+  return display.icaoType ? display.displayName : UNCLASSIFIED_TYPE_LABEL;
 }
 
 export function getAircraftTypes(aircraft: AircraftFilterRecord[] = []) {
@@ -110,29 +118,51 @@ export function getAircraftTypeGroups(
   aircraft: AircraftFilterRecord[] = [],
   extraTypes: string[] = [],
 ) {
-  const typeToCategory = new Map();
+  const typeToEntry = new Map();
   for (const item of aircraft) {
     const type = aircraftTypeLabel(item);
     if (!type) continue;
-    if (typeToCategory.has(type)) continue;
-    typeToCategory.set(type, getAircraftCategoryCode(item));
+    if (typeToEntry.has(type)) continue;
+    const display = resolveAircraftDisplayModel(item);
+    const label = getAircraftTypeFilterLabel(display);
+    typeToEntry.set(type, {
+      category: getAircraftCategoryCode(item),
+      item: {
+        value: type,
+        label,
+        shortLabel: display.icaoType ? display.shortName : label,
+        icaoType: display.icaoType,
+      },
+    });
   }
   for (const type of extraTypes) {
-    if (type && !typeToCategory.has(type)) {
-      typeToCategory.set(type, "OTHER");
+    const value = String(type || "").trim().toUpperCase();
+    if (value && !typeToEntry.has(value)) {
+      const display = resolveAircraftDisplayModel({ type: value });
+      typeToEntry.set(value, {
+        category: "OTHER",
+        item: {
+          value,
+          label: display.displayName,
+          shortLabel: display.shortName,
+          icaoType: display.icaoType,
+        },
+      });
     }
   }
 
   const buckets = new Map(CATEGORY_ORDER.map((code) => [code, new Set()]));
-  for (const [type, category] of typeToCategory) {
-    buckets.get(category).add(type);
+  for (const entry of typeToEntry.values()) {
+    buckets.get(entry.category).add(entry.item);
   }
 
   return CATEGORY_ORDER.map((category) => ({
     category,
     label: getCategoryLabel(category),
     labelKey: getCategoryLabelKey(category),
-    types: [...buckets.get(category)].sort((a, b) => String(a).localeCompare(String(b))),
+    types: [...buckets.get(category)].sort((a: any, b: any) =>
+      String(a.label).localeCompare(String(b.label)),
+    ),
   })).filter((group) => group.types.length > 0);
 }
 

--- a/src/features/aircraft/positions/aircraftPositionsModel.test.ts
+++ b/src/features/aircraft/positions/aircraftPositionsModel.test.ts
@@ -27,6 +27,7 @@ const responseNow = 1_700_000_003_000;
       track: 87,
       seen_pos: 1.25,
       t: "b738",
+      desc: "BOEING 737-800",
       category: "a3",
     },
     { responseNow, receiveTime },
@@ -37,6 +38,7 @@ const responseNow = 1_700_000_003_000;
   assert.equal(aircraft.altitude, 12000);
   assert.equal(aircraft.velocity, 250);
   assert.equal(aircraft.type, "B738");
+  assert.equal(aircraft.desc, "BOEING 737-800");
   assert.equal(aircraft.category, "A3");
   assert.equal(aircraft.positionTime, 1_700_000_001_750);
   assert.equal(aircraft.receiveTime, receiveTime);

--- a/src/features/aircraft/positions/aircraftPositionsModel.ts
+++ b/src/features/aircraft/positions/aircraftPositionsModel.ts
@@ -20,6 +20,7 @@ type RawAdsbAircraft = {
   gs?: unknown;
   track?: unknown;
   t?: string;
+  desc?: string;
   category?: string;
   positionTime?: unknown;
   positionQuality?: AircraftPositionQuality | null;
@@ -44,6 +45,7 @@ type NormalizedAircraftPosition = {
   velocity: unknown;
   track: unknown;
   type: string;
+  desc: string;
   category: string;
   positionTime: unknown;
   receiveTime: number;
@@ -119,6 +121,7 @@ export function normalizeAdsbAircraft(
     velocity: aircraft.gs ?? null,
     track: aircraft.track ?? 0,
     type: typeof aircraft.t === "string" ? aircraft.t.trim().toUpperCase() : "",
+    desc: typeof aircraft.desc === "string" ? aircraft.desc.trim() : "",
     category:
       typeof aircraft.category === "string"
         ? aircraft.category.trim().toUpperCase()

--- a/src/features/aircraft/preview/aircraftPreviewTypeModel.test.ts
+++ b/src/features/aircraft/preview/aircraftPreviewTypeModel.test.ts
@@ -3,22 +3,32 @@ import assert from "node:assert/strict";
 import { getAircraftPreviewTypeDisplay } from "./aircraftPreviewTypeModel";
 
 assert.deepEqual(
-  getAircraftPreviewTypeDisplay({ type: " b789 ", category: " a5 " }),
+  getAircraftPreviewTypeDisplay({ type: " e75l ", category: " a3 " }),
   {
-    primary: "B789",
-    secondary: "A5",
+    primary: "E75L",
+    secondary: "Embraer 175",
+    icaoType: "E75L",
+    category: "A3",
   },
 );
 
 assert.deepEqual(
-  getAircraftPreviewTypeDisplay({ category: " a3 " }),
+  getAircraftPreviewTypeDisplay({
+    type: " a21n ",
+    category: " a3 ",
+    desc: "AIRBUS A-321neo",
+  }),
   {
-    primary: "A3",
-    secondary: null,
+    primary: "A21N",
+    secondary: "Airbus A321neo",
+    icaoType: "A21N",
+    category: "A3",
   },
 );
 
 assert.deepEqual(getAircraftPreviewTypeDisplay({}), {
   primary: "N/A",
   secondary: null,
+  icaoType: "",
+  category: "",
 });

--- a/src/features/aircraft/preview/aircraftPreviewTypeModel.ts
+++ b/src/features/aircraft/preview/aircraftPreviewTypeModel.ts
@@ -1,9 +1,17 @@
+import { resolveAircraftDisplayModel } from "../aircraftTypeDisplayModel";
+
 export function getAircraftPreviewTypeDisplay(aircraft) {
-  const type = (aircraft?.type || "").trim().toUpperCase();
-  const category = (aircraft?.category || "").trim().toUpperCase();
+  const display = resolveAircraftDisplayModel(aircraft);
+  const primary = display.icaoType || display.displayName;
+  const secondary =
+    display.icaoType && display.displayName !== display.icaoType
+      ? display.displayName
+      : null;
 
   return {
-    primary: type || category || "N/A",
-    secondary: type && category ? category : null,
+    primary,
+    secondary,
+    icaoType: display.icaoType,
+    category: display.category,
   };
 }

--- a/src/features/aircraft/tracking/trackedFlightMetadataStorage.ts
+++ b/src/features/aircraft/tracking/trackedFlightMetadataStorage.ts
@@ -9,6 +9,7 @@ type FlightRouteMetadata = Record<string, unknown>;
 
 type TrackedFlightMetadata = {
   type?: string;
+  desc?: string;
   category?: string;
   origin?: string;
   destination?: string;
@@ -48,6 +49,10 @@ function normalizeCallsign(callsign: unknown) {
 
 function clean(value: unknown) {
   return String(value || "").trim().toUpperCase();
+}
+
+function cleanText(value: unknown) {
+  return String(value || "").trim();
 }
 
 function getLocalStorage(): TrackedFlightMetadataStorage | null {
@@ -99,6 +104,7 @@ function sanitizeFlightRoute(route: unknown) {
 function extractMetadata(aircraft: TrackedFlightMetadataAircraft = {}) {
   const metadata = {
     type: clean(aircraft.type),
+    desc: cleanText(aircraft.desc),
     category: clean(aircraft.category),
     origin: clean(aircraft.origin),
     destination: clean(aircraft.destination),
@@ -158,6 +164,7 @@ export function mergeTrackedFlightMetadata<T extends TrackedFlightMetadataAircra
   return {
     ...aircraft,
     type: clean(aircraft.type) || metadata.type || "",
+    desc: cleanText(aircraft.desc) || metadata.desc || "",
     category: clean(aircraft.category) || metadata.category || "",
     origin: clean(aircraft.origin) || metadata.origin || "",
     destination: clean(aircraft.destination) || metadata.destination || "",

--- a/src/features/airport/explorer/airportExplorerUiModel.test.ts
+++ b/src/features/airport/explorer/airportExplorerUiModel.test.ts
@@ -16,7 +16,7 @@ assert.equal(
 );
 assert.equal(
   DEFAULT_AIRPORT_EXPLORER_UI_STATE.showAirspaces,
-  false,
+  true,
 );
 
 console.log("airportExplorerUiModel.test.ts ok");

--- a/src/features/airport/explorer/airportExplorerUiModel.ts
+++ b/src/features/airport/explorer/airportExplorerUiModel.ts
@@ -6,6 +6,6 @@ export const DEFAULT_AIRPORT_EXPLORER_UI_STATE = {
   showMapLabels: false,
   showRunwayBeams: true,
   showNavaidMarkers: false,
-  showAirspaces: false,
+  showAirspaces: true,
   ...DEFAULT_AIRCRAFT_FILTERS,
 };

--- a/src/features/airport/map/airspaceOverlayModel.test.ts
+++ b/src/features/airport/map/airspaceOverlayModel.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildAirspaceOverlayAnimationPlan,
   buildAirspaceOverlayFeatures,
+  resolveAirspaceInitialOpacity,
   resolveAirspaceOverlayFocusStyle,
   resolveAirspaceOverlayStyle,
 } from "./airspaceOverlayModel";
@@ -117,6 +118,21 @@ const polygon = {
   assert.equal(reducedPlan.itemDurationMs, 0);
   assert.equal(reducedPlan.totalDurationMs, 0);
   assert.deepEqual(reducedPlan.steps.map((step) => step.delayMs), [0, 0]);
+}
+
+{
+  assert.equal(
+    resolveAirspaceInitialOpacity({ visible: true, animateInitialEnter: true }),
+    0,
+  );
+  assert.equal(
+    resolveAirspaceInitialOpacity({ visible: true, animateInitialEnter: false }),
+    1,
+  );
+  assert.equal(
+    resolveAirspaceInitialOpacity({ visible: false, animateInitialEnter: true }),
+    0,
+  );
 }
 
 {

--- a/src/features/airport/map/airspaceOverlayModel.ts
+++ b/src/features/airport/map/airspaceOverlayModel.ts
@@ -113,6 +113,17 @@ export function buildAirspaceOverlayAnimationPlan(
   };
 }
 
+export function resolveAirspaceInitialOpacity({
+  visible,
+  animateInitialEnter,
+}: {
+  visible: boolean;
+  animateInitialEnter: boolean;
+}) {
+  if (!visible) return 0;
+  return animateInitialEnter ? 0 : 1;
+}
+
 function approximateGeometryBoundsArea(geometry: AirspaceOverlayRecord = {}) {
   const pairs: number[][] = [];
   collectCoordinatePairs(geometry.coordinates, pairs);


### PR DESCRIPTION
## Summary
- add a shared aircraft type display resolver and feed desc through aircraft metadata normalization
- use friendly aircraft type names in preview cards, tracking/sidebar surfaces, and aircraft type filters while keeping ICAO codes as secondary metadata
- show category-only aircraft as Unknown and group them as All Unclassified in filters
- enable airspaces by default, animate the initial airspace overlay load, and bump ADSBao to 1.8.1

## Verification
- pnpm test
- pnpm lint (passes with existing VirtualNearbyList TanStack Virtual React Compiler warning)
- pnpm build
- local browser check on /airport/KBOS?locale=zh-CN