### PR TITLE
Implement Asana B-006 airport facilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Runtime version strings and ADSBao User-Agent values share
 - **Frontend**: React, Next.js App Router, Tailwind CSS v4, DaisyUI, Lucide.
 - **Maps**: Leaflet plus MapLibre-backed tiles and custom aircraft/runway layers.
 - **Data layer**: OpenAIP served through same-origin Next.js API routes with
-  Supabase migration support for OpenAIP-shaped static/cache tables. Runway
-  threshold geometry is imported from OurAirports for accurate map overlays.
+  Supabase migration support for OpenAIP-shaped static/cache tables. OurAirports
+  augments runway threshold geometry, ATC frequencies, and navaid coverage.
 - **Runtime**: Vercel Git deployments, same-origin proxy routes, Web Analytics,
   Speed Insights, and optional Sentry monitoring.
 - **Auth and feature flags**: Clerk identity with Supabase-backed user feature
@@ -47,7 +47,7 @@ Runtime version strings and ADSBao User-Agent values share
 | Path | Source | Purpose |
 |---|---|---|
 | `/api/search` | OpenAIP Core API | Airport search |
-| `/api/airport/[ident]` | OpenAIP Core API + OurAirports runway geometry | Airport detail, runways, frequencies, navaids, airspaces, reporting points, obstacles, runway map |
+| `/api/airport/[ident]` | OpenAIP Core API + OurAirports static facilities | Airport detail, runways, frequencies, navaids, airspaces, reporting points, obstacles, runway map |
 | `/api/proxy/metar/:icao` | AviationWeather | METAR weather context |
 | `/api/proxy/aircraft/positions/:lat/:lon/:dist` | adsb.lol | Nearby aircraft |
 | `/api/proxy/aircraft/callsign/:callsign` | ADS-B callsign providers | Tracked aircraft state |
@@ -112,6 +112,12 @@ Import runway threshold geometry with:
 
 ```bash
 pnpm import:runways
+```
+
+Import OurAirports ATC frequency and navaid augmentation data with:
+
+```bash
+pnpm import:facilities
 ```
 
 ## Project Structure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ Legacy desktop distribution, Electron packaging, Homebrew cask publishing, the p
 
 ### Airport directory (OpenAIP → Next.js API)
 
-Global airport context is sourced from [OpenAIP](https://www.openaip.net/) through server-only route handlers. `/api/search` resolves ranked airport matches, and `/api/airport/[ident]` returns airport detail, runways, frequencies, nearby airports, navaids, airspaces, reporting points, and obstacles. OpenAIP Core runway records do not include threshold coordinates, so runway map overlays are backed by a narrow `public.runway_geometries` table imported from OurAirports runway data. The browser-side `airportDirectoryClient` is a thin wrapper over these routes — feature code does not see the provider boundary or the server-only OpenAIP API key.
+Global airport context is sourced from [OpenAIP](https://www.openaip.net/) through server-only route handlers. `/api/search` resolves ranked airport matches, and `/api/airport/[ident]` returns airport detail, runways, frequencies, nearby airports, navaids, airspaces, reporting points, and obstacles. OpenAIP Core runway records do not include threshold coordinates, so runway map overlays are backed by a narrow `public.runway_geometries` table imported from OurAirports runway data. OurAirports `airport_frequencies` and `navaids` static tables also augment OpenAIP frequency/navaid coverage after normalization and conservative deduplication. The browser-side `airportDirectoryClient` is a thin wrapper over these routes — feature code does not see the provider boundary or the server-only OpenAIP API key.
 
 ### Vercel data paths
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build --webpack",
     "lint": "eslint .",
     "ff": "tsx scripts/feature-flags.ts",
+    "import:facilities": "tsx scripts/import-airport-facilities.ts",
     "generate:watching-spots": "tsx scripts/generate-candidate-watching-spots.ts",
     "import:runways": "tsx scripts/import-runway-geometries.ts",
     "test": "tsx scripts/run-tests.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/scripts/import-airport-facilities.ts
+++ b/scripts/import-airport-facilities.ts
@@ -1,0 +1,202 @@
+import { createClient } from "@supabase/supabase-js";
+
+const FREQUENCIES_URL =
+  process.env.OURAIRPORTS_FREQUENCIES_URL ||
+  "https://davidmegginson.github.io/ourairports-data/airport-frequencies.csv";
+const NAVAIDS_URL =
+  process.env.OURAIRPORTS_NAVAIDS_URL ||
+  "https://davidmegginson.github.io/ourairports-data/navaids.csv";
+
+const CHUNK_SIZE = 1000;
+
+const parseCsvRows = (text: string) => {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let quoted = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+
+    if (quoted) {
+      if (char === "\"" && next === "\"") {
+        field += "\"";
+        index += 1;
+      } else if (char === "\"") {
+        quoted = false;
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      quoted = true;
+    } else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else if (char !== "\r") {
+      field += char;
+    }
+  }
+
+  if (field || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  const [header = [], ...records] = rows;
+  return records
+    .filter((record) => record.length > 1)
+    .map((record) =>
+      Object.fromEntries(header.map((key, index) => [key, record[index] ?? ""])),
+    );
+};
+
+const numberOrNull = (value: unknown) => {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const numeric = Number(text);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const normalizeIdent = (value: unknown) =>
+  String(value ?? "")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+const mapFrequencyRow = (row: Record<string, string>) => {
+  const id = numberOrNull(row.id);
+  const airportIdent = normalizeIdent(row.airport_ident);
+  if (id == null || !airportIdent) return null;
+  return {
+    id,
+    airport_ref: numberOrNull(row.airport_ref),
+    airport_ident: airportIdent,
+    type: String(row.type || "").trim().toUpperCase(),
+    description: String(row.description || "").trim(),
+    frequency_mhz: numberOrNull(row.frequency_mhz),
+  };
+};
+
+const mapNavaidRow = (row: Record<string, string>) => {
+  const id = numberOrNull(row.id);
+  const ident = normalizeIdent(row.ident);
+  if (id == null || !ident) return null;
+  return {
+    id,
+    filename: String(row.filename || "").trim(),
+    ident,
+    name: String(row.name || "").trim(),
+    type: String(row.type || "").trim().toUpperCase(),
+    frequency_khz: numberOrNull(row.frequency_khz),
+    latitude_deg: numberOrNull(row.latitude_deg),
+    longitude_deg: numberOrNull(row.longitude_deg),
+    elevation_ft: numberOrNull(row.elevation_ft),
+    iso_country: String(row.iso_country || "").trim().toUpperCase(),
+    dme_frequency_khz: numberOrNull(row.dme_frequency_khz),
+    dme_channel: String(row.dme_channel || "").trim(),
+    dme_latitude_deg: numberOrNull(row.dme_latitude_deg),
+    dme_longitude_deg: numberOrNull(row.dme_longitude_deg),
+    dme_elevation_ft: numberOrNull(row.dme_elevation_ft),
+    slaved_variation_deg: numberOrNull(row.slaved_variation_deg),
+    magnetic_variation_deg: numberOrNull(row.magnetic_variation_deg),
+    usage_type: String(row.usage_type || "").trim(),
+    power: String(row.power || "").trim(),
+    associated_airport: normalizeIdent(row.associated_airport),
+  };
+};
+
+const requireEnv = (name: string, value: string | undefined) => {
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
+
+async function fetchCsvRows(url: string) {
+  const response = await fetch(url, {
+    headers: { Accept: "text/csv" },
+  });
+  if (!response.ok) {
+    throw new Error(`OurAirports download failed: ${url} HTTP ${response.status}`);
+  }
+  return parseCsvRows(await response.text());
+}
+
+async function replaceRows({
+  supabase,
+  table,
+  rows,
+}: {
+  supabase: any;
+  table: string;
+  rows: Record<string, any>[];
+}) {
+  console.log(`[import-airport-facilities] Clearing ${table}`);
+  const tableQuery = supabase.from(table) as any;
+  const { error: deleteError } = await tableQuery.delete().neq("id", -1);
+  if (deleteError) throw new Error(`${table} clear failed: ${deleteError.message}`);
+
+  let imported = 0;
+  for (let index = 0; index < rows.length; index += CHUNK_SIZE) {
+    const chunk = rows.slice(index, index + CHUNK_SIZE);
+    const { error } = await tableQuery.upsert(chunk, { onConflict: "id" });
+    if (error) throw new Error(`${table} upsert failed: ${error.message}`);
+    imported += chunk.length;
+    console.log(`[import-airport-facilities] Imported ${imported}/${rows.length} ${table}`);
+  }
+}
+
+async function main() {
+  const supabaseUrl = requireEnv(
+    "NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL",
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  );
+  const serviceKey = requireEnv(
+    "SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SECRET_KEY",
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY,
+  );
+
+  console.log(`[import-airport-facilities] Fetching ${FREQUENCIES_URL}`);
+  const frequencyRows = (await fetchCsvRows(FREQUENCIES_URL))
+    .map(mapFrequencyRow)
+    .filter(Boolean);
+  console.log(`[import-airport-facilities] Fetching ${NAVAIDS_URL}`);
+  const navaidRows = (await fetchCsvRows(NAVAIDS_URL))
+    .map(mapNavaidRow)
+    .filter(Boolean);
+
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: {
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+      persistSession: false,
+    },
+  });
+
+  await replaceRows({
+    supabase,
+    table: "airport_frequencies",
+    rows: frequencyRows,
+  });
+  await replaceRows({
+    supabase,
+    table: "navaids",
+    rows: navaidRows,
+  });
+
+  console.log(
+    `[import-airport-facilities] Done. Imported ${frequencyRows.length} frequencies and ${navaidRows.length} navaids.`,
+  );
+}
+
+main().catch((error) => {
+  console.error("[import-airport-facilities] failed:", error);
+  process.exit(1);
+});

--- a/scripts/import-airport-facilities.ts
+++ b/scripts/import-airport-facilities.ts
@@ -66,6 +66,11 @@ const numberOrNull = (value: unknown) => {
   return Number.isFinite(numeric) ? numeric : null;
 };
 
+const positiveNumberOrNull = (value: unknown) => {
+  const numeric = numberOrNull(value);
+  return numeric != null && numeric > 0 ? numeric : null;
+};
+
 const normalizeIdent = (value: unknown) =>
   String(value ?? "")
     .trim()
@@ -82,7 +87,7 @@ const mapFrequencyRow = (row: Record<string, string>) => {
     airport_ident: airportIdent,
     type: String(row.type || "").trim().toUpperCase(),
     description: String(row.description || "").trim(),
-    frequency_mhz: numberOrNull(row.frequency_mhz),
+    frequency_mhz: positiveNumberOrNull(row.frequency_mhz),
   };
 };
 

--- a/src/app/api/dao/airportFacilities.dao.test.ts
+++ b/src/app/api/dao/airportFacilities.dao.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+
+import {
+  AIRPORT_FREQUENCIES_TABLE,
+  NAVAIDS_TABLE,
+  createAirportFacilityRepository,
+  createAirportFacilityRepositoryFromEnv,
+} from "./airportFacilities.dao";
+
+function createFakeSupabaseClient(tableData: Record<string, any[]> = {}) {
+  const calls: Array<Record<string, any>> = [];
+
+  const createQuery = (table: string) => {
+    const query: Record<string, any> = {
+      select(columns: string) {
+        calls.push({ type: "select", table, columns });
+        return query;
+      },
+      eq(column: string, value: unknown) {
+        calls.push({ type: "eq", table, column, value });
+        return query;
+      },
+      gte(column: string, value: unknown) {
+        calls.push({ type: "gte", table, column, value });
+        return query;
+      },
+      lte(column: string, value: unknown) {
+        calls.push({ type: "lte", table, column, value });
+        return query;
+      },
+      order(column: string, options: Record<string, any>) {
+        calls.push({ type: "order", table, column, options });
+        return query;
+      },
+      limit(count: number) {
+        calls.push({ type: "limit", table, count });
+        return query;
+      },
+      then(resolve: (value: any) => void) {
+        return Promise.resolve({ data: tableData[table] || [], error: null }).then(resolve);
+      },
+    };
+    return query;
+  };
+
+  const createClientImpl = (supabaseUrl: string, supabaseKey: string, options: any) => {
+    calls.push({ type: "createClient", supabaseUrl, supabaseKey, options });
+    return {
+      from(table: string) {
+        calls.push({ type: "from", table });
+        return createQuery(table);
+      },
+    };
+  };
+
+  return { calls, createClientImpl };
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    [AIRPORT_FREQUENCIES_TABLE]: [
+      {
+        id: 1,
+        airport_ident: "KBOS",
+        type: "TWR",
+        description: "BOSTON TOWER",
+        frequency_mhz: 128.8,
+      },
+    ],
+  });
+  const repository = createAirportFacilityRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    createClientImpl,
+  });
+
+  const frequencies = await repository.readFrequenciesByAirportIdent(" kbos ");
+
+  assert.equal(frequencies.length, 1);
+  assert.equal(frequencies[0].airportIdent, "KBOS");
+  assert.equal(frequencies[0].source, "ourairports");
+  assert.deepEqual(calls.slice(1), [
+    { type: "from", table: AIRPORT_FREQUENCIES_TABLE },
+    {
+      type: "select",
+      table: AIRPORT_FREQUENCIES_TABLE,
+      columns: "id,airport_ref,airport_ident,type,description,frequency_mhz",
+    },
+    {
+      type: "eq",
+      table: AIRPORT_FREQUENCIES_TABLE,
+      column: "airport_ident",
+      value: "KBOS",
+    },
+    {
+      type: "order",
+      table: AIRPORT_FREQUENCIES_TABLE,
+      column: "type",
+      options: { ascending: true },
+    },
+    {
+      type: "order",
+      table: AIRPORT_FREQUENCIES_TABLE,
+      column: "frequency_mhz",
+      options: { ascending: true },
+    },
+  ]);
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    [NAVAIDS_TABLE]: [
+      {
+        id: 86260,
+        ident: "BOS",
+        name: "BOSTON",
+        type: "VOR-DME",
+        frequency_khz: 112700,
+        latitude_deg: 42.3576,
+        longitude_deg: -70.9896,
+      },
+    ],
+  });
+  const repository = createAirportFacilityRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    createClientImpl,
+  });
+
+  const navaids = await repository.readNavaidsNearAirport({
+    lat: 42.3656,
+    lon: -71.0096,
+    radiusNm: 60,
+    limit: 50,
+  });
+
+  assert.equal(navaids.length, 1);
+  assert.equal(navaids[0].ident, "BOS");
+  assert.equal(navaids[0].source, "ourairports");
+  assert.ok(calls.some((call) => call.type === "gte" && call.column === "latitude_deg"));
+  assert.ok(calls.some((call) => call.type === "lte" && call.column === "longitude_deg"));
+  assert.ok(calls.some((call) => call.type === "limit" && call.count === 50));
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient();
+  const repository = createAirportFacilityRepositoryFromEnv({
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SERVICE_ROLE_KEY: "sb_service_role_test",
+    },
+    createClientImpl,
+  });
+
+  assert.ok(repository);
+  assert.equal(calls[0].supabaseKey, "sb_service_role_test");
+}
+
+console.log("airportFacilities.dao.test.ts ok");

