### PR TITLE
Polish app transition motion

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -156,7 +156,7 @@ export default function AircraftPreviewCard({
       {entity && !isMobile && (
         <aside
           key={identityKey}
-          className={`aircraft-preview-card aircraft-preview-card--desktop-reveal ${
+          className={`aircraft-preview-card app-preview-transition aircraft-preview-card--desktop-reveal ${
             !isAirport && !isNavaid && hasPhoto ? "aircraft-preview-card--has-photo" : ""
           } ${isAirport ? "aircraft-preview-card--airport" : ""} aircraft-preview-card--photo-${photoTone}`}
           aria-label={previewAriaLabel}

--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -34,7 +34,7 @@ export default function MobilePreviewCard({
         "bottom-[calc(64px+env(safe-area-inset-bottom))]",
         "w-[min(342px,calc(100vw-24px))] max-w-[calc(100vw-24px)]",
         "isolate overflow-hidden select-none pointer-events-none",
-        "mobile-preview-card-enter",
+        "app-preview-transition mobile-preview-card-enter",
         "rounded-[var(--atc-radius-card)] border border-atc-line-strong/85 text-atc-text",
         // Solid card under a warm top-left gradient layer (same 135deg
         // language as the sidebar identity surface). Use background +
@@ -66,7 +66,7 @@ export function MobilePreviewTraceStatus({ active, children }: Record<string, an
         "self-stretch mx-[14px] text-center text-atc-dim",
         "font-[var(--font-mono)] text-[10px] font-semibold tracking-[0.08em] leading-[1.15] uppercase",
         "pointer-events-none whitespace-normal overflow-hidden",
-        "transition-[max-height,margin-top,opacity,transform] duration-[280ms] ease",
+        "transition-[max-height,margin-top,opacity,transform] duration-[var(--motion-ui-slow)] ease-[var(--motion-ease-out)]",
         active
           ? "max-h-[44px] mt-1 opacity-100 translate-y-0"
           : "max-h-0 mt-0 opacity-0 -translate-y-1",
@@ -226,7 +226,7 @@ export const MobilePreviewTrackButton = React.forwardRef(
           "shadow-[0_8px_16px_color-mix(in_oklab,var(--primary-bright)_16%,transparent),inset_0_-2px_0_color-mix(in_oklab,var(--primary-ink)_28%,transparent)]",
           "font-[var(--font-display)] text-[11px] font-extrabold not-italic tracking-normal leading-[1.15] text-center",
           "[-webkit-tap-highlight-color:transparent]",
-          "transition-[box-shadow,filter,transform] duration-150 ease-out",
+          "transition-[box-shadow,filter,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
           "hover:brightness-[1.04] active:scale-[0.97] active:brightness-[0.96]",
           "focus-visible:outline-2 focus-visible:outline-[color-mix(in_oklab,var(--primary-bright)_72%,white)] focus-visible:outline-offset-[3px]",
           "disabled:cursor-not-allowed disabled:opacity-45",
@@ -254,7 +254,7 @@ export const MobilePreviewFeedbackLink = React.forwardRef(
           "border-0 bg-transparent text-atc-dim cursor-pointer",
           "font-sans text-[10px] font-bold tracking-normal leading-[1.15] text-center",
           "[-webkit-tap-highlight-color:transparent]",
-          "transition-[color,opacity,transform] duration-150 ease-out",
+          "transition-[color,opacity,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
           "hover:text-atc-text hover:opacity-90 active:text-atc-text active:scale-[0.97]",
           "focus-visible:outline-2 focus-visible:outline-[color-mix(in_oklab,var(--primary-bright)_72%,white)] focus-visible:outline-offset-[3px]",
           className,

--- a/src/components/airport/explorer/AirportExplorerDesktopSidebar.tsx
+++ b/src/components/airport/explorer/AirportExplorerDesktopSidebar.tsx
@@ -10,9 +10,10 @@ export default function AirportExplorerDesktopSidebar({
   return (
     <div
       className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+      data-open={open ? "true" : "false"}
       style={{ width: open ? width : "0" }}
     >
-      <div className="h-full" style={{ width }}>
+      <div className="app-panel-transition h-full" style={{ width }}>
         <AirportSidebar {...sidebarProps} />
       </div>
     </div>

--- a/src/components/airport/search/AirportRow.tsx
+++ b/src/components/airport/search/AirportRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { airportDisplayName, airportSubtitle } from "@/utils/airport";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 
@@ -7,11 +8,13 @@ export default function AirportRow({
   airport,
   onOpen,
   featured = false,
+  motionOrder = 0,
 }) {
   const { locale } = useI18n();
+  const motionStyle = { "--motion-order": motionOrder } as CSSProperties;
 
   return (
-    <li>
+    <li style={motionStyle}>
       <button
         type="button"
         className={`search-airport-row group endf-underline -mx-6 grid w-[calc(100%+3rem)] grid-cols-[72px_minmax(0,1fr)] items-center gap-3 px-6 py-3 text-left transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] ${

--- a/src/components/airport/search/AirportSearchResults.tsx
+++ b/src/components/airport/search/AirportSearchResults.tsx
@@ -35,11 +35,12 @@ export function AirportSearchResults({
           {t("search.noAirportMatched", { query: query.trim() })}
         </div>
       ) : (
-        <ul className="dither-list px-6 divide-y divide-[var(--atc-line)]">
-          {rows.map((airport) => (
+        <ul className="app-list-motion dither-list px-6 divide-y divide-[var(--atc-line)]">
+          {rows.map((airport, index) => (
             <AirportRow
               key={airport.icao || airport.code || airport.name}
               airport={airport}
+              motionOrder={Math.min(index, 5)}
               onOpen={onOpen}
             />
           ))}

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -585,9 +585,10 @@ function FlightExplorerContent({ callsign }) {
         {!isMobile && (
           <div
             className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+            data-open={sidebarOpen ? "true" : "false"}
             style={{ width: sidebarOpen ? desktopSidebarWidth : "0" }}
           >
-            <div className="h-full" style={{ width: desktopSidebarWidth }}>
+            <div className="app-panel-transition h-full" style={{ width: desktopSidebarWidth }}>
               <FlightSidebar {...sidebarProps} />
             </div>
           </div>

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -18,6 +18,7 @@ export default function HomeScreen() {
   const pathname = usePathname();
   const { locale } = useI18n();
   const currentIcao = normalizePathIcao(pathname);
+  const screenTransitionKey = currentIcao ? `airport:${currentIcao}` : "search";
   const [airport, setAirport] = useState(null);
 
   useEffect(() => {
@@ -63,15 +64,21 @@ export default function HomeScreen() {
   };
 
   if (!currentIcao) {
-    return <SearchScreen onOpenAirport={handleOpenAirport} />;
+    return (
+      <div key={screenTransitionKey} className="app-route-transition min-h-dvh">
+        <SearchScreen onOpenAirport={handleOpenAirport} />
+      </div>
+    );
   }
 
   return (
-    <AirportCaptionScreen
-      icao={currentIcao}
-      airport={airport}
-      onBack={handleBack}
-    />
+    <div key={screenTransitionKey} className="app-route-transition min-h-dvh">
+      <AirportCaptionScreen
+        icao={currentIcao}
+        airport={airport}
+        onBack={handleBack}
+      />
+    </div>
   );
 }
 

--- a/src/components/sidebar/AircraftList.tsx
+++ b/src/components/sidebar/AircraftList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { getAircraftIdentity } from "../../features/airport/context/airportContextUiModel";
 import AircraftRow from "./AircraftRow";
 
@@ -10,13 +11,17 @@ export default function AircraftList({
   onSelectAircraft,
 }) {
   return (
-    <ul className="divide-y divide-atc-line">
+    <ul key={resetKey} className="app-list-motion divide-y divide-atc-line">
       {aircraft.map((item, index) => {
         const aircraftId = getAircraftIdentity(item);
+        const motionStyle = {
+          "--motion-order": Math.min(index, 5),
+        } as CSSProperties;
         return (
           <li
             key={aircraftId || index}
             className="relative list-none [perspective:800px]"
+            style={motionStyle}
           >
             <AircraftRow
               aircraft={item}

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import NumberFlow from "@number-flow/react";
@@ -315,7 +316,7 @@ export default function AircraftTable({
         {listRows.length === 0 &&
         filteredAirports.length === 0 &&
         !pinnedAircraft ? (
-          <div className="px-[var(--airport-sidebar-inset)] py-8 text-center text-[11px] font-semibold uppercase tracking-normal text-atc-faint">
+          <div className="app-panel-transition px-[var(--airport-sidebar-inset)] py-8 text-center text-[11px] font-semibold uppercase tracking-normal text-atc-faint">
             {aircraft.length + airports.length
               ? t("sidebar.noMatches")
               : t("sidebar.nothingInRange")}
@@ -340,21 +341,27 @@ export default function AircraftTable({
               />
             )}
             {filteredAirports.length > 0 && (
-              <ul className="divide-y divide-atc-line">
-                {filteredAirports.map((airport) => (
-                  <li
-                    key={`airport:${airport.icao}`}
-                    className="relative list-none [perspective:800px]"
-                  >
-                    <AirportSlot
-                      airport={airport}
-                      cascadeOrder={-1}
-                      airportId={airport.icao}
-                      selected={airport.icao === selectedAirportIcao}
-                      onSelectAirport={onSelectAirport}
-                    />
-                  </li>
-                ))}
+              <ul className="app-list-motion divide-y divide-atc-line">
+                {filteredAirports.map((airport, index) => {
+                  const motionStyle = {
+                    "--motion-order": Math.min(index, 5),
+                  } as CSSProperties;
+                  return (
+                    <li
+                      key={`airport:${airport.icao}`}
+                      className="relative list-none [perspective:800px]"
+                      style={motionStyle}
+                    >
+                      <AirportSlot
+                        airport={airport}
+                        cascadeOrder={-1}
+                        airportId={airport.icao}
+                        selected={airport.icao === selectedAirportIcao}
+                        onSelectAirport={onSelectAirport}
+                      />
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </>

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -92,6 +92,44 @@ export default function AirportSidebar({
       />
     </>
   );
+  const activeViewContent =
+    activeView === "briefing" ? (
+      <WeatherBriefingStack
+        icao={icao}
+        iata={iata}
+        name={name}
+        city={city}
+        country={country}
+        metar={metar}
+        metarRaw={metarRaw}
+        metarLoading={metarLoading}
+        metarError={metarError}
+        airportCode={iata || icao}
+        airportLat={lat}
+        airportLon={lon}
+      />
+    ) : activeView === "atc" ? (
+      <AtcFrequencyPanel icao={icao} frequencies={atcFrequencies} />
+    ) : activeView === "spotting" ? (
+      <SpottingPanel
+        spots={spottingSpots}
+        selectedSpotId={selectedCandidateWatchingSpotId}
+        onSelectSpot={onSelectCandidateWatchingSpot}
+      />
+    ) : (
+      <AircraftTable
+        aircraft={aircraft}
+        airports={airports}
+        focusLat={focusLat}
+        focusLon={focusLon}
+        selectedAircraftId={selectedAircraftId}
+        selectedAirportIcao={selectedAirportIcao}
+        movementFilter={movementFilter}
+        onSelectAircraft={onSelectAircraft}
+        onSelectAirport={onSelectAirport}
+        fill={!isMobileOverlay}
+      />
+    );
 
   return (
     <SidebarShell
@@ -105,43 +143,16 @@ export default function AirportSidebar({
       onClose={onClose}
       header={header}
     >
-      {activeView === "briefing" ? (
-        <WeatherBriefingStack
-          icao={icao}
-          iata={iata}
-          name={name}
-          city={city}
-          country={country}
-          metar={metar}
-          metarRaw={metarRaw}
-          metarLoading={metarLoading}
-          metarError={metarError}
-          airportCode={iata || icao}
-          airportLat={lat}
-          airportLon={lon}
-        />
-      ) : activeView === "atc" ? (
-        <AtcFrequencyPanel icao={icao} frequencies={atcFrequencies} />
-      ) : activeView === "spotting" ? (
-        <SpottingPanel
-          spots={spottingSpots}
-          selectedSpotId={selectedCandidateWatchingSpotId}
-          onSelectSpot={onSelectCandidateWatchingSpot}
-        />
-      ) : (
-        <AircraftTable
-          aircraft={aircraft}
-          airports={airports}
-          focusLat={focusLat}
-          focusLon={focusLon}
-          selectedAircraftId={selectedAircraftId}
-          selectedAirportIcao={selectedAirportIcao}
-          movementFilter={movementFilter}
-          onSelectAircraft={onSelectAircraft}
-          onSelectAirport={onSelectAirport}
-          fill={!isMobileOverlay}
-        />
-      )}
+      <div
+        key={`${activeView}:${movementFilter}`}
+        className={
+          isMobileOverlay
+            ? "app-panel-transition"
+            : "app-panel-transition flex h-full min-h-0 flex-col"
+        }
+      >
+        {activeViewContent}
+      </div>
     </SidebarShell>
   );
 }
@@ -173,7 +184,7 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
           <ExternalLink aria-hidden="true" className="size-3.5" strokeWidth={2.3} />
         </a>
       ) : null}
-      <div className="grid gap-3">
+      <div className="app-list-motion grid gap-3">
         {frequencies.map((frequency) => (
           <TextPillListItem
             key={`${frequency.type}-${frequency.frequencyMHz}-${frequency.source}`}
@@ -217,7 +228,7 @@ function SpottingPanel({
           {spots.length} spots
         </span>
       </div>
-      <div className="grid gap-2">
+      <div className="app-list-motion grid gap-2">
         {spots.map((spot) => {
           const active = Boolean(selectedSpotId && selectedSpotId === spot.id);
           return (

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -13,7 +13,7 @@ import AirportRow from "./AirportRow";
 // scrollbar reasonable before measurement settles.
 const ROW_HEIGHT_ESTIMATE_PX = 56;
 const OVERSCAN_ROWS = 6;
-const ENTER_ANIMATION_MS = 260;
+const ENTER_ANIMATION_MS = 300;
 
 // Windowed render for the nearby list. Both aircraft and airport rows live in
 // a single scroll container so the virtualizer can manage them as one stream.
@@ -72,7 +72,7 @@ export default function VirtualNearbyList({
   const totalSize = virtualizer.getTotalSize();
 
   return (
-    <div ref={parentRef} className="h-full overflow-y-auto">
+    <div ref={parentRef} className="app-virtual-list-motion h-full overflow-y-auto">
       <div
         style={{ height: `${totalSize}px`, position: "relative", width: "100%" }}
       >

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -146,7 +146,8 @@ const toolbarButtonVariants = cva(
     "size-[var(--atc-toolbar-cell-size)] text-xs",
     "overflow-hidden rounded-full",
     "font-[var(--font-nav)] font-semibold leading-none",
-    "transition-[background,color,box-shadow] duration-150",
+    "toolbar-interactive-feedback transition-[background,color,box-shadow,transform] duration-150",
+    "hover:-translate-y-px active:translate-y-0 motion-reduce:transform-none",
     "outline-none focus-visible:ring-2 focus-visible:ring-atc-accent/60",
     "disabled:cursor-not-allowed disabled:opacity-50",
     // svg child sizing — Lucide ships 24px by default; clamp to 15px

--- a/src/style.css
+++ b/src/style.css
@@ -86,6 +86,14 @@
     --z-index-toast: 700;
 }
 
+:root {
+    --motion-ui-fast: 200ms;
+    --motion-ui-med: 240ms;
+    --motion-ui-slow: 300ms;
+    --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+    --motion-ease-snap: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 @keyframes nearby-row-enter {
     from {
         opacity: 0;
@@ -98,7 +106,105 @@
 }
 
 .nearby-row-enter {
-    animation: nearby-row-enter 240ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
+    animation: nearby-row-enter var(--motion-ui-med) var(--motion-ease-out) both;
+}
+
+@keyframes app-route-enter {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes app-panel-enter {
+    from {
+        opacity: 0;
+        transform: translateX(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes app-row-enter {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.app-route-transition {
+    animation: app-route-enter var(--motion-ui-slow) var(--motion-ease-snap) both;
+    will-change: opacity, transform;
+}
+
+.app-panel-transition {
+    animation: app-panel-enter var(--motion-ui-med) var(--motion-ease-out) both;
+    will-change: opacity, transform;
+}
+
+.airport-desktop-sidebar .app-panel-transition {
+    transition:
+        opacity var(--motion-ui-med) var(--motion-ease-out),
+        transform var(--motion-ui-med) var(--motion-ease-out);
+}
+
+.airport-desktop-sidebar[data-open="false"] .app-panel-transition {
+    opacity: 0;
+    transform: translateX(-8px);
+}
+
+.app-list-motion > * {
+    animation: app-row-enter var(--motion-ui-med) var(--motion-ease-out) both;
+}
+
+.app-list-motion > :nth-child(2) {
+    animation-delay: 18ms;
+}
+
+.app-list-motion > :nth-child(3) {
+    animation-delay: 36ms;
+}
+
+.app-list-motion > :nth-child(4) {
+    animation-delay: 54ms;
+}
+
+.app-list-motion > :nth-child(5) {
+    animation-delay: 72ms;
+}
+
+.app-list-motion > :nth-child(n + 6) {
+    animation-delay: 90ms;
+}
+
+.toolbar-interactive-feedback {
+    transition-timing-function: var(--motion-ease-out);
+}
+
+@keyframes app-preview-enter {
+    from {
+        opacity: 0;
+        transform: translateY(10px) scale(0.985);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.app-preview-transition {
+    animation: app-preview-enter var(--motion-ui-slow) var(--motion-ease-snap) both;
+    will-change: opacity, transform;
 }
 
 @keyframes mobile-preview-card-enter {
@@ -148,7 +254,7 @@
 
 .mobile-preview-card-enter {
     transform: translate(-50%, 0);
-    animation: mobile-preview-card-enter 260ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: mobile-preview-card-enter var(--motion-ui-slow) var(--motion-ease-snap) both;
 }
 
 @keyframes map-settings-sheet-enter {
@@ -205,6 +311,10 @@
 
 @media (prefers-reduced-motion: reduce) {
     .nearby-row-enter,
+    .app-route-transition,
+    .app-panel-transition,
+    .app-preview-transition,
+    .app-list-motion > *,
     .mobile-preview-card-enter,
     .candidate-watching-spot-preview-motion,
     .candidate-watching-spot-marker__shell,
@@ -212,6 +322,7 @@
     .map-settings-sheet-overlay {
         animation: none;
         transform: none;
+        transition: none;
     }
 }
 
@@ -242,17 +353,20 @@
 }
 
 .toolbar-reveal {
-    animation: toolbar-reveal-expand 360ms cubic-bezier(0.2, 0.65, 0.2, 1) both;
+    animation: toolbar-reveal-expand var(--motion-ui-slow) var(--motion-ease-snap) both;
 }
 
 .toolbar-reveal > * {
-    animation: toolbar-reveal-fade 200ms ease-out 360ms both;
+    animation: toolbar-reveal-fade var(--motion-ui-fast) var(--motion-ease-out) 180ms both;
 }
 
 @media (prefers-reduced-motion: reduce) {
     .toolbar-reveal,
-    .toolbar-reveal > * {
+    .toolbar-reveal > *,
+    .toolbar-interactive-feedback {
         animation: none;
+        transform: none;
+        transition: none;
     }
 }
 
@@ -4497,7 +4611,7 @@ body {
 }
 
 .aircraft-preview-card--desktop-reveal::before {
-    animation: endf-placeholder-hold 430ms steps(1, end) both;
+    animation: endf-placeholder-hold var(--motion-ui-slow) steps(1, end) both;
     background:
         radial-gradient(
             circle,
@@ -4523,7 +4637,7 @@ body {
 }
 
 .aircraft-preview-card--desktop-reveal::after {
-    animation: endf-placeholder-cursor 430ms steps(1, end) both;
+    animation: endf-placeholder-cursor var(--motion-ui-slow) steps(1, end) both;
     background: color-mix(in oklab, var(--endf-yellow) 78%, transparent);
     border-radius: 999px;
     box-shadow: 0 0 16px color-mix(in oklab, var(--endf-yellow) 28%, transparent);
@@ -4540,8 +4654,8 @@ body {
 .aircraft-preview-card--desktop-reveal > *,
 .aircraft-preview-card--desktop-reveal .aircraft-preview-metadata-card {
     animation:
-        endf-content-reveal 430ms steps(1, end) both,
-        endf-text-decode 430ms steps(3, end) both;
+        endf-content-reveal var(--motion-ui-slow) steps(1, end) both,
+        endf-text-decode var(--motion-ui-slow) steps(3, end) both;
 }
 
 .aircraft-preview-card--has-photo {
@@ -4553,8 +4667,7 @@ body {
     right: 0;
     bottom: calc(100% - 22px);
     left: 0;
-    animation: aircraft-preview-media-reveal 520ms cubic-bezier(0.16, 1, 0.3, 1)
-        both;
+    animation: aircraft-preview-media-reveal var(--motion-ui-slow) var(--motion-ease-snap) both;
     z-index: 1;
 }
 
@@ -4676,10 +4789,10 @@ body {
     text-transform: uppercase;
     transform: translateY(-4px);
     transition:
-        max-height 0.28s ease,
-        margin-top 0.28s ease,
-        opacity 0.18s ease,
-        transform 0.28s ease;
+        max-height var(--motion-ui-slow) var(--motion-ease-out),
+        margin-top var(--motion-ui-slow) var(--motion-ease-out),
+        opacity var(--motion-ui-fast) var(--motion-ease-out),
+        transform var(--motion-ui-slow) var(--motion-ease-out);
     white-space: normal;
 }
 


### PR DESCRIPTION
## Summary
- Add shared 200-300ms motion tokens and reduced-motion coverage for app route, panel, list, toolbar, and preview transitions.
- Apply transition wrappers to airport/flight sidebars, search/list surfaces, and desktop/mobile preview cards.
- Align virtual nearby-list enter timing with the visible motion budget.

## Validation
- git diff --check
- /opt/homebrew/bin/pnpm lint (0 errors; existing TanStack Virtual React Compiler warning)
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm build
- Browser: local /aircraft/UAL964, /airport/KBOS desktop preview, /airport/KBOS mobile preview; verified 0.2s/0.24s/0.3s computed animation durations