### PR TITLE
[codex] Fix spotting zero count and nearby search

### DIFF
--- a/scripts/generate-candidate-watching-spots.ts
+++ b/scripts/generate-candidate-watching-spots.ts
@@ -5,10 +5,9 @@ import { createRunwayGeometryRepositoryFromEnv } from "../src/app/api/dao/runway
 import { buildRunwayMapFromGeometries } from "../src/features/airport/runways/runwayGeometryMap";
 import {
   buildCandidateWatchingSpotFile,
+  buildCandidateWatchingSpotSearchBBox,
   buildOverpassQuery,
-  buildRunwayExtensionCorridors,
   filterAndScoreCandidateElements,
-  unionBBoxes,
 } from "../src/features/airport/watcher/candidateWatchingSpotsModel";
 
 type ScriptRecord = Record<string, any>;
@@ -184,17 +183,22 @@ async function generateForAirport(inputCode: string) {
   const airportIdent = resolveAirportIdent(outputCode);
   const airportCenter = airportCenterFor(airportIdent);
   const runwayMap = await readRunwayMap(airportIdent);
-  if (!runwayMap?.runways?.length || !airportCenter) {
+  if (!airportCenter) {
     console.warn(
-      `[watching-spots] Skipping ${outputCode}: runway endpoint geometry or airport center is unavailable.`,
+      `[watching-spots] Skipping ${outputCode}: airport center is unavailable.`,
     );
     return null;
   }
 
-  const corridors = buildRunwayExtensionCorridors(runwayMap);
-  const bbox = unionBBoxes(corridors.map((corridor: ScriptRecord) => corridor.bbox));
+  if (!runwayMap?.runways?.length) {
+    console.warn(
+      `[watching-spots] ${outputCode}: runway endpoint geometry unavailable; scoring nearby candidates without runway alignment.`,
+    );
+  }
+
+  const bbox = buildCandidateWatchingSpotSearchBBox({ airportCenter });
   if (!bbox) {
-    console.warn(`[watching-spots] Skipping ${outputCode}: no runway corridors.`);
+    console.warn(`[watching-spots] Skipping ${outputCode}: no nearby search area.`);
     return null;
   }
 

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -61,10 +61,7 @@ export default function AirportSidebar({
     if (activeView === "atc" && atcFrequencies.length === 0) {
       setActiveView("traffic");
     }
-    if (activeView === "spotting" && spottingSpots.length === 0) {
-      setActiveView("traffic");
-    }
-  }, [activeView, atcFrequencies.length, spottingSpots.length]);
+  }, [activeView, atcFrequencies.length]);
 
   const handleSpottingView = () => {
     setActiveView("spotting");

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -63,15 +63,13 @@ export default function SidebarViewSwitch({
           onClick={() => onViewChange?.("atc")}
         />
       )}
-      {spottingCount > 0 && (
-        <SidebarMetricCard
-          label={t("sidebar.spotting")}
-          value={<NumberFlow value={spottingCount} />}
-          unit="PHOTO"
-          active={activeView === "spotting"}
-          onClick={onOpenSpotting}
-        />
-      )}
+      <SidebarMetricCard
+        label={t("sidebar.spotting")}
+        value={<NumberFlow value={spottingCount} />}
+        unit="PHOTO"
+        active={activeView === "spotting"}
+        onClick={onOpenSpotting}
+      />
       {showMovementCards && (
         <>
           <SidebarMetricCard

--- a/src/features/airport/watcher/candidateWatchingSpotsModel.test.ts
+++ b/src/features/airport/watcher/candidateWatchingSpotsModel.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import {
   buildCandidateWatchingSpotFile,
+  buildCandidateWatchingSpotSearchBBox,
   buildOverpassQuery,
   buildRunwayExtensionCorridors,
   filterAndScoreCandidateElements,
@@ -42,6 +43,16 @@ const query = buildOverpassQuery({
 assert.ok(query.includes("[out:json][timeout:25];"));
 assert.ok(query.includes('nwr["tourism"="viewpoint"](41.900000,-71.100000,42.100000,-70.900000);'));
 assert.ok(query.includes("out center tags;"));
+
+const searchBBox = buildCandidateWatchingSpotSearchBBox({
+  airportCenter: { lat: 42, lon: -71.01 },
+  radiusMeters: 2000,
+});
+
+assert.ok(searchBBox.south < 42);
+assert.ok(searchBBox.north > 42);
+assert.ok(searchBBox.west < -71.01);
+assert.ok(searchBBox.east > -71.01);
 
 const scored = filterAndScoreCandidateElements({
   airportIcao: "KAAA",
@@ -100,6 +111,16 @@ const scored = filterAndScoreCandidateElements({
     },
     {
       type: "node",
+      id: 107,
+      lat: 42.017,
+      lon: -71.01,
+      tags: {
+        tourism: "viewpoint",
+        name: "Nearby Off Axis View",
+      },
+    },
+    {
+      type: "node",
       id: 103,
       lat: 42.08,
       lon: -71.08,
@@ -112,9 +133,12 @@ const scored = filterAndScoreCandidateElements({
   limit: 5,
 });
 
-assert.equal(scored.length, 2);
+assert.equal(scored.length, 3);
 assert.equal(scored[0].id, "osm-node-101");
-assert.equal(scored[1].id, "osm-node-106");
+const footwaySpot = scored.find((spot) => spot.id === "osm-node-106");
+const offAxisSpot = scored.find((spot) => spot.id === "osm-node-107");
+assert.ok(footwaySpot);
+assert.ok(offAxisSpot);
 assert.ok(scored[0].score > scored[1].score);
 assert.equal(scored[0].sourceObjectId, "101");
 assert.equal(scored[0].source, "osm");
@@ -124,6 +148,8 @@ assert.equal(scored[0].runwayAlignment?.end, "09");
 assert.ok(scored[0].score > 0);
 assert.ok(scored[0].reason.includes("runway"));
 assert.ok(scored[0].disclaimer.includes("map-derived candidate"));
+assert.equal(offAxisSpot.runwayAlignment, null);
+assert.ok(offAxisSpot.reason.includes("near KAAA"));
 
 const file = buildCandidateWatchingSpotFile({
   airportIcao: "kaaa",
@@ -134,6 +160,6 @@ const file = buildCandidateWatchingSpotFile({
 assert.equal(file.airportIcao, "KAAA");
 assert.equal(file.generatedAt, "2026-06-02T12:00:00.000Z");
 assert.equal(file.sourceAttribution, "© OpenStreetMap contributors");
-assert.equal(file.spots.length, 2);
+assert.equal(file.spots.length, 3);
 
 console.log("candidateWatchingSpotsModel.test.ts ok");

--- a/src/features/airport/watcher/candidateWatchingSpotsModel.ts
+++ b/src/features/airport/watcher/candidateWatchingSpotsModel.ts
@@ -15,6 +15,7 @@ type BBox = {
 const METERS_PER_DEGREE_LATITUDE = 111_320;
 const DEFAULT_EXTENSION_METERS = 3_800;
 const DEFAULT_LATERAL_BUFFER_METERS = 320;
+const DEFAULT_SEARCH_RADIUS_METERS = DEFAULT_EXTENSION_METERS;
 const DEFAULT_LIMIT = 5;
 
 export const CANDIDATE_WATCHING_SPOT_ATTRIBUTION =
@@ -248,6 +249,25 @@ export function buildOverpassQuery(bbox: BBox) {
 out center tags;`;
 }
 
+export function buildCandidateWatchingSpotSearchBBox({
+  airportCenter,
+  radiusMeters = DEFAULT_SEARCH_RADIUS_METERS,
+}: CandidateRecord = {}): BBox | null {
+  const lat = toFiniteNumber(airportCenter?.lat);
+  const lon = toFiniteNumber(airportCenter?.lon);
+  const radius = Math.max(1, Number(radiusMeters) || DEFAULT_SEARCH_RADIUS_METERS);
+  if (lat == null || lon == null) return null;
+
+  const latDelta = radius / METERS_PER_DEGREE_LATITUDE;
+  const lonDelta = radius / metersPerDegreeLongitude(lat);
+  return {
+    south: lat - latDelta,
+    west: lon - lonDelta,
+    north: lat + latDelta,
+    east: lon + lonDelta,
+  };
+}
+
 const scoreAgainstCorridor = (point: LatLon, corridor: CandidateRecord) => {
   const local = pointToLocalMeters(point, corridor.origin);
   const along = local.x * corridor.vector.x + local.y * corridor.vector.y;
@@ -271,10 +291,19 @@ export function filterAndScoreCandidateElements({
   runwayMap,
   elements = [],
   limit = DEFAULT_LIMIT,
+  searchRadiusMeters = DEFAULT_SEARCH_RADIUS_METERS,
 }: CandidateRecord = {}) {
   const corridors = buildRunwayExtensionCorridors(runwayMap);
   const normalizedAirport = normalizeAirportIcao(airportIcao);
   const spots = [];
+  const center =
+    toFiniteNumber(airportCenter?.lat) != null && toFiniteNumber(airportCenter?.lon) != null
+      ? { lat: Number(airportCenter.lat), lon: Number(airportCenter.lon) }
+      : null;
+  const maxDistanceMeters = Math.max(
+    1,
+    Number(searchRadiusMeters) || DEFAULT_SEARCH_RADIUS_METERS,
+  );
 
   for (const element of elements || []) {
     const tags = element?.tags || {};
@@ -287,14 +316,19 @@ export function filterAndScoreCandidateElements({
       .map((corridor: CandidateRecord) => scoreAgainstCorridor(point, corridor))
       .filter(Boolean)
       .sort((left: CandidateRecord, right: CandidateRecord) => right.score - left.score)[0];
-    if (!alignment) continue;
+    if (!alignment && !center) continue;
 
     const centerDistance =
-      airportCenter?.lat != null && airportCenter?.lon != null
-        ? distanceMeters(point, airportCenter)
+      center
+        ? distanceMeters(point, center)
         : alignment.distanceMeters;
-    const distanceComponent = Math.max(0, 28 - Math.min(centerDistance / 180, 28));
-    const alignmentComponent = alignment.score * 38;
+    if (center && centerDistance > maxDistanceMeters) continue;
+
+    const distanceComponent = Math.max(
+      0,
+      34 - Math.min((centerDistance / maxDistanceMeters) * 34, 34),
+    );
+    const alignmentComponent = alignment ? alignment.score * 24 : 0;
     const qualityComponent = qualityScoreForTags(tags);
     const score = Math.max(
       0,
@@ -317,12 +351,16 @@ export function filterAndScoreCandidateElements({
       category,
       score,
       distanceMeters: Math.round(centerDistance),
-      runwayAlignment: {
-        runwayId: alignment.runwayId,
-        end: alignment.end,
-        score: alignment.score,
-      },
-      reason: `${category} near the extended ${alignment.end || ""} runway alignment at ${normalizedAirport}.`,
+      runwayAlignment: alignment
+        ? {
+            runwayId: alignment.runwayId,
+            end: alignment.end,
+            score: alignment.score,
+          }
+        : null,
+      reason: alignment
+        ? `${category} near the extended ${alignment.end || ""} runway alignment at ${normalizedAirport}.`
+        : `${category} near ${normalizedAirport}.`,
       disclaimer: CANDIDATE_WATCHING_SPOT_DISCLAIMER,
     });
   }


### PR DESCRIPTION
## Summary
- show the spotting metric even when an airport has 0 candidate photo spots
- allow candidate watching spots to be selected by nearby distance instead of requiring runway-extension alignment
- keep runway alignment as a scoring bonus and update the generator to query a nearby airport-centered bbox

## Validation
- `/opt/homebrew/bin/pnpm lint` (0 errors; existing VirtualNearbyList React Compiler warning)
- `/opt/homebrew/bin/pnpm test` (98 test files passed)
- `/opt/homebrew/bin/pnpm build`
- Browser: `http://localhost:3000/airport/KLAX` showed `拍机点 0 PHOTO`; clicking it kept the Spotting panel open and showed `0 spots`
