### PR TITLE
Add location audio alerts and trace cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/aircraft/preview/AircraftPreviewCard.airport.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewCard.airport.test.ts
@@ -45,8 +45,18 @@ assert.match(
 );
 assert.match(
   styleSource,
-  /\.aircraft-preview-card--airport \{[\s\S]*?width: 320px;/,
+  /\.aircraft-preview-card \{[\s\S]*?width: 320px;[\s\S]*?padding: 0;/,
+  "desktop aircraft preview card should be 40px wider than the prior 280px default",
+);
+assert.match(
+  styleSource,
+  /\.aircraft-preview-card--airport \{[\s\S]*?width: 360px;/,
   "desktop airport preview card should be wider than the default preview card",
+);
+assert.match(
+  styleSource,
+  /@media \(min-width: 768px\) \{[\s\S]*?\.aircraft-preview-card \{[\s\S]*?width: 264px;/,
+  "desktop map-shell aircraft preview card should also be 40px wider",
 );
 assert.match(
   desktopSource,

--- a/src/components/aircraft/preview/AircraftPreviewTelemetry.test.ts
+++ b/src/components/aircraft/preview/AircraftPreviewTelemetry.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const stylePath = fileURLToPath(new URL("../../../style.css", import.meta.url));
+const styleSource = readFileSync(stylePath, "utf8");
+
+assert.match(
+  styleSource,
+  /\.aircraft-preview-telemetry \{[\s\S]*?grid-template-columns: repeat\(3, 1fr\);/,
+  "aircraft preview telemetry should keep three equal grid columns",
+);
+assert.match(
+  styleSource,
+  /\.aircraft-preview-telemetry \.aircraft-preview-stat:nth-child\(2\) \{[\s\S]*?align-items: center;[\s\S]*?text-align: center;/,
+  "aircraft preview telemetry middle stat should be centered in its grid column",
+);
+assert.match(
+  styleSource,
+  /\.aircraft-preview-telemetry \.aircraft-preview-stat:nth-child\(2\) \.aircraft-preview-stat__value \{[\s\S]*?justify-content: center;/,
+  "aircraft preview telemetry middle value should align to the center",
+);
+
+console.log("AircraftPreviewTelemetry.test.ts ok");

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -25,8 +25,14 @@ import {
   areCriticalLoadingRequestsSettled,
   resolveAircraftLoadingOverlayState,
 } from "@/features/aircraft/positions/aircraftLoadingOverlayModel";
-import { resolveUserLocationRequest } from "@/features/airport/map/userLocationModel";
+import {
+  resolveNextUserLocationAudioMode,
+  resolveUserLocationRequest,
+  USER_LOCATION_AUDIO_MODES,
+  type UserLocationAudioMode,
+} from "@/features/airport/map/userLocationModel";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUserLocationAircraftAudio } from "@/hooks/useUserLocationAircraftAudio";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -70,6 +76,9 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     mapFollowsAircraft,
   } = useExplorerUi();
   const [userLocation, setUserLocation] = useState(null);
+  const [userLocationMode, setUserLocationMode] = useState<UserLocationAudioMode>(
+    USER_LOCATION_AUDIO_MODES.OFF,
+  );
   const [userLocationPending, setUserLocationPending] = useState(false);
   const [userLocationNotice, setUserLocationNotice] = useState("");
   const airportProfile = useMemo(
@@ -77,6 +86,19 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     [icao, airport],
   );
   const { weather, traffic } = useAirportExplorerData(airportProfile);
+  const userLocationActive = Boolean(userLocation);
+  const userLocationAudioActive =
+    userLocationActive &&
+    userLocationMode === USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO;
+  const {
+    cue: userLocationAudioCue,
+    pulseBeat: userLocationPulseBeat,
+    unlockAudio,
+  } = useUserLocationAircraftAudio({
+    enabled: userLocationAudioActive,
+    userLocation,
+    aircraft: traffic.aircraft,
+  });
   const nearbyAirports = useNearbyAirports({
     icao: airportProfile.icao,
     lat: airportProfile.lat,
@@ -162,13 +184,27 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   }, [userLocationNotice]);
 
   const locateUser = useCallback(() => {
-    if (userLocation) {
+    const nextMode = resolveNextUserLocationAudioMode({
+      mode: userLocationMode,
+      hasLocation: Boolean(userLocation),
+    });
+
+    if (nextMode === USER_LOCATION_AUDIO_MODES.OFF) {
       setUserLocation(null);
+      setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
+      setUserLocationNotice("");
+      return;
+    }
+
+    if (nextMode === USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO && userLocation) {
+      unlockAudio();
+      setUserLocationMode(USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO);
       setUserLocationNotice("");
       return;
     }
 
     if (typeof navigator === "undefined" || !navigator.geolocation) {
+      setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
       setUserLocationNotice(t("map.locationUnavailable"));
       return;
     }
@@ -185,21 +221,25 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
 
         if (!result.location) {
           setUserLocation(null);
+          setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
           setUserLocationNotice(t("map.locationUnavailable"));
           return;
         }
 
         if (result.tooFar) {
           setUserLocation(null);
+          setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
           setUserLocationNotice(t("map.locationTooFar"));
           return;
         }
 
         setUserLocation(result.location);
+        setUserLocationMode(USER_LOCATION_AUDIO_MODES.LOCATION);
         setUserLocationNotice("");
       },
       (error) => {
         setUserLocationPending(false);
+        setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
         setUserLocationNotice(
           error?.code === error?.PERMISSION_DENIED
             ? t("map.locationDenied")
@@ -212,7 +252,14 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
         maximumAge: 0,
       },
     );
-  }, [airportProfile.lat, airportProfile.lon, t, userLocation]);
+  }, [
+    airportProfile.lat,
+    airportProfile.lon,
+    unlockAudio,
+    t,
+    userLocation,
+    userLocationMode,
+  ]);
 
   const criticalLoadingSettled = areCriticalLoadingRequestsSettled({
     aircraftPositionsSettled: traffic.aircraftPositionsSettled,
@@ -309,7 +356,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
               lastUpdated={traffic.lastUpdated}
               routeProvider={traffic.routeProvider}
               loadingStatus={sourceLoadingStatus}
-              userLocationActive={Boolean(userLocation)}
+              userLocationActive={userLocationActive}
+              userLocationAudioActive={userLocationAudioActive}
               userLocationPending={userLocationPending}
               userLocationNotice={userLocationNotice}
               onLocateUser={locateUser}
@@ -347,6 +395,14 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             loadingOverlayActive={loadingOverlayActive}
             loadingOverlaySources={loadingOverlaySources}
             userLocation={userLocation}
+            userLocationPulseIntervalMs={
+              userLocationAudioActive
+                ? userLocationAudioCue?.intervalMs
+                : undefined
+            }
+            userLocationPulseBeat={
+              userLocationAudioActive ? userLocationPulseBeat : undefined
+            }
           />
 
           {isMobile && sidebarOpen && (

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -11,6 +11,7 @@ export default function ExplorerMapMenu({
   routeProvider = "",
   loadingStatus = "",
   userLocationActive = false,
+  userLocationAudioActive = false,
   userLocationPending = false,
   userLocationNotice = "",
   onLocateUser = null,
@@ -48,6 +49,7 @@ export default function ExplorerMapMenu({
         showNavaidMarkers={showNavaidMarkers}
         showAirspaces={showAirspaces}
         userLocationActive={userLocationActive}
+        userLocationAudioActive={userLocationAudioActive}
         userLocationPending={userLocationPending}
         userLocationNotice={userLocationNotice}
         showSidebarToggle={isMobile}

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -80,6 +80,8 @@ export default function AirportMap({
   loadingOverlayCallsign = "",
   loadingOverlaySources = {},
   userLocation = null,
+  userLocationPulseIntervalMs = null,
+  userLocationPulseBeat = null,
   children = null,
 }: Record<string, any>) {
   const { locale } = useI18n();
@@ -316,7 +318,11 @@ export default function AirportMap({
           />
           <SelectedAircraftTrace theme={currentTheme} />
           <MapRangeLegend />
-          <UserLocationMarker location={userLocation} />
+          <UserLocationMarker
+            location={userLocation}
+            pulseIntervalMs={userLocationPulseIntervalMs}
+            pulseBeat={userLocationPulseBeat}
+          />
           {children}
           {visibleAircraft.map((ac) => (
             <AircraftPosition

--- a/src/components/map/RunwayAnnotationLayer.test.ts
+++ b/src/components/map/RunwayAnnotationLayer.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const layerPath = fileURLToPath(
+  new URL("./RunwayAnnotationLayer.tsx", import.meta.url),
+);
+const source = readFileSync(layerPath, "utf8");
+
+assert.match(
+  source,
+  /const isLeafletLayer =/,
+  "runway annotation layer should validate Leaflet sublayers before grouping them",
+);
+assert.match(
+  source,
+  /const addSublayer =/,
+  "runway annotation layer should add Leaflet sublayers individually",
+);
+assert.match(
+  source,
+  /catch \(error\)/,
+  "runway annotation layer should skip a bad sublayer without crashing the map",
+);
+assert.match(
+  source,
+  /const layer = L\.layerGroup\(\)\.addTo\(map\)/,
+  "runway annotation layer should attach an empty parent group before adding children",
+);
+
+console.log("RunwayAnnotationLayer.test.ts ok");

--- a/src/components/map/RunwayAnnotationLayer.tsx
+++ b/src/components/map/RunwayAnnotationLayer.tsx
@@ -43,12 +43,19 @@ const runwayLabelIcon = (ident: string, theme: string) =>
     iconAnchor: [17, 22],
   });
 
+const isLeafletLayer = (layer: unknown): layer is L.Layer =>
+  Boolean(
+    layer &&
+      typeof (layer as L.Layer).addTo === "function" &&
+      typeof (layer as L.Layer).remove === "function",
+  );
+
 // Dispatches on the `kind` returned by buildRunwayApproachVisualization:
 // light theme draws a dashed extended centerline; dark theme keeps the
 // glowing wedge + gradient controller. The pipelines are different
 // enough (polyline vs. polygon + per-frame gradient) that a single
 // style block would be artificial.
-const buildApproachLayer = ({ kind, data, theme }: Record<string, any>) => {
+const buildApproachLayer = ({ kind, data, map, theme }: Record<string, any>) => {
   if (kind === "approach-lines") {
     const layer = L.geoJSON(data as any, {
       interactive: false,
@@ -72,6 +79,7 @@ const buildApproachLayer = ({ kind, data, theme }: Record<string, any>) => {
   // Extra renderer padding so beams that extend past the viewport edge
   // aren't clipped — default 0.1 is ~80px but beams can reach ~408px.
   const beamRenderer = L.svg({ padding: 1 });
+  beamRenderer.addTo(map);
   const layer = L.geoJSON(data as any, {
     renderer: beamRenderer,
     interactive: false,
@@ -114,7 +122,7 @@ export default function RunwayAnnotationLayer({
       },
     });
 
-    const sublayers = [lineLayer];
+    const sublayers: L.Layer[] = [lineLayer].filter(isLeafletLayer);
     let beamLayer = null;
     let beamRenderer = null;
 
@@ -126,10 +134,11 @@ export default function RunwayAnnotationLayer({
       const built = buildApproachLayer({
         kind: visualization.kind,
         data: visualization.data,
+        map,
         theme,
       });
-      sublayers.unshift(built.layer as any);
-      beamLayer = built.beamLayer;
+      if (isLeafletLayer(built.layer)) sublayers.unshift(built.layer);
+      beamLayer = isLeafletLayer(built.beamLayer) ? built.beamLayer : null;
       beamRenderer = built.beamRenderer;
     }
 
@@ -145,13 +154,29 @@ export default function RunwayAnnotationLayer({
           }),
         ),
       );
-      sublayers.push(labelLayer as any);
+      if (isLeafletLayer(labelLayer)) sublayers.push(labelLayer);
     }
 
-    const layer = L.layerGroup(sublayers).addTo(map);
+    if (!sublayers.length) return undefined;
+
+    const layer = L.layerGroup().addTo(map);
     layerRef.current = layer;
 
-    const removeGradients = beamLayer
+    let beamLayerAdded = false;
+    const addSublayer = (sublayer: L.Layer, label: string) => {
+      try {
+        layer.addLayer(sublayer);
+        if (sublayer === beamLayer) beamLayerAdded = true;
+      } catch (error) {
+        console.warn(`[RunwayAnnotationLayer] skipped ${label}`, error);
+      }
+    };
+
+    sublayers.forEach((sublayer, index) => {
+      addSublayer(sublayer, `sublayer-${index}`);
+    });
+
+    const removeGradients = beamLayer && beamLayerAdded
       ? createRunwayBeamGradientController({ map, beamLayer: beamLayer as any, theme })
       : () => {};
 

--- a/src/components/map/UserLocationControl.test.ts
+++ b/src/components/map/UserLocationControl.test.ts
@@ -8,6 +8,10 @@ const explorerPath = fileURLToPath(
 const drawerPath = fileURLToPath(
   new URL("./controls/MapLayerDrawer.tsx", import.meta.url),
 );
+const airportMapPath = fileURLToPath(new URL("./AirportMap.tsx", import.meta.url));
+const markerPath = fileURLToPath(
+  new URL("./UserLocationMarker.tsx", import.meta.url),
+);
 const enPath = fileURLToPath(new URL("../../config/i18n/en.ts", import.meta.url));
 const zhPath = fileURLToPath(
   new URL("../../config/i18n/zh-CN.ts", import.meta.url),
@@ -15,18 +19,60 @@ const zhPath = fileURLToPath(
 
 const explorerSource = readFileSync(explorerPath, "utf8");
 const drawerSource = readFileSync(drawerPath, "utf8");
+const airportMapSource = readFileSync(airportMapPath, "utf8");
+const markerSource = readFileSync(markerPath, "utf8");
 const enSource = readFileSync(enPath, "utf8");
 const zhSource = readFileSync(zhPath, "utf8");
 
 assert.match(
   explorerSource,
-  /if \(userLocation\) \{[\s\S]*?setUserLocation\(null\);[\s\S]*?setUserLocationNotice\(""\);[\s\S]*?return;/,
-  "active user location control should toggle the marker off before requesting geolocation again",
+  /resolveNextUserLocationAudioMode\(\{[\s\S]*?mode: userLocationMode,[\s\S]*?hasLocation: Boolean\(userLocation\),[\s\S]*?\}\)/,
+  "user location control should resolve the next three-state location/audio mode before requesting geolocation",
 );
 assert.match(
   drawerSource,
   /mapLayers\.hideUserLocation/,
-  "active user location button should be labeled as a hide action",
+  "audio-enabled user location button should be labeled as a hide action",
+);
+assert.match(
+  drawerSource,
+  /mapLayers\.enableUserLocationAudio/,
+  "location-on user location button should offer the aircraft proximity sound state",
+);
+assert.match(
+  explorerSource,
+  /cue: userLocationAudioCue/,
+  "airport explorer should keep the proximity audio cue available for synchronized map motion",
+);
+assert.match(
+  explorerSource,
+  /userLocationAudioCue\?\.intervalMs/,
+  "airport explorer should pass the active proximity interval into the map",
+);
+assert.match(
+  explorerSource,
+  /pulseBeat: userLocationPulseBeat/,
+  "airport explorer should use the audio hook's beat as the synchronized pulse source",
+);
+assert.match(
+  airportMapSource,
+  /<UserLocationMarker[\s\S]*?pulseIntervalMs=\{userLocationPulseIntervalMs\}[\s\S]*?\/>/,
+  "airport map should pass the proximity cue interval into the user location marker",
+);
+assert.match(
+  airportMapSource,
+  /pulseBeat=\{userLocationPulseBeat\}/,
+  "airport map should pass the audio beat into the user location marker",
+);
+assert.match(
+  markerSource,
+  /--user-location-pulse-duration/,
+  "user location marker should expose a CSS animation duration tied to the proximity cue",
+);
+assert.match(
+  markerSource,
+  /key=\{pulseBeat \|\| "idle"\}/,
+  "user location marker should restart the pulse animation from the audio beat",
 );
 assert.doesNotMatch(
   drawerSource,
@@ -35,8 +81,18 @@ assert.doesNotMatch(
 );
 assert.match(
   enSource,
+  /enableUserLocationAudio: "Enable aircraft proximity sound"/,
+  "English copy should expose the aircraft proximity sound action",
+);
+assert.match(
+  enSource,
   /hideUserLocation: "Hide my location"/,
   "English copy should expose a hide-my-location action",
+);
+assert.match(
+  zhSource,
+  /enableUserLocationAudio: "开启飞机接近提示音"/,
+  "Chinese copy should expose the aircraft proximity sound action",
 );
 assert.match(
   zhSource,

--- a/src/components/map/UserLocationMarker.tsx
+++ b/src/components/map/UserLocationMarker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext";
@@ -14,6 +15,8 @@ const USER_LOCATION_ICON_SIZE_PX = 18;
 
 export default function UserLocationMarker({
   location = null,
+  pulseIntervalMs = null,
+  pulseBeat = null,
 }: Record<string, any>) {
   const map = useMapInstance();
   const markerRef = useRef(null);
@@ -80,9 +83,18 @@ export default function UserLocationMarker({
   return createPortal(
     <div className="user-location-marker" aria-label="Current location">
       <span
+        key={pulseBeat || "idle"}
         className="user-location-marker__pulse"
         aria-hidden="true"
-        style={{ "--user-location-pulse-diameter": `${pulseDiameterPx}px` }}
+        style={
+          {
+            "--user-location-pulse-diameter": `${pulseDiameterPx}px`,
+            "--user-location-pulse-duration":
+              pulseIntervalMs && Number.isFinite(Number(pulseIntervalMs))
+                ? `${Math.max(180, Number(pulseIntervalMs))}ms`
+                : undefined,
+          } as CSSProperties
+        }
       />
       <span className="user-location-marker__diamond" aria-hidden="true" />
     </div>,

--- a/src/components/map/controls/MapLayerDrawer.tsx
+++ b/src/components/map/controls/MapLayerDrawer.tsx
@@ -52,6 +52,7 @@ export default function MapLayerDrawer({
   showNavaidMarkers,
   showAirspaces = true,
   userLocationActive = false,
+  userLocationAudioActive = false,
   userLocationPending = false,
   userLocationNotice = "",
   onToggleMapLabels,
@@ -71,6 +72,13 @@ export default function MapLayerDrawer({
     onToggleNavaidMarkers,
     onToggleAirspaces,
   };
+  const userLocationTitle = userLocationPending
+    ? t("mapLayers.locatingUser")
+    : userLocationAudioActive
+      ? t("mapLayers.hideUserLocation")
+      : userLocationActive
+        ? t("mapLayers.enableUserLocationAudio")
+        : t("mapLayers.showUserLocation");
 
   return (
     <div
@@ -128,25 +136,19 @@ export default function MapLayerDrawer({
           <ToolbarButton
             tone="rail"
             active={userLocationActive}
-            aria-label={
-              userLocationPending
-                ? t("mapLayers.locatingUser")
-                : userLocationActive
-                  ? t("mapLayers.hideUserLocation")
-                  : t("mapLayers.showUserLocation")
-            }
+            aria-label={userLocationTitle}
             aria-pressed={userLocationActive}
-            title={
-              userLocationPending
-                ? t("mapLayers.locatingUser")
-                : userLocationActive
-                  ? t("mapLayers.hideUserLocation")
-                  : t("mapLayers.showUserLocation")
-            }
+            title={userLocationTitle}
+            className={cn(
+              userLocationAudioActive &&
+                "before:content-[''] before:absolute before:right-[6px] before:top-[6px] before:z-[2] before:h-1.5 before:w-1.5 before:rounded-full before:bg-atc-accent before:shadow-[0_0_8px_var(--atc-accent)]",
+            )}
             disabled={userLocationPending}
             onClick={onLocateUser}
           >
-            <MapControlIcon iconKey="locateFixed" />
+            <MapControlIcon
+              iconKey={userLocationAudioActive ? "radar" : "locateFixed"}
+            />
           </ToolbarButton>
         )}
       </Toolbar>

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -23,6 +23,7 @@ export default function MapControlBar({
   showNavaidMarkers = false,
   showAirspaces = true,
   userLocationActive = false,
+  userLocationAudioActive = false,
   userLocationPending = false,
   userLocationNotice = "",
   showSidebarToggle = true,
@@ -81,6 +82,7 @@ export default function MapControlBar({
         showNavaidMarkers={showNavaidMarkers}
         showAirspaces={showAirspaces}
         userLocationActive={userLocationActive}
+        userLocationAudioActive={userLocationAudioActive}
         userLocationPending={userLocationPending}
         userLocationNotice={userLocationNotice}
         onToggleMapLabels={onToggleMapLabels}

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -329,6 +329,7 @@ const en = {
     hideAirspaces: "Hide airspace",
     userLocation: "My location",
     showUserLocation: "Show my location",
+    enableUserLocationAudio: "Enable aircraft proximity sound",
     hideUserLocation: "Hide my location",
     locatingUser: "Locating...",
   },

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -324,6 +324,7 @@ const zhCN = {
     hideAirspaces: "隐藏空域",
     userLocation: "我的位置",
     showUserLocation: "显示我的位置",
+    enableUserLocationAudio: "开启飞机接近提示音",
     hideUserLocation: "隐藏我的位置",
     locatingUser: "正在定位...",
   },

--- a/src/features/aircraft/trace/aircraftTraceModel.test.ts
+++ b/src/features/aircraft/trace/aircraftTraceModel.test.ts
@@ -139,19 +139,38 @@ import {
 {
   const merged = mergeTraceHistory({
     fallbackHistory: [
-      { lat: 42.0, lon: -71.0, timestampMs: 1_000 },
-      { lat: 42.01, lon: -70.99, timestampMs: 2_000 },
+      { lat: 42.0, lon: -71.0, timestampMs: 60_000 },
+      { lat: 42.01, lon: -70.99, timestampMs: 120_000 },
     ],
     recentTrace: [
-      { lat: 41.95, lon: -71.05, timestampMs: 500 },
-      { lat: 42.01, lon: -70.99, timestampMs: 2_000 },
-      { lat: 42.02, lon: -70.98, timestampMs: 3_000 },
+      { lat: 41.95, lon: -71.05, timestampMs: 30_000 },
+      { lat: 42.01, lon: -70.99, timestampMs: 120_000 },
+      { lat: 42.02, lon: -70.98, timestampMs: 180_000 },
     ],
   });
 
   assert.deepEqual(
     merged.map((point) => point.timestampMs),
-    [500, 1_000, 2_000, 3_000],
+    [30_000, 60_000, 120_000, 180_000],
+  );
+}
+
+{
+  const merged = mergeTraceHistory({
+    fallbackHistory: [
+      { lat: 42.0, lon: -71.0, timestampMs: 60_000 },
+      { lat: 42.01, lon: -70.99, timestampMs: 95_000 },
+    ],
+    recentTrace: [
+      { lat: 42.02, lon: -70.98, timestampMs: 119_000 },
+      { lat: 42.03, lon: -70.97, timestampMs: 120_000 },
+    ],
+  });
+
+  assert.deepEqual(
+    merged.map((point) => point.timestampMs),
+    [119_000, 120_000],
+    "recent and fallback history should keep only the latest point in each minute",
   );
 }
 
@@ -171,19 +190,18 @@ import {
 }
 
 {
-  // Recent wins over full on overlap; live wins over both.
+  // Recent wins over full on exact overlap; live wins over both.
   const fullSource = [
-    { lat: 42.0, lon: -71.0, timestampMs: 1_000, altitude: 5_000 },
-    { lat: 42.01, lon: -70.99, timestampMs: 2_000, altitude: 6_000 },
-    { lat: 42.02, lon: -70.98, timestampMs: 3_000, altitude: 7_000 },
+    { lat: 42.0, lon: -71.0, timestampMs: 60_000, altitude: 5_000 },
+    { lat: 42.01, lon: -70.99, timestampMs: 120_000, altitude: 6_000 },
+    { lat: 42.02, lon: -70.98, timestampMs: 180_000, altitude: 7_000 },
   ];
   const recentSource = [
-    { lat: 42.015, lon: -70.985, timestampMs: 2_500, altitude: 6_500 },
-    { lat: 42.025, lon: -70.975, timestampMs: 3_000, altitude: 7_100 },
-    { lat: 42.03, lon: -70.97, timestampMs: 4_000, altitude: 7_500 },
+    { lat: 42.025, lon: -70.975, timestampMs: 120_000, altitude: 7_100 },
+    { lat: 42.03, lon: -70.97, timestampMs: 240_000, altitude: 7_500 },
   ];
   const liveSource = [
-    { lat: 42.035, lon: -70.965, timestampMs: 4_200, altitude: 7_600 },
+    { lat: 42.035, lon: -70.965, timestampMs: 240_000, altitude: 7_600 },
   ];
 
   const merged = mergeTracesByPriority({
@@ -194,25 +212,50 @@ import {
     ],
   });
 
-  // Recent should win at the 3_000 ms bucket (altitude 7_100, not 7_000).
-  const at3 = merged.find((p) => p.timestampMs === 3_000);
-  assert.equal(at3.altitude, 7_100, "recent should override full at overlap");
+  // Recent should win at the 120_000 ms point (altitude 7_100, not 6_000).
+  const at120 = merged.find((p) => p.timestampMs === 120_000);
+  assert.equal(at120.altitude, 7_100, "recent should override full at overlap");
 
-  // Live (priority 2) drops in its own bucket (4_200 → bucket 4) and
-  // overrides the recent point at 4_000 (also bucket 4).
-  const bucket4 = merged.filter((p) => Math.floor(p.timestampMs / 1000) === 4);
-  assert.equal(bucket4.length, 1, "1-second bucket should collapse to one point");
-  assert.equal(bucket4[0].timestampMs, 4_200, "live should win the 4s bucket");
-  assert.equal(bucket4[0].altitude, 7_600);
+  // Live (priority 2) wins the exact 240_000 ms overlap with recent.
+  const at240 = merged.find((p) => p.timestampMs === 240_000);
+  assert.equal(at240.altitude, 7_600);
 
-  // Full-only points (1_000) survive when no higher-priority source has them.
-  const at1 = merged.find((p) => p.timestampMs === 1_000);
-  assert.equal(at1.altitude, 5_000);
+  // Full-only points survive when no higher-priority source has that minute.
+  const at60 = merged.find((p) => p.timestampMs === 60_000);
+  assert.equal(at60.altitude, 5_000);
 
   // Output is sorted ascending by timestamp.
   for (let i = 1; i < merged.length; i++) {
     assert.ok(merged[i].timestampMs >= merged[i - 1].timestampMs);
   }
+}
+
+{
+  const merged = mergeTracesByPriority({
+    sources: [
+      {
+        points: [
+          { lat: 42.0, lon: -71.0, timestampMs: 60_000, altitude: 5_000 },
+          { lat: 42.01, lon: -70.99, timestampMs: 119_000, altitude: 5_500 },
+          { lat: 42.02, lon: -70.98, timestampMs: 120_000, altitude: 6_000 },
+        ],
+        priority: 0,
+      },
+      {
+        points: [
+          { lat: 42.03, lon: -70.97, timestampMs: 118_000, altitude: 6_500 },
+        ],
+        priority: 1,
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    merged.map((point) => point.timestampMs),
+    [119_000, 120_000],
+    "same-minute trace points should collapse to the latest point in each minute",
+  );
+  assert.equal(merged[0].altitude, 5_500);
 }
 
 {

--- a/src/features/aircraft/trace/aircraftTraceModel.ts
+++ b/src/features/aircraft/trace/aircraftTraceModel.ts
@@ -10,6 +10,7 @@ const DEFAULT_SOLID_TRACE_MAX_GAP_MS = 90 * 1000;
 const DEFAULT_TRACE_CONNECTOR_MAX_GAP_MS = 10 * 60 * 1000;
 const TRACE_MAX_GROUND_SPEED_KNOTS = 1500;
 const TRACE_MAX_GAP_MS = 60 * 60 * 1000;
+const TRACE_MINUTE_BUCKET_MS = 60 * 1000;
 
 type TraceRecord = Record<string, any>;
 type TracePoint = TraceRecord & {
@@ -160,13 +161,44 @@ function dedupeTracePointKey(point: TraceRecord = {}) {
   ].join(":");
 }
 
+function traceMinuteBucket(timestampMs: number) {
+  return Math.floor(timestampMs / TRACE_MINUTE_BUCKET_MS);
+}
+
+export function dedupeTracePointsByMinuteLatest(points = []) {
+  const buckets = new Map();
+  const normalized = Array.isArray(points)
+    ? points
+        .filter(
+          (point) =>
+            isFiniteNumber(point?.lat) &&
+            isFiniteNumber(point?.lon) &&
+            Number.isFinite(Number(point?.timestampMs ?? point?.time)),
+        )
+        .map((point) => ({
+          ...point,
+          timestampMs: Number(point?.timestampMs ?? point?.time),
+          lat: Number(point.lat),
+          lon: Number(point.lon),
+        }))
+        .sort((a, b) => a.timestampMs - b.timestampMs)
+    : [];
+
+  for (const point of normalized) {
+    buckets.set(traceMinuteBucket(point.timestampMs), point);
+  }
+
+  return Array.from(buckets.values()).sort(
+    (a, b) => a.timestampMs - b.timestampMs,
+  );
+}
+
 // Resolve overlapping trace points across multiple sources, preferring
-// the higher-priority source on collision. Sources are bucketed by 1-second
-// timestamp because adsb.lol publishes second-aligned offsets and our live
-// poll rounds to the broadcast second too — so "same physical broadcast"
-// reliably collapses to the same bucket regardless of which endpoint
-// supplied it. Callers pass sources in any order; the explicit `priority`
-// field is what determines the winner (higher wins).
+// the latest point within each minute. If two sources publish the same
+// timestamp in that minute, the explicit `priority` field breaks the tie
+// (higher wins). The map renders the resulting point set directly, so this
+// keeps recent/full/live traces from drawing multiple dots or labels for
+// the same minute.
 //
 // Used by the aircraft detail page where three sources overlap:
 //   priority 2 — live polled position (freshest, includes telemetry)
@@ -182,11 +214,18 @@ export function mergeTracesByPriority({ sources = [] } = {}) {
       if (!isFiniteNumber(point?.lat) || !isFiniteNumber(point?.lon)) continue;
       const timestampMs = Number(point?.timestampMs ?? point?.time);
       if (!Number.isFinite(timestampMs)) continue;
-      const bucket = Math.floor(timestampMs / 1000);
+      const bucket = traceMinuteBucket(timestampMs);
       const existing = buckets.get(bucket);
-      if (existing && existing.priority >= priority) continue;
+      if (
+        existing &&
+        (existing.timestampMs > timestampMs ||
+          (existing.timestampMs === timestampMs && existing.priority >= priority))
+      ) {
+        continue;
+      }
       buckets.set(bucket, {
         priority,
+        timestampMs,
         point: {
           timestampMs,
           lat: Number(point.lat),
@@ -411,15 +450,7 @@ export function mergeTraceHistory({
   const merged = [...recentTrace, ...normalizedFallback].sort(
     (a, b) => a.timestampMs - b.timestampMs,
   );
-  const seen = new Set();
-  const deduped = [];
-  for (const point of merged) {
-    const key = dedupeTracePointKey(point);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    deduped.push(point);
-  }
-  return deduped;
+  return dedupeTracePointsByMinuteLatest(merged);
 }
 
 export function downsampleTracePoints(

--- a/src/features/aircraft/trace/traceGeometry.test.ts
+++ b/src/features/aircraft/trace/traceGeometry.test.ts
@@ -36,4 +36,38 @@ import { computeTraceGeometry } from "./traceGeometry";
   );
 }
 
+{
+  const base = 1_700_000_000_000 - (1_700_000_000_000 % 60_000);
+  const tracePoints = Array.from({ length: 6 }, (_, minute) => [
+    {
+      lat: 42 + minute * 0.12,
+      lon: -71,
+      timestampMs: base + minute * 60_000 + 5_000,
+      altitude: 2_000 + minute * 100,
+    },
+    {
+      lat: 42.01 + minute * 0.12,
+      lon: -70.99,
+      timestampMs: base + minute * 60_000 + 45_000,
+      altitude: 2_050 + minute * 100,
+    },
+  ]).flat();
+
+  const geometry = computeTraceGeometry({ tracePoints, maxRenderPoints: 80 });
+
+  assert.ok(geometry, "minute-deduped trace should still produce geometry");
+  assert.ok(
+    geometry.samplePoints.every(
+      (point) => (point.timestampMs - base) % 60_000 === 45_000,
+    ),
+    "sample dots should use the latest point in each minute",
+  );
+  assert.ok(
+    geometry.labelPoints.every(
+      (point) => (point.timestampMs - base) % 60_000 === 45_000,
+    ),
+    "time/altitude labels should use the latest point in each minute",
+  );
+}
+
 console.log("traceGeometry.test.ts ok");

--- a/src/features/aircraft/trace/traceGeometry.ts
+++ b/src/features/aircraft/trace/traceGeometry.ts
@@ -4,6 +4,7 @@
 
 import {
   buildAircraftTraceCurve,
+  dedupeTracePointsByMinuteLatest,
   downsampleTracePoints,
   segmentTracePoints,
 } from "./aircraftTraceModel";
@@ -59,7 +60,10 @@ export function computeTraceGeometry({
 }) {
   if (!Array.isArray(tracePoints) || tracePoints.length < 2) return null;
 
-  const segmented = segmentTracePoints(tracePoints);
+  const minuteTracePoints = dedupeTracePointsByMinuteLatest(tracePoints);
+  if (minuteTracePoints.length < 2) return null;
+
+  const segmented = segmentTracePoints(minuteTracePoints);
   const segments = segmented.segments
     .map((segment, index) => {
       if (!Array.isArray(segment.points) || segment.points.length < 2) {

--- a/src/features/airport/map/userLocationAudioModel.test.ts
+++ b/src/features/airport/map/userLocationAudioModel.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import {
+  buildAircraftProximityAudioCue,
+  USER_LOCATION_AIRCRAFT_ALERT_RANGE_NM,
+  USER_LOCATION_AIRCRAFT_ALERT_RANGE_METERS,
+} from "./userLocationAudioModel";
+
+const userLocation = { lat: 42.3656, lon: -71.0096 };
+
+{
+  assert.equal(USER_LOCATION_AIRCRAFT_ALERT_RANGE_NM, 6);
+  assert.equal(USER_LOCATION_AIRCRAFT_ALERT_RANGE_METERS, 11_112);
+}
+
+{
+  const cue = buildAircraftProximityAudioCue({
+    userLocation,
+    aircraft: [
+      {
+        icao24: "far",
+        callsign: "FAR1",
+        lat: 42.3656,
+        lon: -70.89,
+        altitude: 0,
+      },
+      {
+        icao24: "near",
+        callsign: "NEAR1",
+        lat: 42.3656,
+        lon: -71.0096,
+        altitude: 6000,
+      },
+    ],
+  });
+
+  assert.equal(cue?.aircraftId, "near");
+  assert.ok((cue?.distanceNm ?? Infinity) < 1.1);
+  assert.ok((cue?.intervalMs ?? Infinity) < 700);
+  assert.ok((cue?.toneHz ?? 0) > 900);
+}
+
+{
+  const farCue = buildAircraftProximityAudioCue({
+    userLocation,
+    aircraft: [
+      {
+        icao24: "far",
+        callsign: "FAR1",
+        lat: 42.3656,
+        lon: -70.89,
+        altitude: 0,
+      },
+    ],
+  });
+
+  assert.equal(farCue?.aircraftId, "far");
+  assert.ok((farCue?.distanceNm ?? 0) < USER_LOCATION_AIRCRAFT_ALERT_RANGE_NM);
+  assert.ok((farCue?.intervalMs ?? 0) > 1800);
+}
+
+{
+  assert.equal(
+    buildAircraftProximityAudioCue({
+      userLocation,
+      aircraft: [
+        {
+          icao24: "outside",
+          callsign: "OUT1",
+          lat: 42.3656,
+          lon: -70.75,
+          altitude: 0,
+        },
+      ],
+    }),
+    null,
+  );
+}
+
+{
+  assert.equal(
+    buildAircraftProximityAudioCue({
+      userLocation,
+      aircraft: [
+        {
+          icao24: "ground",
+          callsign: "GROUND1",
+          lat: 42.3656,
+          lon: -71.0096,
+          altitude: 0,
+          onGround: true,
+        },
+      ],
+    }),
+    null,
+  );
+}
+
+console.log("userLocationAudioModel.test.ts ok");

--- a/src/features/airport/map/userLocationAudioModel.ts
+++ b/src/features/airport/map/userLocationAudioModel.ts
@@ -1,0 +1,109 @@
+import { getDistanceNm } from "@/utils/aircraftTrafficIntent";
+import { toFiniteNumber } from "@/utils/math";
+
+export const USER_LOCATION_AIRCRAFT_ALERT_RANGE_NM = 6;
+export const USER_LOCATION_AIRCRAFT_ALERT_RANGE_METERS =
+  USER_LOCATION_AIRCRAFT_ALERT_RANGE_NM * 1852;
+export const USER_LOCATION_AIRCRAFT_MIN_INTERVAL_MS = 360;
+export const USER_LOCATION_AIRCRAFT_MAX_INTERVAL_MS = 2400;
+export const USER_LOCATION_AIRCRAFT_MIN_TONE_HZ = 620;
+export const USER_LOCATION_AIRCRAFT_MAX_TONE_HZ = 1120;
+
+const FEET_PER_NAUTICAL_MILE = 6076.12;
+
+type UserLocationAudioRecord = Record<string, any>;
+export type UserLocationAircraftAudioCue = {
+  aircraftId: string;
+  callsign: string;
+  distanceNm: number;
+  intervalMs: number;
+  toneHz: number;
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const resolveAircraftId = (aircraft: UserLocationAudioRecord) =>
+  aircraft?.icao24 || aircraft?.hex || aircraft?.callsign || "";
+
+function resolveAltitudeNm(aircraft: UserLocationAudioRecord) {
+  const altitude = toFiniteNumber(aircraft?.altitude ?? aircraft?.alt_baro);
+  if (altitude == null || altitude <= 0) return 0;
+  return altitude / FEET_PER_NAUTICAL_MILE;
+}
+
+function resolveAircraftDistanceNm({
+  userLocation,
+  aircraft,
+}: {
+  userLocation?: UserLocationAudioRecord | null;
+  aircraft?: UserLocationAudioRecord | null;
+}) {
+  const horizontalDistanceNm = getDistanceNm(
+    userLocation?.lat,
+    userLocation?.lon,
+    aircraft?.lat,
+    aircraft?.lon,
+  );
+  if (horizontalDistanceNm == null) return null;
+
+  const verticalDistanceNm = resolveAltitudeNm(aircraft || {});
+  return Math.hypot(horizontalDistanceNm, verticalDistanceNm);
+}
+
+export function buildAircraftProximityAudioCue({
+  userLocation,
+  aircraft = [],
+  alertRangeNm = USER_LOCATION_AIRCRAFT_ALERT_RANGE_NM,
+}: {
+  userLocation?: UserLocationAudioRecord | null;
+  aircraft?: UserLocationAudioRecord[];
+  alertRangeNm?: number;
+} = {}): UserLocationAircraftAudioCue | null {
+  if (!userLocation) return null;
+
+  const nearest = aircraft.reduce(
+    (best, item) => {
+      if (!item || item.onGround) return best;
+
+      const distanceNm = resolveAircraftDistanceNm({ userLocation, aircraft: item });
+      if (distanceNm == null || distanceNm > alertRangeNm) return best;
+      if (best && best.distanceNm <= distanceNm) return best;
+
+      return {
+        aircraftId: resolveAircraftId(item),
+        callsign: item.callsign || "",
+        distanceNm,
+      };
+    },
+    null as null | {
+      aircraftId: string;
+      callsign: string;
+      distanceNm: number;
+    },
+  );
+
+  if (!nearest) return null;
+
+  const proximity = 1 - clamp(nearest.distanceNm / alertRangeNm, 0, 1);
+  const intervalMs = Math.round(
+    USER_LOCATION_AIRCRAFT_MAX_INTERVAL_MS -
+      proximity *
+        (USER_LOCATION_AIRCRAFT_MAX_INTERVAL_MS -
+          USER_LOCATION_AIRCRAFT_MIN_INTERVAL_MS),
+  );
+  const toneHz = Math.round(
+    USER_LOCATION_AIRCRAFT_MIN_TONE_HZ +
+      proximity *
+        (USER_LOCATION_AIRCRAFT_MAX_TONE_HZ -
+          USER_LOCATION_AIRCRAFT_MIN_TONE_HZ),
+  );
+
+  return {
+    aircraftId: nearest.aircraftId,
+    callsign: nearest.callsign,
+    distanceNm: nearest.distanceNm,
+    intervalMs,
+    toneHz,
+  };
+}

--- a/src/features/airport/map/userLocationModel.test.ts
+++ b/src/features/airport/map/userLocationModel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  resolveNextUserLocationAudioMode,
   resolveUserLocationPulseDiameterPx,
   resolveUserLocationRequest,
   USER_LOCATION_PULSE_RADIUS_METERS,
@@ -7,6 +8,31 @@ import {
 } from "./userLocationModel";
 
 const KBOS = { lat: 42.3656, lon: -71.0096 };
+
+{
+  assert.equal(
+    resolveNextUserLocationAudioMode({ mode: "off", hasLocation: false }),
+    "location",
+  );
+  assert.equal(
+    resolveNextUserLocationAudioMode({ mode: "location", hasLocation: true }),
+    "location-audio",
+  );
+  assert.equal(
+    resolveNextUserLocationAudioMode({
+      mode: "location-audio",
+      hasLocation: true,
+    }),
+    "off",
+  );
+  assert.equal(
+    resolveNextUserLocationAudioMode({
+      mode: "location-audio",
+      hasLocation: false,
+    }),
+    "location",
+  );
+}
 
 {
   const result = resolveUserLocationRequest({
@@ -47,7 +73,7 @@ const KBOS = { lat: 42.3656, lon: -71.0096 };
 }
 
 {
-  assert.equal(USER_LOCATION_PULSE_RADIUS_METERS, 1000);
+  assert.equal(USER_LOCATION_PULSE_RADIUS_METERS, 11_112);
   assert.equal(
     resolveUserLocationPulseDiameterPx({
       centerPoint: { x: 100, y: 100 },

--- a/src/features/airport/map/userLocationModel.ts
+++ b/src/features/airport/map/userLocationModel.ts
@@ -1,8 +1,18 @@
 import { getDistanceNm } from "@/utils/aircraftTrafficIntent";
+import { USER_LOCATION_AIRCRAFT_ALERT_RANGE_METERS } from "./userLocationAudioModel";
 
 export const USER_LOCATION_MAX_DISTANCE_NM = 80;
-export const USER_LOCATION_PULSE_RADIUS_METERS = 1000;
+export const USER_LOCATION_PULSE_RADIUS_METERS =
+  USER_LOCATION_AIRCRAFT_ALERT_RANGE_METERS;
 export const USER_LOCATION_MIN_PULSE_DIAMETER_PX = 18;
+export const USER_LOCATION_AUDIO_MODES = {
+  OFF: "off",
+  LOCATION: "location",
+  LOCATION_AUDIO: "location-audio",
+} as const;
+
+export type UserLocationAudioMode =
+  (typeof USER_LOCATION_AUDIO_MODES)[keyof typeof USER_LOCATION_AUDIO_MODES];
 
 type UserLocationCoords = {
   latitude?: unknown;
@@ -17,10 +27,29 @@ type ResolveUserLocationRequestOptions = {
   maxDistanceNm?: number;
 };
 
+type ResolveNextUserLocationAudioModeOptions = {
+  mode?: unknown;
+  hasLocation?: boolean;
+};
+
 const toFiniteNumber = (value: unknown) => {
   const number = Number(value);
   return Number.isFinite(number) ? number : null;
 };
+
+export function resolveNextUserLocationAudioMode({
+  mode,
+  hasLocation = false,
+}: ResolveNextUserLocationAudioModeOptions = {}): UserLocationAudioMode {
+  if (!hasLocation) return USER_LOCATION_AUDIO_MODES.LOCATION;
+  if (mode === USER_LOCATION_AUDIO_MODES.LOCATION) {
+    return USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO;
+  }
+  if (mode === USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO) {
+    return USER_LOCATION_AUDIO_MODES.OFF;
+  }
+  return USER_LOCATION_AUDIO_MODES.LOCATION;
+}
 
 export function resolveUserLocationPulseDiameterPx({
   centerPoint,

--- a/src/hooks/useAircraftTrace.ts
+++ b/src/hooks/useAircraftTrace.ts
@@ -87,8 +87,8 @@ function liveAircraftToTracePoint(aircraft: AircraftTraceHookRecord | null) {
 //     overlap.
 //   - The live point grows the trail forward in real time and is the
 //     freshest source, so it wins over both. We append it as a new entry
-//     on every selectedAircraft tick — the priority merge dedupes the
-//     repeats by 1-second timestamp bucket.
+//     on every selectedAircraft tick — the priority merge keeps only the
+//     latest point for each minute.
 //   - The persisted source seeds the trail instantly on reload so a
 //     refresh of /aircraft/[callsign] doesn't blank the trace while the
 //     fresh fetches resolve. It sits at the lowest priority because the

--- a/src/hooks/useUserLocationAircraftAudio.ts
+++ b/src/hooks/useUserLocationAircraftAudio.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { buildAircraftProximityAudioCue } from "@/features/airport/map/userLocationAudioModel";
+
+type UserLocationAircraftAudioRecord = Record<string, any>;
+
+type BrowserAudioContext = AudioContext & {
+  webkitAudioContext?: typeof AudioContext;
+};
+
+const getAudioContextConstructor = () => {
+  if (typeof window === "undefined") return null;
+  return (
+    window.AudioContext ||
+    (window as Window & { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext ||
+    null
+  );
+};
+
+export function useUserLocationAircraftAudio({
+  enabled = false,
+  userLocation = null,
+  aircraft = [],
+}: {
+  enabled?: boolean;
+  userLocation?: UserLocationAircraftAudioRecord | null;
+  aircraft?: UserLocationAircraftAudioRecord[];
+}) {
+  const audioContextRef = useRef<BrowserAudioContext | null>(null);
+  const [pulseBeat, setPulseBeat] = useState(0);
+  const cue = useMemo(
+    () => buildAircraftProximityAudioCue({ userLocation, aircraft }),
+    [aircraft, userLocation],
+  );
+  const cueAircraftId = cue?.aircraftId || "";
+  const cueIntervalMs = cue?.intervalMs || null;
+  const cueToneHz = cue?.toneHz || null;
+
+  const unlockAudio = useCallback(() => {
+    const AudioContextConstructor = getAudioContextConstructor();
+    if (!AudioContextConstructor) return false;
+
+    if (!audioContextRef.current) {
+      audioContextRef.current =
+        new AudioContextConstructor() as BrowserAudioContext;
+    }
+
+    if (audioContextRef.current.state === "suspended") {
+      void audioContextRef.current.resume();
+    }
+
+    return true;
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setPulseBeat(0);
+      if (audioContextRef.current?.state === "running") {
+        void audioContextRef.current.suspend();
+      }
+      return undefined;
+    }
+
+    if (!cueAircraftId || !cueIntervalMs || !cueToneHz) return undefined;
+    unlockAudio();
+
+    const playCue = () => {
+      setPulseBeat((value) => value + 1);
+      const context = audioContextRef.current;
+      if (!context || context.state !== "running") return;
+
+      const start = context.currentTime;
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+
+      oscillator.type = "sine";
+      oscillator.frequency.setValueAtTime(cueToneHz, start);
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(0.08, start + 0.012);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.09);
+
+      oscillator.connect(gain);
+      gain.connect(context.destination);
+      oscillator.start(start);
+      oscillator.stop(start + 0.1);
+    };
+
+    playCue();
+    const interval = window.setInterval(playCue, cueIntervalMs);
+    return () => window.clearInterval(interval);
+  }, [cueAircraftId, cueIntervalMs, cueToneHz, enabled, unlockAudio]);
+
+  useEffect(
+    () => () => {
+      if (audioContextRef.current) {
+        void audioContextRef.current.close();
+        audioContextRef.current = null;
+      }
+    },
+    [],
+  );
+
+  return {
+    cue,
+    pulseBeat,
+    unlockAudio,
+  };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -2656,7 +2656,7 @@ body {
     position: absolute;
     width: var(--user-location-pulse-diameter, 18px);
     z-index: 0;
-    animation: user-location-pulse 1s ease-out infinite;
+    animation: user-location-pulse var(--user-location-pulse-duration, 1s) ease-out infinite;
 }
 
 .user-location-marker__diamond {
@@ -4350,7 +4350,7 @@ body {
     bottom: 20px;
     right: 20px;
     z-index: var(--z-index-popover);
-    width: 280px;
+    width: 320px;
     max-width: calc(100vw - 32px);
     padding: 18px 18px 14px;
     /* Solid theme-color surface — no transparency, no frosted-glass.
@@ -4436,6 +4436,15 @@ body {
     min-width: 0;
 }
 
+.aircraft-preview-telemetry .aircraft-preview-stat:nth-child(2) {
+    align-items: center;
+    text-align: center;
+}
+
+.aircraft-preview-telemetry .aircraft-preview-stat:nth-child(2) .aircraft-preview-stat__value {
+    justify-content: center;
+}
+
 /* The right-most stat (V/S) hugs the card's right edge so it stays in
    visual rhythm with the right-aligned type tag and the metadata
    rows. */
@@ -4518,7 +4527,7 @@ body {
    the media card is mounted only after the photo lookup resolves and
    slides upward from behind the metadata card. */
 .aircraft-preview-card {
-    width: 280px;
+    width: 320px;
     padding: 0;
     overflow: visible;
     border: 0;
@@ -4528,7 +4537,7 @@ body {
 }
 
 .aircraft-preview-card--airport {
-    width: 320px;
+    width: 360px;
 }
 
 .aircraft-preview-card--desktop-reveal {
@@ -5677,7 +5686,7 @@ body {
         bottom: 16px;
         max-width: calc(100vw - 26px);
         right: 16px;
-        width: 224px;
+        width: 264px;
     }
 
     .aircraft-preview-card__media-slot {


### PR DESCRIPTION
## Summary
- add tri-state user location control with aircraft proximity audio alerts and synced 6 NM pulse ring
- widen and align aircraft preview cards, including telemetry column alignment
- collapse aircraft traces and trace labels to the latest point per minute
- bump version to 1.8.2

## Verification
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm lint
- /opt/homebrew/bin/pnpm build