### PR TITLE
[codex] Tune airport zoom map features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.8.3",
+  "version": "1.8.4",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/changelog/ChangelogPanel.tsx
+++ b/src/components/changelog/ChangelogPanel.tsx
@@ -10,6 +10,16 @@ import { CHANGELOG } from "@/config/changelog";
 // optional current marker, summary, then short highlights.
 
 const CHINESE_RELEASE_COPY = {
+  "v1.8.4": {
+    title: "机场缩放层级减噪",
+    summary:
+      "机场地图的缩放层级现在共用一张 feature 配置表,统一控制跑道标签、距离圈文字、附近机场跑道和机场地面附近飞机隐藏。",
+    highlights: [
+      "机场级继续隐藏跑道端点标签,只在细节级显示",
+      "进近级隐藏机场 3 海里内飞机,机场级缩小到 0.5 海里",
+      "缩放相关地图功能集中到同一配置表维护",
+    ],
+  },
   "v1.8.3": {
     title: "机制页与导航细节",
     summary:

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -234,7 +234,6 @@ export default function AirportMap({
       airportLon: icao ? lon : null,
       nearbyAirports,
       zoom,
-      groundAreaRadiusNm: groundRadiusNm,
     });
   }, [
     aircraft,
@@ -243,7 +242,6 @@ export default function AirportMap({
     lon,
     nearbyAirports,
     zoom,
-    groundRadiusNm,
   ]);
   const selectedAircraft = useMemo(
     () =>

--- a/src/components/map/AirportMarker.tsx
+++ b/src/components/map/AirportMarker.tsx
@@ -8,7 +8,7 @@ import {
   safeAddToMap,
   safeRemoveFromMap,
 } from "../../features/airport/map/leafletLayerSafety";
-import { ZOOM_APPROACH } from "../../utils/airportMapDisplay";
+import { shouldShowAirportAreaCountForZoom } from "../../features/airport/map/airportMapZoomFeatures";
 import { getDistanceNm } from "../../utils/aircraftTrafficIntent";
 import { AirportLabelBadge } from "@/components/ui/AirportLabelBadge";
 
@@ -27,10 +27,9 @@ export default function AirportMarker({
     typeof document !== "undefined" ? document.createElement("div") : null,
   );
 
-  // Count aircraft within `groundRadiusNm` of the focal airport, shown
-  // as a "NEAR n" line under the badge. Only computed at approach zoom
-  // so the badge stays minimal at wider views.
-  const showAreaCount = Number(zoom) === ZOOM_APPROACH;
+  // Count aircraft within `groundRadiusNm` of the focal airport when
+  // zoom-feature config enables the "NEAR n" badge detail.
+  const showAreaCount = shouldShowAirportAreaCountForZoom(zoom);
   const areaCount = useMemo(() => {
     if (!showAreaCount || !lat || !lon) return 0;
     return aircraft.filter((item) => {

--- a/src/components/map/AreaMarker.tsx
+++ b/src/components/map/AreaMarker.tsx
@@ -11,14 +11,10 @@ import {
   safeAddToMap,
   safeRemoveFromMap,
 } from "../../features/airport/map/leafletLayerSafety";
-import { ZOOM_AIRPORT } from "../../utils/airportMapDisplay";
+import { shouldShowRangeRingLabelsForZoom } from "../../features/airport/map/airportMapZoomFeatures";
 
 const DEFAULT_RING_INTERVAL_NM = 3;
 const DEFAULT_RING_MAX_NM = 30;
-
-// Per-ring labels show at the airport preset and closer; below that
-// the MapRangeLegend scale bar carries distance context.
-const RING_LABEL_MIN_ZOOM = ZOOM_AIRPORT;
 
 export default function AreaMarker({
   lat,
@@ -52,7 +48,7 @@ export default function AreaMarker({
 
     safeRemoveFromMap(ringLabelsRef.current, map);
     ringLabelsRef.current = null;
-    if (Number(zoom) >= RING_LABEL_MIN_ZOOM) {
+    if (shouldShowRangeRingLabelsForZoom(zoom)) {
       const labels = buildAirportRangeRingLabels(L, {
         lat,
         lon,

--- a/src/components/map/NearbyAirportLayer.tsx
+++ b/src/components/map/NearbyAirportLayer.tsx
@@ -13,6 +13,7 @@ import {
   buildRunwayCenterlineCollection,
   buildRunwayEndLabels,
 } from "../../features/airport/map/runwayAnnotationModel";
+import { shouldShowNearbyAirportRunwaysForZoom } from "../../features/airport/map/airportMapZoomFeatures";
 import { airportLabelBadgeHtml } from "@/components/ui/AirportLabelBadge";
 
 const escapeHtml = (value: unknown) =>
@@ -76,7 +77,7 @@ const runwayLabelIcon = (ident: string, theme: string) =>
 const runwayLayers = ({ airport, map, theme, zoom, showBadges }: Record<string, any>) => {
   if (!airport?.runwayMap?.runways?.length) return [];
   const centerlines = buildRunwayCenterlineCollection(airport.runwayMap);
-  const showRunways = Number(zoom) >= 10;
+  const showRunways = shouldShowNearbyAirportRunwaysForZoom(zoom);
   if (!showRunways) return [];
 
   const layers = [

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -6,6 +6,18 @@
 
 export const CHANGELOG = [
   {
+    version: "v1.8.4",
+    kind: "patch",
+    title: "Airport zoom declutter tuning",
+    summary:
+      "Airport map zoom levels now share one feature configuration for runway labels, range labels, nearby runways, and surface-traffic suppression.",
+    highlights: [
+      "Airport-level runway end labels stay hidden until detail zoom",
+      "Nearby airport-surface traffic hides within 3nm at approach zoom and 0.5nm at airport zoom",
+      "Zoom-specific map feature toggles now live in one configuration table",
+    ],
+  },
+  {
     version: "v1.8.3",
     kind: "patch",
     title: "Mechanism page and navigation polish",

--- a/src/config/siteMeta.test.ts
+++ b/src/config/siteMeta.test.ts
@@ -7,14 +7,14 @@ import {
 } from "./siteMeta";
 
 assert.equal(ADSBAO_PRODUCT_NAME, "ADSBao");
-assert.equal(ADSBAO_SITE_VERSION, "1.8.3");
+assert.equal(ADSBAO_SITE_VERSION, "1.8.4");
 assert.equal(
   buildAdsbaoUserAgent("adsbdb/v0"),
-  "ADSBao/1.8.3 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+  "ADSBao/1.8.4 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
 );
 assert.equal(
   buildAdsbaoUserAgent(),
-  "ADSBao/1.8.3 (+https://github.com/orriduck/ADSBao)",
+  "ADSBao/1.8.4 (+https://github.com/orriduck/ADSBao)",
 );
 
 console.log("siteMeta.test.ts ok");

--- a/src/config/siteMeta.ts
+++ b/src/config/siteMeta.ts
@@ -1,5 +1,5 @@
 export const ADSBAO_PRODUCT_NAME = "ADSBao";
-export const ADSBAO_SITE_VERSION = "1.8.3";
+export const ADSBAO_SITE_VERSION = "1.8.4";
 export const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
 
 export function buildAdsbaoUserAgent(suffix = "") {

--- a/src/features/airport/map/airportMapModel.test.ts
+++ b/src/features/airport/map/airportMapModel.test.ts
@@ -12,6 +12,7 @@ import {
 
 const aircraft = [
   { icao24: "near", lat: 42.3657, lon: -71.0097 },
+  { icao24: "airport-ring", lat: 42.3816, lon: -71.0096 },
   { icao24: "near-secondary", lat: 42.58, lon: -70.92 },
   { icao24: "far", lat: 42.55, lon: -71.22 },
   { icao24: "missing", lat: null, lon: -71.22 },
@@ -59,7 +60,7 @@ assert.deepEqual(
 assert.deepEqual(
   getVisibleAircraft({ aircraft, airportLat: 42.3656, airportLon: -71.0096, zoom: ZOOM_AIRPORT })
     .map((item) => item.icao24),
-  ["near", "near-secondary", "far"],
+  ["airport-ring", "near-secondary", "far"],
 );
 
 assert.deepEqual(

--- a/src/features/airport/map/airportMapModel.ts
+++ b/src/features/airport/map/airportMapModel.ts
@@ -1,10 +1,5 @@
-import { ZOOM_APPROACH } from "../../../utils/airportMapDisplay";
 import { getDistanceNm } from "../../../utils/aircraftTrafficIntent";
-
-// Fallback used when the caller doesn't supply a ground-area radius.
-// Matches the focal-airport's default first-ring interval so the
-// ground filter aligns with the visual layer.
-const DEFAULT_GROUND_AREA_RADIUS_NM = 3;
+import { airportGroundTrafficHideRadiusNmForZoom } from "./airportMapZoomFeatures";
 
 type AirportMapCoordinate = {
   icao?: unknown;
@@ -33,7 +28,6 @@ type AirportGroundFilterOptions = {
 type VisibleAircraftOptions = AirportGroundFilterOptions & {
   aircraft: AirportMapAircraft[];
   zoom?: unknown;
-  groundAreaRadiusNm?: number;
 };
 
 export const resolveDocumentTheme = (documentElement: Pick<Element, "getAttribute"> | null | undefined) =>
@@ -103,9 +97,9 @@ export const getVisibleAircraft = ({
   airportLon,
   nearbyAirports = [],
   zoom,
-  groundAreaRadiusNm = DEFAULT_GROUND_AREA_RADIUS_NM,
 }: VisibleAircraftOptions) => {
-  const atApproachZoom = Number(zoom) === ZOOM_APPROACH;
+  const airportGroundTrafficHideRadiusNm =
+    airportGroundTrafficHideRadiusNmForZoom(zoom);
   const groundFilters = airportGroundFilters({
     airportLat,
     airportLon,
@@ -114,9 +108,9 @@ export const getVisibleAircraft = ({
 
   return aircraft.filter((ac) => {
     if (ac.lat == null || ac.lon == null) return false;
-    if (!atApproachZoom) return true;
+    if (airportGroundTrafficHideRadiusNm == null) return true;
     return !groundFilters.some((airport) =>
-      isInsideAirportGroundArea(ac, airport, groundAreaRadiusNm),
+      isInsideAirportGroundArea(ac, airport, airportGroundTrafficHideRadiusNm),
     );
   });
 };

--- a/src/features/airport/map/airportMapZoomFeatures.test.ts
+++ b/src/features/airport/map/airportMapZoomFeatures.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+
+import {
+  ZOOM_AIRPORT,
+  ZOOM_APPROACH,
+  ZOOM_DETAIL,
+} from "../../../utils/airportMapDisplay";
+import {
+  airportMapZoomFeaturesFor,
+  airportGroundTrafficHideRadiusNmForZoom,
+  shouldShowAirportAreaCountForZoom,
+  shouldShowNearbyAirportRunwaysForZoom,
+  shouldShowRangeRingLabelsForZoom,
+  shouldShowRunwayEndLabelsForZoom,
+} from "./airportMapZoomFeatures";
+
+assert.deepEqual(airportMapZoomFeaturesFor(ZOOM_APPROACH), {
+  airportGroundTrafficHideRadiusNm: 3,
+  showAirportAreaCount: true,
+  showNearbyAirportRunways: true,
+  showRangeRingLabels: false,
+  showRunwayEndLabels: false,
+});
+
+assert.deepEqual(airportMapZoomFeaturesFor(ZOOM_AIRPORT), {
+  airportGroundTrafficHideRadiusNm: 0.5,
+  showAirportAreaCount: false,
+  showNearbyAirportRunways: true,
+  showRangeRingLabels: true,
+  showRunwayEndLabels: false,
+});
+
+assert.deepEqual(airportMapZoomFeaturesFor(ZOOM_DETAIL), {
+  airportGroundTrafficHideRadiusNm: null,
+  showAirportAreaCount: false,
+  showNearbyAirportRunways: true,
+  showRangeRingLabels: true,
+  showRunwayEndLabels: true,
+});
+
+assert.deepEqual(airportMapZoomFeaturesFor(12), {
+  airportGroundTrafficHideRadiusNm: null,
+  showAirportAreaCount: false,
+  showNearbyAirportRunways: false,
+  showRangeRingLabels: false,
+  showRunwayEndLabels: false,
+});
+
+assert.equal(airportGroundTrafficHideRadiusNmForZoom(ZOOM_APPROACH), 3);
+assert.equal(airportGroundTrafficHideRadiusNmForZoom(ZOOM_AIRPORT), 0.5);
+assert.equal(airportGroundTrafficHideRadiusNmForZoom(ZOOM_DETAIL), null);
+assert.equal(shouldShowAirportAreaCountForZoom(ZOOM_APPROACH), true);
+assert.equal(shouldShowAirportAreaCountForZoom(ZOOM_AIRPORT), false);
+assert.equal(shouldShowNearbyAirportRunwaysForZoom(ZOOM_AIRPORT), true);
+assert.equal(shouldShowRangeRingLabelsForZoom(ZOOM_AIRPORT), true);
+assert.equal(shouldShowRunwayEndLabelsForZoom(ZOOM_DETAIL), true);

--- a/src/features/airport/map/airportMapZoomFeatures.ts
+++ b/src/features/airport/map/airportMapZoomFeatures.ts
@@ -1,0 +1,66 @@
+import {
+  ZOOM_AIRPORT,
+  ZOOM_APPROACH,
+  ZOOM_DETAIL,
+} from "../../../utils/airportMapDisplay";
+
+type AirportMapZoomFeatures = {
+  airportGroundTrafficHideRadiusNm: number | null;
+  showAirportAreaCount: boolean;
+  showNearbyAirportRunways: boolean;
+  showRangeRingLabels: boolean;
+  showRunwayEndLabels: boolean;
+};
+
+const DEFAULT_GROUND_AREA_RADIUS_NM = 3;
+
+const AIRPORT_MAP_ZOOM_FEATURE_DEFAULTS: AirportMapZoomFeatures = Object.freeze({
+  airportGroundTrafficHideRadiusNm: null,
+  showAirportAreaCount: false,
+  showNearbyAirportRunways: false,
+  showRangeRingLabels: false,
+  showRunwayEndLabels: false,
+});
+
+export const AIRPORT_MAP_ZOOM_FEATURES_BY_LEVEL: Record<number, AirportMapZoomFeatures> = Object.freeze({
+  [ZOOM_APPROACH]: Object.freeze({
+    airportGroundTrafficHideRadiusNm: DEFAULT_GROUND_AREA_RADIUS_NM,
+    showAirportAreaCount: true,
+    showNearbyAirportRunways: true,
+    showRangeRingLabels: false,
+    showRunwayEndLabels: false,
+  }),
+  [ZOOM_AIRPORT]: Object.freeze({
+    airportGroundTrafficHideRadiusNm: 0.5,
+    showAirportAreaCount: false,
+    showNearbyAirportRunways: true,
+    showRangeRingLabels: true,
+    showRunwayEndLabels: false,
+  }),
+  [ZOOM_DETAIL]: Object.freeze({
+    airportGroundTrafficHideRadiusNm: null,
+    showAirportAreaCount: false,
+    showNearbyAirportRunways: true,
+    showRangeRingLabels: true,
+    showRunwayEndLabels: true,
+  }),
+});
+
+export const airportMapZoomFeaturesFor = (zoom: unknown): AirportMapZoomFeatures =>
+  AIRPORT_MAP_ZOOM_FEATURES_BY_LEVEL[Number(zoom)] ??
+  AIRPORT_MAP_ZOOM_FEATURE_DEFAULTS;
+
+export const airportGroundTrafficHideRadiusNmForZoom = (zoom: unknown) =>
+  airportMapZoomFeaturesFor(zoom).airportGroundTrafficHideRadiusNm;
+
+export const shouldShowAirportAreaCountForZoom = (zoom: unknown) =>
+  airportMapZoomFeaturesFor(zoom).showAirportAreaCount;
+
+export const shouldShowNearbyAirportRunwaysForZoom = (zoom: unknown) =>
+  airportMapZoomFeaturesFor(zoom).showNearbyAirportRunways;
+
+export const shouldShowRangeRingLabelsForZoom = (zoom: unknown) =>
+  airportMapZoomFeaturesFor(zoom).showRangeRingLabels;
+
+export const shouldShowRunwayEndLabelsForZoom = (zoom: unknown) =>
+  airportMapZoomFeaturesFor(zoom).showRunwayEndLabels;

--- a/src/features/airport/map/runwayAnnotationModel.test.ts
+++ b/src/features/airport/map/runwayAnnotationModel.test.ts
@@ -65,9 +65,10 @@ assert.deepEqual(buildRunwayEndLabels(runwayMap), [
 ]);
 
 assert.equal(shouldShowRunwayEndLabels(ZOOM_APPROACH), false);
-assert.equal(shouldShowRunwayEndLabels(ZOOM_AIRPORT), true);
+assert.equal(shouldShowRunwayEndLabels(ZOOM_AIRPORT), false);
 assert.equal(shouldShowRunwayEndLabels(ZOOM_DETAIL), true);
 assert.deepEqual(buildRunwayEndLabels(runwayMap, { zoom: ZOOM_APPROACH }), []);
+assert.deepEqual(buildRunwayEndLabels(runwayMap, { zoom: ZOOM_AIRPORT }), []);
 
 assert.deepEqual(buildRunwayCenterlineCollection(runwayMap), {
   type: "FeatureCollection",

--- a/src/features/airport/map/runwayAnnotationModel.ts
+++ b/src/features/airport/map/runwayAnnotationModel.ts
@@ -1,10 +1,11 @@
 import { RUNWAY_APPROACH_BEAM_CONFIG } from "../../../config/airportMap";
 import { ZOOM_APPROACH } from "../../../utils/airportMapDisplay";
+import { shouldShowRunwayEndLabelsForZoom } from "./airportMapZoomFeatures";
 
 const METERS_PER_DEGREE_LATITUDE = 111_320;
 const STATUTE_MILE_METERS = 1_609.344;
 
-export const shouldShowRunwayEndLabels = (zoom) => Number(zoom) > ZOOM_APPROACH;
+export const shouldShowRunwayEndLabels = shouldShowRunwayEndLabelsForZoom;
 
 type RunwayAnnotationRecord = Record<string, any>;
 


### PR DESCRIPTION
## Summary
- centralize airport map zoom-level feature behavior into `airportMapZoomFeatures`
- keep runway end labels hidden until detail zoom and tune airport-ground traffic suppression to 3nm at approach / 0.5nm at airport zoom
- bump ADSBao to v1.8.4 with changelog and User-Agent metadata updates

## Validation
- `/opt/homebrew/bin/pnpm test` (106 test files passed)
- `/opt/homebrew/bin/pnpm lint` (0 errors; existing `VirtualNearbyList.tsx` TanStack Virtual warning)
- `/opt/homebrew/bin/pnpm build`
- local browser check on `/airport/KBOS`: approach/airport runway labels stayed hidden; detail zoom showed runway end labels