--- a/src/app/api/dao/airportFacilities.dao.ts
+++ b/src/app/api/dao/airportFacilities.dao.ts
@@ -1,0 +1,201 @@
+import { createServerSupabaseClient } from "./supabaseClient";
+
+type AirportFacilityRecord = Record<string, any>;
+
+export const AIRPORT_FREQUENCIES_TABLE = "airport_frequencies";
+export const NAVAIDS_TABLE = "navaids";
+
+const AIRPORT_FREQUENCY_COLUMNS = [
+  "id",
+  "airport_ref",
+  "airport_ident",
+  "type",
+  "description",
+  "frequency_mhz",
+].join(",");
+
+const NAVAID_COLUMNS = [
+  "id",
+  "filename",
+  "ident",
+  "name",
+  "type",
+  "frequency_khz",
+  "latitude_deg",
+  "longitude_deg",
+  "elevation_ft",
+  "iso_country",
+  "dme_frequency_khz",
+  "dme_channel",
+  "dme_latitude_deg",
+  "dme_longitude_deg",
+  "dme_elevation_ft",
+  "slaved_variation_deg",
+  "magnetic_variation_deg",
+  "usage_type",
+  "power",
+  "associated_airport",
+].join(",");
+
+const NM_PER_LAT_DEGREE = 60;
+
+const normalizeIdent = (value: unknown) =>
+  String(value || "")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+const numberOrNull = (value: unknown) => {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const normalizeSourceRow = (row: AirportFacilityRecord = {}) => ({
+  ...row,
+  source: "ourairports",
+});
+
+const mapFrequencyRow = (row: AirportFacilityRecord | null | undefined) => {
+  if (!row) return null;
+  return normalizeSourceRow({
+    id: row.id,
+    airportRef: row.airport_ref,
+    airportIdent: normalizeIdent(row.airport_ident),
+    type: row.type || "",
+    description: row.description || "",
+    frequencyMhz: numberOrNull(row.frequency_mhz),
+  });
+};
+
+const mapNavaidRow = (row: AirportFacilityRecord | null | undefined) => {
+  if (!row) return null;
+  return normalizeSourceRow({
+    id: row.id,
+    filename: row.filename || "",
+    ident: normalizeIdent(row.ident),
+    name: row.name || "",
+    type: row.type || "",
+    frequencyKhz: numberOrNull(row.frequency_khz),
+    lat: numberOrNull(row.latitude_deg),
+    lon: numberOrNull(row.longitude_deg),
+    elevationFt: numberOrNull(row.elevation_ft),
+    country: row.iso_country || "",
+    dme: {
+      frequencyKhz: numberOrNull(row.dme_frequency_khz),
+      channel: row.dme_channel || "",
+      lat: numberOrNull(row.dme_latitude_deg),
+      lon: numberOrNull(row.dme_longitude_deg),
+      elevationFt: numberOrNull(row.dme_elevation_ft),
+    },
+    slavedVariationDeg: numberOrNull(row.slaved_variation_deg),
+    magneticVariationDeg: numberOrNull(row.magnetic_variation_deg),
+    usageType: row.usage_type || "",
+    power: row.power || "",
+    associatedAirport: normalizeIdent(row.associated_airport),
+  });
+};
+
+const boundingBoxForAirport = ({
+  lat,
+  lon,
+  radiusNm,
+}: AirportFacilityRecord = {}) => {
+  const centerLat = numberOrNull(lat);
+  const centerLon = numberOrNull(lon);
+  const radius = Math.max(1, Math.min(Number(radiusNm) || 60, 250));
+  if (centerLat == null || centerLon == null) return null;
+
+  const latDelta = radius / NM_PER_LAT_DEGREE;
+  const lonNmPerDegree =
+    NM_PER_LAT_DEGREE * Math.max(0.2, Math.cos((centerLat * Math.PI) / 180));
+  const lonDelta = radius / lonNmPerDegree;
+  return {
+    south: centerLat - latDelta,
+    north: centerLat + latDelta,
+    west: centerLon - lonDelta,
+    east: centerLon + lonDelta,
+  };
+};
+
+export function createAirportFacilityRepository({
+  supabaseUrl,
+  supabaseKey,
+  createClientImpl,
+}: {
+  supabaseUrl?: string;
+  supabaseKey?: string;
+  createClientImpl?: any;
+} = {}) {
+  const client = createServerSupabaseClient({
+    supabaseUrl,
+    supabaseKey,
+    createClientImpl,
+  });
+  if (!client) return null;
+
+  return {
+    async readFrequenciesByAirportIdent(ident: unknown) {
+      const airportIdent = normalizeIdent(ident);
+      if (!airportIdent) return [];
+
+      const { data, error } = await client
+        .from(AIRPORT_FREQUENCIES_TABLE)
+        .select(AIRPORT_FREQUENCY_COLUMNS)
+        .eq("airport_ident", airportIdent)
+        .order("type", { ascending: true })
+        .order("frequency_mhz", { ascending: true });
+
+      if (error) {
+        throw new Error(`Airport frequencies read failed (${error.message})`);
+      }
+
+      return (data || []).map(mapFrequencyRow).filter(Boolean);
+    },
+
+    async readNavaidsNearAirport({
+      lat,
+      lon,
+      radiusNm = 60,
+      limit = 50,
+    }: AirportFacilityRecord = {}) {
+      const bounds = boundingBoxForAirport({ lat, lon, radiusNm });
+      if (!bounds) return [];
+      const safeLimit = Math.max(1, Math.min(Number(limit) || 50, 100));
+
+      const { data, error } = await client
+        .from(NAVAIDS_TABLE)
+        .select(NAVAID_COLUMNS)
+        .gte("latitude_deg", bounds.south)
+        .lte("latitude_deg", bounds.north)
+        .gte("longitude_deg", bounds.west)
+        .lte("longitude_deg", bounds.east)
+        .order("ident", { ascending: true })
+        .limit(safeLimit);
+
+      if (error) {
+        throw new Error(`Navaids read failed (${error.message})`);
+      }
+
+      return (data || []).map(mapNavaidRow).filter(Boolean);
+    },
+  };
+}
+
+export function createAirportFacilityRepositoryFromEnv({
+  env = process.env,
+  createClientImpl,
+}: {
+  env?: Record<string, string | undefined>;
+  createClientImpl?: any;
+} = {}) {
+  return createAirportFacilityRepository({
+    supabaseUrl: env.NEXT_PUBLIC_SUPABASE_URL || env.SUPABASE_URL,
+    supabaseKey:
+      env.SUPABASE_SECRET_KEY ||
+      env.SUPABASE_SERVICE_ROLE_KEY ||
+      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
+      env.SUPABASE_PUBLISHABLE_KEY,
+    createClientImpl,
+  });
+}

--- a/src/components/aircraft/preview/CandidateWatchingSpotPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/CandidateWatchingSpotPreviewMobileCard.tsx
@@ -4,7 +4,6 @@ import { Camera } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import {
   MobilePreviewContent,
-  MobilePreviewDetailRow,
   MobilePreviewIdentity,
 } from "./MobilePreviewCard";
 import {
@@ -29,8 +28,8 @@ export default function CandidateWatchingSpotPreviewMobileCard({
   );
   const category = formatCandidateWatchingSpotCategory(spot);
   const distance = formatCandidateWatchingSpotDistance(spot, t);
-  const disclaimer = String(spot?.disclaimer || t("watcherMode.disclaimer")).trim();
   const attribution = sourceAttribution || t("watcherMode.attribution");
+  const summaryLabel = distance || category || null;
 
   return (
     <MobilePreviewContent>
@@ -38,23 +37,21 @@ export default function CandidateWatchingSpotPreviewMobileCard({
         <MobilePreviewIdentity
           icon={Camera}
           label={t("preview.candidateWatchingSpotPreview")}
-          primary={t("preview.candidateWatchingSpotPreview").toUpperCase()}
-          secondary={distance || category || null}
+          primary={name}
+          primaryClassName="whitespace-normal break-words text-[18px] leading-[1.05]"
+          secondary={null}
         />
-        <MobilePreviewDetailRow wrap>
-          {name}
-        </MobilePreviewDetailRow>
-        {category && distance ? (
-          <MobilePreviewDetailRow>
-            {category}
-          </MobilePreviewDetailRow>
-        ) : null}
-        <MobilePreviewDetailRow wrap>
-          {disclaimer}
-        </MobilePreviewDetailRow>
-        <MobilePreviewDetailRow>
-          {attribution}
-        </MobilePreviewDetailRow>
+        <div className="flex min-w-0 items-baseline justify-between gap-3 font-[var(--font-mono)]">
+          <span
+            translate="no"
+            className="notranslate min-w-0 shrink-0 truncate whitespace-nowrap text-left text-[10px] font-semibold leading-tight tracking-normal text-atc-dim"
+          >
+            {summaryLabel}
+          </span>
+          <span className="min-w-0 truncate whitespace-nowrap text-right text-[10px] font-medium leading-tight tracking-normal text-atc-dim">
+            {attribution}
+          </span>
+        </div>
       </div>
     </MobilePreviewContent>
   );

--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -122,12 +122,14 @@ export function MobilePreviewIdentity({
   icon: Icon,
   label,
   primary,
+  primaryClassName,
   secondary = null,
   secondaryClassName,
 }: {
   icon: LucideIcon;
   label: string;
   primary: React.ReactNode;
+  primaryClassName?: string;
   secondary?: React.ReactNode;
   secondaryClassName?: string;
 }) {
@@ -143,7 +145,10 @@ export function MobilePreviewIdentity({
         </span>
         <span
           translate="no"
-          className="notranslate min-w-0 truncate whitespace-nowrap font-[var(--font-mono)] text-[20px] font-extrabold leading-none tracking-normal text-atc-text"
+          className={cn(
+            "notranslate min-w-0 truncate whitespace-nowrap font-[var(--font-mono)] text-[20px] font-extrabold leading-none tracking-normal text-atc-text",
+            primaryClassName,
+          )}
         >
           {primary}
         </span>

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -33,6 +33,8 @@ import {
 import { useCandidateWatchingSpots } from "@/features/airport/watcher/useCandidateWatchingSpots";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUserLocationAircraftAudio } from "@/hooks/useUserLocationAircraftAudio";
+import { MAP_MODE_IDS } from "@/features/airport/map-settings/mapSettingsModel";
+import { ZOOM_DETAIL } from "@/utils/airportMapDisplay";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -80,6 +82,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     selectCandidateWatchingSpot,
     setSelectedCandidateWatchingSpotId,
     mapFollowsAircraft,
+    setMapZoom,
+    applyMapMode,
     setUserLocationPreferences,
   } = useExplorerUi();
   const [userLocation, setUserLocation] = useState(null);
@@ -115,7 +119,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   });
   const candidateWatchingSpots = useCandidateWatchingSpots({
     airportIcao: airportProfile.icao,
-    enabled: showCandidateWatchingSpots,
+    enabled: Boolean(airportProfile.icao),
   });
   const selection = useMemo(
     () =>
@@ -383,6 +387,11 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     userLocationAudioActive,
   ]);
 
+  const openSpottingDetail = useCallback(() => {
+    applyMapMode(MAP_MODE_IDS.SPOTTING);
+    setMapZoom(ZOOM_DETAIL);
+  }, [applyMapMode, setMapZoom]);
+
   const criticalLoadingSettled = areCriticalLoadingRequestsSettled({
     aircraftPositionsSettled: traffic.aircraftPositionsSettled,
     metarSettled: weather.metarSettled,
@@ -426,10 +435,13 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     metarError: weather.metarError,
     aircraft: traffic.aircraft,
     airports: nearbyAirports.airports,
+    frequencies: airport?.frequencies || [],
+    candidateWatchingSpots: candidateWatchingSpots.spots,
     focusLat: airportProfile.lat,
     focusLon: airportProfile.lon,
     selectedAircraftId,
     selectedAirportIcao,
+    selectedCandidateWatchingSpotId,
     lastUpdated: traffic.lastUpdated,
     feedStatus: traffic.feedStatus,
     feedSource: traffic.feedSource,
@@ -437,6 +449,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     loadingStatus: sourceLoadingStatus,
     onSelectAircraft: selectAircraft,
     onSelectAirport: selectAirport,
+    onSelectCandidateWatchingSpot: selectCandidateWatchingSpot,
+    onOpenSpotting: openSpottingDetail,
     onBack,
     onMap: closeSidebar,
   };
@@ -515,7 +529,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             selectedAirspaceId={selectedAirspaceId}
             selectedCandidateWatchingSpotId={selectedCandidateWatchingSpotId}
             candidateWatchingSpots={candidateWatchingSpots.spots}
-            candidateWatchingSpotCount={candidateWatchingSpots.spots.length}
+            candidateWatchingSpotCount={0}
             followsCenter={mapFollowsAircraft}
             floatingSidebarAware={!isMobile && sidebarOpen}
             onSelectAircraft={selectAircraft}

--- a/src/components/changelog/ChangelogPanel.tsx
+++ b/src/components/changelog/ChangelogPanel.tsx
@@ -10,6 +10,18 @@ import { CHANGELOG } from "@/config/changelog";
 // optional current marker, summary, then short highlights.
 
 const CHINESE_RELEASE_COPY = {
+  "v1.10.0": {
+    title: "机场设施数据与侧栏打磨",
+    summary:
+      "机场详情页现在在 OpenAIP 基础上恢复 Supabase 托管的 OurAirports 设施数据,补齐 ATC 频率和附近导航台覆盖,侧栏呈现也更紧凑。",
+    highlights: [
+      "OurAirports 机场频率和导航台通过独立 Supabase 表与导入脚本恢复",
+      "OpenAIP 仍作为主机场目录,详情页会合并恢复后的设施数据",
+      "ATC 频率改为固定宽度频率 badge,source chip 更紧凑,LiveATC 搜索入口放到列表上方",
+      "机场侧栏加入独立 ATC 与拍机点面板,和 metric grid 保持对齐",
+      "移动端拍机点预览优先显示真实点位名,距离与 OSM attribution 合并为一行",
+    ],
+  },
   "v1.8.4": {
     title: "机场缩放层级减噪",
     summary:

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -193,7 +193,7 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
               .map((source) => (
                 <span
                   key={source}
-                  className="rounded-full border border-atc-line px-2 py-1 font-mono text-[8px] font-semibold uppercase leading-none text-atc-faint"
+                  className="rounded-full border border-atc-line px-2 py-1 font-mono text-[7px] font-semibold uppercase leading-none text-atc-faint"
                 >
                   {source}
                 </span>

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ExternalLink } from "lucide-react";
 import AircraftTable from "./AircraftTable";
 import AirportIdentity from "./AirportIdentity";
 import SidebarShell from "./SidebarShell";
@@ -164,6 +165,17 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
           {frequencies.length} channels
         </span>
       </div>
+      {normalizedIcao ? (
+        <a
+          href={liveAtcHref}
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+          className="mt-1 mb-0.5 inline-flex items-center justify-center gap-1.5 rounded-[var(--atc-radius-card)] border border-atc-line bg-atc-card/50 px-3 py-2 text-center text-[11px] font-bold uppercase tracking-normal text-atc-text transition-colors hover:bg-[var(--atc-control-hover-bg)]"
+        >
+          <span>Search {normalizedIcao} on LiveATC</span>
+          <ExternalLink aria-hidden="true" className="size-3.5" strokeWidth={2.3} />
+        </a>
+      ) : null}
       <div className="grid gap-3">
         {frequencies.map((frequency) => (
           <TextPillListItem
@@ -189,16 +201,6 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
           />
         ))}
       </div>
-      {normalizedIcao ? (
-        <a
-          href={liveAtcHref}
-          target="_blank"
-          rel="noopener noreferrer nofollow"
-          className="mt-1 rounded-[var(--atc-radius-card)] border border-atc-line bg-atc-card/50 px-3 py-2 text-center text-[11px] font-bold uppercase tracking-normal text-atc-text transition-colors hover:bg-[var(--atc-control-hover-bg)]"
-        >
-          Search {normalizedIcao} on LiveATC
-        </a>
-      ) : null}
     </div>
   );
 }

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AircraftTable from "./AircraftTable";
 import AirportIdentity from "./AirportIdentity";
 import SidebarShell from "./SidebarShell";
 import SidebarViewSwitch from "./SidebarViewSwitch";
 import WeatherBriefingStack from "./WeatherBriefingStack";
+import { TextPillListItem } from "@/components/ui/TextPillListItem";
 import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel";
 
 export default function AirportSidebar({
@@ -23,6 +24,9 @@ export default function AirportSidebar({
   metarError = null,
   aircraft = [],
   airports = [],
+  frequencies = [],
+  candidateWatchingSpots = [],
+  selectedCandidateWatchingSpotId = "",
   focusLat = null,
   focusLon = null,
   selectedAircraftId = "",
@@ -34,17 +38,37 @@ export default function AirportSidebar({
   loadingStatus = "",
   onSelectAircraft,
   onSelectAirport,
+  onSelectCandidateWatchingSpot,
+  onOpenSpotting,
   onBack,
   onMap = null,
   onClose = null,
 }) {
   const isMobileOverlay = Boolean(onClose);
   const [activeView, setActiveView] = useState("traffic");
+  const atcFrequencies = Array.isArray(frequencies) ? frequencies : [];
+  const spottingSpots = Array.isArray(candidateWatchingSpots)
+    ? candidateWatchingSpots
+    : [];
   const movementFilter =
     routeProvider === ROUTE_PROVIDER.FLIGHTAWARE &&
     (activeView === "departures" || activeView === "arrivals")
       ? activeView
       : "all";
+
+  useEffect(() => {
+    if (activeView === "atc" && atcFrequencies.length === 0) {
+      setActiveView("traffic");
+    }
+    if (activeView === "spotting" && spottingSpots.length === 0) {
+      setActiveView("traffic");
+    }
+  }, [activeView, atcFrequencies.length, spottingSpots.length]);
+
+  const handleSpottingView = () => {
+    setActiveView("spotting");
+    onOpenSpotting?.();
+  };
 
   const header = (
     <>
@@ -64,6 +88,9 @@ export default function AirportSidebar({
         metar={metar}
         aircraft={aircraft}
         routeProvider={routeProvider}
+        frequencies={atcFrequencies}
+        candidateSpotCount={spottingSpots.length}
+        onOpenSpotting={handleSpottingView}
       />
     </>
   );
@@ -95,6 +122,14 @@ export default function AirportSidebar({
           airportLat={lat}
           airportLon={lon}
         />
+      ) : activeView === "atc" ? (
+        <AtcFrequencyPanel icao={icao} frequencies={atcFrequencies} />
+      ) : activeView === "spotting" ? (
+        <SpottingPanel
+          spots={spottingSpots}
+          selectedSpotId={selectedCandidateWatchingSpotId}
+          onSelectSpot={onSelectCandidateWatchingSpot}
+        />
       ) : (
         <AircraftTable
           aircraft={aircraft}
@@ -111,4 +146,136 @@ export default function AirportSidebar({
       )}
     </SidebarShell>
   );
+}
+
+function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
+  const normalizedIcao = String(icao || "").trim().toUpperCase();
+  const liveAtcHref = `https://www.liveatc.net/search/?icao=${encodeURIComponent(
+    normalizedIcao,
+  )}`;
+
+  return (
+    <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-[var(--airport-sidebar-inset)] pb-6 pt-2">
+      <div className="flex items-baseline justify-between border-b border-atc-line pb-2">
+        <h2 className="text-[12px] font-bold uppercase tracking-normal text-atc-text">
+          ATC Frequencies
+        </h2>
+        <span className="font-mono text-[10px] font-semibold uppercase text-atc-faint">
+          {frequencies.length} channels
+        </span>
+      </div>
+      <div className="grid gap-3">
+        {frequencies.map((frequency) => (
+          <TextPillListItem
+            key={`${frequency.type}-${frequency.frequencyMHz}-${frequency.source}`}
+            pill={
+              <span className="notranslate" translate="no">
+                {formatFrequencyBadge(frequency.frequencyMHz)}
+              </span>
+            }
+            title={formatFrequencyType(frequency.type)}
+            subtitle={
+              frequency.callsign || frequency.description || "Airport frequency"
+            }
+            meta={visibleFrequencySources(frequency)
+              .map((source) => (
+                <span
+                  key={source}
+                  className="rounded-full border border-atc-line px-2 py-1 font-mono text-[8px] font-semibold uppercase leading-none text-atc-faint"
+                >
+                  {source}
+                </span>
+              ))}
+          />
+        ))}
+      </div>
+      {normalizedIcao ? (
+        <a
+          href={liveAtcHref}
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+          className="mt-1 rounded-[var(--atc-radius-card)] border border-atc-line bg-atc-card/50 px-3 py-2 text-center text-[11px] font-bold uppercase tracking-normal text-atc-text transition-colors hover:bg-[var(--atc-control-hover-bg)]"
+        >
+          Search {normalizedIcao} on LiveATC
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+function SpottingPanel({
+  spots = [],
+  selectedSpotId = "",
+  onSelectSpot,
+}) {
+  return (
+    <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-[var(--airport-sidebar-inset)] pb-6 pt-2">
+      <div className="flex items-baseline justify-between border-b border-atc-line pb-2">
+        <h2 className="text-[12px] font-bold uppercase tracking-normal text-atc-text">
+          Spotting
+        </h2>
+        <span className="font-mono text-[10px] font-semibold uppercase text-atc-faint">
+          {spots.length} spots
+        </span>
+      </div>
+      <div className="grid gap-2">
+        {spots.map((spot) => {
+          const active = Boolean(selectedSpotId && selectedSpotId === spot.id);
+          return (
+            <button
+              type="button"
+              key={spot.id}
+              data-active={active ? "true" : undefined}
+              onClick={() => onSelectSpot?.(spot.id)}
+              className="group rounded-[var(--atc-radius-card)] border border-atc-line bg-atc-card/70 p-3 text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:border-transparent data-[active=true]:bg-[var(--atc-click-bg)]"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-[11px] font-bold uppercase tracking-normal text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
+                    {spot.name || spot.category || "Candidate spot"}
+                  </div>
+                  <div className="mt-1 text-[11px] font-medium text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
+                    {spot.category || "map candidate"}
+                  </div>
+                </div>
+                {Number.isFinite(Number(spot.score)) ? (
+                  <span className="shrink-0 font-mono text-[10px] font-semibold text-atc-faint group-data-[active=true]:text-[var(--atc-click-muted)]">
+                    {Math.round(Number(spot.score))}
+                  </span>
+                ) : null}
+              </div>
+              {spot.runwayAlignment?.end ? (
+                <div className="mt-2 font-mono text-[9px] font-semibold uppercase text-atc-faint group-data-[active=true]:text-[var(--atc-click-muted)]">
+                  RWY {spot.runwayAlignment.end}
+                </div>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatFrequencyMhz(value) {
+  const frequency = Number(value);
+  if (!Number.isFinite(frequency)) return "—";
+  return frequency.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function formatFrequencyBadge(value) {
+  const frequency = Number(value);
+  if (!Number.isFinite(frequency)) return "—";
+  return frequency.toFixed(3);
+}
+
+function formatFrequencyType(value) {
+  const text = String(value || "other").replace(/-/g, " ");
+  return text.replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function visibleFrequencySources(frequency) {
+  const sources = (frequency.sources || [frequency.source]).filter(Boolean);
+  if (sources.length === 1 && sources[0] === "openaip") return [];
+  return sources;
 }

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -13,11 +13,16 @@ export default function SidebarViewSwitch({
   metar = null,
   aircraft = [],
   routeProvider = "",
+  frequencies = [],
+  candidateSpotCount = 0,
+  onOpenSpotting,
 }) {
   const { t } = useI18n();
   const temperature = formatTemperature(metar);
   const rule = metar?.flightCategory?.toUpperCase() || "WX";
   const showMovementCards = routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
+  const atcCount = Array.isArray(frequencies) ? frequencies.length : 0;
+  const spottingCount = Number(candidateSpotCount) || 0;
 
   // Pre-compute departure / arrival counts only when FlightAware is on.
   // The aircraft.movement field is already resolved upstream by
@@ -49,6 +54,24 @@ export default function SidebarViewSwitch({
         active={activeView === "traffic"}
         onClick={() => onViewChange?.("traffic")}
       />
+      {atcCount > 0 && (
+        <SidebarMetricCard
+          label={t("sidebar.atc")}
+          value={<NumberFlow value={atcCount} />}
+          unit="FREQ"
+          active={activeView === "atc"}
+          onClick={() => onViewChange?.("atc")}
+        />
+      )}
+      {spottingCount > 0 && (
+        <SidebarMetricCard
+          label={t("sidebar.spotting")}
+          value={<NumberFlow value={spottingCount} />}
+          unit="PHOTO"
+          active={activeView === "spotting"}
+          onClick={onOpenSpotting}
+        />
+      )}
       {showMovementCards && (
         <>
           <SidebarMetricCard

--- a/src/components/ui/MetricCard.tsx
+++ b/src/components/ui/MetricCard.tsx
@@ -58,11 +58,11 @@ const cardVariants = cva(
     "select-none [appearance:none]",
     "transition-[background,border-color,box-shadow,color] duration-150",
     // Fixed-format rows: label → value → unit.
-    "grid-rows-[14px_minmax(34px,auto)_12px]",
+    "grid-rows-[14px_34px_12px]",
     // Compact variant inside the desktop map kit sidebar.
     "[.airport-map-kit_&]:rounded-[var(--atc-radius-card)]",
     "[.airport-map-kit_&]:gap-1",
-    "[.airport-map-kit_&]:grid-rows-[11px_minmax(27px,auto)_10px]",
+    "[.airport-map-kit_&]:grid-rows-[11px_27px_10px]",
     "[.airport-map-kit_&]:min-h-19",
     "[.airport-map-kit_&]:p-3.5",
     // Active state — solid ink block + click-foreground text, edge
@@ -102,7 +102,7 @@ const cardVariants = cva(
 
 const valueClass = cn(
   "flex items-center justify-center",
-  "max-w-full min-w-0 min-h-8.5 overflow-hidden",
+  "max-w-full min-w-0 h-8.5 overflow-hidden",
   "font-[var(--font-display)] not-italic font-black text-atc-text",
   "text-3xl leading-none tracking-normal",
   // Active card — flip to the click foreground so the value reads
@@ -110,7 +110,7 @@ const valueClass = cn(
   // color, but text-atc-text on <strong> shadows it.
   "group-data-[active=true]:text-[var(--atc-click-fg)]",
   // Compact in desktop map kit context.
-  "[.airport-map-kit_&]:text-2xl [.airport-map-kit_&]:min-h-7",
+  "[.airport-map-kit_&]:text-2xl [.airport-map-kit_&]:h-7",
 );
 
 const labelClass = cn(
@@ -123,10 +123,10 @@ const labelClass = cn(
 );
 
 const unitClass = cn(
-  "block text-atc-faint uppercase text-[10px] font-semibold",
-  "tracking-normal leading-3 min-h-3",
+  "flex h-3 items-center justify-center text-atc-faint uppercase text-[10px] font-semibold",
+  "tracking-normal leading-3",
   "group-data-[active=true]:text-[var(--atc-click-muted)]",
-  "[.airport-map-kit_&]:text-[8px] [.airport-map-kit_&]:leading-2.5 [.airport-map-kit_&]:min-h-2.5",
+  "[.airport-map-kit_&]:h-2.5 [.airport-map-kit_&]:text-[8px] [.airport-map-kit_&]:leading-2.5",
 );
 
 export function MetricCard({

--- a/src/components/ui/TextPillListItem.tsx
+++ b/src/components/ui/TextPillListItem.tsx
@@ -29,18 +29,18 @@ export function TextPillListItem({
       <span
         className={cn(
           "inline-flex min-w-18 items-center justify-center rounded-full px-3 py-1.5",
-          "bg-atc-text text-center text-[11px] font-black uppercase leading-none text-atc-bg",
+          "bg-atc-text text-center text-[10px] font-black uppercase leading-none text-atc-bg",
           "group-data-[active=true]:bg-[var(--atc-click-fg)] group-data-[active=true]:text-[var(--atc-click-bg)]",
         )}
       >
         {pill}
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[14px] font-extrabold leading-tight text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
+        <span className="block truncate text-[13px] font-extrabold leading-tight text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
           {title}
         </span>
         {subtitle ? (
-          <span className="mt-0.5 block text-[12px] font-medium leading-snug text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
+          <span className="mt-0.5 block text-[11px] font-medium leading-snug text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
             {subtitle}
           </span>
         ) : null}

--- a/src/components/ui/TextPillListItem.tsx
+++ b/src/components/ui/TextPillListItem.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type TextPillListItemProps = {
+  pill: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  meta?: ReactNode;
+  active?: boolean;
+  as?: "div" | "button";
+  onClick?: () => void;
+  className?: string;
+};
+
+export function TextPillListItem({
+  pill,
+  title,
+  subtitle,
+  meta,
+  active = false,
+  as = "div",
+  onClick,
+  className,
+}: TextPillListItemProps) {
+  const body = (
+    <>
+      <span
+        className={cn(
+          "inline-flex min-w-18 items-center justify-center rounded-full px-3 py-1.5",
+          "bg-atc-text text-center text-[11px] font-black uppercase leading-none text-atc-bg",
+          "group-data-[active=true]:bg-[var(--atc-click-fg)] group-data-[active=true]:text-[var(--atc-click-bg)]",
+        )}
+      >
+        {pill}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[14px] font-extrabold leading-tight text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
+          {title}
+        </span>
+        {subtitle ? (
+          <span className="mt-0.5 block text-[12px] font-medium leading-snug text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
+            {subtitle}
+          </span>
+        ) : null}
+      </span>
+      {meta ? (
+        <span className="flex shrink-0 flex-wrap justify-end gap-1">{meta}</span>
+      ) : null}
+    </>
+  );
+  const classes = cn(
+    "group grid w-full grid-cols-[max-content_minmax(0,1fr)_auto] items-center gap-3 rounded-[var(--atc-radius-card)] px-0 py-2.5 text-left",
+    "transition-colors duration-150",
+    "data-[active=true]:text-[var(--atc-click-fg)]",
+    as === "button" && "cursor-pointer focus:outline-none",
+    className,
+  );
+
+  if (as === "button") {
+    return (
+      <button
+        type="button"
+        data-ui="text-pill-list-item"
+        data-active={active ? "true" : undefined}
+        onClick={onClick}
+        className={classes}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      data-ui="text-pill-list-item"
+      data-active={active ? "true" : undefined}
+      className={classes}
+    >
+      {body}
+    </div>
+  );
+}

--- a/src/config/about.ts
+++ b/src/config/about.ts
@@ -110,10 +110,10 @@ export const ABOUT_DATA_SOURCES = [
   {
     glyph: "RWY",
     titleKey: "about.sources.ourAirportsRunways.title",
-    title: "OurAirports Runway Geometry",
+    title: "OurAirports Static Facilities",
     descriptionKey: "about.sources.ourAirportsRunways.description",
     description:
-      "Runway threshold coordinates used only for accurate runway map overlays.",
+      "Runway threshold coordinates plus ATC frequency and navaid augmentation data.",
     host: "ourairports.com",
     href: "https://ourairports.com/data/",
   },

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -6,6 +6,20 @@
 
 export const CHANGELOG = [
   {
+    version: "v1.10.0",
+    kind: "feat",
+    title: "Airport facilities and sidebar polish",
+    summary:
+      "Airport detail pages now restore Supabase-backed OurAirports facility data alongside OpenAIP, improving ATC frequency and nearby navaid coverage with a tighter sidebar experience.",
+    highlights: [
+      "OurAirports airport frequencies and navaids return through dedicated Supabase tables and import tooling",
+      "OpenAIP airport details merge restored facility data while keeping OpenAIP as the primary directory",
+      "ATC frequencies use fixed-width frequency pills with compact source chips and a LiveATC search link above the list",
+      "The airport sidebar adds focused ATC and spotting panels that align with the existing metric grid",
+      "Mobile spotting previews now prioritize the actual spot name and keep distance plus OSM attribution on one line",
+    ],
+  },
+  {
     version: "v1.9.0",
     kind: "feat",
     title: "Watcher Mode candidate photo spots",

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -84,9 +84,9 @@ const en = {
           "Airport, runway, frequency, navaid, airspace, reporting point, and obstacle context for search and maps. Licensed CC BY-NC 4.0.",
       },
       ourAirportsRunways: {
-        title: "OurAirports Runway Geometry",
+        title: "OurAirports Static Facilities",
         description:
-          "Runway threshold coordinates used only for accurate runway map overlays.",
+          "Runway threshold coordinates plus ATC frequency and navaid augmentation data.",
       },
       wikipedia: {
         title: "Wikipedia Summary",
@@ -225,6 +225,8 @@ const en = {
     unknownAirport: "Unknown airport",
     departures: "Departures",
     arrivals: "Arrivals",
+    atc: "ATC",
+    spotting: "Spotting",
   },
   metrics: {
     speed: "Speed",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -80,8 +80,8 @@ const zhCN = {
           "为搜索和地图提供机场、跑道、频率、导航台、空域、报告点和障碍物资料。许可协议为 CC BY-NC 4.0。",
       },
       ourAirportsRunways: {
-        title: "OurAirports 跑道几何",
-        description: "仅用于精确跑道地图叠加的跑道端点坐标。",
+        title: "OurAirports 静态设施",
+        description: "用于跑道端点坐标、ATC 频率和导航台资料补充。",
       },
       wikipedia: {
         title: "Wikipedia 摘要",
@@ -220,6 +220,8 @@ const zhCN = {
     unknownAirport: "未知机场",
     departures: "起飞",
     arrivals: "到达",
+    atc: "ATC",
+    spotting: "拍机点",
   },
   metrics: {
     speed: "速度",

--- a/src/config/siteMeta.test.ts
+++ b/src/config/siteMeta.test.ts
@@ -7,14 +7,14 @@ import {
 } from "./siteMeta";
 
 assert.equal(ADSBAO_PRODUCT_NAME, "ADSBao");
-assert.equal(ADSBAO_SITE_VERSION, "1.9.0");
+assert.equal(ADSBAO_SITE_VERSION, "1.10.0");
 assert.equal(
   buildAdsbaoUserAgent("adsbdb/v0"),
-  "ADSBao/1.9.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+  "ADSBao/1.10.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
 );
 assert.equal(
   buildAdsbaoUserAgent(),
-  "ADSBao/1.9.0 (+https://github.com/orriduck/ADSBao)",
+  "ADSBao/1.10.0 (+https://github.com/orriduck/ADSBao)",
 );
 
 console.log("siteMeta.test.ts ok");

--- a/src/config/siteMeta.ts
+++ b/src/config/siteMeta.ts
@@ -1,5 +1,5 @@
 export const ADSBAO_PRODUCT_NAME = "ADSBao";
-export const ADSBAO_SITE_VERSION = "1.9.0";
+export const ADSBAO_SITE_VERSION = "1.10.0";
 export const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
 
 export function buildAdsbaoUserAgent(suffix = "") {

--- a/src/features/airport/directory/airportFacilityModel.test.ts
+++ b/src/features/airport/directory/airportFacilityModel.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+
+import {
+  mergeAirportFrequencies,
+  mergeNearbyNavaids,
+} from "./airportFacilityModel";
+
+{
+  const frequencies = mergeAirportFrequencies({
+    openAipFrequencies: [
+      {
+        id: "openaip-tower",
+        airportIdent: "KBOS",
+        type: "TWR",
+        description: "Boston Tower",
+        frequencyMhz: 128.8,
+        source: "openaip",
+      },
+    ],
+    ourAirportsFrequencies: [
+      {
+        id: 1001,
+        airportIdent: "KBOS",
+        type: "TOWER",
+        description: "BOSTON TOWER",
+        frequencyMhz: "128.800",
+        source: "ourairports",
+      },
+      {
+        id: 1002,
+        airportIdent: "KBOS",
+        type: "ATIS",
+        description: "ATIS",
+        frequencyMhz: 135.0,
+        source: "ourairports",
+      },
+    ],
+  });
+
+  assert.equal(frequencies.length, 2);
+  assert.equal(frequencies[0].type, "tower");
+  assert.equal(frequencies[0].frequencyMHz, 128.8);
+  assert.equal(frequencies[0].callsign, "Boston Tower");
+  assert.deepEqual(frequencies[0].sources, ["openaip", "ourairports"]);
+  assert.equal(frequencies[1].type, "atis");
+  assert.equal(frequencies[1].source, "ourairports");
+}
+
+{
+  const frequencies = mergeAirportFrequencies({
+    openAipFrequencies: [
+      {
+        id: "openaip-ground",
+        airportIdent: "KBOS",
+        type: "2",
+        description: "GND",
+        frequencyMhz: 121.9,
+        source: "openaip",
+      },
+      {
+        id: "openaip-clearance",
+        airportIdent: "KBOS",
+        type: "3",
+        description: "CLNC DEL",
+        frequencyMhz: 121.65,
+        source: "openaip",
+      },
+    ],
+  });
+
+  assert.equal(frequencies[0].type, "ground");
+  assert.equal(frequencies[1].type, "clearance");
+}
+
+{
+  const navaids = mergeNearbyNavaids({
+    airport: { lat: 42.3656, lon: -71.0096 },
+    openAipNavaids: [
+      {
+        id: "openaip-bos",
+        ident: "BOS",
+        name: "Boston",
+        type: "4",
+        frequencyKhz: 112700,
+        lat: 42.3575,
+        lon: -70.9894,
+        source: "openaip",
+      },
+    ],
+    ourAirportsNavaids: [
+      {
+        id: 86260,
+        ident: "BOS",
+        name: "BOSTON",
+        type: "VOR-DME",
+        frequencyKhz: 112700,
+        lat: 42.3576,
+        lon: -70.9896,
+        source: "ourairports",
+      },
+      {
+        id: 93000,
+        ident: "LWM",
+        name: "LAWRENCE",
+        type: "NDB",
+        frequencyKhz: 382,
+        lat: 42.7392,
+        lon: -71.0946,
+        source: "ourairports",
+      },
+    ],
+  });
+
+  assert.equal(navaids.length, 2);
+  assert.equal(navaids[0].ident, "BOS");
+  assert.equal(navaids[0].type, "vordme");
+  assert.equal(navaids[0].distanceNm < 1.2, true);
+  assert.deepEqual(navaids[0].sources, ["openaip", "ourairports"]);
+  assert.equal(navaids[1].ident, "LWM");
+  assert.equal(navaids[1].type, "ndb");
+  assert.equal(navaids[1].source, "ourairports");
+}
+
+console.log("airportFacilityModel.test.ts ok");

--- a/src/features/airport/directory/airportFacilityModel.ts
+++ b/src/features/airport/directory/airportFacilityModel.ts
@@ -1,0 +1,327 @@
+import { getDistanceNm } from "../../../utils/aircraftTrafficIntent";
+import { toFiniteNumber } from "../../../utils/math";
+
+type FacilityRecord = Record<string, any>;
+
+const NAVAID_DEDUPE_DISTANCE_NM = 0.5;
+const NAVAID_DEDUPE_FREQUENCY_KHZ = 2;
+const FREQUENCY_DEDUPE_MHZ = 0.005;
+
+const FREQUENCY_TYPE_ALIASES: Record<string, string> = {
+  APP: "approach",
+  APPROACH: "approach",
+  DEP: "departure",
+  DEPARTURE: "departure",
+  TWR: "tower",
+  TOWER: "tower",
+  GND: "ground",
+  GROUND: "ground",
+  CLD: "clearance",
+  CLR: "clearance",
+  CLEARANCE: "clearance",
+  ATIS: "atis",
+  GATE: "gate",
+  UNICOM: "unicom",
+  CTAF: "ctaf",
+};
+
+const NAVAID_TYPE_ALIASES: Record<string, string> = {
+  VOR: "vor",
+  "VOR-DME": "vordme",
+  VORDME: "vordme",
+  "VOR/DME": "vordme",
+  DME: "dme",
+  NDB: "ndb",
+  TACAN: "tacan",
+  VORTAC: "vortac",
+};
+
+const NAVAID_NUMERIC_TYPES: Record<string, string> = {
+  "0": "dme",
+  "1": "ndb",
+  "2": "vor",
+  "3": "vordme",
+  "4": "vordme",
+  "5": "tacan",
+  "6": "vortac",
+};
+
+const SOURCE_ORDER = ["openaip", "ourairports"];
+const FREQUENCY_TYPE_ORDER = [
+  "tower",
+  "ground",
+  "approach",
+  "departure",
+  "clearance",
+  "atis",
+  "ctaf",
+  "unicom",
+  "gate",
+  "other",
+];
+
+const cleanString = (value: unknown) => String(value ?? "").trim();
+
+const upperString = (value: unknown) => cleanString(value).toUpperCase();
+
+const finiteOrNull = (value: unknown) => {
+  const numeric = toFiniteNumber(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const sourceRank = (source: unknown) => {
+  const index = SOURCE_ORDER.indexOf(String(source || ""));
+  return index === -1 ? SOURCE_ORDER.length : index;
+};
+
+const frequencyTypeRank = (type: unknown) => {
+  const index = FREQUENCY_TYPE_ORDER.indexOf(String(type || ""));
+  return index === -1 ? FREQUENCY_TYPE_ORDER.length : index;
+};
+
+const uniqueSources = (...records: FacilityRecord[]) =>
+  [...new Set(
+    records
+      .flatMap((record) => record?.sources || record?.source || [])
+      .map((source) => String(source || "").trim())
+      .filter(Boolean),
+  )].sort((left, right) => sourceRank(left) - sourceRank(right));
+
+const normalizeFrequencyType = (value: unknown) => {
+  const normalized = upperString(value).replace(/[^A-Z0-9]/g, "");
+  return FREQUENCY_TYPE_ALIASES[normalized] || "other";
+};
+
+const resolveFrequencyType = (...values: unknown[]) => {
+  for (const value of values) {
+    const type = normalizeFrequencyType(value);
+    if (type !== "other") return type;
+    const normalized = upperString(value);
+    if (/\bAPP(ROACH)?\b/.test(normalized)) return "approach";
+    if (/\bDEP(ARTURE)?\b/.test(normalized)) return "departure";
+    if (/\bTWR\b|\bTOWER\b/.test(normalized)) return "tower";
+    if (/\bGND\b|\bGROUND\b/.test(normalized)) return "ground";
+    if (/\bCLNC\b|\bCLD\b|\bCLR\b|\bCLEARANCE\b/.test(normalized)) {
+      return "clearance";
+    }
+    if (/\bATIS\b/.test(normalized)) return "atis";
+    if (/\bUNICOM\b/.test(normalized)) return "unicom";
+    if (/\bCTAF\b/.test(normalized)) return "ctaf";
+    if (/\bGATE\b/.test(normalized)) return "gate";
+  }
+  return "other";
+};
+
+const normalizeNavaidType = (value: unknown) => {
+  const raw = upperString(value);
+  if (NAVAID_NUMERIC_TYPES[raw]) return NAVAID_NUMERIC_TYPES[raw];
+  const normalized = raw.replace(/[^A-Z0-9]/g, "");
+  return NAVAID_TYPE_ALIASES[raw] || NAVAID_TYPE_ALIASES[normalized] || "other";
+};
+
+const normalizeAirportIdent = (value: unknown) =>
+  upperString(value).replace(/[^A-Z0-9]/g, "");
+
+function normalizeAirportFrequency(record: FacilityRecord | null | undefined) {
+  if (!record) return null;
+  const airportIdent = normalizeAirportIdent(record.airportIdent ?? record.airport_ident);
+  const frequencyMHz = finiteOrNull(
+    record.frequencyMHz ?? record.frequencyMhz ?? record.frequency_mhz,
+  );
+  if (!airportIdent || frequencyMHz == null) return null;
+
+  const source = cleanString(record.source) || "unknown";
+  const description = cleanString(record.description ?? record.name);
+  const callsign = cleanString(record.callsign) || description;
+  return {
+    id: cleanString(record.id) || `${source}:${airportIdent}:${frequencyMHz}`,
+    airportIdent,
+    type: resolveFrequencyType(record.type, callsign, description),
+    frequencyMHz: Math.round(frequencyMHz * 1000) / 1000,
+    callsign,
+    description,
+    source,
+    sources: [source],
+    primary: record.primary === true,
+    publicUse: record.publicUse !== false,
+  };
+}
+
+function frequencyDedupeKey(frequency: FacilityRecord) {
+  return `${frequency.airportIdent}:${frequency.type}:${frequency.frequencyMHz.toFixed(3)}`;
+}
+
+export function mergeAirportFrequencies({
+  openAipFrequencies = [],
+  ourAirportsFrequencies = [],
+}: FacilityRecord = {}) {
+  const merged = new Map<string, FacilityRecord>();
+
+  for (const frequency of [...openAipFrequencies, ...ourAirportsFrequencies]
+    .map(normalizeAirportFrequency)
+    .filter(Boolean)) {
+    const existing = [...merged.values()].find(
+      (item) =>
+        item.airportIdent === frequency.airportIdent &&
+        item.type === frequency.type &&
+        Math.abs(item.frequencyMHz - frequency.frequencyMHz) <= FREQUENCY_DEDUPE_MHZ,
+    );
+    if (existing) {
+      const sources = uniqueSources(existing, frequency);
+      merged.set(frequencyDedupeKey(existing), {
+        ...existing,
+        callsign: existing.callsign || frequency.callsign,
+        description: existing.description || frequency.description,
+        primary: existing.primary || frequency.primary,
+        publicUse: existing.publicUse && frequency.publicUse,
+        source: sources[0],
+        sources,
+      });
+      continue;
+    }
+
+    merged.set(frequencyDedupeKey(frequency), frequency);
+  }
+
+  return [...merged.values()].sort((left, right) => {
+    const byType = frequencyTypeRank(left.type) - frequencyTypeRank(right.type);
+    if (byType !== 0) return byType;
+    return left.frequencyMHz - right.frequencyMHz;
+  });
+}
+
+function normalizeNavaid(record: FacilityRecord | null | undefined) {
+  if (!record) return null;
+  const lat = finiteOrNull(record.lat ?? record.latitude ?? record.latitude_deg);
+  const lon = finiteOrNull(record.lon ?? record.longitude ?? record.longitude_deg);
+  const ident = upperString(record.ident ?? record.identifier);
+  if (!ident || lat == null || lon == null) return null;
+
+  const source = cleanString(record.source) || "unknown";
+  const frequencyKhz = finiteOrNull(
+    record.frequencyKhz ?? record.frequencyKHz ?? record.frequency_khz,
+  );
+  return {
+    id: cleanString(record.id) || `${source}:${ident}:${lat}:${lon}`,
+    ident,
+    name: cleanString(record.name) || ident,
+    type: normalizeNavaidType(record.type),
+    frequencyKhz: frequencyKhz == null ? null : Math.round(frequencyKhz),
+    lat,
+    lon,
+    elevationFt: finiteOrNull(record.elevationFt ?? record.elevation_ft),
+    country: upperString(record.country ?? record.iso_country),
+    dme: {
+      frequencyKhz: finiteOrNull(
+        record.dme?.frequencyKhz ?? record.dme_frequency_khz,
+      ),
+      channel: cleanString(record.dme?.channel ?? record.dme_channel),
+    },
+    usageType: cleanString(record.usageType ?? record.usage_type),
+    power: cleanString(record.power),
+    associatedAirport: normalizeAirportIdent(
+      record.associatedAirport ?? record.associated_airport,
+    ),
+    magneticVariationDeg: finiteOrNull(
+      record.magneticVariationDeg ?? record.magnetic_variation_deg,
+    ),
+    slavedVariationDeg: finiteOrNull(
+      record.slavedVariationDeg ?? record.slaved_variation_deg,
+    ),
+    source,
+    sources: [source],
+  };
+}
+
+const compatibleNavaidTypes = (left: string, right: string) => {
+  if (left === right) return true;
+  const vorFamily = new Set(["vor", "vordme", "vortac", "tacan", "dme"]);
+  return vorFamily.has(left) && vorFamily.has(right);
+};
+
+const closeNavaidFrequency = (
+  left: number | null | undefined,
+  right: number | null | undefined,
+) => {
+  if (left == null || right == null) return true;
+  return Math.abs(left - right) <= NAVAID_DEDUPE_FREQUENCY_KHZ;
+};
+
+function isDuplicateNavaid(left: FacilityRecord, right: FacilityRecord) {
+  if (left.ident !== right.ident) return false;
+  if (!compatibleNavaidTypes(left.type, right.type)) return false;
+  if (!closeNavaidFrequency(left.frequencyKhz, right.frequencyKhz)) return false;
+  return (
+    getDistanceNm(left.lat, left.lon, right.lat, right.lon) <=
+    NAVAID_DEDUPE_DISTANCE_NM
+  );
+}
+
+function mergeNavaidRecords(existing: FacilityRecord, next: FacilityRecord) {
+  const sources = uniqueSources(existing, next);
+  const preferred = sourceRank(next.source) < sourceRank(existing.source) ? next : existing;
+  const secondary = preferred === existing ? next : existing;
+
+  return {
+    ...preferred,
+    name: preferred.name || secondary.name,
+    type:
+      preferred.type === "other" && secondary.type !== "other"
+        ? secondary.type
+        : preferred.type,
+    frequencyKhz: preferred.frequencyKhz ?? secondary.frequencyKhz,
+    elevationFt: preferred.elevationFt ?? secondary.elevationFt,
+    country: preferred.country || secondary.country,
+    dme: {
+      frequencyKhz:
+        preferred.dme?.frequencyKhz ?? secondary.dme?.frequencyKhz ?? null,
+      channel: preferred.dme?.channel || secondary.dme?.channel || "",
+    },
+    associatedAirport:
+      preferred.associatedAirport || secondary.associatedAirport || "",
+    usageType: preferred.usageType || secondary.usageType || "",
+    power: preferred.power || secondary.power || "",
+    magneticVariationDeg:
+      preferred.magneticVariationDeg ?? secondary.magneticVariationDeg,
+    slavedVariationDeg:
+      preferred.slavedVariationDeg ?? secondary.slavedVariationDeg,
+    source: sources[0],
+    sources,
+  };
+}
+
+export function mergeNearbyNavaids({
+  airport = {},
+  openAipNavaids = [],
+  ourAirportsNavaids = [],
+}: FacilityRecord = {}) {
+  const originLat = finiteOrNull(airport.lat ?? airport.latitude_deg);
+  const originLon = finiteOrNull(airport.lon ?? airport.longitude_deg);
+  const merged: FacilityRecord[] = [];
+
+  for (const navaid of [...openAipNavaids, ...ourAirportsNavaids]
+    .map(normalizeNavaid)
+    .filter(Boolean)) {
+    const index = merged.findIndex((item) => isDuplicateNavaid(item, navaid));
+    if (index >= 0) {
+      merged[index] = mergeNavaidRecords(merged[index], navaid);
+      continue;
+    }
+    merged.push(navaid);
+  }
+
+  return merged
+    .map((navaid: FacilityRecord) => ({
+      ...navaid,
+      distanceNm:
+        originLat == null || originLon == null
+          ? null
+          : getDistanceNm(navaid.lat, navaid.lon, originLat, originLon),
+    }))
+    .sort((left: FacilityRecord, right: FacilityRecord) => {
+      const leftDistance = left.distanceNm ?? Number.POSITIVE_INFINITY;
+      const rightDistance = right.distanceNm ?? Number.POSITIVE_INFINITY;
+      if (leftDistance !== rightDistance) return leftDistance - rightDistance;
+      return String(left.ident).localeCompare(String(right.ident));
+    });
+}

--- a/src/features/airport/openaip/openAipDirectory.test.ts
+++ b/src/features/airport/openaip/openAipDirectory.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { searchOpenAipAirports } from "./openAipDirectory";
+import { getOpenAipAirportPage, searchOpenAipAirports } from "./openAipDirectory";
 
 const airports = await searchOpenAipAirports({
   query: "shanghai",
@@ -45,5 +45,113 @@ assert.deepEqual(
   ["ZSSS", "ZSPD"],
 );
 assert.ok(airports.every((airport) => airport.ident.length <= 4));
+
+{
+  const page = await getOpenAipAirportPage({
+    ident: "KBOS",
+    radiusNm: 60,
+    nearbyLimit: 12,
+    runwayGeometryRepository: null,
+    facilityRepository: {
+      async readFrequenciesByAirportIdent() {
+        return [
+          {
+            id: 42,
+            airportIdent: "KBOS",
+            type: "TOWER",
+            description: "BOSTON TOWER",
+            frequencyMhz: 128.8,
+            source: "ourairports",
+          },
+        ];
+      },
+      async readNavaidsNearAirport() {
+        return [
+          {
+            id: 86260,
+            ident: "BOS",
+            name: "BOSTON",
+            type: "VOR-DME",
+            frequencyKhz: 112700,
+            lat: 42.3576,
+            lon: -70.9896,
+            source: "ourairports",
+          },
+        ];
+      },
+    },
+    client: {
+      async listAirports({ search }: Record<string, any> = {}) {
+        if (search === "KBOS") {
+          return {
+            items: [
+              {
+                _id: "openaip-kbos",
+                name: "Logan International Airport",
+                icaoCode: "KBOS",
+                iataCode: "BOS",
+                country: "US",
+                type: 3,
+                geometry: { type: "Point", coordinates: [-71.0096, 42.3656] },
+                elevation: { value: 6, unit: 0 },
+              },
+            ],
+          };
+        }
+        return { items: [] };
+      },
+      async getAirport() {
+        return {
+          _id: "openaip-kbos",
+          name: "Logan International Airport",
+          icaoCode: "KBOS",
+          iataCode: "BOS",
+          country: "US",
+          type: 3,
+          geometry: { type: "Point", coordinates: [-71.0096, 42.3656] },
+          frequencies: [
+            {
+              _id: "openaip-twr",
+              value: 128.8,
+              type: "TWR",
+              name: "Boston Tower",
+            },
+          ],
+          runways: [],
+        };
+      },
+      async listNavaids() {
+        return {
+          items: [
+            {
+              _id: "openaip-bos",
+              name: "Boston",
+              identifier: "BOS",
+              type: 4,
+              frequency: { value: 112.7 },
+              geometry: { type: "Point", coordinates: [-70.9894, 42.3575] },
+            },
+          ],
+        };
+      },
+      async listAirspaces() {
+        return { items: [] };
+      },
+      async listReportingPoints() {
+        return { items: [] };
+      },
+      async listObstacles() {
+        return { items: [] };
+      },
+    },
+  });
+
+  assert.equal(page.frequencies.length, 1);
+  assert.equal(page.frequencies[0].type, "tower");
+  assert.deepEqual(page.frequencies[0].sources, ["openaip", "ourairports"]);
+  assert.equal(page.nearbyNavaids.length, 1);
+  assert.equal(page.nearbyNavaids[0].type, "vordme");
+  assert.deepEqual(page.nearbyNavaids[0].sources, ["openaip", "ourairports"]);
+}
 
 console.log("openAipDirectory.test.ts: ok");

--- a/src/features/airport/openaip/openAipDirectory.ts
+++ b/src/features/airport/openaip/openAipDirectory.ts
@@ -13,7 +13,12 @@ import {
 } from "./openAipNormalizer";
 import { createOpenAipClientFromEnv } from "./openAipClient";
 import { AirportDirectoryConfigurationError } from "../directory/airportDirectory.models";
+import { createAirportFacilityRepositoryFromEnv } from "../../../app/api/dao/airportFacilities.dao";
 import { createRunwayGeometryRepositoryFromEnv } from "../../../app/api/dao/runwayGeometries.dao";
+import {
+  mergeAirportFrequencies,
+  mergeNearbyNavaids,
+} from "../directory/airportFacilityModel";
 import { buildRunwayMapFromGeometries } from "../runways/runwayGeometryMap";
 
 type OpenAipDirectoryRecord = Record<string, any>;
@@ -179,6 +184,13 @@ const getRunwayGeometryRepository = (
   return createRunwayGeometryRepositoryFromEnv();
 };
 
+const getAirportFacilityRepository = (
+  repository: OpenAipDirectoryRecord | null | undefined,
+) => {
+  if (repository !== undefined) return repository;
+  return createAirportFacilityRepositoryFromEnv();
+};
+
 const readRunwayGeometryMaps = async ({
   repository,
   airports = [],
@@ -211,6 +223,39 @@ const readRunwayGeometryMaps = async ({
     );
   }
   return maps;
+};
+
+const readOurAirportsFrequencies = async ({
+  repository,
+  airportIdent,
+}: OpenAipDirectoryRecord = {}) => {
+  if (!repository?.readFrequenciesByAirportIdent || !airportIdent) return [];
+  try {
+    return await repository.readFrequenciesByAirportIdent(airportIdent);
+  } catch (error: any) {
+    console.warn("[openaip] OurAirports frequencies read failed:", error?.message || error);
+    return [];
+  }
+};
+
+const readOurAirportsNavaids = async ({
+  repository,
+  airport,
+  radiusNm,
+  limit,
+}: OpenAipDirectoryRecord = {}) => {
+  if (!repository?.readNavaidsNearAirport || !airport) return [];
+  try {
+    return await repository.readNavaidsNearAirport({
+      lat: airport.lat,
+      lon: airport.lon,
+      radiusNm,
+      limit,
+    });
+  } catch (error: any) {
+    console.warn("[openaip] OurAirports navaids read failed:", error?.message || error);
+    return [];
+  }
 };
 
 export async function searchOpenAipAirportDocuments({
@@ -272,9 +317,11 @@ export async function getOpenAipAirportPage({
   nearbyLimit = 12,
   client,
   runwayGeometryRepository,
+  facilityRepository,
 }: OpenAipDirectoryRecord = {}) {
   const openAip = getClient(client);
   const runwayRepository = getRunwayGeometryRepository(runwayGeometryRepository);
+  const airportFacilityRepository = getAirportFacilityRepository(facilityRepository);
   const airportMatch = await findOpenAipAirportByIdent({ ident, client: openAip });
   if (!airportMatch?._id) {
     return {
@@ -371,17 +418,38 @@ export async function getOpenAipAirportPage({
     ...item,
     runwayMap: runwayMaps.get(item.icao) || null,
   }));
+  const openAipFrequencies = (airportDocument.frequencies || [])
+    .map((frequency: OpenAipDirectoryRecord) => mapOpenAipFrequency(frequency, airportDocument))
+    .filter(Boolean);
+  const openAipNavaids = nearbyNavaidDocuments.map(mapOpenAipNavaid).filter(Boolean);
+  const [ourAirportsFrequencies, ourAirportsNavaids] = await Promise.all([
+    readOurAirportsFrequencies({
+      repository: airportFacilityRepository,
+      airportIdent: airport.icao || airport.ident,
+    }),
+    readOurAirportsNavaids({
+      repository: airportFacilityRepository,
+      airport,
+      radiusNm,
+      limit: Math.min(100, limit * 3),
+    }),
+  ]);
 
   return {
     airport,
     runways: (airportDocument.runways || [])
       .map((runway: OpenAipDirectoryRecord) => mapOpenAipRunway(runway, airportDocument))
       .filter(Boolean),
-    frequencies: (airportDocument.frequencies || [])
-      .map((frequency: OpenAipDirectoryRecord) => mapOpenAipFrequency(frequency, airportDocument))
-      .filter(Boolean),
+    frequencies: mergeAirportFrequencies({
+      openAipFrequencies,
+      ourAirportsFrequencies,
+    }),
     nearbyAirports,
-    nearbyNavaids: nearbyNavaidDocuments.map(mapOpenAipNavaid).filter(Boolean),
+    nearbyNavaids: mergeNearbyNavaids({
+      airport,
+      openAipNavaids,
+      ourAirportsNavaids,
+    }).slice(0, limit),
     airspaces: airspaceDocuments.map(mapOpenAipAirspace).filter(Boolean),
     reportingPoints: reportingPointDocuments
       .map(mapOpenAipReportingPoint)

--- a/supabase/migrations/20260603022859_restore_ourairports_facilities.sql
+++ b/supabase/migrations/20260603022859_restore_ourairports_facilities.sql
@@ -1,0 +1,85 @@
+-- Restore narrow OurAirports static facilities used to augment OpenAIP airport
+-- detail pages. OpenAIP remains the primary airport directory; these tables
+-- only provide extra ATC frequency and nearby navaid coverage.
+
+create table if not exists public.airport_frequencies (
+  id bigint primary key,
+  airport_ref bigint,
+  airport_ident text not null,
+  type text not null default '',
+  description text not null default '',
+  frequency_mhz double precision,
+  imported_at timestamptz not null default timezone('utc', now()),
+  constraint airport_frequencies_airport_ident_format
+    check (airport_ident ~ '^[A-Z0-9]{2,8}$'),
+  constraint airport_frequencies_frequency_positive
+    check (frequency_mhz is null or frequency_mhz > 0)
+);
+
+create index if not exists airport_frequencies_airport_ident_idx
+  on public.airport_frequencies (airport_ident);
+
+create table if not exists public.navaids (
+  id bigint primary key,
+  filename text not null default '',
+  ident text not null default '',
+  name text not null default '',
+  type text not null default '',
+  frequency_khz double precision,
+  latitude_deg double precision,
+  longitude_deg double precision,
+  elevation_ft double precision,
+  iso_country text not null default '',
+  dme_frequency_khz double precision,
+  dme_channel text not null default '',
+  dme_latitude_deg double precision,
+  dme_longitude_deg double precision,
+  dme_elevation_ft double precision,
+  slaved_variation_deg double precision,
+  magnetic_variation_deg double precision,
+  usage_type text not null default '',
+  power text not null default '',
+  associated_airport text not null default '',
+  imported_at timestamptz not null default timezone('utc', now()),
+  constraint navaids_latitude_range check (
+    latitude_deg is null or latitude_deg between -90 and 90
+  ),
+  constraint navaids_longitude_range check (
+    longitude_deg is null or longitude_deg between -180 and 180
+  ),
+  constraint navaids_dme_latitude_range check (
+    dme_latitude_deg is null or dme_latitude_deg between -90 and 90
+  ),
+  constraint navaids_dme_longitude_range check (
+    dme_longitude_deg is null or dme_longitude_deg between -180 and 180
+  )
+);
+
+create index if not exists navaids_associated_airport_idx
+  on public.navaids (associated_airport)
+  where associated_airport <> '';
+
+create index if not exists navaids_lat_lon_idx
+  on public.navaids (latitude_deg, longitude_deg);
+
+alter table public.airport_frequencies enable row level security;
+alter table public.navaids enable row level security;
+
+grant select on table public.airport_frequencies to anon, authenticated;
+grant select on table public.navaids to anon, authenticated;
+
+grant select, insert, update, delete on table public.airport_frequencies
+  to service_role;
+grant select, insert, update, delete on table public.navaids
+  to service_role;
+
+drop policy if exists "Airport frequencies are readable by everyone"
+  on public.airport_frequencies;
+create policy "Airport frequencies are readable by everyone"
+on public.airport_frequencies
+for select to anon, authenticated using (true);
+
+drop policy if exists "Navaids are readable by everyone" on public.navaids;
+create policy "Navaids are readable by everyone"
+on public.navaids
+for select to anon, authenticated using (true);


### PR DESCRIPTION
## Summary
- Merge and normalize OpenAIP + OurAirports ATC frequency and nearby navaid records with conservative dedupe and source attribution.
- Add the ATC metric/detail panel and Spotting metric/detail panel to the airport sidebar, including the LiveATC search link without using LiveATC as data.
- Restore narrow OurAirports facility tables plus import tooling, and update docs/source attribution.

## Asana
- B-006a -- Merge and normalize navaids from OurAirports and OpenAIP
- B-006b -- Replace airport secondary photo spot badge with dedicated spotting metric card
- B-006c -- Add ATC frequencies metrics card and detail list to airport sidebar

## Validation
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm lint (passes with existing VirtualNearbyList TanStack Virtual warning)
- /opt/homebrew/bin/pnpm build
- Local browser checked /airport/KBOS ATC panel: frequency badges fixed to xxx.xxx, grid-aligned, single OpenAIP source hidden, LiveATC link present.
