### PR TITLE
Add navaid count badges for full trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/dao/airportFacilities.dao.test.ts
+++ b/src/app/api/dao/airportFacilities.dao.test.ts
@@ -12,8 +12,13 @@ function createFakeSupabaseClient(tableData: Record<string, any[]> = {}) {
 
   const createQuery = (table: string) => {
     const query: Record<string, any> = {
-      select(columns: string) {
-        calls.push({ type: "select", table, columns });
+      select(columns: string, options?: Record<string, any>) {
+        calls.push({
+          type: "select",
+          table,
+          columns,
+          ...(options ? { options } : {}),
+        });
         return query;
       },
       eq(column: string, value: unknown) {
@@ -37,7 +42,11 @@ function createFakeSupabaseClient(tableData: Record<string, any[]> = {}) {
         return query;
       },
       then(resolve: (value: any) => void) {
-        return Promise.resolve({ data: tableData[table] || [], error: null }).then(resolve);
+        const tableValue = tableData[table] || [];
+        const payload = Array.isArray(tableValue)
+          ? { data: tableValue, error: null }
+          : { data: tableValue.data || [], count: tableValue.count, error: null };
+        return Promise.resolve(payload).then(resolve);
       },
     };
     return query;
@@ -154,6 +163,37 @@ function createFakeSupabaseClient(tableData: Record<string, any[]> = {}) {
 
   assert.ok(repository);
   assert.equal(calls[0].supabaseKey, "sb_service_role_test");
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    [NAVAIDS_TABLE]: { data: [], count: 37 },
+  });
+  const repository = createAirportFacilityRepository({
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "sb_secret_test",
+    createClientImpl,
+  });
+
+  const count = await repository.readNavaidCountInBounds({
+    bbox: {
+      south: 36.597889,
+      north: 40.979898,
+      west: -78.75,
+      east: -73.125,
+    },
+  });
+
+  assert.equal(count, 37);
+  assert.ok(
+    calls.some(
+      (call) =>
+        call.type === "select" &&
+        call.columns === "id" &&
+        call.options?.count === "exact" &&
+        call.options?.head === true,
+    ),
+  );
 }
 
 console.log("airportFacilities.dao.test.ts ok");

--- a/src/app/api/dao/airportFacilities.dao.ts
+++ b/src/app/api/dao/airportFacilities.dao.ts
@@ -210,6 +210,33 @@ export function createAirportFacilityRepository({
 
       return (data || []).map(mapNavaidRow).filter(Boolean);
     },
+
+    async readNavaidCountInBounds({
+      bbox,
+    }: AirportFacilityRecord = {}) {
+      if (!bbox) return 0;
+      const south = numberOrNull(bbox.south);
+      const north = numberOrNull(bbox.north);
+      const west = numberOrNull(bbox.west);
+      const east = numberOrNull(bbox.east);
+      if (south == null || north == null || west == null || east == null) {
+        return 0;
+      }
+
+      const { count, error } = await client
+        .from(NAVAIDS_TABLE)
+        .select("id", { count: "exact", head: true })
+        .gte("latitude_deg", Math.min(south, north))
+        .lte("latitude_deg", Math.max(south, north))
+        .gte("longitude_deg", Math.min(west, east))
+        .lte("longitude_deg", Math.max(west, east));
+
+      if (error) {
+        throw new Error(`Navaid count tile read failed (${error.message})`);
+      }
+
+      return Math.max(0, Number(count) || 0);
+    },
   };
 }
 

--- a/src/app/api/navaid-counts/[z]/[x]/[y]/route.ts
+++ b/src/app/api/navaid-counts/[z]/[x]/[y]/route.ts
@@ -1,0 +1,60 @@
+import {
+  createCorsPreflightResponse,
+  enforceProxyRequest,
+  jsonProxyResponse,
+} from "@/app/api/_shared/apiProxySecurity";
+import {
+  getNavaidCountTile,
+} from "@/features/airport/context/aviationContextTile.mechanism";
+import {
+  NAVAID_COUNT_TILE_CACHE_HEADERS,
+  normalizeContextTileParams,
+} from "@/features/airport/context/aviationContextTileModel";
+import { AirportDirectoryConfigurationError } from "@/features/airport/directory/airportDirectory.models";
+
+const rateLimit = {
+  key: "api:navaid-count-tile",
+  maxRequests: 180,
+  windowMs: 60_000,
+};
+
+export const runtime = "nodejs";
+
+export function OPTIONS(request) {
+  return createCorsPreflightResponse(request);
+}
+
+export async function GET(request, { params }) {
+  const securityResponse = enforceProxyRequest(request, { rateLimit });
+  if (securityResponse) return securityResponse;
+
+  const tile = normalizeContextTileParams(await params);
+  if (!tile) {
+    return jsonProxyResponse(
+      request,
+      { error: "Invalid navaid count tile" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const payload = await getNavaidCountTile({ tile });
+    return jsonProxyResponse(request, payload, {
+      headers: NAVAID_COUNT_TILE_CACHE_HEADERS,
+    });
+  } catch (error) {
+    if (error instanceof AirportDirectoryConfigurationError) {
+      return jsonProxyResponse(
+        request,
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+    console.error("[api/navaid-counts] tile load failed", error);
+    return jsonProxyResponse(
+      request,
+      { error: "Failed to load navaid count tile" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/components/changelog/ChangelogPanel.tsx
+++ b/src/components/changelog/ChangelogPanel.tsx
@@ -10,6 +10,17 @@ import { CHANGELOG } from "@/config/changelog";
 // optional current marker, summary, then short highlights.
 
 const CHINESE_RELEASE_COPY = {
+  "v1.11.0": {
+    title: "全航迹地图上下文计数",
+    summary:
+      "全航迹飞机地图现在会在低缩放层级把密集导航台标签替换为缓存的 NAV 计数 badge,长距离航线更容易阅读。",
+    highlights: [
+      "低缩放全航迹地图改为请求聚合导航台计数 tile,不再一次渲染大量单个标签",
+      "NAV 计数 badge 在每个地图 tile 中心显示总数,并带有简短的入场动画",
+      "放大到当前细节阈值后仍显示完整导航台标签",
+      "计数 API 复用航空上下文 tile 的长期缓存策略",
+    ],
+  },
   "v1.10.0": {
     title: "机场设施数据与侧栏打磨",
     summary:
@@ -216,7 +227,7 @@ const CHINESE_RELEASE_COPY = {
       "保留 Tailwind CSS v4 和 DaisyUI",
       "通过 Next 集成接入 Vercel Analytics 和 Speed Insights",
       "Vue composables 迁移为 React hooks",
-      "FlightAware 航路查询迁移到 Route Handler",
+      "飞行航路查询迁移到 Route Handler",
     ],
   },
   "v0.7.1": {
@@ -230,10 +241,10 @@ const CHINESE_RELEASE_COPY = {
   },
   "v0.7.0": {
     title: "飞行航路与交通上下文",
-    summary: "机场感知航路标签、FlightAware 查询和双范围 ADS-B 轮询。",
+    summary: "机场感知航路标签、航路查询和双范围 ADS-B 轮询。",
     highlights: [
       "机场感知飞行航路标签",
-      "通过 Vercel function 查询 FlightAware 航路",
+      "通过 Vercel function 查询飞行航路",
       "双范围轮询: 广域 20 海里加近距 3 海里",
       "机场上下文叠加和地面过滤",
     ],

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -138,6 +138,7 @@ function FlightExplorerContent({ callsign }) {
   const [contextTiles, setContextTiles] = useState({
     airspaces: [],
     navaids: [],
+    navaidCounts: [],
     loading: false,
     error: null,
   });
@@ -636,6 +637,7 @@ function FlightExplorerContent({ callsign }) {
             focalRangeRings={false}
             contextTileOverlays
             contextTileRefreshKey={`${callsign}:${mapFollowsAircraft}:${mapZoom}`}
+            fullTraceContext={!mapFollowsAircraft}
             onContextTilesChange={setContextTiles}
             deferUntilFocal
             loadingOverlayActive={flightTrackingLoadingActive}

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -9,6 +9,7 @@ import MapRangeLegend from "./MapRangeLegend";
 import AirspaceLayer from "./AirspaceLayer";
 import NearbyAirportLayer from "./NearbyAirportLayer";
 import NavaidLabelLayer from "./NavaidLabelLayer";
+import NavaidCountLayer from "./NavaidCountLayer";
 import CandidateWatchingSpotsLayer from "./CandidateWatchingSpotsLayer";
 import AircraftPosition from "./AircraftPosition";
 import UserLocationMarker from "./UserLocationMarker";
@@ -35,6 +36,7 @@ import {
   resolveMapSurfaceVisibility,
 } from "../../features/aircraft/positions/aircraftLoadingOverlayModel";
 import { useAviationContextTiles } from "../../features/airport/context/useAviationContextTiles";
+import { shouldUseNavaidCountTiles } from "../../features/airport/context/aviationContextDisplayModel";
 import { getOffsetMapCenter } from "./mapViewportOffset";
 
 const resolveCurrentTheme = () =>
@@ -59,6 +61,7 @@ export default function AirportMap({
   airspaces = [],
   contextTileOverlays = false,
   contextTileRefreshKey = "",
+  fullTraceContext = false,
   onContextTilesChange = null,
   airport = null,
   showMapLabels = false,
@@ -104,6 +107,7 @@ export default function AirportMap({
   const mapRef = useRef(null);
   const sizeObs = useRef(null);
   const [mapInstance, setMapInstance] = useState(null);
+  const [leafletZoom, setLeafletZoom] = useState(zoom);
   const [loadingOverlayPlayback, setLoadingOverlayPlayback] = useState({
     visible: true,
     exiting: false,
@@ -271,11 +275,31 @@ export default function AirportMap({
     [aircraft, selectedAircraftId, visibleAircraft],
   );
   const selectionActive = Boolean(selectedAircraftId && selectedAircraft);
+  useEffect(() => {
+    if (!mapInstance) {
+      setLeafletZoom(zoom);
+      return undefined;
+    }
+    const updateZoom = () => {
+      const nextZoom = Number(mapInstance.getZoom?.());
+      if (Number.isFinite(nextZoom)) setLeafletZoom(nextZoom);
+    };
+    updateZoom();
+    mapInstance.on?.("zoomend", updateZoom);
+    return () => {
+      mapInstance.off?.("zoomend", updateZoom);
+    };
+  }, [mapInstance, zoom]);
+  const useNavaidCountTiles = shouldUseNavaidCountTiles({
+    fullTraceMode: fullTraceContext,
+    zoom: leafletZoom,
+  });
   const contextTiles = useAviationContextTiles({
     map: mapInstance,
     enabled: contextTileOverlays,
     airspacesEnabled: showAirspaces,
-    navaidsEnabled: showNavaidMarkers,
+    navaidsEnabled: showNavaidMarkers && !useNavaidCountTiles,
+    navaidCountsEnabled: showNavaidMarkers && useNavaidCountTiles,
     refreshKey: contextTileRefreshKey,
   });
   const renderedAirspaces = useMemo(() => {
@@ -305,8 +329,11 @@ export default function AirportMap({
         navaids: contextTiles.navaids.map(
           (item) => item?.id || `${item?.ident}:${item?.lat}:${item?.lon}`,
         ),
+        navaidCounts: contextTiles.navaidCounts.map(
+          (item) => item?.key || `${item?.z}:${item?.x}:${item?.y}`,
+        ),
       }),
-    [contextTiles.airspaces, contextTiles.navaids],
+    [contextTiles.airspaces, contextTiles.navaidCounts, contextTiles.navaids],
   );
 
   useEffect(() => {
@@ -316,6 +343,7 @@ export default function AirportMap({
     onContextTilesChange({
       airspaces: contextTiles.airspaces,
       navaids: contextTiles.navaids,
+      navaidCounts: contextTiles.navaidCounts,
       loading: contextTiles.loading,
       error: contextTiles.error,
     });
@@ -326,6 +354,7 @@ export default function AirportMap({
     contextTiles.loading,
     onContextTilesChange,
     contextTiles.airspaces,
+    contextTiles.navaidCounts,
     contextTiles.navaids,
   ]);
 
@@ -406,9 +435,14 @@ export default function AirportMap({
           <NavaidLabelLayer
             navaids={renderedNavaids}
             theme={currentTheme}
-            visible={showNavaidMarkers}
+            visible={showNavaidMarkers && !useNavaidCountTiles}
             selectedNavaidKey={selectedNavaidKey}
             onSelectNavaid={onSelectNavaid}
+          />
+          <NavaidCountLayer
+            counts={contextTiles.navaidCounts}
+            theme={currentTheme}
+            visible={showNavaidMarkers && useNavaidCountTiles}
           />
           <RunwayAnnotationLayer
             runwayMap={runwayMap}

--- a/src/components/map/NavaidCountLayer.tsx
+++ b/src/components/map/NavaidCountLayer.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import { renderToStaticMarkup } from "react-dom/server";
+import { useMapInstance } from "./MapContext";
+import { AIRPORT_MAP_PANES } from "../../config/airportMap";
+import { ensureAirportMapPane } from "../../features/airport/map/mapPane";
+import {
+  safeAddToMap,
+  safeRemoveFromMap,
+} from "../../features/airport/map/leafletLayerSafety";
+
+function NavaidCountMarker({ count }: { count: number }) {
+  return (
+    <div
+      className="navaid-count-marker navaid-count-marker--enter notranslate"
+      translate="no"
+    >
+      <strong>{count}</strong>
+      <span>NAV</span>
+    </div>
+  );
+}
+
+const navaidCountIcon = (count: number, theme: string) =>
+  L.divIcon({
+    className: `navaid-count-icon navaid-count-icon--${theme}`,
+    html: renderToStaticMarkup(<NavaidCountMarker count={count} />),
+    iconSize: [54, 30],
+    iconAnchor: [27, 15],
+  });
+
+export default function NavaidCountLayer({
+  counts = [],
+  theme = "dark",
+  visible = false,
+}: Record<string, any>) {
+  const map = useMapInstance();
+  const layerRef = useRef(null);
+
+  useEffect(() => {
+    if (!map || !visible) return undefined;
+
+    safeRemoveFromMap(layerRef.current, map);
+    const markers = counts
+      .map((item) => ({
+        ...item,
+        count: Math.trunc(Number(item?.count)),
+        lat: Number(item?.lat),
+        lon: Number(item?.lon),
+      }))
+      .filter(
+        (item) =>
+          Number.isFinite(item.count) &&
+          item.count > 0 &&
+          Number.isFinite(item.lat) &&
+          Number.isFinite(item.lon),
+      );
+    if (!markers.length) return undefined;
+
+    const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.badge);
+    const layer = L.layerGroup(
+      markers.map((item) =>
+        L.marker([item.lat, item.lon], {
+          interactive: false,
+          keyboard: false,
+          title: `${item.count} navaids`,
+          icon: navaidCountIcon(item.count, theme),
+          pane,
+        }),
+      ),
+    );
+
+    const added = safeAddToMap(layer, map, { label: "NavaidCountLayer" });
+    if (!added) return undefined;
+    layerRef.current = layer;
+
+    return () => {
+      safeRemoveFromMap(layer, map);
+      layerRef.current = null;
+    };
+  }, [counts, map, theme, visible]);
+
+  return null;
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -6,6 +6,19 @@
 
 export const CHANGELOG = [
   {
+    version: "v1.11.0",
+    kind: "feat",
+    title: "Full-trace map context counts",
+    summary:
+      "Full-trace aircraft maps now keep long routes readable by replacing dense low-zoom navaid labels with cached NAV count badges.",
+    highlights: [
+      "Low-zoom full-trace maps request aggregate navaid count tiles instead of thousands of individual labels",
+      "NAV count badges show one centered total per map tile with a short reduced-motion-safe entry animation",
+      "Detailed navaid labels still return at the existing zoom threshold",
+      "The count API reuses the long-lived aviation context tile cache headers",
+    ],
+  },
+  {
     version: "v1.10.0",
     kind: "feat",
     title: "Airport facilities and sidebar polish",
@@ -282,7 +295,7 @@ export const CHANGELOG = [
       "Tailwind CSS v4 + DaisyUI retained",
       "Vercel Analytics + Speed Insights via Next integrations",
       "Vue composables → React hooks",
-      "FlightAware route lookup moved to a Route Handler",
+      "Flight route lookup moved to a Route Handler",
     ],
   },
   {
@@ -301,10 +314,10 @@ export const CHANGELOG = [
     kind: "feat",
     title: "Flight route + traffic context",
     summary:
-      "Airport-aware route labels, FlightAware lookup, dual-range ADS-B polling.",
+      "Airport-aware route labels, route lookup, dual-range ADS-B polling.",
     highlights: [
       "Airport-aware flight route labels",
-      "FlightAware route lookup via Vercel function",
+      "Flight route lookup via Vercel function",
       "Dual-range polling (wide 20 NM + close 3 NM)",
       "Airport context overlays + ground filtering",
     ],

--- a/src/config/siteMeta.test.ts
+++ b/src/config/siteMeta.test.ts
@@ -7,14 +7,14 @@ import {
 } from "./siteMeta";
 
 assert.equal(ADSBAO_PRODUCT_NAME, "ADSBao");
-assert.equal(ADSBAO_SITE_VERSION, "1.10.0");
+assert.equal(ADSBAO_SITE_VERSION, "1.11.0");
 assert.equal(
   buildAdsbaoUserAgent("adsbdb/v0"),
-  "ADSBao/1.10.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+  "ADSBao/1.11.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
 );
 assert.equal(
   buildAdsbaoUserAgent(),
-  "ADSBao/1.10.0 (+https://github.com/orriduck/ADSBao)",
+  "ADSBao/1.11.0 (+https://github.com/orriduck/ADSBao)",
 );
 
 console.log("siteMeta.test.ts ok");

--- a/src/config/siteMeta.ts
+++ b/src/config/siteMeta.ts
@@ -1,5 +1,5 @@
 export const ADSBAO_PRODUCT_NAME = "ADSBao";
-export const ADSBAO_SITE_VERSION = "1.10.0";
+export const ADSBAO_SITE_VERSION = "1.11.0";
 export const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
 
 export function buildAdsbaoUserAgent(suffix = "") {

--- a/src/features/airport/context/aviationContextDisplayModel.test.ts
+++ b/src/features/airport/context/aviationContextDisplayModel.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+
+import {
+  NAVAID_COUNT_MAX_DETAIL_ZOOM,
+  buildNavaidCountMarker,
+  shouldUseNavaidCountTiles,
+} from "./aviationContextDisplayModel";
+
+assert.equal(NAVAID_COUNT_MAX_DETAIL_ZOOM, 8);
+
+assert.equal(
+  shouldUseNavaidCountTiles({ fullTraceMode: true, zoom: 6 }),
+  true,
+);
+assert.equal(
+  shouldUseNavaidCountTiles({ fullTraceMode: true, zoom: 9 }),
+  false,
+);
+assert.equal(
+  shouldUseNavaidCountTiles({ fullTraceMode: false, zoom: 6 }),
+  false,
+);
+
+{
+  assert.deepEqual(
+    buildNavaidCountMarker({
+      tile: { z: 6, x: 18, y: 24 },
+      bbox: { west: -78.75, south: 36.597889, east: -73.125, north: 40.979898 },
+      count: 37,
+    }),
+    {
+      key: "navaid-counts:6:18:24",
+      count: 37,
+      lat: 38.7888935,
+      lon: -75.9375,
+      z: 6,
+      x: 18,
+      y: 24,
+    },
+  );
+  assert.equal(buildNavaidCountMarker({ count: 0 }), null);
+}
+
+console.log("aviationContextDisplayModel.test.ts ok");

--- a/src/features/airport/context/aviationContextDisplayModel.ts
+++ b/src/features/airport/context/aviationContextDisplayModel.ts
@@ -1,0 +1,57 @@
+type ContextRecord = Record<string, any>;
+
+export const NAVAID_COUNT_MAX_DETAIL_ZOOM = 8;
+
+const numberOrNull = (value: unknown) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+export function shouldUseNavaidCountTiles({
+  fullTraceMode = false,
+  zoom,
+}: ContextRecord = {}) {
+  const numericZoom = numberOrNull(zoom);
+  return Boolean(
+    fullTraceMode &&
+      numericZoom != null &&
+      numericZoom <= NAVAID_COUNT_MAX_DETAIL_ZOOM,
+  );
+}
+
+export function buildNavaidCountMarker({
+  tile,
+  bbox,
+  count,
+}: ContextRecord = {}) {
+  const numericCount = Math.trunc(Number(count));
+  if (!Number.isFinite(numericCount) || numericCount <= 0) return null;
+  const z = numberOrNull(tile?.z);
+  const x = numberOrNull(tile?.x);
+  const y = numberOrNull(tile?.y);
+  const west = numberOrNull(bbox?.west);
+  const east = numberOrNull(bbox?.east);
+  const south = numberOrNull(bbox?.south);
+  const north = numberOrNull(bbox?.north);
+  if (
+    z == null ||
+    x == null ||
+    y == null ||
+    west == null ||
+    east == null ||
+    south == null ||
+    north == null
+  ) {
+    return null;
+  }
+
+  return {
+    key: `navaid-counts:${z}:${x}:${y}`,
+    count: numericCount,
+    lat: (south + north) / 2,
+    lon: (west + east) / 2,
+    z,
+    x,
+    y,
+  };
+}

--- a/src/features/airport/context/aviationContextTile.mechanism.test.ts
+++ b/src/features/airport/context/aviationContextTile.mechanism.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+
+import {
+  clearAviationContextTileCache,
+  getNavaidCountTile,
+} from "./aviationContextTile.mechanism";
+
+clearAviationContextTileCache();
+
+{
+  let requestedBbox = null;
+  const payload = await getNavaidCountTile({
+    tile: { z: 6, x: 18, y: 24 },
+    facilityRepository: {
+      async readNavaidCountInBounds({ bbox }) {
+        requestedBbox = bbox;
+        return 37;
+      },
+    },
+  });
+
+  assert.equal(payload.cacheKey, "navaid-counts:6:18:24");
+  assert.equal(payload.source, "ourairports");
+  assert.equal(payload.count, 37);
+  assert.equal(payload.navaidCounts.length, 1);
+  assert.equal(payload.navaidCounts[0].key, "navaid-counts:6:18:24");
+  assert.equal(payload.navaidCounts[0].count, 37);
+  assert.ok(Math.abs(payload.navaidCounts[0].lat - 38.7888935) < 0.000001);
+  assert.equal(payload.navaidCounts[0].lon, -75.9375);
+  assert.equal(payload.navaidCounts[0].z, 6);
+  assert.equal(payload.navaidCounts[0].x, 18);
+  assert.equal(payload.navaidCounts[0].y, 24);
+  assert.ok(requestedBbox);
+}
+
+{
+  const payload = await getNavaidCountTile({
+    tile: { z: 6, x: 19, y: 24 },
+    facilityRepository: {
+      async readNavaidCountInBounds() {
+        return 0;
+      },
+    },
+  });
+
+  assert.equal(payload.count, 0);
+  assert.deepEqual(payload.navaidCounts, []);
+}
+
+console.log("aviationContextTile.mechanism.test.ts ok");

--- a/src/features/airport/context/aviationContextTile.mechanism.ts
+++ b/src/features/airport/context/aviationContextTile.mechanism.ts
@@ -9,6 +9,9 @@ import {
   mapOpenAipReportingPoint,
 } from "../openaip/openAipNormalizer";
 import {
+  buildNavaidCountMarker,
+} from "./aviationContextDisplayModel";
+import {
   bboxToOpenAipParam,
   buildContextTileCacheKey,
   tileToBbox,
@@ -150,6 +153,51 @@ export async function getNavaidTile({
     cacheKey,
     source: "openaip",
     navaids: documents.map(mapOpenAipNavaid).filter(Boolean),
+  });
+}
+
+export async function getNavaidCountTile({
+  tile,
+  client,
+  facilityRepository,
+}: ContextTileRecord = {}) {
+  const cacheKey = buildContextTileCacheKey("navaid-counts", tile);
+  const cached = readCached(cacheKey);
+  if (cached) return cached;
+  const bbox = tileToBbox(tile);
+  const repository =
+    facilityRepository === undefined
+      ? createAirportFacilityRepositoryFromEnv()
+      : facilityRepository;
+  if (repository?.readNavaidCountInBounds) {
+    const count = await repository.readNavaidCountInBounds({ bbox });
+    const marker = buildNavaidCountMarker({ tile, bbox, count });
+    return writeCached(cacheKey, {
+      tile,
+      bbox,
+      cacheKey,
+      source: "ourairports",
+      count,
+      navaidCounts: marker ? [marker] : [],
+    });
+  }
+
+  const openAip = getOpenAipClient(client);
+  const documents = await listItems(
+    openAip.listNavaids({
+      bbox: bboxToOpenAipParam(bbox),
+      limit: 100,
+      fields: "_id",
+    }),
+  );
+  const marker = buildNavaidCountMarker({ tile, bbox, count: documents.length });
+  return writeCached(cacheKey, {
+    tile,
+    bbox,
+    cacheKey,
+    source: "openaip",
+    count: documents.length,
+    navaidCounts: marker ? [marker] : [],
   });
 }
 

--- a/src/features/airport/context/aviationContextTileModel.ts
+++ b/src/features/airport/context/aviationContextTileModel.ts
@@ -21,6 +21,8 @@ export const NAVAID_TILE_CACHE_HEADERS = Object.freeze({
   "Vercel-CDN-Cache-Control": "public, s-maxage=2592000, stale-while-revalidate=604800",
 });
 
+export const NAVAID_COUNT_TILE_CACHE_HEADERS = NAVAID_TILE_CACHE_HEADERS;
+
 export const WAYPOINT_TILE_CACHE_HEADERS = Object.freeze({
   "Cache-Control": "public, max-age=0, s-maxage=604800, stale-while-revalidate=86400",
   "CDN-Cache-Control": "public, s-maxage=604800, stale-while-revalidate=86400",

--- a/src/features/airport/context/useAviationContextTiles.ts
+++ b/src/features/airport/context/useAviationContextTiles.ts
@@ -61,12 +61,14 @@ export function useAviationContextTiles({
   enabled = false,
   airspacesEnabled = false,
   navaidsEnabled = false,
+  navaidCountsEnabled = false,
   waypointsEnabled = false,
   refreshKey = "",
 }: ContextTileRecord = {}) {
   const [tiles, setTiles] = useState([]);
   const [airspaces, setAirspaces] = useState([]);
   const [navaids, setNavaids] = useState([]);
+  const [navaidCounts, setNavaidCounts] = useState([]);
   const [waypoints, setWaypoints] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -105,16 +107,25 @@ export function useAviationContextTiles({
       const urls = [];
       if (airspacesEnabled) urls.push(tilePath("airspace", tile));
       if (navaidsEnabled) urls.push(tilePath("navaids", tile));
+      if (navaidCountsEnabled) urls.push(tilePath("navaid-counts", tile));
       if (waypointsEnabled) urls.push(tilePath("waypoints", tile));
       return urls;
     });
-  }, [airspacesEnabled, enabled, navaidsEnabled, tiles, waypointsEnabled]);
+  }, [
+    airspacesEnabled,
+    enabled,
+    navaidCountsEnabled,
+    navaidsEnabled,
+    tiles,
+    waypointsEnabled,
+  ]);
 
   useEffect(() => {
     let cancelled = false;
     if (requestUrls.length === 0) {
       setAirspaces([]);
       setNavaids([]);
+      setNavaidCounts([]);
       setWaypoints([]);
       setLoading(false);
       setError(null);
@@ -140,6 +151,12 @@ export function useAviationContextTiles({
           (item) => item?.id || `${item?.ident}:${item?.lat}:${item?.lon}`,
         ),
       );
+      setNavaidCounts(
+        uniqueBy(
+          payloads.flatMap((payload) => payload.navaidCounts || []),
+          (item) => item?.key || `${item?.z}:${item?.x}:${item?.y}`,
+        ),
+      );
       setWaypoints(
         uniqueBy(
           payloads.flatMap((payload) => payload.waypoints || []),
@@ -159,6 +176,7 @@ export function useAviationContextTiles({
   return {
     airspaces,
     navaids,
+    navaidCounts,
     waypoints,
     loading,
     error,

--- a/src/style.css
+++ b/src/style.css
@@ -915,6 +915,73 @@ body {
     box-shadow: none;
 }
 
+.navaid-count-icon {
+    pointer-events: none;
+}
+
+.navaid-count-marker {
+    align-items: center;
+    background: color-mix(in oklab, var(--atc-card) 88%, transparent);
+    border: 1px solid color-mix(in oklab, var(--atc-accent) 42%, transparent);
+    border-radius: 999px;
+    box-shadow: 0 8px 22px rgb(0 0 0 / 0.18);
+    color: var(--atc-accent);
+    display: inline-flex;
+    font-family: var(--font-mono);
+    gap: 3px;
+    height: 24px;
+    justify-content: center;
+    min-width: 48px;
+    padding: 0 8px;
+    text-shadow: 0 1px 2px rgb(0 0 0 / 0.22);
+}
+
+.navaid-count-marker--enter {
+    animation: navaid-count-enter 340ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.navaid-count-marker strong {
+    font-size: 11px;
+    font-weight: 900;
+    letter-spacing: 0;
+    line-height: 1;
+}
+
+.navaid-count-marker span {
+    color: color-mix(in oklab, var(--atc-accent) 72%, var(--atc-muted));
+    font-size: 7px;
+    font-weight: 800;
+    letter-spacing: 0;
+    line-height: 1;
+}
+
+.navaid-count-icon--light .navaid-count-marker {
+    background: color-mix(in oklab, var(--atc-card) 94%, transparent);
+    box-shadow: 0 7px 18px rgb(15 23 42 / 0.14);
+    text-shadow: none;
+}
+
+@keyframes navaid-count-enter {
+    from {
+        opacity: 0;
+        transform: translateY(6px) scale(0.9);
+    }
+    70% {
+        opacity: 1;
+        transform: translateY(-1px) scale(1.02);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .navaid-count-marker--enter {
+        animation: none;
+    }
+}
+
 /* Transitions */
 
 /* Shared screen background — search + about. Plain canvas with a


### PR DESCRIPTION
## Summary
- Add cached `/api/navaid-counts/[z]/[x]/[y]` tiles that return one aggregate NAV marker per map tile instead of full navaid labels.
- Switch full-trace low-zoom navaid rendering to count badges while keeping the existing detail threshold at zoom 8.
- Add a small count badge entry animation with reduced-motion fallback.

## Test Plan
- [x] `/opt/homebrew/bin/pnpm test src/features/airport/context/aviationContextDisplayModel.test.ts src/features/airport/context/aviationContextTile.mechanism.test.ts src/app/api/dao/airportFacilities.dao.test.ts`
- [x] `/opt/homebrew/bin/pnpm lint`
- [x] `/opt/homebrew/bin/pnpm build`
- [x] `curl http://localhost:3000/api/navaid-counts/6/18/24`
