### PR TITLE
[codex] Replay map loading overlay on page restore

### DIFF
--- a/src/components/map/MapLoadingOverlay.tsx
+++ b/src/components/map/MapLoadingOverlay.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AIRPORT_EXPLORER_UI_CONFIG } from "@/config/aviation";
 import {
   getLoadingOverlayExitDelay,
   resolveAircraftLoadingOverlayState,
+  shouldReplayLoadingOverlayOnPageVisible,
 } from "@/features/aircraft/positions/aircraftLoadingOverlayModel";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 
@@ -48,9 +49,40 @@ export default function MapLoadingOverlay({
   sidebarAware = false,
   ariaLabel,
 }: Record<string, any>) {
-  const [visible, setVisible] = useState(active);
+  const [visible, setVisible] = useState(true);
   const [exiting, setExiting] = useState(false);
-  const shownAtRef = useRef(active ? Date.now() : 0);
+  const [playbackCycle, setPlaybackCycle] = useState(0);
+  const shownAtRef = useRef(Date.now());
+
+  const replay = useCallback(() => {
+    shownAtRef.current = Date.now();
+    setVisible(true);
+    setExiting(false);
+    setPlaybackCycle((value) => value + 1);
+  }, []);
+
+  useEffect(() => {
+    const handlePageVisible = () => {
+      if (
+        typeof document !== "undefined" &&
+        !shouldReplayLoadingOverlayOnPageVisible({
+          documentHidden: document.hidden,
+        })
+      ) {
+        return;
+      }
+
+      replay();
+    };
+
+    document.addEventListener("visibilitychange", handlePageVisible);
+    window.addEventListener("pageshow", handlePageVisible);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handlePageVisible);
+      window.removeEventListener("pageshow", handlePageVisible);
+    };
+  }, [replay]);
 
   useEffect(() => {
     let delayTimer;
@@ -82,7 +114,7 @@ export default function MapLoadingOverlay({
       if (delayTimer) window.clearTimeout(delayTimer);
       if (fadeTimer) window.clearTimeout(fadeTimer);
     };
-  }, [active, visible]);
+  }, [active, playbackCycle, visible]);
 
   return (
     <div
@@ -99,7 +131,7 @@ export default function MapLoadingOverlay({
       role="status"
       style={{ display: visible ? undefined : "none" }}
     >
-      <div className="adsb-loading-grid" aria-hidden="true">
+      <div key={playbackCycle} className="adsb-loading-grid" aria-hidden="true">
         <span className="adsb-loading-grid__matrix" />
         <span className="adsb-loading-grid__scan" />
       </div>

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.ts
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.ts
@@ -8,11 +8,26 @@ import {
   resolveAircraftLoadingOverlayState,
   resolveMapLoadingPresentation,
   scheduleAfterOverlayPaint,
+  shouldReplayLoadingOverlayOnPageVisible,
   shouldShowAircraftLoadingOverlay,
   shouldTriggerVisibilityRefreshOverlay,
 } from "./aircraftLoadingOverlayModel";
 
-assert.equal(AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS, 500);
+assert.equal(AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS, 1_000);
+
+assert.equal(
+  shouldReplayLoadingOverlayOnPageVisible({
+    documentHidden: false,
+  }),
+  true,
+);
+
+assert.equal(
+  shouldReplayLoadingOverlayOnPageVisible({
+    documentHidden: true,
+  }),
+  false,
+);
 
 assert.equal(
   shouldShowAircraftLoadingOverlay({
@@ -84,13 +99,13 @@ assert.equal(
     now: 1_120,
     minVisibleMs: AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
   }),
-  380,
+  880,
 );
 
 assert.equal(
   getLoadingOverlayExitDelay({
     shownAt: 1_000,
-    now: 1_650,
+    now: 2_050,
     minVisibleMs: AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
   }),
   0,

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.ts
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.ts
@@ -1,4 +1,4 @@
-export const AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS = 500;
+export const AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS = 1_000;
 
 type LoadingSettledOptions = {
   aircraftPositionsSettled?: boolean;
@@ -52,6 +52,10 @@ type OverlayPaintSchedulerOptions = {
   cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame;
   setTimeout?: typeof globalThis.setTimeout;
   clearTimeout?: typeof globalThis.clearTimeout;
+};
+
+type PageVisibleReplayOptions = {
+  documentHidden?: boolean;
 };
 
 export function areCriticalLoadingRequestsSettled({
@@ -139,6 +143,12 @@ export function getLoadingOverlayExitDelay({
   minVisibleMs = AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
 }: LoadingOverlayExitDelayOptions = {}) {
   return Math.max(0, minVisibleMs - Math.max(0, now - shownAt));
+}
+
+export function shouldReplayLoadingOverlayOnPageVisible({
+  documentHidden = false,
+}: PageVisibleReplayOptions = {}) {
+  return !documentHidden;
 }
 
 export function scheduleAfterOverlayPaint(


### PR DESCRIPTION
## Summary
- Rework the map loading overlay so it owns a replay cycle independent of the old hidden-duration refresh gate.
- Keep the dot-matrix scan visible for at least 1 second on initial page load and page-visible restore.
- Restart the scan animation by remounting the grid on `visibilitychange` / `pageshow` without changing the animation CSS.

## Validation
- `/opt/homebrew/bin/pnpm test src/features/aircraft/positions/aircraftLoadingOverlayModel.test.ts` (runs 104 test files)
- `/opt/homebrew/bin/pnpm lint` (0 errors; existing `VirtualNearbyList` TanStack Virtual warning)
- `/opt/homebrew/bin/pnpm build`
- Local Chromium verification on `http://localhost:3000/airport/KBOS` for initial load and page-visible replay