### PR TITLE
[codex] Fix settings save flow

### DIFF
--- a/src/app/api/dao/userMapSettings.dao.test.ts
+++ b/src/app/api/dao/userMapSettings.dao.test.ts
@@ -89,12 +89,13 @@ function createFakeSupabaseClient({
 
   assert.equal(calls[1].type, "from");
   assert.equal(calls[1].table, USER_MAP_SETTINGS_TABLE);
-  assert.equal(calls[2].type, "upsert");
-  assert.equal(calls[2].row.email, "owner@example.com");
-  assert.equal(calls[2].row.environment, "preview");
-  assert.deepEqual(calls[2].options, { onConflict: "email,environment" });
-  assert.equal(calls[2].row.has_selected_mode, true);
-  assert.deepEqual(calls[2].row.settings.layerOverrides, {
+  const upsertCall = calls.find((call) => call.type === "upsert");
+  assert.ok(upsertCall, "repository should write a settings row");
+  assert.equal(upsertCall.row.email, "owner@example.com");
+  assert.equal(upsertCall.row.environment, "preview");
+  assert.deepEqual(upsertCall.options, { onConflict: "email,environment" });
+  assert.equal(upsertCall.row.has_selected_mode, true);
+  assert.deepEqual(upsertCall.row.settings.layerOverrides, {
     [MAP_LAYER_KEYS.AIRSPACES]: true,
   });
   assert.deepEqual(row.settings.layerOverrides, {
@@ -165,6 +166,69 @@ function createFakeSupabaseClient({
     () => repository.readSettingsByEmail("owner@example.com"),
     /User map settings read failed \(permission denied\)/,
   );
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    readData: {
+      email: "owner@example.com",
+      environment: "preview",
+      settings: {
+        selectedMode: MAP_MODE_IDS.CUSTOM,
+        baseMode: MAP_MODE_IDS.CONTROLLER,
+        hasSelectedMode: true,
+        layerOverrides: {
+          [MAP_LAYER_KEYS.AIRSPACES]: true,
+          [MAP_LAYER_KEYS.USER_LOCATION]: true,
+          [MAP_LAYER_KEYS.USER_LOCATION_AUDIO]: true,
+        },
+        updatedAt: "2026-06-02T15:06:00.000Z",
+      },
+      has_selected_mode: true,
+      updated_at: "2026-06-02T15:06:00.000Z",
+    },
+    writeData: {
+      email: "owner@example.com",
+      environment: "preview",
+      settings: {
+        selectedMode: MAP_MODE_IDS.CUSTOM,
+        baseMode: MAP_MODE_IDS.CONTROLLER,
+        hasSelectedMode: true,
+        layerOverrides: {
+          [MAP_LAYER_KEYS.AIRSPACES]: true,
+          [MAP_LAYER_KEYS.USER_LOCATION]: true,
+          [MAP_LAYER_KEYS.USER_LOCATION_AUDIO]: true,
+          [MAP_LAYER_KEYS.MAP_LABELS]: false,
+        },
+        updatedAt: "2026-06-02T15:07:00.000Z",
+      },
+      has_selected_mode: true,
+      updated_at: "2026-06-02T15:07:00.000Z",
+    },
+  });
+  const repository = createUserMapSettingsRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    environment: "preview",
+    createClientImpl,
+  });
+
+  await repository.upsertSettingsByEmail({
+    email: "owner@example.com",
+    settings: {
+      layerOverrides: { [MAP_LAYER_KEYS.MAP_LABELS]: false },
+      updatedAt: "2026-06-02T15:07:00.000Z",
+    },
+  });
+
+  const upsertCall = calls.find((call) => call.type === "upsert");
+  assert.ok(upsertCall, "repository should write the merged settings row");
+  assert.deepEqual(upsertCall.row.settings.layerOverrides, {
+    [MAP_LAYER_KEYS.AIRSPACES]: true,
+    [MAP_LAYER_KEYS.USER_LOCATION]: true,
+    [MAP_LAYER_KEYS.USER_LOCATION_AUDIO]: true,
+    [MAP_LAYER_KEYS.MAP_LABELS]: false,
+  });
 }
 
 console.log("userMapSettings.dao.test.ts ok");

--- a/src/app/api/dao/userMapSettings.dao.ts
+++ b/src/app/api/dao/userMapSettings.dao.ts
@@ -5,6 +5,8 @@ import {
   resolveFeatureFlagEnvironment,
 } from "../../../features/app-shell/feature-flags/userFeatureFlagsModel";
 import {
+  DEFAULT_MAP_SETTINGS,
+  mergeMapSettings,
   normalizeMapSettings,
 } from "../../../features/airport/map-settings/mapSettingsModel";
 
@@ -68,7 +70,13 @@ export function createUserMapSettingsRepository({
       const normalizedEnvironment = normalizeFeatureFlagEnvironment(
         environment || defaultEnvironment,
       );
-      const normalizedSettings = normalizeMapSettings(settings);
+      const existingRow = await this.readSettingsByEmail(normalizedEmail, {
+        environment: normalizedEnvironment,
+      });
+      const normalizedSettings = mergeMapSettings({
+        settings: existingRow?.settings || DEFAULT_MAP_SETTINGS,
+        updates: settings,
+      });
       const updatedAt = normalizedSettings.updatedAt || new Date().toISOString();
 
       const { data, error } = await client

--- a/src/app/api/map-settings/route.ts
+++ b/src/app/api/map-settings/route.ts
@@ -4,10 +4,6 @@ import {
   persistMapSettingsForUser,
   resolveMapSettingsForUser,
 } from "@/features/airport/map-settings/userMapSettings.server";
-import {
-  normalizeMapSettings,
-} from "@/features/airport/map-settings/mapSettingsModel";
-
 export const dynamic = "force-dynamic";
 
 export async function GET() {
@@ -39,7 +35,7 @@ export async function PUT(request: Request) {
   const body = await request.json().catch(() => ({}));
   const settings = await persistMapSettingsForUser({
     user,
-    settings: normalizeMapSettings(body?.settings),
+    settings: body?.settings,
   });
 
   return Response.json(

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -59,6 +59,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     showNavaidMarkers,
     showAirspaces,
     showCandidateWatchingSpots,
+    userLocationEnabled,
+    userLocationAudioEnabled,
     trafficFilter,
     typeFilter,
     altitudeLevel,
@@ -78,6 +80,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     selectCandidateWatchingSpot,
     setSelectedCandidateWatchingSpotId,
     mapFollowsAircraft,
+    setUserLocationPreferences,
   } = useExplorerUi();
   const [userLocation, setUserLocation] = useState(null);
   const [userLocationMode, setUserLocationMode] = useState<UserLocationAudioMode>(
@@ -86,6 +89,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   const [userLocationPending, setUserLocationPending] = useState(false);
   const [userLocationNotice, setUserLocationNotice] = useState("");
   const userLocationWatchIdRef = useRef<number | null>(null);
+  const autoUserLocationAttemptKeyRef = useRef("");
   const airportProfile = useMemo(
     () => resolveAirportProfile({ icao, airport }),
     [icao, airport],
@@ -261,6 +265,11 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
 
       setUserLocation(result.location);
       setUserLocationMode(result.mode);
+      setUserLocationPreferences({
+        userLocationEnabled: true,
+        userLocationAudioEnabled:
+          result.mode === USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO,
+      });
       setUserLocationNotice("");
     };
     const handleError = (error) => {
@@ -298,31 +307,81 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   }, [
     airportProfile.lat,
     airportProfile.lon,
+    setUserLocationPreferences,
     stopUserLocationWatch,
     t,
   ]);
 
+  useEffect(() => {
+    if (!userLocationEnabled) {
+      autoUserLocationAttemptKeyRef.current = "";
+      if (userLocation) clearUserLocation();
+      return;
+    }
+
+    if (userLocation || userLocationPending) return;
+    const attemptKey = `${airportProfile.icao}:${userLocationAudioEnabled}`;
+    if (autoUserLocationAttemptKeyRef.current === attemptKey) return;
+    autoUserLocationAttemptKeyRef.current = attemptKey;
+    requestUserLocation(
+      userLocationAudioEnabled
+        ? USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO
+        : USER_LOCATION_AUDIO_MODES.LOCATION,
+    );
+  }, [
+    airportProfile.icao,
+    clearUserLocation,
+    requestUserLocation,
+    userLocation,
+    userLocationAudioEnabled,
+    userLocationEnabled,
+    userLocationPending,
+  ]);
+
   const toggleUserLocation = useCallback(() => {
-    if (userLocation) {
+    if (userLocation || userLocationEnabled) {
+      setUserLocationPreferences({
+        userLocationEnabled: false,
+        userLocationAudioEnabled: false,
+      });
       clearUserLocation();
       return;
     }
 
     requestUserLocation(USER_LOCATION_AUDIO_MODES.LOCATION);
-  }, [clearUserLocation, requestUserLocation, userLocation]);
+  }, [
+    clearUserLocation,
+    requestUserLocation,
+    setUserLocationPreferences,
+    userLocation,
+    userLocationEnabled,
+  ]);
 
   const toggleUserLocationAudio = useCallback(() => {
     if (!userLocation) return;
     if (userLocationAudioActive) {
       setUserLocationMode(USER_LOCATION_AUDIO_MODES.LOCATION);
+      setUserLocationPreferences({
+        userLocationEnabled: true,
+        userLocationAudioEnabled: false,
+      });
       setUserLocationNotice("");
       return;
     }
 
     unlockAudio();
     setUserLocationMode(USER_LOCATION_AUDIO_MODES.LOCATION_AUDIO);
+    setUserLocationPreferences({
+      userLocationEnabled: true,
+      userLocationAudioEnabled: true,
+    });
     setUserLocationNotice("");
-  }, [unlockAudio, userLocation, userLocationAudioActive]);
+  }, [
+    setUserLocationPreferences,
+    unlockAudio,
+    userLocation,
+    userLocationAudioActive,
+  ]);
 
   const criticalLoadingSettled = areCriticalLoadingRequestsSettled({
     aircraftPositionsSettled: traffic.aircraftPositionsSettled,
@@ -421,8 +480,10 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
               lastUpdated={traffic.lastUpdated}
               routeProvider={traffic.routeProvider}
               loadingStatus={sourceLoadingStatus}
-              userLocationActive={userLocationActive}
-              userLocationAudioActive={userLocationAudioActive}
+              userLocationActive={userLocationEnabled || userLocationActive}
+              userLocationAudioActive={
+                userLocationAudioEnabled || userLocationAudioActive
+              }
               userLocationPending={userLocationPending}
               userLocationNotice={userLocationNotice}
               onToggleUserLocation={toggleUserLocation}

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -21,6 +21,7 @@ import {
   buildPresetMapSettings,
   isSelectableMapModeId,
   mapSettingsToExplorerLayers,
+  mapSettingsToUserLocationPreferences,
   normalizeMapSettings,
 } from "@/features/airport/map-settings/mapSettingsModel";
 import {
@@ -34,10 +35,13 @@ import {
 
 const ExplorerUiContext = createContext(null);
 const DEFAULT_MAP_LAYERS = mapSettingsToExplorerLayers(DEFAULT_MAP_SETTINGS);
+const DEFAULT_USER_LOCATION_PREFERENCES =
+  mapSettingsToUserLocationPreferences(DEFAULT_MAP_SETTINGS);
 
 const initialUiState = {
   ...DEFAULT_AIRPORT_EXPLORER_UI_STATE,
   ...DEFAULT_MAP_LAYERS,
+  ...DEFAULT_USER_LOCATION_PREFERENCES,
   mapSettings: DEFAULT_MAP_SETTINGS,
   sidebarMode: "desktop",
   sidebarOpen: true,
@@ -65,9 +69,12 @@ function toggleValue(value) {
 function applyMapSettingsToUiState(state, settings) {
   const normalizedSettings = normalizeMapSettings(settings);
   const layers = mapSettingsToExplorerLayers(normalizedSettings);
+  const userLocationPreferences =
+    mapSettingsToUserLocationPreferences(normalizedSettings);
   return {
     ...state,
     ...layers,
+    ...userLocationPreferences,
     mapSettings: normalizedSettings,
     selectedAirspaceId: layers.showAirspaces ? state.selectedAirspaceId : "",
     selectedCandidateWatchingSpotId: layers.showCandidateWatchingSpots
@@ -152,6 +159,24 @@ function airportExplorerUiReducer(state, action) {
       );
     case "hydrateMapSettings":
       return applyMapSettingsToUiState(state, action.settings);
+    case "setUserLocationPreferences": {
+      const userLocationEnabled = action.userLocationEnabled === true;
+      const userLocationAudioEnabled =
+        userLocationEnabled && action.userLocationAudioEnabled === true;
+      const locationSettings = buildCustomMapSettings({
+        settings: state.mapSettings,
+        layerKey: MAP_LAYER_KEYS.USER_LOCATION,
+        value: userLocationEnabled,
+      });
+      return applyMapSettingsToUiState(
+        state,
+        buildCustomMapSettings({
+          settings: locationSettings,
+          layerKey: MAP_LAYER_KEYS.USER_LOCATION_AUDIO,
+          value: userLocationAudioEnabled,
+        }),
+      );
+    }
     case "setTrafficFilter":
       return { ...state, trafficFilter: action.trafficFilter };
     case "setTypeFilter":
@@ -289,6 +314,8 @@ export function ExplorerUiProvider({ children }) {
     showNavaidMarkers,
     showAirspaces,
     showCandidateWatchingSpots,
+    userLocationEnabled,
+    userLocationAudioEnabled,
     mapSettings,
     trafficFilter,
     typeFilter,
@@ -477,6 +504,17 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "applyMapMode", modeId });
   }, []);
 
+  const setUserLocationPreferences = useCallback(
+    ({ userLocationEnabled, userLocationAudioEnabled = false }) => {
+      dispatch({
+        type: "setUserLocationPreferences",
+        userLocationEnabled,
+        userLocationAudioEnabled,
+      });
+    },
+    [],
+  );
+
   const setTrafficFilter = useCallback((trafficFilter) => {
     dispatch({ type: "setTrafficFilter", trafficFilter });
   }, []);
@@ -553,6 +591,8 @@ export function ExplorerUiProvider({ children }) {
       showNavaidMarkers,
       showAirspaces,
       showCandidateWatchingSpots,
+      userLocationEnabled,
+      userLocationAudioEnabled,
       mapSettings,
       savedMapSettings,
       mapSettingsSaveStatus,
@@ -580,6 +620,7 @@ export function ExplorerUiProvider({ children }) {
       toggleAirspaces,
       toggleCandidateWatchingSpots,
       applyMapMode,
+      setUserLocationPreferences,
       saveMapSettings,
       restoreMapSettings,
       selectAircraft,
@@ -605,6 +646,8 @@ export function ExplorerUiProvider({ children }) {
       showNavaidMarkers,
       showAirspaces,
       showCandidateWatchingSpots,
+      userLocationEnabled,
+      userLocationAudioEnabled,
       mapSettings,
       savedMapSettings,
       mapSettingsSaveStatus,
@@ -632,6 +675,7 @@ export function ExplorerUiProvider({ children }) {
       toggleAirspaces,
       toggleCandidateWatchingSpots,
       applyMapMode,
+      setUserLocationPreferences,
       saveMapSettings,
       restoreMapSettings,
       selectAircraft,

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -127,8 +127,9 @@ export default function MapSettingsSheet({
   const hasSavedMapSettings = Boolean(savedMapSettings);
   const saving = mapSettingsSaveStatus === "saving";
   const restoring = mapSettingsRestoreStatus === "restoring";
-  const handleSaveMapSettings = () => {
-    onSaveMapSettings?.({
+  const handleSaveMapSettings = async () => {
+    if (saving || !onSaveMapSettings) return;
+    const savedSettings = await onSaveMapSettings({
       layers: explorerLayerStateToMapSettingsLayers({
         showMapLabels,
         showRunwayBeams: showBeams,
@@ -139,6 +140,9 @@ export default function MapSettingsSheet({
         userLocationAudioActive,
       }),
     });
+    if (savedSettings) {
+      onOpenChange?.(false);
+    }
   };
 
   return (

--- a/src/features/aircraft/positions/aircraftPositions.mechanism.test.ts
+++ b/src/features/aircraft/positions/aircraftPositions.mechanism.test.ts
@@ -41,7 +41,7 @@ try {
     true,
   );
   if (result.source === "adsb.fi") {
-    assert.deepEqual(result.payload.ac, [
+    assert.deepEqual((result.payload as unknown as { ac: unknown[] }).ac, [
       { hex: "a360b7", flight: "JBU396  " },
     ]);
   }

--- a/src/features/airport/map-settings/mapSettingsModel.test.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.test.ts
@@ -7,6 +7,7 @@ import {
   buildMapSettingsFromLayerState,
   buildPresetMapSettings,
   getMapModePreset,
+  mergeMapSettings,
   normalizeMapSettings,
   resolveMapSettingsLayers,
 } from "./mapSettingsModel";
@@ -140,6 +141,39 @@ import {
     [MAP_LAYER_KEYS.CANDIDATE_WATCHING_SPOTS]: true,
     [MAP_LAYER_KEYS.USER_LOCATION]: true,
     [MAP_LAYER_KEYS.USER_LOCATION_AUDIO]: false,
+  });
+}
+
+{
+  const merged = mergeMapSettings({
+    settings: normalizeMapSettings({
+      selectedMode: MAP_MODE_IDS.CUSTOM,
+      baseMode: MAP_MODE_IDS.CONTROLLER,
+      layerOverrides: {
+        [MAP_LAYER_KEYS.AIRSPACES]: true,
+        [MAP_LAYER_KEYS.USER_LOCATION]: true,
+        [MAP_LAYER_KEYS.USER_LOCATION_AUDIO]: true,
+      },
+      hasSelectedMode: true,
+      updatedAt: "2026-06-02T15:06:00.000Z",
+    }),
+    updates: {
+      layerOverrides: {
+        [MAP_LAYER_KEYS.MAP_LABELS]: false,
+      },
+      updatedAt: "2026-06-02T15:07:00.000Z",
+    },
+  });
+
+  assert.equal(merged.selectedMode, MAP_MODE_IDS.CUSTOM);
+  assert.equal(merged.baseMode, MAP_MODE_IDS.CONTROLLER);
+  assert.equal(merged.hasSelectedMode, true);
+  assert.equal(merged.updatedAt, "2026-06-02T15:07:00.000Z");
+  assert.deepEqual(merged.layerOverrides, {
+    [MAP_LAYER_KEYS.AIRSPACES]: true,
+    [MAP_LAYER_KEYS.USER_LOCATION]: true,
+    [MAP_LAYER_KEYS.USER_LOCATION_AUDIO]: true,
+    [MAP_LAYER_KEYS.MAP_LABELS]: false,
   });
 }
 

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -194,6 +194,62 @@ export function normalizeMapSettings(settings: MapSettingsRecord = {}) {
   };
 }
 
+function hasOwnSetting(settings: MapSettingsRecord, key: string) {
+  return Object.prototype.hasOwnProperty.call(settings || {}, key);
+}
+
+export function mergeMapSettings({
+  settings = DEFAULT_MAP_SETTINGS,
+  updates = {},
+}: MapSettingsOptions = {}) {
+  const normalized = normalizeMapSettings(settings);
+  const updateRecord =
+    updates && typeof updates === "object" && !Array.isArray(updates)
+      ? updates
+      : {};
+  const replacingMode =
+    hasOwnSetting(updateRecord, "selectedMode") ||
+    hasOwnSetting(updateRecord, "baseMode");
+  const nextLayerOverrides = hasOwnSetting(updateRecord, "layerOverrides")
+    ? replacingMode
+      ? normalizeMapLayerOverrides(updateRecord.layerOverrides)
+      : {
+          ...normalized.layerOverrides,
+          ...normalizeMapLayerOverrides(updateRecord.layerOverrides),
+        }
+    : normalized.layerOverrides;
+  const selectedMode =
+    hasOwnSetting(updateRecord, "selectedMode") &&
+    isMapModeId(updateRecord.selectedMode)
+      ? updateRecord.selectedMode
+      : normalized.selectedMode;
+  const baseMode =
+    hasOwnSetting(updateRecord, "baseMode") &&
+    isPresetMapModeId(updateRecord.baseMode)
+      ? updateRecord.baseMode
+      : normalized.baseMode;
+
+  return normalizeMapSettings({
+    selectedMode,
+    baseMode,
+    layerOverrides: nextLayerOverrides,
+    audioEnabled: hasOwnSetting(updateRecord, "audioEnabled")
+      ? updateRecord.audioEnabled === true
+      : normalized.audioEnabled,
+    hasSelectedMode:
+      hasOwnSetting(updateRecord, "hasSelectedMode") ||
+      hasOwnSetting(updateRecord, "has_selected_mode")
+        ? updateRecord.hasSelectedMode === true ||
+          updateRecord.has_selected_mode === true
+        : normalized.hasSelectedMode,
+    updatedAt:
+      hasOwnSetting(updateRecord, "updatedAt") ||
+      hasOwnSetting(updateRecord, "updated_at")
+        ? updateRecord.updatedAt || updateRecord.updated_at || ""
+        : normalized.updatedAt,
+  });
+}
+
 export function resolveMapSettingsLayers(settings: MapSettingsRecord = DEFAULT_MAP_SETTINGS) {
   const normalized = normalizeMapSettings(settings);
   const preset = getMapModePreset(getMapSettingsBaseMode(normalized));
@@ -279,6 +335,18 @@ export function mapSettingsToExplorerLayers(settings: MapSettingsRecord = DEFAUL
     showNavaidMarkers: layers[MAP_LAYER_KEYS.NAVAID_MARKERS],
     showAirspaces: layers[MAP_LAYER_KEYS.AIRSPACES],
     showCandidateWatchingSpots: layers[MAP_LAYER_KEYS.CANDIDATE_WATCHING_SPOTS],
+  };
+}
+
+export function mapSettingsToUserLocationPreferences(
+  settings: MapSettingsRecord = DEFAULT_MAP_SETTINGS,
+) {
+  const layers = resolveMapSettingsLayers(settings);
+  const enabled = layers[MAP_LAYER_KEYS.USER_LOCATION] === true;
+  return {
+    userLocationEnabled: enabled,
+    userLocationAudioEnabled:
+      enabled && layers[MAP_LAYER_KEYS.USER_LOCATION_AUDIO] === true,
   };
 }
 

--- a/src/features/airport/map-settings/userMapSettings.server.ts
+++ b/src/features/airport/map-settings/userMapSettings.server.ts
@@ -4,10 +4,6 @@ import {
 import {
   getClerkUserPrimaryEmail,
 } from "../../app-shell/feature-flags/userFeatureFlagsModel";
-import {
-  normalizeMapSettings,
-} from "./mapSettingsModel";
-
 type UserMapSettingsServerRecord = Record<string, any>;
 
 export async function resolveMapSettingsForUser({
@@ -36,7 +32,7 @@ export async function persistMapSettingsForUser({
 
   const row = await repository.upsertSettingsByEmail({
     email,
-    settings: normalizeMapSettings(settings),
+    settings,
   });
   return row?.settings || null;
 }


### PR DESCRIPTION
## Summary
- Persist user-location and user-location-audio preferences as part of hydrated map settings.
- Merge partial map-settings saves with existing persisted settings instead of replacing the full object with stale defaults.
- Await the save promise in the settings sheet and close only after a successful save.

## Root cause
Saved map settings already carried user-location layer keys, but the Explorer UI only hydrated visible map layers. User location lived in `AirportExplorer` component state, so a reload lost the saved preference. The server save path also normalized incoming partial payloads before persistence, which could turn a narrow update into a default-shaped full settings object and overwrite unrelated persisted fields.

## Verification
- `/opt/homebrew/bin/pnpm exec tsx src/features/airport/map-settings/mapSettingsModel.test.ts`
- `/opt/homebrew/bin/pnpm exec tsx src/app/api/dao/userMapSettings.dao.test.ts`
- `/opt/homebrew/bin/pnpm exec tsx src/features/aircraft/positions/aircraftPositions.mechanism.test.ts`
- `/opt/homebrew/bin/pnpm test` — 96 test files passed
- `/opt/homebrew/bin/pnpm lint` — passed with existing TanStack Virtual warning only
- `/opt/homebrew/bin/pnpm exec tsc --noEmit`
- `/opt/homebrew/bin/pnpm build`
- Chrome signed-in local verification on `http://localhost:3000/airport/KBOS`: Save/Restore visible, “我的位置” persisted after reload, settings dialog closed after save, and `.user-location-marker` rendered after reload.
