### PR TITLE
[codex] Unify shared UI design tokens

### DIFF
--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -2,6 +2,40 @@
 
 import { useEffect, useState } from "react";
 import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap";
+import { cn } from "@/lib/utils";
+
+const rootClassName =
+  "flex min-w-0 flex-col items-end justify-center gap-px whitespace-nowrap font-display [font-feature-settings:'tnum'_1] [text-shadow:0_1px_8px_var(--atc-bg)]";
+
+const mapCornerClassName = cn(
+  "absolute right-3 top-[calc(100%+6px)] hidden max-w-[calc(100vw-132px)] transform-none",
+  "[.airport-map-menu_&]:flex",
+  "[.airport-map-kit_&]:right-0.5 [.airport-map-kit_&]:top-[calc(100%+10px)]",
+  "md:[.airport-map-kit_&]:top-[calc(100%+8px)]",
+  "[.airport-map-menu--mobile_&]:left-1/2 [.airport-map-menu--mobile_&]:right-auto [.airport-map-menu--mobile_&]:top-[calc(100%+7px)]",
+  "[.airport-map-menu--mobile_&]:max-w-[min(288px,calc(100vw-32px))] [.airport-map-menu--mobile_&]:-translate-x-1/2",
+  "[.airport-map-menu--mobile_&]:items-center [.airport-map-menu--mobile_&]:text-center",
+  "[.airport-map-menu--mobile_&]:[filter:drop-shadow(0_7px_11px_color-mix(in_oklab,var(--atc-bg)_72%,transparent))_drop-shadow(0_1px_1px_color-mix(in_oklab,var(--atc-text)_24%,transparent))]",
+);
+
+const lineClassName = cn(
+  "flex w-full min-w-0 flex-wrap items-center justify-end gap-[7px]",
+  "text-[10px] font-semibold leading-none text-atc-dim uppercase",
+  "[.airport-map-kit_&]:gap-[5px] [.airport-map-kit_&]:text-[8px]",
+  "[.airport-map-menu--mobile_&]:justify-center [.airport-map-menu--mobile_&]:gap-1.5",
+  "[.airport-map-menu--mobile_&]:text-center [.airport-map-menu--mobile_&]:text-[9px]",
+);
+
+const diamondClassName =
+  "inline-block size-[7px] flex-none rotate-45 bg-atc-orange [.airport-map-kit_&]:size-[5px] [.airport-map-menu--mobile_&]:size-1.5";
+
+const loadingClassName = cn(
+  "min-h-0 max-w-[min(280px,calc(100vw-132px))] overflow-hidden whitespace-normal",
+  "text-right font-mono text-[8px] font-semibold uppercase leading-none text-atc-dim",
+  "opacity-0 transition-opacity duration-200 ease-out [overflow-wrap:anywhere] will-change-[opacity] motion-reduce:transition-none",
+  "[.airport-map-kit_&]:max-w-[min(224px,calc(100vw-106px))] [.airport-map-kit_&]:text-[7px]",
+  "[.airport-map-menu--mobile_&]:max-w-[min(288px,calc(100vw-32px))] [.airport-map-menu--mobile_&]:text-center [.airport-map-menu--mobile_&]:text-[7px]",
+);
 
 export default function MapSourceStatusDisplay({
   feedSource = "",
@@ -38,18 +72,20 @@ export default function MapSourceStatusDisplay({
     return null;
   }
 
-  const rootClassName = [
-    "map-source-status",
-    `map-source-status--${placement}`,
-    `map-source-status--${feedStatus}`,
-  ].join(" ");
-
+  const isMapCorner = placement === "map-corner";
+  const isInfer = feedStatus === "infer";
   const hasPrimary = feedSource || routeProviderLabel || updatedLabel;
 
   return (
-    <div className={rootClassName} aria-label="Map data sources">
+    <div
+      className={cn(
+        rootClassName,
+        isMapCorner && mapCornerClassName,
+      )}
+      aria-label="Map data sources"
+    >
       {hasPrimary ? (
-        <span className="map-source-status__line">
+        <span className={lineClassName}>
           {feedSource ? (
             <EndfieldValueSwap
               identityKey={`source:${feedSource}`}
@@ -58,12 +94,15 @@ export default function MapSourceStatusDisplay({
                   {feedSource}
                 </span>
               )}
-              className="map-source-status__source"
+              className={cn("flex-none overflow-visible", isInfer && "text-atc-faint")}
               direction="reverse"
             />
           ) : null}
           {feedSource && routeProviderLabel ? (
-            <span aria-hidden="true" className="map-source-status__diamond" />
+            <span
+              aria-hidden="true"
+              className={diamondClassName}
+            />
           ) : null}
           {routeProviderLabel ? (
             <EndfieldValueSwap
@@ -73,15 +112,21 @@ export default function MapSourceStatusDisplay({
                   {routeProviderLabel}
                 </span>
               )}
-              className="map-source-status__route"
+              className="flex-none [.airport-map-menu--mobile_&]:text-[8px]"
               direction="reverse"
             />
           ) : null}
           {(feedSource || routeProviderLabel) && updatedLabel ? (
-            <span aria-hidden="true" className="map-source-status__diamond" />
+            <span
+              aria-hidden="true"
+              className={diamondClassName}
+            />
           ) : null}
           {updatedLabel ? (
-            <span className="map-source-status__time" aria-live="off">
+            <span
+              className={cn("flex-none tabular-nums", isInfer && "text-atc-faint")}
+              aria-live="off"
+            >
               {updatedLabel}
             </span>
           ) : null}
@@ -89,10 +134,15 @@ export default function MapSourceStatusDisplay({
       ) : null}
       {loadingActive || displayedLoadingStatus ? (
         <span
-          className={`map-source-status__loading-slot ${loadingActive ? "is-active" : ""}`}
+          className="flex w-full min-w-0 items-center justify-end overflow-hidden [.airport-map-menu--mobile_&]:justify-center [.airport-map-menu--mobile_&]:text-center"
           aria-hidden={!loadingActive}
         >
-          <span className="map-source-status__loading">
+          <span
+            className={cn(
+              loadingClassName,
+              loadingActive && "opacity-100",
+            )}
+          >
             {displayedLoadingStatus}
           </span>
         </span>

--- a/src/components/map/controls/MapLayerDrawer.tsx
+++ b/src/components/map/controls/MapLayerDrawer.tsx
@@ -92,9 +92,7 @@ export default function MapLayerDrawer({
         "[.airport-map-menu--mobile_&]:right-auto",
         "[.airport-map-menu--mobile_&]:left-1/2",
         "[.airport-map-menu--mobile_&]:origin-top",
-        // Open / closed transitions — pure Tailwind, drives the same
-        // opacity + translate + scale animation .map-action-drawer
-        // used to do in style.css.
+        // Open / closed transitions stay co-located with the drawer state.
         "transition-[opacity,transform] duration-[180ms] ease-out",
         open
           ? cn(

--- a/src/components/ui/FilterCard.tsx
+++ b/src/components/ui/FilterCard.tsx
@@ -23,24 +23,24 @@ const forwardRef = React.forwardRef as <
 const filterCardVariants = cva(
   cn(
     "group relative isolate w-full overflow-hidden",
-    "grid items-center justify-items-center gap-[6px]",
+    "grid items-center justify-items-center gap-1.5",
     "rounded-[var(--atc-radius-card)] border border-[var(--sidebar-tile-rest-border)] bg-clip-padding",
-    "bg-[color-mix(in_oklab,var(--atc-card)_74%,transparent)]",
-    "shadow-[inset_0_1px_0_color-mix(in_oklab,var(--atc-text)_5%,transparent)]",
+    "bg-[var(--atc-control-surface-muted)]",
+    "shadow-[var(--atc-control-inset-shadow-subtle)]",
     "text-atc-text text-center cursor-pointer",
-    "px-[14px] py-[12px] min-w-0",
+    "px-3.5 py-3 min-w-0",
     "outline-none transition-[background,box-shadow,color] duration-150",
     // Hover — light dim of the card surface.
-    "hover:bg-[color-mix(in_oklab,var(--atc-card)_58%,transparent)]",
+    "hover:bg-[var(--atc-control-surface-hover)]",
     // Active / open — invert to the ink background with edge-glow
     // box-shadow. Matches MetricCard's active treatment so a filter
     // chip in the "on" state reads the same as the selected tab.
     "data-[active=true]:bg-[var(--atc-click-bg)]",
     "data-[active=true]:text-[var(--atc-click-fg)]",
-    "data-[active=true]:shadow-[inset_0_-1px_0_var(--sidebar-tile-edge-glow),inset_0_-12px_20px_color-mix(in_oklab,var(--atc-click-fg)_7%,transparent)]",
+    "data-[active=true]:shadow-[var(--atc-control-active-shadow)]",
     "data-[state=open]:bg-[var(--atc-click-bg)]",
     "data-[state=open]:text-[var(--atc-click-fg)]",
-    "data-[state=open]:shadow-[inset_0_-1px_0_var(--sidebar-tile-edge-glow),inset_0_-12px_20px_color-mix(in_oklab,var(--atc-click-fg)_7%,transparent)]",
+    "data-[state=open]:shadow-[var(--atc-control-active-shadow)]",
     // Focus-visible — yellow ring.
     "focus-visible:shadow-[inset_0_0_0_2px_var(--endf-yellow)]",
     // SelectTrigger ships a ChevronDown as a direct svg child. Pin
@@ -52,8 +52,8 @@ const filterCardVariants = cva(
     // Chevron color follows the dimmed label when the select is open.
     "data-[state=open]:[&>svg]:text-[var(--atc-click-muted)]",
     // Compact spacing inside the desktop map kit sidebar.
-    "[.airport-map-kit_&]:gap-[5px]",
-    "[.airport-map-kit_&]:px-[11px] [.airport-map-kit_&]:py-[10px]",
+    "[.airport-map-kit_&]:gap-1",
+    "[.airport-map-kit_&]:px-3 [.airport-map-kit_&]:py-2.5",
     // Bottom-glow halo — same animation as MetricCard, fires on
     // [data-active=true] (filter chips that are on) and
     // [data-state=open] (open select menus). --sidebar-tile-bottom-glow
@@ -135,7 +135,7 @@ export function FilterCardValue({
   return (
     <strong
       className={cn(
-        "uppercase text-[12px] font-extrabold leading-[1.2] tracking-normal",
+        "uppercase text-xs font-extrabold leading-[1.2] tracking-normal",
         "text-atc-text max-w-full break-words [overflow-wrap:anywhere]",
         // Promote to click-fg when the card flips to ink — same
         // ancestor-selector approach as FilterCardLabel above.
@@ -164,14 +164,14 @@ export function FilterCardGrid({
       role="group"
       data-ui="filter-grid"
       className={cn(
-        "grid gap-2 px-[var(--airport-sidebar-inset)] py-[10px]",
+        "grid gap-2 px-[var(--airport-sidebar-inset)] py-2.5",
         "border-t border-b",
         "border-t-[color-mix(in_oklab,var(--atc-line)_72%,transparent)]",
         "border-b-[color-mix(in_oklab,var(--atc-line)_72%,transparent)]",
         columns === 2
           ? "grid-cols-[repeat(2,minmax(0,1fr))]"
           : "grid-cols-[repeat(3,minmax(0,1fr))]",
-        "[.airport-map-kit_&]:gap-[6px] [.airport-map-kit_&]:py-[8px]",
+        "[.airport-map-kit_&]:gap-1.5 [.airport-map-kit_&]:py-2",
         className,
       )}
       {...props}

--- a/src/components/ui/MenuPanel.tsx
+++ b/src/components/ui/MenuPanel.tsx
@@ -15,11 +15,9 @@ const forwardRef = React.forwardRef as <
   ) => React.ReactNode,
 ) => React.ForwardRefExoticComponent<Props & React.RefAttributes<Element>>;
 
-// Shared dropdown / popover / select panel chrome. Replaces the
-// .aircraft-filter-card-content, .aircraft-filter-type-panel, and
-// language-switch ad-hoc Tailwind blob with a single primitive so
-// changing the panel surface (background, border, shadow) only
-// touches one file.
+// Shared dropdown / popover / select panel chrome. Replaces the old ad-hoc
+// filter and language-switch panels with a single primitive so changing the
+// panel surface (background, border, shadow) only touches one file.
 //
 // Usage:
 //   <MenuPanel>
@@ -44,8 +42,8 @@ export const MenuPanel = forwardRef(function MenuPanel(
         "flex flex-col font-[var(--airport-sidebar-sans)]",
         "rounded-[var(--atc-radius-card)] border border-atc-line bg-atc-card",
         "text-atc-text",
-        "shadow-[0_12px_32px_color-mix(in_oklab,var(--atc-bg)_60%,transparent),0_2px_6px_color-mix(in_oklab,var(--atc-bg)_40%,transparent)]",
-        "p-[6px] tracking-normal",
+        "shadow-[var(--atc-menu-panel-shadow)]",
+        "p-1.5 tracking-normal",
         className,
       )}
       {...props}
@@ -59,17 +57,16 @@ const menuItemVariants = cva(
     "border-0 bg-transparent",
     // Row radius — kept small so the selected / hover background reads
     // as a flat strip inside the panel, not a separate floating pill.
-    // Change here to update every dropdown row shape in the app.
-    "rounded-[6px] px-[10px] py-[8px] gap-1",
+    "rounded-[6px] px-2.5 py-2 gap-1",
     "transition-[background,color] duration-150",
     "outline-none",
     "tracking-normal leading-[1.2]",
     // Hover + focus-visible — light elev tint.
-    "hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)]",
-    "focus-visible:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)]",
+    "hover:bg-[var(--atc-control-hover-bg)]",
+    "focus-visible:bg-[var(--atc-control-hover-bg)]",
     "hover:text-atc-text",
     // Selected — accent-tinted background, promoted weight.
-    "data-[selected=true]:bg-[color-mix(in_oklab,var(--atc-accent)_12%,transparent)]",
+    "data-[selected=true]:bg-[var(--atc-control-selected-bg)]",
     "data-[selected=true]:text-atc-text",
     // Radix Select uses data-state=checked instead of data-selected.
     "data-[state=checked]:font-semibold",
@@ -79,7 +76,7 @@ const menuItemVariants = cva(
       variant: {
         // Default flat row — single line of text. Tuned 2 steps down
         // from the previous 13px so dropdown menus read as a denser,
-        // secondary UI surface. Change here to reflect every menu.
+        // secondary UI surface.
         row: cn(
           "text-[11px] font-medium text-atc-faint",
           "data-[selected=true]:font-semibold",

--- a/src/components/ui/MetricCard.test.ts
+++ b/src/components/ui/MetricCard.test.ts
@@ -7,8 +7,8 @@ const source = readFileSync(metricCardPath, "utf8");
 
 assert.match(
   source,
-  /rounded-\[10px\] border border-\[var\(--sidebar-tile-rest-border\)\] bg-clip-padding/,
-  "metric cards should use the neutral resting border without blending it into the active background",
+  /rounded-\[var\(--atc-radius-card\)\] border border-\[var\(--sidebar-tile-rest-border\)\] bg-clip-padding/,
+  "metric cards should use the shared card radius token and the neutral resting border without blending it into the active background",
 );
 assert.doesNotMatch(
   source,

--- a/src/components/ui/MetricCard.tsx
+++ b/src/components/ui/MetricCard.tsx
@@ -31,14 +31,14 @@ export function MetricGrid({ className, children, label = "Metrics" }: MetricGri
       role="group"
       aria-label={label}
       className={cn(
-        "grid grid-cols-2 gap-[10px] bg-transparent",
-        "px-[var(--airport-sidebar-inset)] pb-[18px] pt-[2px]",
+        "grid grid-cols-2 gap-2.5 bg-transparent",
+        "px-[var(--airport-sidebar-inset)] pb-4.5 pt-0.5",
         // Flight sidebar wants a slightly wider gap; opt-in via class.
         "data-[layout=flight]:gap-3",
         // Desktop map kit context — tighter rhythm so the sidebar
         // doesn't dominate vertically next to the dense map area.
         "[.airport-map-kit_&]:gap-2",
-        "[.airport-map-kit_&]:pb-[14px]",
+        "[.airport-map-kit_&]:pb-3.5",
         className,
       )}
     >
@@ -50,27 +50,27 @@ export function MetricGrid({ className, children, label = "Metrics" }: MetricGri
 const cardVariants = cva(
   cn(
     "relative isolate overflow-hidden",
-    "grid content-center justify-items-center gap-[7px]",
-    "rounded-[10px] border border-[var(--sidebar-tile-rest-border)] bg-clip-padding",
-    "bg-[color-mix(in_oklab,var(--atc-card)_82%,transparent)]",
-    "shadow-[inset_0_1px_0_color-mix(in_oklab,var(--atc-text)_6%,transparent)]",
-    "text-atc-text text-center min-h-[104px] p-[18px] min-w-0",
+    "grid content-center justify-items-center gap-2",
+    "rounded-[var(--atc-radius-card)] border border-[var(--sidebar-tile-rest-border)] bg-clip-padding",
+    "bg-[var(--atc-control-surface)]",
+    "shadow-[var(--atc-control-inset-shadow)]",
+    "text-atc-text text-center min-h-26 p-4.5 min-w-0",
     "select-none [appearance:none]",
     "transition-[background,border-color,box-shadow,color] duration-150",
-    // Three rows: label (14px) → value (auto, ≥34px) → unit (12px).
+    // Fixed-format rows: label → value → unit.
     "grid-rows-[14px_minmax(34px,auto)_12px]",
     // Compact variant inside the desktop map kit sidebar.
     "[.airport-map-kit_&]:rounded-[var(--atc-radius-card)]",
-    "[.airport-map-kit_&]:gap-[5px]",
+    "[.airport-map-kit_&]:gap-1",
     "[.airport-map-kit_&]:grid-rows-[11px_minmax(27px,auto)_10px]",
-    "[.airport-map-kit_&]:min-h-[76px]",
-    "[.airport-map-kit_&]:p-[14px]",
+    "[.airport-map-kit_&]:min-h-19",
+    "[.airport-map-kit_&]:p-3.5",
     // Active state — solid ink block + click-foreground text, edge
-    // glow on bottom, label / unit dim down. Replaces the
-    // .sidebar-metric-card--active styles previously in style.css.
+    // glow on bottom, label / unit dim down. The state lives here
+    // instead of a sidebar-specific global selector.
     "data-[active=true]:bg-[var(--atc-click-bg)]",
     "data-[active=true]:text-[var(--atc-click-fg)]",
-    "data-[active=true]:shadow-[inset_0_-1px_0_var(--sidebar-tile-edge-glow),inset_0_-14px_22px_color-mix(in_oklab,var(--atc-click-fg)_7%,transparent)]",
+    "data-[active=true]:shadow-[var(--atc-control-active-shadow-strong)]",
     // Bottom-glow halo painted underneath the value. Owned by ::after
     // so it can fade in + slide up without affecting the card's box.
     // The token is a linear-gradient, so set the background shorthand
@@ -89,7 +89,7 @@ const cardVariants = cva(
         true: cn(
           "cursor-pointer",
           // Hover only tints non-active cards; active cards keep ink.
-          "hover:bg-[color-mix(in_oklab,var(--atc-elev)_58%,transparent)]",
+          "hover:bg-[var(--atc-control-hover-bg)]",
           "data-[active=true]:hover:bg-[var(--atc-click-bg)]",
           "focus:outline-none",
         ),
@@ -102,15 +102,15 @@ const cardVariants = cva(
 
 const valueClass = cn(
   "flex items-center justify-center",
-  "max-w-full min-w-0 min-h-[34px] overflow-hidden",
+  "max-w-full min-w-0 min-h-8.5 overflow-hidden",
   "font-[var(--font-display)] not-italic font-black text-atc-text",
-  "text-[30px] leading-none tracking-normal",
+  "text-3xl leading-none tracking-normal",
   // Active card — flip to the click foreground so the value reads
   // on the ink background. The parent <button> already sets this
   // color, but text-atc-text on <strong> shadows it.
   "group-data-[active=true]:text-[var(--atc-click-fg)]",
   // Compact in desktop map kit context.
-  "[.airport-map-kit_&]:text-[24px] [.airport-map-kit_&]:min-h-[27px]",
+  "[.airport-map-kit_&]:text-2xl [.airport-map-kit_&]:min-h-7",
 );
 
 const labelClass = cn(
@@ -126,7 +126,7 @@ const unitClass = cn(
   "block text-atc-faint uppercase text-[10px] font-semibold",
   "tracking-normal leading-3 min-h-3",
   "group-data-[active=true]:text-[var(--atc-click-muted)]",
-  "[.airport-map-kit_&]:text-[8px] [.airport-map-kit_&]:leading-[10px] [.airport-map-kit_&]:min-h-[10px]",
+  "[.airport-map-kit_&]:text-[8px] [.airport-map-kit_&]:leading-2.5 [.airport-map-kit_&]:min-h-2.5",
 );
 
 export function MetricCard({
@@ -147,7 +147,7 @@ export function MetricCard({
         translate={valueTranslate ? undefined : "no"}
         className={cn(
           valueClass,
-          valueSize === "compact" && "text-[24px]",
+          valueSize === "compact" && "text-2xl",
           !valueTranslate && "notranslate",
         )}
       >

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -22,16 +22,15 @@ const forwardRef = React.forwardRef as <
 // each owning its own bespoke CSS.
 //
 // Tailwind utilities live inline on the component so the styling is
-// co-located with the JSX (no .page-nav-dock__bar / .map-ctrl-bar to
-// chase). The .toolbar-reveal class still lives in style.css because
+// co-located with the JSX. The .toolbar-reveal class still lives in style.css because
 // it owns the entrance @keyframes (clip-path expand + over-clip end
 // state so box-shadow stays visible).
 //
-// One size — 32px cells in a 42px pill — is baked into the primitive
+// One fixed size — 32px cells in a 42px pill — is baked into the primitive
 // so callers can't drift. Tone (soft vs rail) stays a variant because
 // the two surfaces (cards vs map) need different hover tints. If you
-// need a chunkier pill on a new surface, change it here, not at the
-// caller.
+// need a chunkier pill on a new surface, change the toolbar tokens,
+// not each caller.
 
 // Edge-glow halo — radial fades just outside the pill's left + right
 // edges so the toolbar reads as glowing against the dark map. Only
@@ -71,23 +70,23 @@ const toolbarVariants = cva(
   cn(
     "relative items-center isolate",
     "rounded-full",
-    "bg-[color-mix(in_oklab,var(--atc-card)_88%,transparent)]",
-    "shadow-[var(--app-toolbar-shadow),inset_0_1px_0_color-mix(in_oklab,var(--atc-text)_10%,transparent)]",
+    "bg-[var(--atc-toolbar-surface)]",
+    "shadow-[var(--app-toolbar-shadow),var(--atc-toolbar-inset-shadow)]",
     // Re-enable interaction inside containers that turn it off so the
     // bare map area can still receive taps around the floating pill.
     // .airport-map-menu--mobile (and other map overlays) set
     // pointer-events: none on the strip; the pill itself must opt back
     // in or every toolbar button becomes inert.
     "pointer-events-auto",
-    // 32px button cells + 5px padding/gap = 42px overall pill height.
-    // Hardcoded so the toolbar footprint stays identical across pages.
-    "min-h-[42px] gap-[5px] p-[5px]",
+    // 32px button cells in a 42px shell. Gap/padding stay on the
+    // Tailwind spacing scale; only the fixed shell/cell dimensions are tokens.
+    "min-h-[var(--atc-toolbar-shell-min-height)] gap-1 p-1",
     mapKitGlow,
   ),
   {
     variants: {
       layout: {
-        // page-nav-dock + map-ctrl-bar — full-width flex, can stretch.
+        // Full-width toolbar, can stretch.
         flex: "flex",
         // sidebar-top-toolbar — shrink-to-content pill.
         inline: "inline-flex",
@@ -141,10 +140,10 @@ export function ToolbarSeparator({
 const toolbarButtonVariants = cva(
   cn(
     "relative isolate inline-flex items-center justify-center flex-none",
-    // 32px cell — hardcoded so the button footprint stays identical
+    // 32px tokenized cell — keeps the button footprint identical
     // across every toolbar surface in the app. If a surface needs a
-    // chunkier pill, change this value here, not at the caller.
-    "h-8 w-8 text-[10px]",
+    // chunkier pill, change the token instead of each caller.
+    "size-[var(--atc-toolbar-cell-size)] text-xs",
     "overflow-hidden rounded-full",
     "font-[var(--font-nav)] font-semibold leading-none",
     "transition-[background,color,box-shadow] duration-150",
@@ -153,7 +152,7 @@ const toolbarButtonVariants = cva(
     // svg child sizing — Lucide ships 24px by default; clamp to 15px
     // so the icon stays subordinate to the pill's chromed background.
     // Keep the icon above the active-state ::after glow layer.
-    "[&_svg]:h-[15px] [&_svg]:w-[15px] [&_svg]:relative [&_svg]:z-[1]",
+    "[&_svg]:size-4 [&_svg]:relative [&_svg]:z-[1]",
     // Active-state bottom-glow gradient — same language as MetricCard /
     // FilterCard. Lives on ::after so it can fade in + slide up
     // independently of the box's background. --sidebar-tile-bottom-glow
@@ -177,7 +176,7 @@ const toolbarButtonVariants = cva(
           "hover:bg-[var(--atc-click-bg)] hover:text-[var(--atc-click-fg)]",
           "focus-visible:bg-[var(--atc-click-bg)] focus-visible:text-[var(--atc-click-fg)]",
           "data-[active=true]:bg-[var(--atc-click-bg)] data-[active=true]:text-[var(--atc-click-fg)]",
-          "data-[active=true]:shadow-[inset_0_-1px_0_var(--sidebar-tile-edge-glow),inset_0_-8px_14px_color-mix(in_oklab,var(--atc-click-fg)_9%,transparent)]",
+          "data-[active=true]:shadow-[var(--atc-toolbar-button-active-shadow)]",
         ),
         // Map control rail button — dim base + light elev tint on
         // hover (subtler than soft because the map background already
@@ -185,10 +184,10 @@ const toolbarButtonVariants = cva(
         // control matches the shared treatment.
         rail: cn(
           "bg-transparent text-atc-dim",
-          "hover:bg-[color-mix(in_oklab,var(--atc-elev)_72%,transparent)]",
-          "focus-visible:bg-[color-mix(in_oklab,var(--atc-elev)_72%,transparent)]",
+          "hover:bg-[var(--atc-control-hover-bg-strong)]",
+          "focus-visible:bg-[var(--atc-control-hover-bg-strong)]",
           "data-[active=true]:bg-[var(--atc-click-bg)] data-[active=true]:text-[var(--atc-click-fg)]",
-          "data-[active=true]:shadow-[inset_0_-1px_0_var(--sidebar-tile-edge-glow),inset_0_-8px_14px_color-mix(in_oklab,var(--atc-click-fg)_9%,transparent)]",
+          "data-[active=true]:shadow-[var(--atc-toolbar-button-active-shadow)]",
         ),
       },
     },
@@ -225,7 +224,7 @@ export function ToolbarAccountSlot({
   return (
     <div
       className={cn(
-        "flex-none inline-flex items-center justify-center h-8 w-8",
+        "flex-none inline-flex items-center justify-center size-[var(--atc-toolbar-cell-size)]",
         className,
       )}
       {...props}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         atcIcon:
-          "rounded-full bg-[color-mix(in_oklab,var(--atc-card)_82%,transparent)] text-atc-dim shadow-[0_8px_24px_color-mix(in_oklab,var(--atc-bg)_62%,transparent)] hover:bg-[color-mix(in_oklab,var(--atc-elev)_72%,transparent)] hover:text-atc-text",
+          "rounded-full bg-[var(--atc-control-surface)] text-atc-dim shadow-[var(--atc-icon-button-shadow)] hover:bg-[var(--atc-control-hover-bg-strong)] hover:text-atc-text",
       },
       size: {
         default: "h-9 px-4 py-2",

--- a/src/components/ui/designTokens.test.ts
+++ b/src/components/ui/designTokens.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const stylePath = fileURLToPath(new URL("../../style.css", import.meta.url));
+const uiFiles = [
+  "Toolbar.tsx",
+  "MetricCard.tsx",
+  "FilterCard.tsx",
+  "MenuPanel.tsx",
+  "select.tsx",
+  "button.tsx",
+];
+
+const styleSource = readFileSync(stylePath, "utf8");
+const uiSource = uiFiles
+  .map((file) => readFileSync(fileURLToPath(new URL(`./${file}`, import.meta.url)), "utf8"))
+  .join("\n");
+
+for (const token of [
+  "--atc-control-surface",
+  "--atc-control-surface-muted",
+  "--atc-control-hover-bg",
+  "--atc-control-active-shadow",
+  "--atc-menu-panel-shadow",
+  "--atc-toolbar-cell-size",
+  "--atc-toolbar-shell-min-height",
+]) {
+  assert.match(styleSource, new RegExp(`${token}:`), `${token} should be defined in the global design-token layer`);
+  assert.match(uiSource, new RegExp(`var\\(${token}\\)`), `${token} should be consumed by shared UI primitives`);
+}
+
+for (const overTokenizedPrefix of [
+  "--atc-motion-",
+  "--atc-menu-row-",
+  "--atc-menu-count-",
+  "--atc-metric-",
+  "--atc-filter-",
+]) {
+  assert.equal(
+    styleSource.includes(overTokenizedPrefix),
+    false,
+    `${overTokenizedPrefix} tokens duplicate Tailwind's default scale and should stay as utilities`,
+  );
+}
+
+for (const repeatedLiteral of [
+  "color-mix(in_oklab,var(--atc-elev)_55%,transparent)",
+  "color-mix(in_oklab,var(--atc-elev)_72%,transparent)",
+  "color-mix(in_oklab,var(--atc-click-fg)_7%,transparent)",
+  "color-mix(in_oklab,var(--atc-bg)_60%,transparent)",
+  "min-h-[42px]",
+]) {
+  assert.equal(
+    uiSource.includes(repeatedLiteral),
+    false,
+    `${repeatedLiteral} should be expressed through a shared design token in UI primitives`,
+  );
+}
+
+for (const migratedGlobalClass of [".map-action-drawer", ".map-source-status"]) {
+  assert.equal(
+    styleSource.includes(migratedGlobalClass),
+    false,
+    `${migratedGlobalClass} is owned by Tailwind classes in its component, not global CSS`,
+  );
+}
+
+console.log("designTokens.test.ts ok");

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -61,8 +61,8 @@ SelectScrollDownButton.displayName =
 
 // SelectContent chrome — same look as MenuPanel (bg, border, shadow,
 // padding) so every dropdown surface in the app shares one visual.
-// Keep adjusting size / colour / shadow on MenuPanel.jsx; this one
-// inherits the same tokens via the className below.
+// Keep adjusting size / colour / shadow through the shared menu tokens;
+// this one inherits those tokens via the className below.
 const SelectContent = forwardRef(({ className, children, position = "popper", viewportClassName, ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
@@ -72,7 +72,7 @@ const SelectContent = forwardRef(({ className, children, position = "popper", vi
         "relative z-toast max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden",
         "flex flex-col font-[var(--airport-sidebar-sans)] tracking-normal",
         "rounded-[var(--atc-radius-card)] border border-atc-line bg-atc-card text-atc-text",
-        "shadow-[0_12px_32px_color-mix(in_oklab,var(--atc-bg)_60%,transparent),0_2px_6px_color-mix(in_oklab,var(--atc-bg)_40%,transparent)]",
+        "shadow-[var(--atc-menu-panel-shadow)]",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
@@ -82,7 +82,7 @@ const SelectContent = forwardRef(({ className, children, position = "popper", vi
       {...props}>
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
-        className={cn("p-[6px]", position === "popper" &&
+        className={cn("p-1.5", position === "popper" &&
           "w-full min-w-[var(--radix-select-trigger-width)]", viewportClassName)}>
         {children}
       </SelectPrimitive.Viewport>
@@ -102,7 +102,7 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName
 
 // SelectItem inherits MenuItem's `row` variant (text + hover + selected
 // language) and adds pr-8 to reserve room for the absolute check on
-// the right. Adjust dropdown row type / spacing in MenuPanel.jsx.
+// the right. Adjust dropdown row type / spacing through MenuPanel tokens.
 const SelectItem = forwardRef(({ className, children, ...props }, ref) => (
   <SelectPrimitiveItem
     ref={ref}

--- a/src/style.css
+++ b/src/style.css
@@ -622,14 +622,12 @@ body {
     mix-blend-mode: screen;
 }
 
-
 /* Light — saturate(0) removes tile color; multiply on light gray canvas
    renders the map as neutral ink. */
 :root[data-theme="light"] .atc-tile-base {
     filter: saturate(0) contrast(0.85) brightness(1.02);
     mix-blend-mode: multiply;
 }
-
 
 .runway-end-label {
     align-items: center;
@@ -733,8 +731,6 @@ body {
     filter: blur(2.4px);
     mix-blend-mode: multiply;
 }
-
-
 
 /* Light-theme approach: dashed extended centerline replaces the dark
    theme's glowing wedge — reads cleaner on the bright basemap. */
@@ -924,8 +920,6 @@ body {
 
 /* Selectable rows — featured search rows + about data-source rows */
 
-
-
 .search-input {
     background: linear-gradient(
         145deg,
@@ -943,7 +937,6 @@ body {
     outline: 2px solid var(--atc-orange);
     outline-offset: 2px;
 }
-
 
 .background-rays {
     inset: 0;
@@ -1028,10 +1021,6 @@ body {
     mix-blend-mode: multiply;
     opacity: 0.52;
 }
-
-
-
-
 
 .airport-desktop-sidebar {
     width: var(--app-sidebar-width);
@@ -1267,24 +1256,6 @@ body {
     }
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 .glass-panel {
     background: linear-gradient(
         145deg,
@@ -1328,7 +1299,6 @@ body {
         backdrop-filter: blur(10px) saturate(125%);
     }
 }
-
 
 .weather-instrument-panel {
     display: flex;
@@ -1515,7 +1485,6 @@ body {
     text-transform: uppercase;
 }
 
-
 /* Shared weather-instrument token — small uppercase mono label on top,
    larger mono value below. Used by every cell on the wind / temp /
    flight-rules / local cards, plus the METAR token strip, so the briefing
@@ -1685,6 +1654,32 @@ body {
     --atc-radius-card: 16px;
     --atc-radius-control: 999px;
     --atc-radius-pill: 999px;
+    --atc-control-surface: color-mix(in oklab, var(--atc-card) 82%, transparent);
+    --atc-control-surface-muted: color-mix(in oklab, var(--atc-card) 74%, transparent);
+    --atc-control-surface-hover: color-mix(in oklab, var(--atc-card) 58%, transparent);
+    --atc-toolbar-surface: color-mix(in oklab, var(--atc-card) 88%, transparent);
+    --atc-control-hover-bg: color-mix(in oklab, var(--atc-elev) 55%, transparent);
+    --atc-control-hover-bg-strong: color-mix(in oklab, var(--atc-elev) 72%, transparent);
+    --atc-control-selected-bg: color-mix(in oklab, var(--atc-accent) 12%, transparent);
+    --atc-control-inset-shadow: inset 0 1px 0 color-mix(in oklab, var(--atc-text) 6%, transparent);
+    --atc-control-inset-shadow-subtle: inset 0 1px 0 color-mix(in oklab, var(--atc-text) 5%, transparent);
+    --atc-toolbar-inset-shadow: inset 0 1px 0 color-mix(in oklab, var(--atc-text) 10%, transparent);
+    --atc-control-active-shadow:
+        inset 0 -1px 0 var(--sidebar-tile-edge-glow),
+        inset 0 -12px 20px color-mix(in oklab, var(--atc-click-fg) 7%, transparent);
+    --atc-control-active-shadow-strong:
+        inset 0 -1px 0 var(--sidebar-tile-edge-glow),
+        inset 0 -14px 22px color-mix(in oklab, var(--atc-click-fg) 7%, transparent);
+    --atc-toolbar-button-active-shadow:
+        inset 0 -1px 0 var(--sidebar-tile-edge-glow),
+        inset 0 -8px 14px color-mix(in oklab, var(--atc-click-fg) 9%, transparent);
+    --atc-menu-panel-shadow:
+        0 12px 32px color-mix(in oklab, var(--atc-bg) 60%, transparent),
+        0 2px 6px color-mix(in oklab, var(--atc-bg) 40%, transparent);
+    --atc-icon-button-shadow:
+        0 8px 24px color-mix(in oklab, var(--atc-bg) 62%, transparent);
+    --atc-toolbar-cell-size: 2rem;
+    --atc-toolbar-shell-min-height: 42px;
     --app-panel-shadow:
         0 22px 58px color-mix(in oklab, var(--atc-bg) 42%, transparent),
         0 8px 22px color-mix(in oklab, var(--atc-text) 7%, transparent),
@@ -1829,7 +1824,6 @@ body {
 .dither-page-panel p {
     letter-spacing: 0;
 }
-
 
 .search-input {
     background: color-mix(in oklab, var(--atc-card) 94%, transparent);
@@ -2014,7 +2008,6 @@ body {
     border-radius: 999px;
 }
 
-.map-action-drawer,
 .route-feedback-modal__content {
     border-radius: var(--atc-radius-card);
     box-shadow: var(--app-panel-shadow);
@@ -2079,7 +2072,6 @@ body {
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
 }
-
 
 @media (max-width: 720px) {
     .dither-page-panel {
@@ -2167,7 +2159,6 @@ body {
     position: relative;
 }
 
-
 .temp-card__band-row {
     align-items: center;
     column-gap: 10px;
@@ -2238,7 +2229,6 @@ body {
     margin-top: 10px;
 }
 
-
 .traffic-counts span {
     color: var(--atc-faint);
     display: block;
@@ -2246,7 +2236,6 @@ body {
     font-size: 10px;
     text-transform: uppercase;
 }
-
 
 .weather-view-dots {
     align-items: center;
@@ -2282,11 +2271,6 @@ body {
     transform: scale(1.08);
     width: 18px;
 }
-
-
-
-
-
 
 .traffic-counts {
     display: grid;
@@ -2357,114 +2341,6 @@ body {
     justify-content: center;
 }
 
-.map-source-status {
-    align-items: flex-end;
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-display);
-    font-feature-settings: "tnum" 1;
-    gap: 1px;
-    justify-content: center;
-    min-width: 0;
-    text-shadow: 0 1px 8px var(--atc-bg);
-    white-space: nowrap;
-}
-
-.map-source-status--map-corner {
-    display: none;
-    max-width: calc(100vw - 132px);
-    position: absolute;
-    right: 12px;
-    top: calc(100% + 6px);
-    transform: none;
-}
-
-.airport-map-menu .map-source-status--map-corner {
-    display: flex;
-}
-
-.airport-map-menu:has(.map-action-drawer.open) .map-source-status--map-corner {
-    opacity: 0;
-    pointer-events: none;
-}
-
-.map-source-status__line {
-    align-items: center;
-    color: var(--atc-dim);
-    display: flex;
-    flex-wrap: wrap;
-    font-size: 10px;
-    font-weight: 600;
-    gap: 7px;
-    justify-content: flex-end;
-    letter-spacing: -0.025em;
-    line-height: 1;
-    min-width: 0;
-    text-transform: uppercase;
-    width: 100%;
-}
-
-.map-source-status__source,
-.map-source-status__route,
-.map-source-status__diamond,
-.map-source-status__time {
-    flex: 0 0 auto;
-}
-
-.map-source-status__time {
-    font-variant-numeric: tabular-nums;
-}
-
-.map-source-status__loading-slot {
-    align-items: center;
-    display: flex;
-    justify-content: flex-end;
-    min-width: 0;
-    overflow: hidden;
-    width: 100%;
-}
-
-.map-source-status__loading {
-    color: var(--atc-dim);
-    font-family: var(--font-mono);
-    font-size: 8px;
-    font-weight: 600;
-    letter-spacing: 0;
-    line-height: 1;
-    max-width: min(280px, calc(100vw - 132px));
-    min-height: 0;
-    opacity: 0;
-    overflow-wrap: anywhere;
-    overflow: hidden;
-    text-align: right;
-    text-transform: uppercase;
-    transition: opacity 200ms ease-out;
-    white-space: normal;
-    will-change: opacity;
-}
-
-.map-source-status__loading-slot.is-active .map-source-status__loading {
-    opacity: 1;
-}
-
-.map-source-status__source {
-    flex: 0 0 auto;
-    overflow: visible;
-}
-
-.map-source-status__diamond {
-    background: var(--atc-orange);
-    display: inline-block;
-    height: 7px;
-    transform: rotate(45deg);
-    width: 7px;
-}
-
-.map-source-status--infer .map-source-status__source,
-.map-source-status--infer .map-source-status__time {
-    color: var(--atc-faint);
-}
-
 .map-ctrl-zone {
     align-items: center;
     display: flex;
@@ -2472,52 +2348,6 @@ body {
     position: relative;
     width: max-content;
     z-index: 1;
-}
-
-.map-action-drawer {
-    align-items: center;
-    background:
-        linear-gradient(
-            180deg,
-            color-mix(in oklab, var(--atc-elev) 36%, transparent),
-            color-mix(in oklab, var(--atc-card) 92%, transparent)
-        );
-    border: 1px solid var(--atc-line-strong);
-    border-radius: var(--atc-radius-control);
-    box-shadow:
-        0 14px 28px color-mix(in oklab, var(--atc-bg) 68%, transparent),
-        inset 0 1px 0 color-mix(in oklab, var(--atc-text) 8%, transparent);
-    display: flex;
-    flex-direction: row;
-    gap: 2px;
-    opacity: 0;
-    padding: 6px;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    top: calc(100% + 8px);
-    transform: translateY(-4px) scale(0.98);
-    transform-origin: right top;
-    transition:
-        opacity 0.18s ease,
-        transform 0.18s ease;
-}
-
-.map-action-drawer.open {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0) scale(1);
-}
-
-.airport-map-menu--mobile .map-action-drawer {
-    left: 50%;
-    right: auto;
-    transform: translate(-50%, -4px) scale(0.98);
-    transform-origin: top center;
-}
-
-.airport-map-menu--mobile .map-action-drawer.open {
-    transform: translate(-50%, 0) scale(1);
 }
 
 /* Clerk avatar clamp inside the map control rail Toolbar AccountSlot.
@@ -2733,7 +2563,6 @@ body {
         transition: none;
     }
 }
-
 
 .aircraft-nose-beam {
     position: absolute;
@@ -3513,7 +3342,6 @@ body {
     width: 100%;
 }
 
-
 .aircraft-table-route-face--route span {
     min-width: 0;
 }
@@ -3632,24 +3460,7 @@ body {
     text-align: right;
 }
 
-
-
-
 @media (max-width: 1080px) {
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
     .glass-panel {
         max-height: none;
     }
@@ -3660,9 +3471,6 @@ body {
 }
 
 @media (max-width: 620px) {
-    
-    
-    
     .glass-panel {
         border-radius: var(--atc-radius-panel);
         padding: 16px;
@@ -3670,7 +3478,6 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .map-action-drawer,
     .aircraft-trace-label {
         transition: none;
     }
@@ -3694,18 +3501,13 @@ body {
     .adsb-loading-grid {
         transition: none;
     }
-
-    }
+}
 
 /* ============================================================
    Sidebar layout (v0.9 redesign)
    Two-column shell: fixed sidebar + flexible map. Sidebar surface
    is bare — hairlines and grid only.
    ============================================================ */
-
-
-
-
 
 .airport-sidebar-panel--mobile,
 .flight-sidebar-panel--mobile {
@@ -3739,10 +3541,6 @@ body {
     max-height: none;
 }
 
-
-
-
-
 .sidebar-shell {
     /* Shared baseline tokens for every sidebar variant: padding inset and
        the typography stack. Defined on the shell so AircraftTable rows
@@ -3758,7 +3556,6 @@ body {
     isolation: isolate;
     position: relative;
 }
-
 
 .airport-sidebar-panel {
     --airport-sidebar-inset: 28px;
@@ -3995,28 +3792,6 @@ body {
     color: var(--atc-click-muted);
 }
 
-
-/* Keep the label / value / unit above the active-state glow pseudo. */
-
-/* Active glow — same "light from the bottom border rising up" effect used by
- * the aircraft filter cards. Fades in over ~360ms when the tab becomes
- * active. */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 .airport-briefing-stack {
     display: grid;
     gap: 0;
@@ -4217,8 +3992,6 @@ body {
     scroll-snap-stop: always;
 }
 
-
-
 .dark {
     --sidebar: var(--theme-sidebar-dark-bg);
     --sidebar-foreground: var(--atc-text);
@@ -4368,18 +4141,9 @@ body {
     isolation: isolate;
 }
 
-
-
-
-
-
 .aircraft-preview-card--has-photo {
     overflow: hidden;
 }
-
-
-
-
 
 .aircraft-preview-photo__credit {
     position: absolute;
@@ -4399,11 +4163,6 @@ body {
     text-transform: uppercase;
     white-space: nowrap;
 }
-
-
-
-
-
 
 .aircraft-preview-card__divider {
     height: 1px;
@@ -5112,7 +4871,6 @@ body {
     color: var(--atc-text);
 }
 
-
 /* Section header band — `// LABEL` left, mono count right, hairline
    rule under it. Used in place of the old border-b w/ uppercase pair. */
 .endf-section-head {
@@ -5153,13 +4911,11 @@ body {
     transform: skewX(calc(-1 * var(--endf-skew)));
 }
 
-
 .endf-tab--outline {
     background: transparent;
     border: 1px solid var(--endf-accent-ink);
     color: var(--atc-text);
 }
-
 
 /* Airport/IATA code badge — wider parallelogram with a stronger 13px
    weight-900 face. Matches the search bar's ENTER chip family but sized
@@ -5191,8 +4947,6 @@ body {
     transform: skewX(calc(-1 * var(--endf-skew)));
 }
 
-
-
 /* Diamond bullet — solid rhombus, 6px square rotated 45deg.
    Defaults to accent-ink so light theme renders it as near-black; dark
    theme already aliases accent-ink → yellow so contrast holds there. */
@@ -5221,8 +4975,6 @@ body {
    watermark text in the background and a value/label pair on top.
    Used for reward-style rows and prominent action surfaces. */
 
-
-
 /* Poster-headline title — `< AIRPORT EXPLORER >` style. Saira 800-900
    uppercase with subtle yellow brackets that scale with the text. The
    wider tracking emulates Novecento Sans Wide's poster proportions. */
@@ -5231,9 +4983,7 @@ body {
     letter-spacing: 0.01em;
 }
 
-
 /* Vertical brand watermark — for hero corners. */
-
 
 /* Hairline corner ticks — wraps a panel/row to add bracket marks. */
 .endf-cornered {
@@ -5355,10 +5105,6 @@ body {
     .aircraft-preview-card--desktop-reveal .aircraft-preview-metadata-card,
     .aircraft-preview-card__media-slot,
     .aircraft-preview-card__trace-status,
-    .map-source-status__line,
-    .map-source-status__route,
-    .map-source-status__loading-slot,
-    .map-source-status__loading,
     .endf-underline::after {
         transition: none;
         animation: none;
@@ -5518,8 +5264,6 @@ body {
         margin-top: 10px;
     }
 
-    
-    
     .dither-page-panel .search-input {
         gap: 10px;
         margin: 0 19px 13px;
@@ -5639,11 +5383,6 @@ body {
         font-size: 9px;
     }
 
-
-    
-    
-    
-    
     .changelog-screen li.changelog-entry {
         padding: 10px 0;
     }
@@ -5926,17 +5665,6 @@ body {
     height: auto;
 }
 
-
-.airport-map-kit .map-source-status--map-corner {
-    right: 2px;
-    top: calc(100% + 10px);
-}
-
-.airport-map-kit .map-action-drawer {
-    border-radius: calc(var(--atc-radius-card) + 2px);
-    top: calc(100% + 10px);
-}
-
 .airport-map-kit .aircraft-preview-metadata-card,
 .airport-map-kit .aircraft-preview-media-card {
     box-shadow:
@@ -5974,7 +5702,6 @@ body {
         height: 47px;
         padding: 0 18px;
     }
-
 
     .airport-map-kit .airport-sidebar-identity {
         padding: 20px var(--airport-sidebar-inset) 18px;
@@ -6092,31 +5819,6 @@ body {
         width: 18px;
     }
 
-    .airport-map-kit .map-source-status--map-corner {
-        top: calc(100% + 8px);
-    }
-
-    .airport-map-kit .map-source-status__line {
-        font-size: 8px;
-        gap: 5px;
-    }
-
-    .airport-map-kit .map-source-status__diamond {
-        height: 5px;
-        width: 5px;
-    }
-
-    .airport-map-kit .map-source-status__loading {
-        font-size: 7px;
-        max-width: min(224px, calc(100vw - 106px));
-    }
-
-    .airport-map-kit .map-action-drawer {
-        gap: 2px;
-        padding: 5px;
-        top: calc(100% + 8px);
-    }
-
     .airport-map-kit .aircraft-label {
         font-size: 8px;
         letter-spacing: 0.2px;
@@ -6155,47 +5857,4 @@ body {
         pointer-events: none;
     }
 
-    .airport-map-menu--mobile .map-source-status--map-corner {
-        align-items: center;
-        left: 50%;
-        max-width: min(288px, calc(100vw - 32px));
-        right: auto;
-        text-align: center;
-        top: calc(100% + 7px);
-        transform: translateX(-50%);
-        filter:
-            drop-shadow(0 7px 11px color-mix(in oklab, var(--atc-bg) 72%, transparent))
-            drop-shadow(0 1px 1px color-mix(in oklab, var(--atc-text) 24%, transparent));
-    }
-
-    .airport-map-menu--mobile .map-source-status__loading-slot,
-    .airport-map-menu--mobile .map-source-status__line,
-    .airport-map-menu--mobile .map-source-status__route {
-        justify-content: center;
-        text-align: center;
-    }
-
-    .airport-map-menu--mobile .map-source-status__loading {
-        max-width: min(288px, calc(100vw - 32px));
-        text-align: center;
-    }
-
-    .airport-map-menu--mobile .map-source-status__line {
-        font-size: 9px;
-        gap: 6px;
-    }
-
-    .airport-map-menu--mobile .map-source-status__route {
-        font-size: 8px;
-        gap: 4px;
-    }
-
-    .airport-map-menu--mobile .map-source-status__diamond {
-        height: 6px;
-        width: 6px;
-    }
-
-    .airport-map-menu--mobile .map-source-status__loading {
-        font-size: 7px;
-    }
 }


### PR DESCRIPTION
## Summary

Closes #327.

This PR starts the design-token cleanup with a narrower rule: use Tailwind's default scale for ordinary spacing, type, radius, and motion, and reserve custom tokens for semantic values Tailwind cannot express cleanly.

- adds shared semantic tokens for control/menu/toolbar surfaces, hover and selected backgrounds, active shadows, panel shadows, icon shadows, and the fixed toolbar cell/shell dimensions
- updates `Toolbar`, `MetricCard`, `FilterCard`, `MenuPanel`, `SelectContent`, and the `atcIcon` button variant to consume those semantic tokens while keeping normal sizing on Tailwind utilities
- moves the map source-status UI out of global `style.css` and into static Tailwind classes in `MapSourceStatusDisplay`
- removes migrated global CSS for the map layer drawer/source-status blocks and cleans up stale migration comments/blank CSS residue
- adds a structural `designTokens.test.ts` guard so shared UI primitives do not reintroduce repeated `color-mix(...)` blobs, over-tokenized metric/filter/menu/motion scale tokens, or migrated global map preview classes

The visual output is intended to stay close to current production; this is token/CSS consolidation, not a redesign.

## Validation

- `pnpm test` — 105 test files passed
- `pnpm lint` — exit 0; existing `VirtualNearbyList.tsx` React Compiler/TanStack Virtual warning remains
- `pnpm build` — exit 0
- Local browser — checked `http://localhost:3000/airport/KBOS` at desktop `1280x900` and mobile `390x844`; toolbar/source status rendered, no horizontal overflow
- Local preview cards — clicked one airport (`OWD`), one aircraft (`AAL567`), and one airspace (`BOSTON CLASS B AREA A`) on both desktop `1280x900` and mobile `390x844`; all six preview cards rendered and screenshots were captured
- Vercel preview — checked `https://adsbao-git-codex-design-token-unification-327-orriduck.vercel.app/airport/KBOS` at desktop `1280x900` and mobile `390x844`; clicked airport, visible aircraft, and airspace previews on both viewports; source status stayed visible and no horizontal overflow
