### PR TITLE
Refine oceanic tracking layer safety

### DIFF
--- a/src/components/map/FlightAwareRouteArc.tsx
+++ b/src/components/map/FlightAwareRouteArc.tsx
@@ -3,13 +3,13 @@
 import { useEffect, useRef, useState } from "react";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext";
-import {
-  AIRPORT_MAP_PANES,
-} from "@/config/airportMap";
+import { AIRPORT_MAP_PANES } from "@/config/airportMap";
 import { resolveDocumentTheme } from "@/features/airport/map/airportMapModel";
+import { buildFlightAwareRouteLayerStyles } from "@/features/airport/map/flightAwareRouteArcStyleModel";
 import {
-  buildFlightAwareRouteLayerStyles,
-} from "@/features/airport/map/flightAwareRouteArcStyleModel";
+  safeAddToMap,
+  safeRemoveFromMap,
+} from "@/features/airport/map/leafletLayerSafety";
 import { ensureAirportMapPane } from "@/features/airport/map/mapPane";
 
 const getCurrentTheme = () =>
@@ -18,13 +18,7 @@ const getCurrentTheme = () =>
     : "dark";
 
 function removeLayers(layers = [], map) {
-  layers.forEach((layer) => {
-    if (layer && map?.hasLayer(layer)) layer.removeFrom(map);
-  });
-}
-
-function isLeafletMapReady(map) {
-  return Boolean(map?._container && map?._mapPane && map?.getPane?.("overlayPane"));
+  layers.forEach((layer) => safeRemoveFromMap(layer, map));
 }
 
 function toUsablePath(path = []) {
@@ -38,16 +32,10 @@ function toUsablePath(path = []) {
     : [];
 }
 
-function addLayerToReadyMap(layer, map, layers) {
-  if (!layer || !isLeafletMapReady(map)) return null;
-  try {
-    layer.addTo(map);
-    layers.push(layer);
-    return layer;
-  } catch {
-    layer.remove?.();
-    return null;
-  }
+function addRouteLayer(layer, map, layers) {
+  const added = safeAddToMap(layer, map, { label: "FlightAwareRouteArc" });
+  if (added) layers.push(added);
+  return added;
 }
 
 export default function FlightAwareRouteArc({
@@ -78,7 +66,7 @@ export default function FlightAwareRouteArc({
     layersRef.current = [];
 
     const usablePath = toUsablePath(path);
-    if (!map || !isLeafletMapReady(map) || usablePath.length < 2) {
+    if (!map || usablePath.length < 2) {
       return undefined;
     }
 
@@ -89,7 +77,7 @@ export default function FlightAwareRouteArc({
       opacity,
     });
     const layers = [];
-    addLayerToReadyMap(
+    addRouteLayer(
       L.polyline(usablePath, {
         pane,
         ...routeStyles.glow,
@@ -101,7 +89,7 @@ export default function FlightAwareRouteArc({
       map,
       layers,
     );
-    addLayerToReadyMap(
+    addRouteLayer(
       L.polyline(usablePath, {
         pane,
         ...routeStyles.route,

--- a/src/components/map/SelectedAircraftTrace.tsx
+++ b/src/components/map/SelectedAircraftTrace.tsx
@@ -8,6 +8,10 @@ import {
   AIRPORT_MAP_PANES,
   SELECTED_AIRCRAFT_TRACE_STYLE,
 } from "../../config/airportMap";
+import {
+  safeAddToMap,
+  safeRemoveFromMap,
+} from "@/features/airport/map/leafletLayerSafety";
 import { ensureAirportMapPane } from "../../features/airport/map/mapPane";
 import { computeTraceGeometry } from "../../features/aircraft/trace/traceGeometry";
 import {
@@ -59,29 +63,17 @@ const getTraceStyle = (theme) =>
     : SELECTED_AIRCRAFT_TRACE_STYLE.dark;
 
 function removeLayers(layers = [], map) {
-  layers.forEach((layer) => {
-    if (layer && map?.hasLayer(layer)) layer.removeFrom(map);
-  });
+  layers.forEach((layer) => safeRemoveFromMap(layer, map));
 }
 
 function removeElements(elements = []) {
   elements.forEach((element) => element?.remove?.());
 }
 
-function isLeafletMapReady(map) {
-  return Boolean(map?._container && map?._mapPane && map?.getPane?.("overlayPane"));
-}
-
-function addLayerToReadyMap(layer, map, layers) {
-  if (!layer || !isLeafletMapReady(map)) return null;
-  try {
-    layer.addTo(map);
-    layers.push(layer);
-    return layer;
-  } catch {
-    layer.remove?.();
-    return null;
-  }
+function addTraceLayer(layer, map, layers) {
+  const added = safeAddToMap(layer, map, { label: "SelectedAircraftTrace" });
+  if (added) layers.push(added);
+  return added;
 }
 
 function gradientIdPart(value) {
@@ -308,7 +300,7 @@ function SingleAircraftTrace({
     removeElements(gradientElsRef.current);
     gradientElsRef.current = [];
 
-    if (!map || !geometry || !isLeafletMapReady(map)) {
+    if (!map || !geometry) {
       if (!aircraftHex) completedRevealKeyRef.current = "";
       isAnimatingRef.current = false;
       return undefined;
@@ -324,7 +316,7 @@ function SingleAircraftTrace({
     const gradientBase = `${gradientIdPart(aircraftHex)}-${Date.now().toString(36)}`;
 
     geometry.connectors.forEach((connector) => {
-      addLayerToReadyMap(
+      addTraceLayer(
         L.polyline(connector.curve.slice().reverse(), {
           pane,
           color: lineColor,
@@ -343,7 +335,7 @@ function SingleAircraftTrace({
 
     geometry.segments.forEach((segment) => {
       const segmentId = gradientIdPart(segment.id);
-      const corePolyline = addLayerToReadyMap(
+      const corePolyline = addTraceLayer(
         L.polyline(segment.curve.slice().reverse(), {
           pane,
           color: lineColor,
@@ -372,7 +364,7 @@ function SingleAircraftTrace({
         );
       }
 
-      const glowPolyline = addLayerToReadyMap(
+      const glowPolyline = addTraceLayer(
         L.polyline(segment.curve.slice().reverse(), {
           pane,
           color: glowColor,
@@ -404,7 +396,7 @@ function SingleAircraftTrace({
 
     geometry.samplePoints.forEach((point, index) => {
       const emphasis = (index + 1) / geometry.samplePoints.length;
-      addLayerToReadyMap(
+      addTraceLayer(
         L.circleMarker([point.lat, point.lon], {
           pane,
           radius: traceStyle.pointRadius,
@@ -465,7 +457,7 @@ function SingleAircraftTrace({
     removeLayers(labelMarkersRef.current, map);
     labelMarkersRef.current = [];
 
-    if (!map || !labelKey || !isLeafletMapReady(map)) return undefined;
+    if (!map || !labelKey) return undefined;
     const labelPoints = labelPointsRef.current;
     if (!Array.isArray(labelPoints) || labelPoints.length === 0) {
       return undefined;
@@ -483,7 +475,7 @@ function SingleAircraftTrace({
         : altitude
           ? `<span class="aircraft-trace-label__alt">${altitude}<span class="aircraft-trace-label__alt-unit">FT</span></span>`
           : "";
-      const marker = addLayerToReadyMap(
+      const marker = addTraceLayer(
         L.marker([point.lat, point.lon], {
           pane,
           icon: L.divIcon({

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -9,6 +9,7 @@ import {
   getFlightRouteAirlineIconUrl,
 } from "../../utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { formatFlightTelemetryMetric } from "@/features/aircraft/tracking/flightTelemetryDisplayModel";
 
 // Tiny self-contained <img> that hides itself if the URL 404s. Avoids
 // stamped broken-image icons in dense list rows when the logo isn't
@@ -47,7 +48,13 @@ export default function AircraftRow({
     routeMunicipalities && routeMunicipalities !== route,
   );
   const distValue = toNumber(aircraft.distanceNm);
-  const altValue = toNumber(aircraft.altitude);
+  const altitudeDisplay = formatFlightTelemetryMetric({
+    metric: "altitude",
+    value: aircraft.altitude,
+    onGround: aircraft.onGround,
+    flightPositionSource: aircraft.flight_position_source,
+    positionQuality: aircraft.positionQuality,
+  });
 
   return (
     <button
@@ -82,10 +89,13 @@ export default function AircraftRow({
       <div className="aircraft-table-cell aircraft-table-cell--altitude text-right font-mono text-[12px] font-semibold text-atc-text">
         {aircraft.onGround ? (
           <span>{t("aircraft.gnd")}</span>
-        ) : altValue == null ? (
+        ) : !altitudeDisplay ? (
           <span>-</span>
         ) : (
-          <NumberWithUnit value={Math.round(altValue)} unit="FT" />
+          <NumberWithUnit
+            value={altitudeDisplay.value}
+            unit={altitudeDisplay.suffix.toUpperCase()}
+          />
         )}
       </div>
     </button>

--- a/src/features/aircraft/tracking/flightTelemetryDisplayModel.test.ts
+++ b/src/features/aircraft/tracking/flightTelemetryDisplayModel.test.ts
@@ -20,6 +20,27 @@ assert.deepEqual(
   { value: 3763, suffix: "m" },
 );
 
+assert.equal(
+  formatFlightTelemetryMetric({
+    metric: "altitude",
+    value: 0,
+    flightPositionSource: "flightaware",
+    positionQuality: { kind: "predicted", source: "flightaware" },
+  }),
+  null,
+);
+
+assert.deepEqual(
+  formatFlightTelemetryMetric({
+    metric: "altitude",
+    value: 0,
+    onGround: true,
+    flightPositionSource: "flightaware",
+    positionQuality: { kind: "predicted", source: "flightaware" },
+  }),
+  { value: 0, suffix: "ft" },
+);
+
 assert.deepEqual(
   formatFlightTelemetryMetric({ metric: "verticalSpeed", value: -1200, alternate: true }),
   { value: -366, suffix: "m/min", format: { signDisplay: "exceptZero" } },

--- a/src/features/aircraft/tracking/flightTelemetryDisplayModel.ts
+++ b/src/features/aircraft/tracking/flightTelemetryDisplayModel.ts
@@ -8,6 +8,26 @@ function toFiniteTelemetryNumber(value: unknown) {
   return Number.isFinite(numeric) ? numeric : null;
 }
 
+function isPredictedFlightAwarePosition({
+  flightPositionSource,
+  positionQuality,
+}: {
+  flightPositionSource?: unknown;
+  positionQuality?: Record<string, unknown> | null;
+} = {}) {
+  const source = String(
+    flightPositionSource ||
+      positionQuality?.flight_position_source ||
+      positionQuality?.source ||
+      "",
+  ).toLowerCase();
+  const kind = String(positionQuality?.kind || "").toLowerCase();
+  return (
+    source === "flightaware" &&
+    (positionQuality?.isPredicted === true || kind === "predicted")
+  );
+}
+
 export function resolveTrackDirectionTranslationKey(track: unknown) {
   const index = resolveTrackDirectionIndex(track);
   return index == null ? null : `directions.${TRACK_DIRECTION_KEYS[index]}`;
@@ -24,10 +44,16 @@ export function formatFlightTelemetryMetric({
   metric,
   value,
   alternate = false,
+  onGround = false,
+  flightPositionSource,
+  positionQuality,
 }: {
   metric?: string;
   value?: unknown;
   alternate?: boolean;
+  onGround?: boolean;
+  flightPositionSource?: unknown;
+  positionQuality?: Record<string, unknown> | null;
 } = {}) {
   const numeric = toFiniteTelemetryNumber(value);
   if (numeric == null) return null;
@@ -39,6 +65,13 @@ export function formatFlightTelemetryMetric({
   }
 
   if (metric === "altitude") {
+    if (
+      !onGround &&
+      numeric === 0 &&
+      isPredictedFlightAwarePosition({ flightPositionSource, positionQuality })
+    ) {
+      return null;
+    }
     return alternate
       ? { value: Math.round(numeric * FOOT_TO_METER), suffix: "m" }
       : { value: Math.round(numeric), suffix: "ft" };

--- a/src/features/airport/map/leafletLayerSafety.test.ts
+++ b/src/features/airport/map/leafletLayerSafety.test.ts
@@ -36,6 +36,30 @@ import { safeAddToMap, safeRemoveFromMap } from "./leafletLayerSafety";
 }
 
 {
+  const warnings: any[] = [];
+  let removeCalls = 0;
+  const layer = {
+    addTo() {
+      throw new Error("Cannot read properties of undefined (reading '_leaflet_pos')");
+    },
+    remove() {
+      removeCalls += 1;
+    },
+  };
+
+  assert.equal(
+    safeAddToMap(layer, {}, {
+      label: "trace-layer",
+      logger: { warn: (...args: any[]) => warnings.push(args) } as any,
+    }),
+    null,
+  );
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0][0], "[trace-layer] addTo skipped (map not ready)");
+  assert.equal(removeCalls, 1);
+}
+
+{
   let removedFrom = null;
   const layer = {
     removeFrom(map) {

--- a/src/features/airport/map/leafletLayerSafety.ts
+++ b/src/features/airport/map/leafletLayerSafety.ts
@@ -7,6 +7,11 @@ export function safeAddToMap(
   try {
     return layer.addTo(map);
   } catch (error) {
+    try {
+      layer.remove?.();
+    } catch {
+      /* layer may not have completed enough setup to remove cleanly */
+    }
     logger.warn?.(`[${label}] addTo skipped (map not ready)`, error.message);
     return null;
   }


### PR DESCRIPTION
## Summary
- Reuse the shared Leaflet layer safety helper for FlightAware route arcs and selected aircraft traces instead of duplicating local map readiness helpers.
- Harden safeAddToMap to clean up partially mounted layers when Leaflet addTo fails, including the _leaflet_pos failure mode.
- Route aircraft-list altitude rendering through the telemetry display model so FlightAware predicted zero altitude displays as unknown, while true ground state still renders as ground.

## Test Plan
- /opt/homebrew/bin/pnpm exec tsx src/features/airport/map/leafletLayerSafety.test.ts
- /opt/homebrew/bin/pnpm exec tsx src/features/aircraft/tracking/flightTelemetryDisplayModel.test.ts
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm lint
- /opt/homebrew/bin/pnpm build
- Chrome local smoke: http://localhost:3000/aircraft/UAL964?verify=1780529174489 refresh recovers FlightAware · predicted, A9178D, airborne, route/trace labels; selected list row shows -/- instead of 0 FT; no runtime overlay.