### PR TITLE
Fix grouped Asana UI polish issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import BrandingVideoBackground from "@/components/effects/BrandingVideoBackground";
 import PageNavigationDock from "@/components/navigation/PageNavigationDock";
 import SidebarBrandMark from "@/components/sidebar/SidebarBrandMark";
@@ -20,6 +21,42 @@ export default function DitherPageShell({
     typeof resolvedDescription === "string"
       ? resolvedDescription.trim().length > 0
       : Boolean(resolvedDescription);
+
+  useEffect(() => {
+    const media = window.matchMedia("(max-width: 720px)");
+    let restore: (() => void) | null = null;
+
+    const applyDocumentScrollLock = () => {
+      restore?.();
+      restore = null;
+      if (!media.matches) return;
+
+      const originalBodyOverflow = document.body.style.overflow;
+      const originalHtmlOverflow = document.documentElement.style.overflow;
+      const originalBodyOverscroll = document.body.style.overscrollBehavior;
+      const originalHtmlOverscroll =
+        document.documentElement.style.overscrollBehavior;
+
+      document.body.style.overflow = "hidden";
+      document.documentElement.style.overflow = "hidden";
+      document.body.style.overscrollBehavior = "none";
+      document.documentElement.style.overscrollBehavior = "none";
+
+      restore = () => {
+        document.body.style.overflow = originalBodyOverflow;
+        document.documentElement.style.overflow = originalHtmlOverflow;
+        document.body.style.overscrollBehavior = originalBodyOverscroll;
+        document.documentElement.style.overscrollBehavior = originalHtmlOverscroll;
+      };
+    };
+
+    applyDocumentScrollLock();
+    media.addEventListener("change", applyDocumentScrollLock);
+    return () => {
+      media.removeEventListener("change", applyDocumentScrollLock);
+      restore?.();
+    };
+  }, []);
 
   return (
     <div

--- a/src/components/changelog/ChangelogPanel.tsx
+++ b/src/components/changelog/ChangelogPanel.tsx
@@ -10,6 +10,18 @@ import { CHANGELOG } from "@/config/changelog";
 // optional current marker, summary, then short highlights.
 
 const CHINESE_RELEASE_COPY = {
+  "v1.11.1": {
+    title: "地图 UI 细节打磨",
+    summary:
+      "地图模式和侧栏 UI 细节现在优化了空域可读性、全航迹视野、移动端页面滚动和紧凑 metric card。",
+    highlights: [
+      "空域图层增加沿边缘向内的标记,同时保留现有 access 颜色语义",
+      "全航迹模式保留空域上下文,但隐藏容易拥挤的边界文字",
+      "全航迹适配会围绕推断的焦点飞机位置重新居中,地图移动更平滑",
+      "移动端 Home、About、Mechanism 页面只在面板内部滚动,不再触发整页双滚动条",
+      "桌面地图侧栏 metric card 对 Airborne / 空中等紧凑状态值不再裁切",
+    ],
+  },
   "v1.11.0": {
     title: "全航迹地图上下文计数",
     summary:

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -648,6 +648,12 @@ function FlightExplorerContent({ callsign }) {
             <FlightAwareRouteArc path={focalFlightAwareRoutePath} />
             <MapFitToTraceController
               routePath={focalFlightAwareRoutePath}
+              centerAnchor={{ lat: focalLat, lon: focalLon }}
+              centerAnchorFollowKey={
+                !mapFollowsAircraft && focalLat != null && focalLon != null
+                  ? `${focalLat}:${focalLon}`
+                  : ""
+              }
               autoFitKey={flightAwareAutoFitKey}
               fitOptions={flightDisplayContext.mapFitOptions}
               onAutoFit={

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -407,6 +407,7 @@ export default function AirportMap({
           <AirspaceLayer
             airspaces={renderedAirspaces}
             visible={showAirspaces}
+            showBoundaryLabels={!fullTraceContext}
             selectedAirspaceId={selectedAirspaceId}
             onSelectAirspace={onSelectAirspace}
           />

--- a/src/components/map/AirspaceLayer.tsx
+++ b/src/components/map/AirspaceLayer.tsx
@@ -31,17 +31,20 @@ let boundaryLabelSequence = 0;
 export default function AirspaceLayer({
   airspaces = [],
   visible = true,
+  showBoundaryLabels = true,
   selectedAirspaceId = "",
   onSelectAirspace = null,
 }: {
   airspaces?: Record<string, any>[];
   visible?: boolean;
+  showBoundaryLabels?: boolean;
   selectedAirspaceId?: string;
   onSelectAirspace?: ((airspaceId: string) => void) | null;
 }) {
   const map = useMapInstance();
   const layerRef = useRef<L.GeoJSON | null>(null);
   const boundaryLabelsRef = useRef<SVGTextElement[]>([]);
+  const boundaryEdgesRef = useRef<SVGElement[]>([]);
   const labelFrameRef = useRef(0);
   const animationFrameRef = useRef(0);
   const hasAnimatedInitialEnterRef = useRef(false);
@@ -64,8 +67,11 @@ export default function AirspaceLayer({
     window.cancelAnimationFrame(labelFrameRef.current);
     boundaryLabelsRef.current.forEach((label) => label.remove());
     boundaryLabelsRef.current = [];
+    boundaryEdgesRef.current.forEach((edge) => edge.remove());
+    boundaryEdgesRef.current = [];
     safeRemoveFromMap(layerRef.current, map);
     const boundaryLabels: SVGTextElement[] = [];
+    const boundaryEdges: SVGElement[] = [];
     const animateInitialEnter =
       visibleRef.current && !hasAnimatedInitialEnterRef.current;
     const initialOpacity = resolveAirspaceInitialOpacity({
@@ -104,15 +110,25 @@ export default function AirspaceLayer({
     applyAirspaceGroupOpacity(
       polygonLayer,
       boundaryLabels,
+      boundaryEdges,
       selectedAirspaceIdRef.current,
       initialOpacity,
     );
     labelFrameRef.current = window.requestAnimationFrame(() => {
+      boundaryEdges.push(
+        ...attachBoundaryEdges(
+          polygonLayer,
+          selectedAirspaceIdRef.current,
+          initialOpacity,
+        ),
+      );
+      boundaryEdgesRef.current = boundaryEdges;
       boundaryLabels.push(
         ...attachBoundaryLabels(
           polygonLayer,
           selectedAirspaceIdRef.current,
           initialOpacity,
+          showBoundaryLabels,
         ),
       );
       boundaryLabelsRef.current = boundaryLabels;
@@ -120,6 +136,7 @@ export default function AirspaceLayer({
         animateAirspaceGroupOpacity({
           layerGroup: polygonLayer,
           labels: boundaryLabels,
+          edges: boundaryEdges,
           selectedAirspaceId: selectedAirspaceIdRef.current,
           visible: true,
           animationFrameRef,
@@ -132,10 +149,12 @@ export default function AirspaceLayer({
       window.cancelAnimationFrame(labelFrameRef.current);
       boundaryLabels.forEach((label) => label.remove());
       boundaryLabelsRef.current = [];
+      boundaryEdges.forEach((edge) => edge.remove());
+      boundaryEdgesRef.current = [];
       safeRemoveFromMap(polygonLayer, map);
       layerRef.current = null;
     };
-  }, [map, features]);
+  }, [map, features, showBoundaryLabels]);
 
   useEffect(() => {
     const polygonLayer = layerRef.current;
@@ -153,6 +172,7 @@ export default function AirspaceLayer({
     animateAirspaceGroupOpacity({
       layerGroup: polygonLayer,
       labels: boundaryLabelsRef.current,
+      edges: boundaryEdgesRef.current,
       selectedAirspaceId,
       visible,
       animationFrameRef,
@@ -181,12 +201,14 @@ function resolveVisibleAirspaceStyle(
 function animateAirspaceGroupOpacity({
   layerGroup,
   labels,
+  edges,
   selectedAirspaceId,
   visible,
   animationFrameRef,
 }: {
   layerGroup: L.GeoJSON;
   labels: SVGTextElement[];
+  edges: SVGElement[];
   selectedAirspaceId: string;
   visible: boolean;
   animationFrameRef: MutableRefObject<number>;
@@ -202,11 +224,18 @@ function animateAirspaceGroupOpacity({
   );
 
   if (reducedMotion || plan.itemDurationMs === 0) {
-    applyAirspaceGroupOpacity(layerGroup, labels, selectedAirspaceId, visible ? 1 : 0);
+    applyAirspaceGroupOpacity(
+      layerGroup,
+      labels,
+      edges,
+      selectedAirspaceId,
+      visible ? 1 : 0,
+    );
     return;
   }
 
   const labelGroups = groupLabelsByLayerIndex(labels);
+  const edgeGroups = groupLabelsByLayerIndex(edges);
   const startedAt = window.performance.now();
   const targetOpacity = visible ? 1 : 0;
   const animations = plan.steps.map((step) => {
@@ -214,6 +243,7 @@ function animateAirspaceGroupOpacity({
     return {
       layer,
       labels: labelGroups.get(step.index) || [],
+      edges: edgeGroups.get(step.index) || [],
       delayMs: step.delayMs,
       fromOpacity: readAirspaceLayerOpacityScale(layer, visible ? 0 : 1),
     };
@@ -235,6 +265,7 @@ function animateAirspaceGroupOpacity({
       applyAirspaceFeatureOpacity(
         animation.layer,
         animation.labels,
+        animation.edges,
         selectedAirspaceId,
         opacityScale,
       );
@@ -242,7 +273,13 @@ function animateAirspaceGroupOpacity({
     }
 
     if (complete) {
-      applyAirspaceGroupOpacity(layerGroup, labels, selectedAirspaceId, targetOpacity);
+      applyAirspaceGroupOpacity(
+        layerGroup,
+        labels,
+        edges,
+        selectedAirspaceId,
+        targetOpacity,
+      );
       animationFrameRef.current = 0;
       return;
     }
@@ -256,14 +293,17 @@ function animateAirspaceGroupOpacity({
 function applyAirspaceGroupOpacity(
   layerGroup: L.GeoJSON,
   labels: SVGTextElement[],
+  edges: SVGElement[],
   selectedAirspaceId: string,
   opacityScale: number,
 ) {
   const labelGroups = groupLabelsByLayerIndex(labels);
+  const edgeGroups = groupLabelsByLayerIndex(edges);
   getAirspaceFeatureLayers(layerGroup).forEach((layer, index) => {
     applyAirspaceFeatureOpacity(
       layer,
       labelGroups.get(index) || [],
+      edgeGroups.get(index) || [],
       selectedAirspaceId,
       opacityScale,
     );
@@ -273,6 +313,7 @@ function applyAirspaceGroupOpacity(
 function applyAirspaceFeatureOpacity(
   layer: any,
   labels: SVGTextElement[],
+  edges: SVGElement[],
   selectedAirspaceId: string,
   opacityScale: number,
 ) {
@@ -281,6 +322,7 @@ function applyAirspaceFeatureOpacity(
   }
   layer.__airspaceOpacityScale = opacityScale;
   labels.forEach((label) => setBoundaryLabelState(label, selectedAirspaceId, opacityScale));
+  edges.forEach((edge) => setBoundaryEdgeState(edge, selectedAirspaceId, opacityScale));
 }
 
 function getAirspaceFeatureLayers(layerGroup: L.GeoJSON) {
@@ -289,13 +331,13 @@ function getAirspaceFeatureLayers(layerGroup: L.GeoJSON) {
   return layers;
 }
 
-function groupLabelsByLayerIndex(labels: SVGTextElement[]) {
-  const groups = new Map<number, SVGTextElement[]>();
-  labels.forEach((label) => {
-    const index = Number(label.dataset.airspaceLayerIndex);
+function groupLabelsByLayerIndex<T extends SVGElement>(elements: T[]) {
+  const groups = new Map<number, T[]>();
+  elements.forEach((element) => {
+    const index = Number(element.dataset.airspaceLayerIndex);
     if (!Number.isInteger(index)) return;
     const group = groups.get(index) || [];
-    group.push(label);
+    group.push(element);
     groups.set(index, group);
   });
   return groups;
@@ -320,12 +362,23 @@ function prefersReducedMotion() {
   return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
 }
 
+function ensureSvgDefs(svg: SVGSVGElement) {
+  let defs = svg.querySelector("defs");
+  if (!defs) {
+    defs = document.createElementNS(SVG_NS, "defs");
+    svg.prepend(defs);
+  }
+  return defs;
+}
+
 function attachBoundaryLabels(
   layerGroup: L.GeoJSON,
   selectedAirspaceId = "",
   opacityScale = 1,
+  showBoundaryLabels = true,
 ): SVGTextElement[] {
   const labels: SVGTextElement[] = [];
+  if (!showBoundaryLabels) return labels;
 
   let layerIndex = 0;
   layerGroup.eachLayer((layer: any) => {
@@ -372,6 +425,57 @@ function attachBoundaryLabels(
   return labels;
 }
 
+function attachBoundaryEdges(
+  layerGroup: L.GeoJSON,
+  selectedAirspaceId = "",
+  opacityScale = 1,
+): SVGElement[] {
+  const edges: SVGElement[] = [];
+
+  let layerIndex = 0;
+  layerGroup.eachLayer((layer: any) => {
+    const currentLayerIndex = layerIndex;
+    layerIndex += 1;
+    const path = typeof layer.getElement === "function"
+      ? layer.getElement()
+      : null;
+    const svg = path?.ownerSVGElement;
+    if (!path || !svg) return;
+
+    const pathId = path.id || `airspace-boundary-${boundaryLabelSequence += 1}`;
+    path.id = pathId;
+    const clipId = `airspace-boundary-clip-${boundaryLabelSequence += 1}`;
+    const defs = ensureSvgDefs(svg);
+    const clipPath = document.createElementNS(SVG_NS, "clipPath");
+    clipPath.id = clipId;
+    const clipUse = document.createElementNS(SVG_NS, "use");
+    clipUse.setAttribute("href", `#${pathId}`);
+    clipUse.setAttributeNS(XLINK_NS, "xlink:href", `#${pathId}`);
+    clipPath.appendChild(clipUse);
+    defs.appendChild(clipPath);
+
+    const edge = document.createElementNS(SVG_NS, "use");
+    edge.dataset.airspaceLayerIndex = String(currentLayerIndex);
+    edge.dataset.airspaceFeatureId = String(layer.feature?.properties?.id || "");
+    edge.classList.add("airspace-boundary-edge");
+    edge.setAttribute("href", `#${pathId}`);
+    edge.setAttributeNS(XLINK_NS, "xlink:href", `#${pathId}`);
+    edge.setAttribute("clip-path", `url(#${clipId})`);
+    edge.setAttribute("fill", "none");
+    edge.setAttribute("stroke", "var(--airspace-boundary-label)");
+    edge.setAttribute("stroke-dasharray", "0.5 9");
+    edge.setAttribute("stroke-linecap", "round");
+    edge.setAttribute("stroke-linejoin", "round");
+    edge.setAttribute("stroke-width", "8");
+    edge.setAttribute("pointer-events", "none");
+    setBoundaryEdgeState(edge, selectedAirspaceId, opacityScale);
+    svg.appendChild(edge);
+    edges.push(edge, clipPath);
+  });
+
+  return edges;
+}
+
 function setBoundaryLabelState(
   label: SVGTextElement,
   selectedAirspaceId: string,
@@ -382,6 +486,18 @@ function setBoundaryLabelState(
     label.dataset.airspaceFeatureId === selectedAirspaceId;
   label.classList.toggle("airspace-boundary-label--focused", isFocused);
   label.style.opacity = String((isFocused ? 1 : 0.5) * opacityScale);
+}
+
+function setBoundaryEdgeState(
+  edge: SVGElement,
+  selectedAirspaceId: string,
+  opacityScale: number,
+) {
+  const isFocused =
+    Boolean(selectedAirspaceId) &&
+    edge.dataset.airspaceFeatureId === selectedAirspaceId;
+  edge.classList.toggle("airspace-boundary-edge--focused", isFocused);
+  edge.style.opacity = String((isFocused ? 0.78 : 0.46) * opacityScale);
 }
 
 function boundaryLabelLines(

--- a/src/components/map/MapFitToTraceController.tsx
+++ b/src/components/map/MapFitToTraceController.tsx
@@ -5,8 +5,14 @@ import L from "leaflet";
 import { useMapInstance } from "./MapContext";
 import { useExplorerUi } from "@/components/explorer/ExplorerUiContext";
 import { useSelectedAircraftTrace } from "@/components/aircraft/trace/SelectedAircraftTraceContext";
-import { buildTraceFitPoints } from "@/features/airport/map/mapFitTraceModel";
-import { withFloatingSidebarFitPadding } from "./mapViewportOffset";
+import {
+  buildTraceFitPoints,
+  resolveTraceFitCenterAnchor,
+} from "@/features/airport/map/mapFitTraceModel";
+import {
+  getOffsetMapCenter,
+  withFloatingSidebarFitPadding,
+} from "./mapViewportOffset";
 
 const DEFAULT_FIT_OPTIONS = Object.freeze({
   padding: Object.freeze([60, 60]),
@@ -29,6 +35,8 @@ const DEFAULT_FIT_OPTIONS = Object.freeze({
 // map stays anchored on the bounds we just computed.
 export default function MapFitToTraceController({
   routePath = [],
+  centerAnchor = null,
+  centerAnchorFollowKey = "",
   autoFitKey = "",
   fitOptions = DEFAULT_FIT_OPTIONS,
   onAutoFit,
@@ -42,6 +50,27 @@ export default function MapFitToTraceController({
     () => buildTraceFitPoints({ traces, routePath }),
     [traces, routePath],
   );
+  const fitCenterAnchor = useMemo(
+    () => resolveTraceFitCenterAnchor(centerAnchor),
+    [centerAnchor],
+  );
+  const panMapToAnchor = useCallback(
+    (anchor, { animate = true } = {}) => {
+      if (!map || !anchor) return;
+      const zoom = map.getZoom?.();
+      const targetCenter = getOffsetMapCenter(
+        map,
+        { lat: anchor[0], lon: anchor[1] },
+        zoom,
+      );
+      map.panTo(targetCenter, {
+        animate,
+        duration: animate ? 0.35 : 0,
+        easeLinearity: 0.22,
+      });
+    },
+    [map],
+  );
   const fitMapToPoints = useCallback(
     (points) => {
       if (!map || points.length === 0) return;
@@ -50,8 +79,11 @@ export default function MapFitToTraceController({
         bounds,
         withFloatingSidebarFitPadding(map, fitOptions || DEFAULT_FIT_OPTIONS),
       );
+      if (fitCenterAnchor) {
+        window.requestAnimationFrame(() => panMapToAnchor(fitCenterAnchor));
+      }
     },
-    [fitOptions, map],
+    [fitCenterAnchor, fitOptions, map, panMapToAnchor],
   );
 
   useEffect(() => {
@@ -75,6 +107,12 @@ export default function MapFitToTraceController({
     fitMapToPoints(fitPoints);
     onAutoFit?.();
   }, [autoFitKey, fitMapToPoints, fitPoints, map, onAutoFit]);
+
+  useEffect(() => {
+    const key = String(centerAnchorFollowKey || "").trim();
+    if (!key || !map || !fitCenterAnchor) return;
+    panMapToAnchor(fitCenterAnchor);
+  }, [centerAnchorFollowKey, fitCenterAnchor, map, panMapToAnchor]);
 
   return null;
 }

--- a/src/components/ui/MetricCard.tsx
+++ b/src/components/ui/MetricCard.tsx
@@ -102,7 +102,7 @@ const cardVariants = cva(
 
 const valueClass = cn(
   "flex items-center justify-center",
-  "max-w-full min-w-0 h-8.5 overflow-hidden",
+  "w-full max-w-full min-w-0 h-8.5 overflow-hidden whitespace-nowrap text-center",
   "font-[var(--font-display)] not-italic font-black text-atc-text",
   "text-3xl leading-none tracking-normal",
   // Active card — flip to the click foreground so the value reads
@@ -110,7 +110,7 @@ const valueClass = cn(
   // color, but text-atc-text on <strong> shadows it.
   "group-data-[active=true]:text-[var(--atc-click-fg)]",
   // Compact in desktop map kit context.
-  "[.airport-map-kit_&]:text-2xl [.airport-map-kit_&]:h-7",
+  "[.airport-map-kit_&]:text-[22px] [.airport-map-kit_&]:h-7",
 );
 
 const labelClass = cn(
@@ -147,7 +147,7 @@ export function MetricCard({
         translate={valueTranslate ? undefined : "no"}
         className={cn(
           valueClass,
-          valueSize === "compact" && "text-2xl",
+          valueSize === "compact" && "text-[22px] [.airport-map-kit_&]:text-[18px]",
           !valueTranslate && "notranslate",
         )}
       >

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -6,6 +6,20 @@
 
 export const CHANGELOG = [
   {
+    version: "v1.11.1",
+    kind: "patch",
+    title: "Map UI polish pass",
+    summary:
+      "Map mode and sidebar UI polish tightens airspace readability, full-trace framing, mobile page scrolling, and compact metric cards.",
+    highlights: [
+      "Airspace overlays add inward edge markings while preserving the existing access color language",
+      "Full-trace mode keeps airspace context visible but hides boundary labels that crowd long routes",
+      "Full-trace fitting recenters around the inferred focal aircraft position for smoother map movement",
+      "Mobile Home, About, and Mechanism pages keep scrolling inside the panel instead of the whole document",
+      "Desktop map-kit metric cards keep compact status values such as Airborne from clipping",
+    ],
+  },
+  {
     version: "v1.11.0",
     kind: "feat",
     title: "Full-trace map context counts",

--- a/src/config/siteMeta.test.ts
+++ b/src/config/siteMeta.test.ts
@@ -7,14 +7,14 @@ import {
 } from "./siteMeta";
 
 assert.equal(ADSBAO_PRODUCT_NAME, "ADSBao");
-assert.equal(ADSBAO_SITE_VERSION, "1.11.0");
+assert.equal(ADSBAO_SITE_VERSION, "1.11.1");
 assert.equal(
   buildAdsbaoUserAgent("adsbdb/v0"),
-  "ADSBao/1.11.0 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+  "ADSBao/1.11.1 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
 );
 assert.equal(
   buildAdsbaoUserAgent(),
-  "ADSBao/1.11.0 (+https://github.com/orriduck/ADSBao)",
+  "ADSBao/1.11.1 (+https://github.com/orriduck/ADSBao)",
 );
 
 console.log("siteMeta.test.ts ok");

--- a/src/config/siteMeta.ts
+++ b/src/config/siteMeta.ts
@@ -1,5 +1,5 @@
 export const ADSBAO_PRODUCT_NAME = "ADSBao";
-export const ADSBAO_SITE_VERSION = "1.11.0";
+export const ADSBAO_SITE_VERSION = "1.11.1";
 export const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
 
 export function buildAdsbaoUserAgent(suffix = "") {

--- a/src/features/airport/map/mapFitTraceModel.test.ts
+++ b/src/features/airport/map/mapFitTraceModel.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
-import { buildTraceFitPoints } from "./mapFitTraceModel";
+import {
+  buildTraceFitPoints,
+  resolveTraceFitCenterAnchor,
+} from "./mapFitTraceModel";
 
 {
   const points = buildTraceFitPoints({
@@ -67,6 +70,19 @@ import { buildTraceFitPoints } from "./mapFitTraceModel";
     points,
     [],
     "route-only geometry should not trigger flight-page trace fitting",
+  );
+}
+
+{
+  assert.deepEqual(
+    resolveTraceFitCenterAnchor({ lat: "42.36", lon: "-71.01" }),
+    [42.36, -71.01],
+    "finite inferred aircraft positions can anchor trace fitting",
+  );
+  assert.equal(
+    resolveTraceFitCenterAnchor({ lat: "bad", lon: "-71.01" }),
+    null,
+    "invalid inferred positions should not recenter the map",
   );
 }
 

--- a/src/features/airport/map/mapFitTraceModel.ts
+++ b/src/features/airport/map/mapFitTraceModel.ts
@@ -15,12 +15,16 @@ type TraceFitOptions = {
   routeEndpoints?: unknown;
 };
 
-function pushFiniteLatLon(points: LatLonTuple[], lat: unknown, lon: unknown) {
+function finiteLatLon(lat: unknown, lon: unknown): LatLonTuple | null {
   const latNum = Number(lat);
   const lonNum = Number(lon);
-  if (Number.isFinite(latNum) && Number.isFinite(lonNum)) {
-    points.push([latNum, lonNum]);
-  }
+  if (!Number.isFinite(latNum) || !Number.isFinite(lonNum)) return null;
+  return [latNum, lonNum];
+}
+
+function pushFiniteLatLon(points: LatLonTuple[], lat: unknown, lon: unknown) {
+  const point = finiteLatLon(lat, lon);
+  if (point) points.push(point);
 }
 
 export function buildTraceFitPoints({
@@ -48,4 +52,8 @@ export function buildTraceFitPoints({
   }
 
   return points;
+}
+
+export function resolveTraceFitCenterAnchor(anchor: TraceFitPoint | null | undefined) {
+  return finiteLatLon(anchor?.lat, anchor?.lon);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -809,6 +809,23 @@ body {
     text-transform: uppercase;
 }
 
+.airspace-boundary-edge {
+    fill: none;
+    opacity: 0.46;
+    pointer-events: none;
+    stroke: var(--airspace-boundary-label);
+    stroke-dasharray: 0.5 9;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 8px;
+}
+
+.airspace-boundary-edge--focused {
+    opacity: 0.78;
+    stroke-dasharray: 0.5 7;
+    stroke-width: 10px;
+}
+
 .airspace-boundary-label--focused {
     opacity: 1;
 }


### PR DESCRIPTION
## Summary
- add clipped inward airspace boundary edge markings while keeping existing airspace colors
- hide airspace boundary labels in full trace mode while preserving airspace fills and edge markings
- keep full-trace map centering anchored to the inferred focal aircraft position
- prevent mobile Dither pages from creating a second document scrollbar
- tighten desktop map-kit metric value sizing so Airborne/status cards do not clip

Asana tickets covered:
- 1215331699954020: UI - 限制空域除了颜色外还要沿边缘划向内的折线
- 1215331699954018: UI - 移动端首页/关于/机制在允许滑动的列表之外会触发整页的滑动条（双重滑动条）
- 1215331699954017: UI - 桌面端的Airborne因为metric card宽度显示不全
- 1215368171314701: UI - Full trace 状态下的空域显示，不显示字
- 1215368171314703: UI - 地图中心点可以依据推断位置为中心，使得地图变化更为平滑

## Validation
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm lint (0 errors; existing TanStack Virtual React Compiler warning)
- /opt/homebrew/bin/pnpm build
- local browser: /airport/KBOS had airspace edge overlays and no metric clipping
- local browser: /aircraft/UAL109 had no clipped metric cards; after Fit Trace, airspace labels = 0 and edge overlays remained

Note: in-app browser screenshot capture timed out on the Leaflet map, so validation used DOM metrics plus visual page inspection through the browser session.