### PR TITLE
[codex] Fix loading overlay replay and live location

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import AirportSidebar from "@/components/sidebar/AirportSidebar";
 import AirportExplorerDesktopSidebar from "./AirportExplorerDesktopSidebar";
 import {
@@ -27,7 +27,7 @@ import {
 } from "@/features/aircraft/positions/aircraftLoadingOverlayModel";
 import {
   resolveNextUserLocationAudioMode,
-  resolveUserLocationRequest,
+  resolveUserLocationWatchUpdate,
   USER_LOCATION_AUDIO_MODES,
   type UserLocationAudioMode,
 } from "@/features/airport/map/userLocationModel";
@@ -81,6 +81,10 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   );
   const [userLocationPending, setUserLocationPending] = useState(false);
   const [userLocationNotice, setUserLocationNotice] = useState("");
+  const userLocationModeRef = useRef<UserLocationAudioMode>(
+    USER_LOCATION_AUDIO_MODES.OFF,
+  );
+  const userLocationWatchIdRef = useRef<number | null>(null);
   const airportProfile = useMemo(
     () => resolveAirportProfile({ icao, airport }),
     [icao, airport],
@@ -183,6 +187,27 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     return () => window.clearTimeout(timer);
   }, [userLocationNotice]);
 
+  useEffect(() => {
+    userLocationModeRef.current = userLocationMode;
+  }, [userLocationMode]);
+
+  const stopUserLocationWatch = useCallback(() => {
+    if (
+      userLocationWatchIdRef.current == null ||
+      typeof navigator === "undefined" ||
+      !navigator.geolocation ||
+      typeof navigator.geolocation.clearWatch !== "function"
+    ) {
+      userLocationWatchIdRef.current = null;
+      return;
+    }
+
+    navigator.geolocation.clearWatch(userLocationWatchIdRef.current);
+    userLocationWatchIdRef.current = null;
+  }, []);
+
+  useEffect(() => stopUserLocationWatch, [stopUserLocationWatch]);
+
   const locateUser = useCallback(() => {
     const nextMode = resolveNextUserLocationAudioMode({
       mode: userLocationMode,
@@ -190,6 +215,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     });
 
     if (nextMode === USER_LOCATION_AUDIO_MODES.OFF) {
+      stopUserLocationWatch();
       setUserLocation(null);
       setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
       setUserLocationNotice("");
@@ -209,52 +235,67 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
       return;
     }
 
-    setUserLocationPending(true);
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        setUserLocationPending(false);
-        const result = resolveUserLocationRequest({
-          coords: position.coords,
-          focalLat: airportProfile.lat,
-          focalLon: airportProfile.lon,
-        });
+    const handlePosition = (position) => {
+      setUserLocationPending(false);
+      const result = resolveUserLocationWatchUpdate({
+        coords: position.coords,
+        focalLat: airportProfile.lat,
+        focalLon: airportProfile.lon,
+        currentMode: userLocationModeRef.current,
+      });
 
-        if (!result.location) {
-          setUserLocation(null);
-          setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
-          setUserLocationNotice(t("map.locationUnavailable"));
-          return;
-        }
-
-        if (result.tooFar) {
-          setUserLocation(null);
-          setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
-          setUserLocationNotice(t("map.locationTooFar"));
-          return;
-        }
-
-        setUserLocation(result.location);
-        setUserLocationMode(USER_LOCATION_AUDIO_MODES.LOCATION);
-        setUserLocationNotice("");
-      },
-      (error) => {
-        setUserLocationPending(false);
+      if (!result.location) {
+        stopUserLocationWatch();
+        setUserLocation(null);
         setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
         setUserLocationNotice(
-          error?.code === error?.PERMISSION_DENIED
-            ? t("map.locationDenied")
+          result.noticeKey === "tooFar"
+            ? t("map.locationTooFar")
             : t("map.locationUnavailable"),
         );
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 10_000,
-        maximumAge: 0,
-      },
+        return;
+      }
+
+      setUserLocation(result.location);
+      setUserLocationMode(result.mode);
+      setUserLocationNotice("");
+    };
+    const handleError = (error) => {
+      stopUserLocationWatch();
+      setUserLocationPending(false);
+      setUserLocationMode(USER_LOCATION_AUDIO_MODES.OFF);
+      setUserLocationNotice(
+        error?.code === error?.PERMISSION_DENIED
+          ? t("map.locationDenied")
+          : t("map.locationUnavailable"),
+      );
+    };
+    const locationOptions = {
+      enableHighAccuracy: true,
+      timeout: 10_000,
+      maximumAge: 0,
+    };
+
+    setUserLocationPending(true);
+    stopUserLocationWatch();
+    if (typeof navigator.geolocation.watchPosition === "function") {
+      userLocationWatchIdRef.current = navigator.geolocation.watchPosition(
+        handlePosition,
+        handleError,
+        locationOptions,
+      );
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      handlePosition,
+      handleError,
+      locationOptions,
     );
   }, [
     airportProfile.lat,
     airportProfile.lon,
+    stopUserLocationWatch,
     unlockAudio,
     t,
     userLocation,

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import L from "leaflet";
 import { MapContext } from "./MapContext";
 import MapTileLayers from "./MapTileLayers";
@@ -29,7 +29,10 @@ import {
   resolveAirportMapFocalCenter,
   resolveDocumentTheme,
 } from "../../features/airport/map/airportMapModel";
-import { resolveMapLoadingPresentation } from "../../features/aircraft/positions/aircraftLoadingOverlayModel";
+import {
+  resolveMapLoadingPresentation,
+  resolveMapSurfaceVisibility,
+} from "../../features/aircraft/positions/aircraftLoadingOverlayModel";
 import { getOffsetMapCenter } from "./mapViewportOffset";
 
 const resolveCurrentTheme = () =>
@@ -91,6 +94,10 @@ export default function AirportMap({
   const mapRef = useRef(null);
   const sizeObs = useRef(null);
   const [mapInstance, setMapInstance] = useState(null);
+  const [loadingOverlayPlayback, setLoadingOverlayPlayback] = useState({
+    visible: true,
+    exiting: false,
+  });
   const [currentTheme, setCurrentTheme] = useState(() => resolveCurrentTheme());
   const focalCenter = useMemo(
     () => resolveAirportMapFocalCenter({ lat, lon }),
@@ -258,16 +265,34 @@ export default function AirportMap({
   });
   const loadingPresentation =
     resolveMapLoadingPresentation(loadingOverlayState as any);
+  const { mapVisible } = resolveMapSurfaceVisibility({
+    loadingOverlayVisible: loadingOverlayPlayback.visible,
+    loadingOverlayExiting: loadingOverlayPlayback.exiting,
+  });
   const loadingOverlayCopy = useMapLoadingOverlayText({
     mode: loadingOverlayState.mode,
     reason: loadingOverlayState.reason,
     variant: loadingOverlayVariant,
     callsign: loadingOverlayCallsign,
   });
+  const handleLoadingOverlayVisibleChange = useCallback((nextVisible, state) => {
+    setLoadingOverlayPlayback({
+      visible: Boolean(nextVisible),
+      exiting: Boolean(state?.exiting),
+    });
+  }, []);
 
   return (
     <div className="relative h-full w-full bg-atc-bg">
-      <div ref={mapEl} className="h-full w-full" />
+      <div
+        ref={mapEl}
+        className="airport-map-surface h-full w-full"
+        aria-hidden={!mapVisible}
+        style={{
+          opacity: mapVisible ? 1 : 0,
+          pointerEvents: mapVisible ? undefined : "none",
+        }}
+      />
 
       {mapInstance && (
         <MapContext.Provider value={mapInstance}>
@@ -351,6 +376,7 @@ export default function AirportMap({
         <MapAttribution
           color={overlayTheme.attributionColor}
           shadowColor={overlayTheme.labelShadowColor}
+          hidden={!mapVisible}
         />
       )}
 
@@ -358,6 +384,7 @@ export default function AirportMap({
         active={loadingPresentation.overlayActive}
         sidebarAware={floatingSidebarAware}
         variant={loadingOverlayVariant}
+        onVisibleChange={handleLoadingOverlayVisibleChange}
         {...loadingOverlayCopy}
       />
     </div>

--- a/src/components/map/MapAttribution.tsx
+++ b/src/components/map/MapAttribution.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-export default function MapAttribution({ color, shadowColor }) {
+export default function MapAttribution({ color, shadowColor, hidden = false }) {
   return (
     <div
-      className="pointer-events-none absolute bottom-3 right-3 whitespace-nowrap font-sans text-[9px]"
+      className="map-attribution pointer-events-none absolute bottom-3 right-3 whitespace-nowrap font-sans text-[9px]"
       style={{
         color,
+        opacity: hidden ? 0 : 1,
         textShadow: `0 0 6px ${shadowColor}`,
       }}
     >

--- a/src/components/map/MapLoadingOverlay.tsx
+++ b/src/components/map/MapLoadingOverlay.tsx
@@ -48,6 +48,7 @@ export default function MapLoadingOverlay({
   variant = "airport",
   sidebarAware = false,
   ariaLabel,
+  onVisibleChange,
 }: Record<string, any>) {
   const [visible, setVisible] = useState(true);
   const [exiting, setExiting] = useState(false);
@@ -83,6 +84,12 @@ export default function MapLoadingOverlay({
       window.removeEventListener("pageshow", handlePageVisible);
     };
   }, [replay]);
+
+  useEffect(() => {
+    if (typeof onVisibleChange === "function") {
+      onVisibleChange(visible, { exiting });
+    }
+  }, [exiting, onVisibleChange, visible]);
 
   useEffect(() => {
     let delayTimer;

--- a/src/config/aviation.ts
+++ b/src/config/aviation.ts
@@ -9,7 +9,7 @@ export const AIRPORT_MAP_ZOOM = {
 export const AIRPORT_EXPLORER_UI_CONFIG = {
   desktopSidebarWidth: "var(--app-sidebar-width)",
   mobileBreakpointPx: 768,
-  adsbLoadingFadeMs: 1100,
+  adsbLoadingFadeMs: 500,
 };
 
 export const AIRCRAFT_TRAFFIC_CONFIG = {

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.ts
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.ts
@@ -7,6 +7,7 @@ import {
   resolveAircraftLoadingOverlayMode,
   resolveAircraftLoadingOverlayState,
   resolveMapLoadingPresentation,
+  resolveMapSurfaceVisibility,
   scheduleAfterOverlayPaint,
   shouldReplayLoadingOverlayOnPageVisible,
   shouldShowAircraftLoadingOverlay,
@@ -250,6 +251,28 @@ assert.deepEqual(
     reason: "",
   }),
   { overlayActive: false, sourceStatusActive: false },
+);
+
+assert.deepEqual(
+  resolveMapSurfaceVisibility({
+    loadingOverlayVisible: true,
+  }),
+  { mapVisible: false },
+);
+
+assert.deepEqual(
+  resolveMapSurfaceVisibility({
+    loadingOverlayVisible: true,
+    loadingOverlayExiting: true,
+  }),
+  { mapVisible: true },
+);
+
+assert.deepEqual(
+  resolveMapSurfaceVisibility({
+    loadingOverlayVisible: false,
+  }),
+  { mapVisible: true },
 );
 
 {

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.ts
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.ts
@@ -34,6 +34,11 @@ type MapLoadingPresentationOptions = {
   reason?: string;
 };
 
+type MapSurfaceVisibilityOptions = {
+  loadingOverlayVisible?: boolean;
+  loadingOverlayExiting?: boolean;
+};
+
 type VisibilityRefreshOverlayOptions = {
   wasActive?: boolean;
   hiddenSince?: number;
@@ -124,6 +129,15 @@ export function resolveMapLoadingPresentation({
   return {
     overlayActive,
     sourceStatusActive: Boolean(active && reason && !overlayActive),
+  };
+}
+
+export function resolveMapSurfaceVisibility({
+  loadingOverlayVisible = false,
+  loadingOverlayExiting = false,
+}: MapSurfaceVisibilityOptions = {}) {
+  return {
+    mapVisible: !loadingOverlayVisible || loadingOverlayExiting,
   };
 }
 

--- a/src/features/airport/map/userLocationModel.test.ts
+++ b/src/features/airport/map/userLocationModel.test.ts
@@ -3,6 +3,7 @@ import {
   resolveNextUserLocationAudioMode,
   resolveUserLocationPulseDiameterPx,
   resolveUserLocationRequest,
+  resolveUserLocationWatchUpdate,
   USER_LOCATION_PULSE_RADIUS_METERS,
   USER_LOCATION_MAX_DISTANCE_NM,
 } from "./userLocationModel";
@@ -70,6 +71,46 @@ const KBOS = { lat: 42.3656, lon: -71.0096 };
   assert.equal(result.location, null);
   assert.equal(result.distanceNm, null);
   assert.equal(result.tooFar, false);
+}
+
+{
+  const result = resolveUserLocationWatchUpdate({
+    coords: { latitude: 42.36, longitude: -71.01, accuracy: 18 },
+    focalLat: KBOS.lat,
+    focalLon: KBOS.lon,
+    currentMode: "location-audio",
+  });
+
+  assert.equal(result.noticeKey, "");
+  assert.equal(result.mode, "location-audio");
+  assert.equal(result.location?.lat, 42.36);
+  assert.equal(result.location?.lon, -71.01);
+}
+
+{
+  const result = resolveUserLocationWatchUpdate({
+    coords: { latitude: 40.6413, longitude: -73.7781, accuracy: 42 },
+    focalLat: KBOS.lat,
+    focalLon: KBOS.lon,
+    currentMode: "location",
+  });
+
+  assert.equal(result.location, null);
+  assert.equal(result.mode, "off");
+  assert.equal(result.noticeKey, "tooFar");
+}
+
+{
+  const result = resolveUserLocationWatchUpdate({
+    coords: { latitude: Number.NaN, longitude: -71.01 },
+    focalLat: KBOS.lat,
+    focalLon: KBOS.lon,
+    currentMode: "location",
+  });
+
+  assert.equal(result.location, null);
+  assert.equal(result.mode, "off");
+  assert.equal(result.noticeKey, "unavailable");
 }
 
 {

--- a/src/features/airport/map/userLocationModel.ts
+++ b/src/features/airport/map/userLocationModel.ts
@@ -27,6 +27,11 @@ type ResolveUserLocationRequestOptions = {
   maxDistanceNm?: number;
 };
 
+type ResolveUserLocationWatchUpdateOptions =
+  ResolveUserLocationRequestOptions & {
+    currentMode?: UserLocationAudioMode;
+  };
+
 type ResolveNextUserLocationAudioModeOptions = {
   mode?: unknown;
   hasLocation?: boolean;
@@ -109,5 +114,45 @@ export function resolveUserLocationRequest({
       distanceNm != null &&
       Number.isFinite(distanceNm) &&
       distanceNm > maxDistanceNm,
+  };
+}
+
+export function resolveUserLocationWatchUpdate({
+  coords,
+  focalLat,
+  focalLon,
+  maxDistanceNm,
+  currentMode = USER_LOCATION_AUDIO_MODES.LOCATION,
+}: ResolveUserLocationWatchUpdateOptions) {
+  const result = resolveUserLocationRequest({
+    coords,
+    focalLat,
+    focalLon,
+    maxDistanceNm,
+  });
+
+  if (!result.location) {
+    return {
+      location: null,
+      mode: USER_LOCATION_AUDIO_MODES.OFF,
+      noticeKey: "unavailable",
+    };
+  }
+
+  if (result.tooFar) {
+    return {
+      location: null,
+      mode: USER_LOCATION_AUDIO_MODES.OFF,
+      noticeKey: "tooFar",
+    };
+  }
+
+  return {
+    location: result.location,
+    mode:
+      currentMode === USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO
+        ? USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO
+        : USER_LOCATION_AUDIO_MODES.LOCATION,
+    noticeKey: "",
   };
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1026,6 +1026,12 @@ body {
     width: var(--app-sidebar-width);
 }
 
+.airport-map-surface,
+.map-attribution {
+    transition: opacity 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+    will-change: opacity;
+}
+
 @media (max-width: 767px) {
     .airport-desktop-sidebar {
         display: none;
@@ -1059,8 +1065,8 @@ body {
     pointer-events: none;
     position: absolute;
     transition:
-        opacity 0.7s ease,
-        backdrop-filter 0.7s ease;
+        opacity 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+        backdrop-filter 0.5s cubic-bezier(0.22, 1, 0.36, 1);
     z-index: var(--z-index-overlay);
 }
 
@@ -1081,7 +1087,7 @@ body {
 }
 
 .adsb-loading-overlay.is-exiting {
-    animation: adsb-loading-fade-out 1.1s ease forwards;
+    animation: adsb-loading-fade-out 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
     -webkit-backdrop-filter: brightness(1) saturate(1);
     backdrop-filter: brightness(1) saturate(1);
 }
@@ -3498,7 +3504,9 @@ body {
     }
 
     .adsb-loading-overlay,
-    .adsb-loading-grid {
+    .adsb-loading-grid,
+    .airport-map-surface,
+    .map-attribution {
         transition: none;
     }
 }


### PR DESCRIPTION
## Summary
- Hide the Leaflet map surface while the ADS-B loading animation is actively replaying, then crossfade the map back in over 500ms as the overlay exits.
- Switch the airport user-location control to live geolocation updates via `watchPosition`, with cleanup on disable, errors, invalid locations, or too-far positions.
- Add model coverage for loading overlay/map visibility and live location update outcomes.

## Validation
- `/opt/homebrew/bin/pnpm test` — 105 test files passed
- `/opt/homebrew/bin/pnpm lint` — 0 errors; existing TanStack Virtual React Compiler warning remains in `VirtualNearbyList.tsx`
- `/opt/homebrew/bin/pnpm build` — production build completed
- Local browser check on `http://localhost:3000/airport/KBOS` before commit verified the map is hidden while the loading overlay is visible and restored after the overlay exits; Browser later blocked a fresh localhost reload policy check while sampling the 500ms timing.
