### PR TITLE
Fix map settings save snapshot

### DIFF
--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -17,6 +17,7 @@ import {
   DEFAULT_MAP_SETTINGS,
   MAP_LAYER_KEYS,
   buildCustomMapSettings,
+  buildMapSettingsFromLayerState,
   buildPresetMapSettings,
   isSelectableMapModeId,
   mapSettingsToExplorerLayers,
@@ -307,6 +308,9 @@ export function ExplorerUiProvider({ children }) {
         persistedMapSettingsRef.current = nextSettings
           ? JSON.stringify(nextSettings)
           : "";
+        if (nextSettings) {
+          dispatch({ type: "hydrateMapSettings", settings: nextSettings });
+        }
       } else if (nextSettings) {
         dispatch({ type: "hydrateMapSettings", settings: nextSettings });
         persistedMapSettingsRef.current = JSON.stringify(nextSettings);
@@ -335,9 +339,16 @@ export function ExplorerUiProvider({ children }) {
     return undefined;
   }, [isLoaded, isSignedIn, mapSettings]);
 
-  const saveMapSettings = useCallback(async () => {
+  const saveMapSettings = useCallback(async (options: Record<string, any> = {}) => {
     if (!isLoaded || !isSignedIn) return null;
-    const nextSettings = normalizeMapSettings(mapSettings);
+    const nextSettings = normalizeMapSettings(
+      options?.layers
+        ? buildMapSettingsFromLayerState({
+            settings: mapSettings,
+            layers: options.layers,
+          })
+        : mapSettings,
+    );
     setMapSettingsSaveStatus("saving");
     try {
       const response = await fetch("/api/map-settings", {
@@ -354,6 +365,7 @@ export function ExplorerUiProvider({ children }) {
         : nextSettings;
       setSavedMapSettings(savedSettings);
       persistedMapSettingsRef.current = JSON.stringify(savedSettings);
+      dispatch({ type: "hydrateMapSettings", settings: savedSettings });
       setMapSettingsSaveStatus("saved");
       return savedSettings;
     } catch {

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -7,6 +7,7 @@ import {
   MAP_MODE_OPTIONS,
   CUSTOM_MAP_MODE_OPTION,
   DISABLED_MAP_MODE_IDS,
+  explorerLayerStateToMapSettingsLayers,
   normalizeMapSettings,
 } from "@/features/airport/map-settings/mapSettingsModel";
 import {
@@ -113,6 +114,18 @@ export default function MapSettingsSheet({
   const hasSavedMapSettings = Boolean(savedMapSettings);
   const saving = mapSettingsSaveStatus === "saving";
   const restoring = mapSettingsRestoreStatus === "restoring";
+  const handleSaveMapSettings = () => {
+    onSaveMapSettings?.({
+      layers: explorerLayerStateToMapSettingsLayers({
+        showMapLabels,
+        showRunwayBeams: showBeams,
+        showNavaidMarkers,
+        showAirspaces,
+        userLocationActive,
+        userLocationAudioActive,
+      }),
+    });
+  };
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -375,7 +388,7 @@ export default function MapSettingsSheet({
                     "hover:shadow-[var(--atc-control-active-shadow-strong)] disabled:cursor-not-allowed disabled:opacity-55",
                   )}
                   disabled={saving || !onSaveMapSettings}
-                  onClick={onSaveMapSettings}
+                  onClick={handleSaveMapSettings}
                 >
                   {saving
                     ? t("mapSettings.savingSettings")

--- a/src/features/airport/map-settings/mapSettingsModel.test.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.test.ts
@@ -4,6 +4,7 @@ import {
   MAP_LAYER_KEYS,
   MAP_MODE_IDS,
   buildCustomMapSettings,
+  buildMapSettingsFromLayerState,
   buildPresetMapSettings,
   getMapModePreset,
   normalizeMapSettings,
@@ -103,6 +104,39 @@ import {
     true,
     "database rows should hydrate has_selected_mode into the settings model",
   );
+}
+
+{
+  const saved = buildMapSettingsFromLayerState({
+    settings: buildPresetMapSettings({
+      modeId: MAP_MODE_IDS.CONTROLLER,
+      now: "2026-06-02T15:04:00.000Z",
+    }),
+    layers: {
+      [MAP_LAYER_KEYS.MAP_LABELS]: false,
+      [MAP_LAYER_KEYS.APPROACH_BEAMS]: true,
+      [MAP_LAYER_KEYS.NAVAID_MARKERS]: true,
+      [MAP_LAYER_KEYS.AIRSPACES]: true,
+      [MAP_LAYER_KEYS.USER_LOCATION]: true,
+      [MAP_LAYER_KEYS.USER_LOCATION_AUDIO]: false,
+    },
+    now: "2026-06-02T15:05:00.000Z",
+  });
+
+  assert.equal(
+    saved.selectedMode,
+    MAP_MODE_IDS.CUSTOM,
+    "saving visible layer overrides should persist the setup as Custom",
+  );
+  assert.equal(saved.baseMode, MAP_MODE_IDS.CONTROLLER);
+  assert.deepEqual(saved.layerOverrides, {
+    [MAP_LAYER_KEYS.MAP_LABELS]: false,
+    [MAP_LAYER_KEYS.APPROACH_BEAMS]: true,
+    [MAP_LAYER_KEYS.NAVAID_MARKERS]: true,
+    [MAP_LAYER_KEYS.AIRSPACES]: true,
+    [MAP_LAYER_KEYS.USER_LOCATION]: true,
+    [MAP_LAYER_KEYS.USER_LOCATION_AUDIO]: false,
+  });
 }
 
 console.log("mapSettingsModel.test.ts ok");

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -244,9 +244,22 @@ export function buildMapSettingsFromLayerState({
   now = new Date().toISOString(),
 }: MapSettingsOptions = {}) {
   const normalized = normalizeMapSettings(settings);
+  const baseMode = getMapSettingsBaseMode(normalized);
+  const baseLayers = getMapModePreset(baseMode).layers;
+  const layerOverrides = normalizeMapLayerOverrides(layers);
+  const nextLayers = {
+    ...resolveMapSettingsLayers(normalized),
+    ...layerOverrides,
+  };
+  const custom = PERSISTED_MAP_LAYER_KEYS.some(
+    (layerKey) => nextLayers[layerKey] !== baseLayers[layerKey],
+  );
+
   return {
     ...normalized,
-    layerOverrides: normalizeMapLayerOverrides(layers),
+    selectedMode: custom ? MAP_MODE_IDS.CUSTOM : baseMode,
+    baseMode,
+    layerOverrides: custom ? normalizeMapLayerOverrides(nextLayers) : {},
     updatedAt: now,
   };
 }


### PR DESCRIPTION
## Summary
- Save the visible Map Settings sheet state, including user location and proximity sound, instead of only the internal mapSettings object.
- Persist visible layer snapshots as Custom when they differ from the base preset.
- Hydrate signed-in saved settings into the visible map state after load/save.

## Validation
- /opt/homebrew/bin/pnpm exec tsx src/features/airport/map-settings/mapSettingsModel.test.ts
- /opt/homebrew/bin/pnpm exec tsx src/app/api/dao/userMapSettings.dao.test.ts
- /opt/homebrew/bin/pnpm lint (passes with the existing VirtualNearbyList React Compiler warning)