### PR TITLE
Add semantic color token foundation

### DIFF
--- a/src/app/api/proxy/map-style/[theme]/route.ts
+++ b/src/app/api/proxy/map-style/[theme]/route.ts
@@ -7,6 +7,7 @@ import {
   readResponseJson,
 } from "@/app/api/_shared/apiProxySecurity";
 import {
+  buildImmersiveMapLibreStyle,
   buildLocalizedMapLibreStyle,
   buildProxiedMapLibreStyle,
   getMapLibreBaseStyleUrl,
@@ -32,7 +33,10 @@ export async function GET(request, { params }) {
   if (securityResponse) return securityResponse;
 
   const { theme: rawTheme } = await params;
-  const theme = rawTheme === "light" ? "light" : "dark";
+  const baseTheme =
+    rawTheme === "light" || rawTheme === "sunrise" || rawTheme === "sunset"
+      ? "light"
+      : "dark";
   const requestUrl = new URL(request.url);
   const locale = requestUrl.searchParams.get("locale") || "en";
   const showLabels = requestUrl.searchParams.get("labels") !== "0";
@@ -40,7 +44,7 @@ export async function GET(request, { params }) {
   let upstreamStyle;
   try {
     upstreamStyle = await fetchJson(
-      getMapLibreBaseStyleUrl(theme),
+      getMapLibreBaseStyleUrl(baseTheme),
       "OpenFreeMap style",
     );
   } catch (error) {
@@ -61,7 +65,7 @@ export async function GET(request, { params }) {
   }
 
   const style = buildLocalizedMapLibreStyle(
-    buildProxiedMapLibreStyle(upstreamStyle),
+    buildImmersiveMapLibreStyle(buildProxiedMapLibreStyle(upstreamStyle), rawTheme),
     { locale, showLabels },
   );
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import ThemedToaster from "@/components/app-shell/ThemedToaster";
 import { I18nProvider } from "@/features/app-shell/i18n/i18nProvider";
 import QueryProvider from "@/features/app-shell/queryProvider";
+import { isConcreteTheme } from "@/utils/theme";
 import "leaflet/dist/leaflet.css";
 import "maplibre-gl/dist/maplibre-gl.css";
 import {
@@ -83,7 +84,7 @@ export const viewport = {
 // Resolve the theme from the request cookie so the server can render
 // <html data-theme="..."> directly — no client-side boot script, no
 // React 19 "script inside component" warning. The cookie carries the
-// RESOLVED theme (light/dark), never "system": useThemePreference
+// RESOLVED theme, never "system": useThemePreference
 // rewrites it on every applyThemePreference call, so even users on
 // system preference get the correct color on subsequent loads. First-
 // ever visitors without a cookie still fall back to dark, since the
@@ -91,7 +92,7 @@ export const viewport = {
 async function resolveInitialTheme() {
   const store = await cookies();
   const raw = store.get("theme")?.value;
-  if (raw === "light" || raw === "dark") return raw;
+  if (isConcreteTheme(raw)) return raw;
   return "dark";
 }
 

--- a/src/components/aircraft/preview/AircraftPreviewIdentity.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewIdentity.tsx
@@ -37,7 +37,7 @@ export default function AircraftPreviewIdentity({ aircraft }) {
           >
             <AirlineLogo
               src={airlineIconUrl}
-              className="h-4 w-[26px] flex-none rounded-[2px] bg-[#f5f3ee] object-contain px-[2px] py-[1px] md:h-[13px] md:w-[21px]"
+              className="h-4 w-[26px] flex-none rounded-[2px] bg-[var(--aviation-logo-plate)] object-contain px-[2px] py-[1px] md:h-[13px] md:w-[21px]"
             />
             <span className="min-w-0 truncate">{route}</span>
           </span>

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -61,7 +61,7 @@ function AirlineLogo({ src }: AirlineLogoProps) {
       loading="lazy"
       decoding="async"
       onError={() => setHidden(true)}
-      className="h-3.5 w-[22px] flex-none rounded-[2px] bg-[oklch(96%_0.006_95)] object-contain px-[2px] py-[1px]"
+      className="h-3.5 w-[22px] flex-none rounded-[2px] bg-[var(--aviation-logo-plate)] object-contain px-[2px] py-[1px]"
     />
   );
 }

--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -40,9 +40,9 @@ export default function MobilePreviewCard({
         // language as the sidebar identity surface). Use background +
         // background-image separately so the gradient's transparent
         // half reveals the solid bg, not the map.
-        "bg-[color-mix(in_oklab,var(--atc-card)_96%,var(--atc-bg))]",
-        "[background-image:linear-gradient(135deg,color-mix(in_oklab,var(--atc-orange)_10%,transparent),transparent_48%)]",
-        "shadow-[var(--app-floating-shadow),inset_0_1px_0_color-mix(in_oklab,var(--atc-text)_8%,transparent)]",
+        "bg-[var(--atc-surface-preview-card)]",
+        "[background-image:var(--atc-preview-accent-wash)]",
+        "shadow-[var(--app-floating-shadow),var(--atc-preview-card-inset)]",
         // Bottom padding matches the 14px horizontal inset on the
         // actions row so the gap around the Track button reads as
         // equal on the left, right, and bottom.
@@ -220,15 +220,15 @@ export const MobilePreviewTrackButton = React.forwardRef(
         type="button"
         className={cn(
           "min-h-[34px] w-full px-[10px] cursor-pointer",
-          "border border-[color-mix(in_oklab,var(--primary-bright)_82%,var(--primary-ink))]",
+          "border border-[var(--atc-action-primary-border)]",
           "rounded-[calc(var(--atc-radius-card)-3px)]",
           "bg-[var(--primary-bright)] text-[var(--primary-ink)]",
-          "shadow-[0_8px_16px_color-mix(in_oklab,var(--primary-bright)_16%,transparent),inset_0_-2px_0_color-mix(in_oklab,var(--primary-ink)_28%,transparent)]",
+          "shadow-[var(--atc-action-primary-shadow)]",
           "font-[var(--font-display)] text-[11px] font-extrabold not-italic tracking-normal leading-[1.15] text-center",
           "[-webkit-tap-highlight-color:transparent]",
           "transition-[box-shadow,filter,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
           "hover:brightness-[1.04] active:scale-[0.97] active:brightness-[0.96]",
-          "focus-visible:outline-2 focus-visible:outline-[color-mix(in_oklab,var(--primary-bright)_72%,white)] focus-visible:outline-offset-[3px]",
+          "focus-visible:outline-2 focus-visible:outline-[var(--atc-action-focus-ring)] focus-visible:outline-offset-[3px]",
           "disabled:cursor-not-allowed disabled:opacity-45",
           className,
         )}
@@ -256,7 +256,7 @@ export const MobilePreviewFeedbackLink = React.forwardRef(
           "[-webkit-tap-highlight-color:transparent]",
           "transition-[color,opacity,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
           "hover:text-atc-text hover:opacity-90 active:text-atc-text active:scale-[0.97]",
-          "focus-visible:outline-2 focus-visible:outline-[color-mix(in_oklab,var(--primary-bright)_72%,white)] focus-visible:outline-offset-[3px]",
+          "focus-visible:outline-2 focus-visible:outline-[var(--atc-action-focus-ring)] focus-visible:outline-offset-[3px]",
           className,
         )}
         {...props}

--- a/src/components/app-shell/ThemeToggle.tsx
+++ b/src/components/app-shell/ThemeToggle.tsx
@@ -1,45 +1,185 @@
 "use client";
 
-import { Monitor, Moon, Sun } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Monitor, Moon, Sun, Sunrise, Sunset } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { MenuPanel } from "@/components/ui/MenuPanel";
+
+const THEME_ITEMS = [
+  { value: "light", iconKey: "sun", immersive: false },
+  { value: "dark", iconKey: "moon", immersive: false },
+  { value: "system", iconKey: "monitor", immersive: false },
+  { value: "sunrise", iconKey: "sunrise", immersive: true },
+  { value: "sunset", iconKey: "sunset", immersive: true },
+];
 
 const THEME_ICONS = {
   monitor: Monitor,
   moon: Moon,
   sun: Sun,
+  sunrise: Sunrise,
+  sunset: Sunset,
+};
+
+const THEME_LABEL_KEYS = {
+  light: "ui.themeLight",
+  dark: "ui.themeDark",
+  system: "ui.themeSystem",
+  sunrise: "ui.themeSunrise",
+  sunset: "ui.themeSunset",
 };
 
 export default function ThemeToggle({
   className,
   iconKey = "monitor",
+  menuAlign = "right",
+  menuPlacement = "top",
   preference = "system",
   showLabel = false,
+  immersiveThemesEnabled = false,
   title,
   onClick,
+  onSelectTheme,
 }) {
   const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const longPressTimerRef = useRef(null);
+  const longPressOpenedRef = useRef(false);
   const ThemeIcon = THEME_ICONS[iconKey] || Monitor;
-  const labelKey =
-    preference === "light"
-      ? "ui.themeLight"
-      : preference === "dark"
-        ? "ui.themeDark"
-        : "ui.themeSystem";
+  const labelKey = THEME_LABEL_KEYS[preference] || THEME_LABEL_KEYS.system;
   const label = t(labelKey);
   const resolvedTitle = title?.startsWith("Theme:")
     ? t("ui.themeTitle", { label })
     : title;
+  const hasMenu = typeof onSelectTheme === "function";
+  const themeItems = immersiveThemesEnabled
+    ? THEME_ITEMS
+    : THEME_ITEMS.filter((item) => !item.immersive);
+  const placementClass =
+    menuPlacement === "bottom" ? "top-full mt-2" : "bottom-full mb-2";
+  const alignClass =
+    menuAlign === "left"
+      ? "left-0"
+      : menuAlign === "center"
+        ? "left-1/2 -translate-x-1/2"
+        : "right-0";
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleDocClick = (event) => {
+      if (!containerRef.current?.contains(event.target)) setOpen(false);
+    };
+    const handleKey = (event) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handleDocClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleDocClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  const handleSelect = (nextTheme) => {
+    onSelectTheme(nextTheme);
+    setOpen(false);
+  };
+
+  const clearLongPressTimer = () => {
+    if (!longPressTimerRef.current) return;
+    window.clearTimeout(longPressTimerRef.current);
+    longPressTimerRef.current = null;
+  };
+
+  const openThemeToolbar = () => {
+    if (!hasMenu) return;
+    longPressOpenedRef.current = true;
+    setOpen(true);
+  };
+
+  const handlePointerDown = () => {
+    if (!hasMenu) return;
+    longPressOpenedRef.current = false;
+    clearLongPressTimer();
+    longPressTimerRef.current = window.setTimeout(openThemeToolbar, 420);
+  };
+
+  const handlePointerEnd = () => {
+    clearLongPressTimer();
+  };
+
+  const handleClick = (event) => {
+    if (longPressOpenedRef.current) {
+      event.preventDefault();
+      longPressOpenedRef.current = false;
+      return;
+    }
+    onClick?.(event);
+  };
+
+  const handleContextMenu = (event) => {
+    if (!hasMenu) return;
+    event.preventDefault();
+    openThemeToolbar();
+  };
+
+  const handleKeyDown = (event) => {
+    if (!hasMenu) return;
+    if (event.key !== "ArrowDown") return;
+    event.preventDefault();
+    setOpen((value) => !value);
+  };
 
   return (
-    <button
-      type="button"
-      className={className}
-      title={resolvedTitle}
-      aria-label={resolvedTitle || label}
-      onClick={onClick}
-    >
-      <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-      {showLabel ? <span>{label}</span> : null}
-    </button>
+    <div ref={containerRef} className="relative isolate z-dropdown inline-flex">
+      {open && hasMenu ? (
+        <MenuPanel
+          role="menu"
+          aria-label={t("ui.themeMenuLabel")}
+          className={`absolute z-dropdown flex-row gap-1 min-w-0 ${placementClass} ${alignClass}`}
+        >
+          {themeItems.map((item) => {
+            const active = item.value === preference;
+            const ItemIcon = THEME_ICONS[item.iconKey] || Monitor;
+            const itemLabel = t(THEME_LABEL_KEYS[item.value]);
+            return (
+              <button
+                key={item.value}
+                type="button"
+                role="menuitemradio"
+                className={className}
+                data-active={active ? "true" : undefined}
+                title={itemLabel}
+                aria-label={itemLabel}
+                aria-checked={active}
+                onClick={() => handleSelect(item.value)}
+              >
+                <ItemIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            );
+          })}
+        </MenuPanel>
+      ) : null}
+
+      <button
+        type="button"
+        className={className}
+        title={resolvedTitle}
+        aria-label={resolvedTitle || label}
+        aria-expanded={hasMenu ? open : undefined}
+        aria-haspopup={hasMenu ? "menu" : undefined}
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+        onKeyDown={handleKeyDown}
+        onPointerCancel={handlePointerEnd}
+        onPointerDown={handlePointerDown}
+        onPointerLeave={handlePointerEnd}
+        onPointerUp={handlePointerEnd}
+      >
+        <ThemeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+        {showLabel ? <span>{label}</span> : null}
+      </button>
+    </div>
   );
 }

--- a/src/components/app-shell/ThemedToaster.tsx
+++ b/src/components/app-shell/ThemedToaster.tsx
@@ -9,18 +9,19 @@ type SonnerTheme = "light" | "dark" | "system";
 // "system" theme reads prefers-color-scheme, but the app's theme is
 // controlled explicitly via the data-theme cookie/attribute, so
 // "system" can disagree with the rest of the UI.
+const resolveToasterTheme = (theme: unknown): SonnerTheme =>
+  theme === "dark" || theme === "sunrise" ? "dark" : "light";
+
 const resolveAttrTheme = (): SonnerTheme => {
   if (typeof document === "undefined") return "dark";
-  return document.documentElement.getAttribute("data-theme") === "light"
-    ? "light"
-    : "dark";
+  return resolveToasterTheme(document.documentElement.getAttribute("data-theme"));
 };
 
 export default function ThemedToaster({
   initialTheme = "dark",
   ...rest
 }: Record<string, any>) {
-  const [theme, setTheme] = useState(initialTheme);
+  const [theme, setTheme] = useState(resolveToasterTheme(initialTheme));
 
   useEffect(() => {
     const sync = () => setTheme(resolveAttrTheme());

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -314,7 +314,7 @@ function Pointer({
             transform: silhouetteTransform,
           } as any}
         />
-        {theme === "dark" && (
+        {(theme === "dark" || theme === "sunrise") && (
           <span aria-hidden="true" className="aircraft-nose-beam" />
         )}
       </div>

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -299,7 +299,7 @@ function Pointer({
             aria-hidden="true"
             style={{
               ...maskStyle,
-              backgroundColor: "rgba(0,0,0,0.95)",
+              backgroundColor: "var(--aviation-aircraft-shadow)",
               opacity: shadowOpacity,
               filter: `blur(${shadowBlur}px)`,
               transform: shadowTransform,
@@ -346,7 +346,7 @@ function Pointer({
               transform: shadowTransform,
             }}
           >
-            <path d="M12 2L16 20L12 17L8 20Z" fill="rgba(0,0,0,0.95)" />
+            <path d="M12 2L16 20L12 17L8 20Z" fill="var(--aviation-aircraft-shadow)" />
           </svg>
         ) : null}
         <svg

--- a/src/components/map/CandidateWatchingSpotsLayer.tsx
+++ b/src/components/map/CandidateWatchingSpotsLayer.tsx
@@ -23,9 +23,9 @@ function CandidateMarkerIcon({ selected = false }: { selected?: boolean }) {
         className={cn(
           "candidate-watching-spot-marker__button",
           "relative isolate flex h-8 w-8 items-center justify-center overflow-hidden rounded-full",
-          "border border-[color-mix(in_oklab,var(--primary-bright)_54%,var(--atc-line))]",
-          "bg-[color-mix(in_oklab,var(--atc-card)_92%,transparent)] text-[var(--primary-bright)]",
-          "shadow-[0_8px_24px_rgba(0,0,0,0.28),var(--atc-control-inset-shadow)]",
+          "border border-[var(--watcher-candidate-marker-border)]",
+          "bg-[var(--watcher-candidate-marker-surface)] text-[var(--watcher-candidate-marker-fg)]",
+          "shadow-[var(--watcher-candidate-marker-shadow),var(--atc-control-inset-shadow)]",
           "transition-[background,border-color,box-shadow,color,transform,filter] duration-300",
           "hover:scale-105 hover:brightness-[1.04] active:scale-95",
           "data-[active=true]:scale-110 data-[active=true]:border-transparent",

--- a/src/components/map/MapTileLayers.tsx
+++ b/src/components/map/MapTileLayers.tsx
@@ -8,6 +8,9 @@ import {
   shouldAttemptMapLibreTiles,
   shouldLogMapTileLayerFailure,
 } from "@/features/airport/map/mapTileLayerModel";
+import { isLightMapTheme } from "@/features/airport/map/airportMapModel";
+
+const MAP_STYLE_THEME_REVISION = "immersive-themes-v2";
 
 export default function MapTileLayers({
   theme = "dark",
@@ -84,6 +87,7 @@ async function loadLocalizedMapStyle({ theme, locale, showLabels, signal }: Reco
   const params = new URLSearchParams({
     locale,
     labels: showLabels ? "1" : "0",
+    v: MAP_STYLE_THEME_REVISION,
   });
   return requestJson(`/api/proxy/map-style/${theme}?${params}`, { signal });
 }
@@ -145,7 +149,7 @@ function setSelectionOpacity(layer, theme, selectionActive) {
   const container = layer?.getContainer?.();
   if (!container) return;
   if (selectionActive) {
-    container.style.opacity = theme === "light" ? "0.92" : "0.88";
+    container.style.opacity = isLightMapTheme(theme) ? "0.92" : "0.88";
     return;
   }
   container.style.opacity = "1";

--- a/src/components/map/SelectedAircraftTrace.tsx
+++ b/src/components/map/SelectedAircraftTrace.tsx
@@ -12,6 +12,7 @@ import {
   safeAddToMap,
   safeRemoveFromMap,
 } from "@/features/airport/map/leafletLayerSafety";
+import { isLightMapTheme } from "@/features/airport/map/airportMapModel";
 import { ensureAirportMapPane } from "../../features/airport/map/mapPane";
 import { computeTraceGeometry } from "../../features/aircraft/trace/traceGeometry";
 import {
@@ -58,7 +59,7 @@ function formatTraceLabelAltitude(point) {
 }
 
 const getTraceStyle = (theme) =>
-  theme === "light"
+  isLightMapTheme(theme)
     ? SELECTED_AIRCRAFT_TRACE_STYLE.light
     : SELECTED_AIRCRAFT_TRACE_STYLE.dark;
 

--- a/src/components/map/controls/MapControlRail.tsx
+++ b/src/components/map/controls/MapControlRail.tsx
@@ -5,6 +5,7 @@ import { LogIn, PanelLeft } from "lucide-react";
 import { getThemeIconKey } from "@/features/app-shell/themePreference";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import LanguageSwitch from "@/components/app-shell/LanguageSwitch";
+import ThemeToggle from "@/components/app-shell/ThemeToggle";
 import {
   Toolbar,
   ToolbarAccountSlot,
@@ -26,6 +27,8 @@ export default function MapControlRail({
   zoomDisabled = false,
   currentTheme,
   themeTitle,
+  immersiveThemesEnabled = false,
+  onSelectTheme,
   settingsOpen,
   settingsSheetId,
   showSidebarToggle = true,
@@ -88,13 +91,17 @@ export default function MapControlRail({
         menuAlign="center"
       />
 
-      <ToolbarButton
-        tone="rail"
+      <ThemeToggle
+        className={RAIL_BUTTON_CLASS}
+        iconKey={getThemeIconKey(currentTheme)}
+        preference={currentTheme}
+        immersiveThemesEnabled={immersiveThemesEnabled}
         title={themeTitle}
         onClick={onCycleTheme}
-      >
-        <MapControlIcon iconKey={getThemeIconKey(currentTheme)} />
-      </ToolbarButton>
+        onSelectTheme={onSelectTheme}
+        menuPlacement="bottom"
+        menuAlign="center"
+      />
 
       <ToolbarButton
         tone="rail"

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -156,7 +156,7 @@ export default function MapSettingsSheet({
           "z-[var(--z-index-modal-content)]",
           "right-2 top-2 bottom-2 h-[calc(100dvh-16px)] w-[min(448px,calc(100vw-16px))]",
           "rounded-[18px] border border-[var(--atc-line-strong)]",
-          "overflow-hidden bg-[color-mix(in_oklab,var(--atc-card)_96%,var(--atc-bg))] p-0 text-atc-text",
+          "overflow-hidden bg-[var(--atc-surface-preview-card)] p-0 text-atc-text",
           "shadow-[var(--app-panel-shadow)]",
           "data-[state=open]:translate-x-0 data-[state=open]:opacity-100",
           "data-[state=closed]:translate-x-[calc(100%+16px)] data-[state=closed]:opacity-0",
@@ -222,15 +222,15 @@ export default function MapSettingsSheet({
                       type="button"
                       className={cn(
                         "grid min-h-[58px] w-full grid-cols-[36px_minmax(0,1fr)_42px] items-center gap-3 rounded-[8px]",
-                        "border border-[var(--atc-line)] bg-[color-mix(in_oklab,var(--atc-bg)_38%,transparent)] px-3 text-left",
-                        "transition hover:border-[var(--atc-line-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-accent)]",
+                        "border border-[var(--atc-border-default)] bg-[var(--atc-surface-row-rest)] px-3 text-left",
+                        "transition hover:border-[var(--atc-line-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-focus-ring)]",
                       )}
                       role="switch"
                       aria-checked={active}
                       aria-label={title}
                       onClick={state[control.handler]}
                     >
-                      <span className="flex h-8 w-8 items-center justify-center rounded-[7px] bg-[color-mix(in_oklab,var(--atc-text)_8%,transparent)] text-atc-text [&>svg]:h-4 [&>svg]:w-4">
+                      <span className="flex h-8 w-8 items-center justify-center rounded-[7px] bg-[var(--atc-surface-icon-wash)] text-atc-text [&>svg]:h-4 [&>svg]:w-4">
                         <MapControlIcon iconKey={control.iconKey} />
                       </span>
                       <span className="min-w-0">
@@ -245,7 +245,7 @@ export default function MapSettingsSheet({
                         className={cn(
                           "relative h-6 w-10 rounded-full border transition",
                           active
-                            ? "border-[var(--atc-accent)] bg-[var(--atc-accent)]"
+                            ? "border-[var(--atc-interaction-primary-accent)] bg-[var(--atc-interaction-primary-accent)]"
                             : "border-[var(--atc-line-strong)] bg-transparent",
                         )}
                         aria-hidden="true"
@@ -266,8 +266,8 @@ export default function MapSettingsSheet({
                     type="button"
                     className={cn(
                       "grid min-h-[58px] w-full grid-cols-[36px_minmax(0,1fr)_42px] items-center gap-3 rounded-[8px]",
-                      "border border-[var(--atc-line)] bg-[color-mix(in_oklab,var(--atc-bg)_38%,transparent)] px-3 text-left",
-                      "transition hover:border-[var(--atc-line-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-accent)]",
+                      "border border-[var(--atc-border-default)] bg-[var(--atc-surface-row-rest)] px-3 text-left",
+                      "transition hover:border-[var(--atc-line-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-focus-ring)]",
                     )}
                     role="switch"
                     aria-checked={userLocationActive}
@@ -275,7 +275,7 @@ export default function MapSettingsSheet({
                     disabled={userLocationPending}
                     onClick={onToggleUserLocation}
                   >
-                    <span className="relative flex h-8 w-8 items-center justify-center rounded-[7px] bg-[color-mix(in_oklab,var(--atc-text)_8%,transparent)] text-atc-text [&>svg]:h-4 [&>svg]:w-4">
+                    <span className="relative flex h-8 w-8 items-center justify-center rounded-[7px] bg-[var(--atc-surface-icon-wash)] text-atc-text [&>svg]:h-4 [&>svg]:w-4">
                       <MapControlIcon iconKey="locateFixed" />
                     </span>
                     <span className="min-w-0">
@@ -290,7 +290,7 @@ export default function MapSettingsSheet({
                       className={cn(
                         "relative h-6 w-10 rounded-full border transition",
                         userLocationActive
-                          ? "border-[var(--atc-accent)] bg-[var(--atc-accent)]"
+                          ? "border-[var(--atc-interaction-primary-accent)] bg-[var(--atc-interaction-primary-accent)]"
                           : "border-[var(--atc-line-strong)] bg-transparent",
                       )}
                       aria-hidden="true"
@@ -312,8 +312,8 @@ export default function MapSettingsSheet({
                     type="button"
                     className={cn(
                       "grid min-h-[58px] w-full grid-cols-[36px_minmax(0,1fr)_42px] items-center gap-3 rounded-[8px]",
-                      "border border-[var(--atc-line)] bg-[color-mix(in_oklab,var(--atc-bg)_38%,transparent)] px-3 text-left",
-                      "transition hover:border-[var(--atc-line-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-accent)]",
+                      "border border-[var(--atc-border-default)] bg-[var(--atc-surface-row-rest)] px-3 text-left",
+                      "transition hover:border-[var(--atc-line-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-focus-ring)]",
                       (!userLocationActive || userLocationPending) &&
                         "cursor-not-allowed opacity-55 hover:border-[var(--atc-line)]",
                     )}
@@ -323,7 +323,7 @@ export default function MapSettingsSheet({
                     disabled={!userLocationActive || userLocationPending}
                     onClick={onToggleUserLocationAudio}
                   >
-                    <span className="relative flex h-8 w-8 items-center justify-center rounded-[7px] bg-[color-mix(in_oklab,var(--atc-text)_8%,transparent)] text-atc-text [&>svg]:h-4 [&>svg]:w-4">
+                    <span className="relative flex h-8 w-8 items-center justify-center rounded-[7px] bg-[var(--atc-surface-icon-wash)] text-atc-text [&>svg]:h-4 [&>svg]:w-4">
                       {userLocationAudioActive ? (
                         <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-atc-accent shadow-[0_0_8px_var(--atc-accent)]" />
                       ) : null}
@@ -341,7 +341,7 @@ export default function MapSettingsSheet({
                       className={cn(
                         "relative h-6 w-10 rounded-full border transition",
                         userLocationAudioActive
-                          ? "border-[var(--atc-accent)] bg-[var(--atc-accent)]"
+                          ? "border-[var(--atc-interaction-primary-accent)] bg-[var(--atc-interaction-primary-accent)]"
                           : "border-[var(--atc-line-strong)] bg-transparent",
                       )}
                       aria-hidden="true"
@@ -360,7 +360,7 @@ export default function MapSettingsSheet({
               </div>
               {userLocationNotice ? (
                 <div
-                  className="mt-3 rounded-[8px] border border-[var(--atc-line)] bg-[color-mix(in_oklab,var(--atc-bg)_44%,transparent)] px-3 py-2 text-[11px] leading-snug text-atc-muted"
+                  className="mt-3 rounded-[8px] border border-[var(--atc-border-default)] bg-[var(--atc-surface-scrim)] px-3 py-2 text-[11px] leading-snug text-atc-muted"
                   role="status"
                   aria-live="polite"
                 >

--- a/src/components/navigation/PageNavigationDock.tsx
+++ b/src/components/navigation/PageNavigationDock.tsx
@@ -38,8 +38,14 @@ export default function PageNavigationDock() {
   const { locale, t } = useI18n();
   const pathname = usePathname();
   const activeHref = resolveActiveHref(pathname);
-  const { themePreference, themeTitle, themeIconKey, cycleTheme } =
-    useThemePreference();
+  const {
+    themePreference,
+    themeTitle,
+    themeIconKey,
+    cycleTheme,
+    immersiveThemesEnabled,
+    selectTheme,
+  } = useThemePreference();
   const { isLoaded, isSignedIn } = useUser();
   const showSignedIn = isLoaded && isSignedIn;
 
@@ -78,8 +84,12 @@ export default function PageNavigationDock() {
           className={buttonClass}
           iconKey={themeIconKey}
           preference={themePreference}
+          immersiveThemesEnabled={immersiveThemesEnabled}
           title={themeTitle}
           onClick={cycleTheme}
+          onSelectTheme={selectTheme}
+          menuPlacement="bottom"
+          menuAlign="right"
         />
 
         <ToolbarSeparator />

--- a/src/components/sidebar/SidebarShell.tsx
+++ b/src/components/sidebar/SidebarShell.tsx
@@ -46,8 +46,14 @@ export default function SidebarShell({
   variant = "airport",
 }: SidebarShellProps) {
   const { t } = useI18n();
-  const { themePreference, themeTitle, themeIconKey, cycleTheme } =
-    useThemePreference();
+  const {
+    themePreference,
+    themeTitle,
+    themeIconKey,
+    cycleTheme,
+    immersiveThemesEnabled,
+    selectTheme,
+  } = useThemePreference();
   const { isLoaded, isSignedIn } = useUser();
   const isMobileOverlay = Boolean(onClose);
   const mapAction = onMap || onClose;
@@ -96,8 +102,12 @@ export default function SidebarShell({
               className={TOOLBAR_BUTTON_CLASS}
               iconKey={themeIconKey}
               preference={themePreference}
+              immersiveThemesEnabled={immersiveThemesEnabled}
               title={themeTitle}
               onClick={cycleTheme}
+              onSelectTheme={selectTheme}
+              menuPlacement="bottom"
+              menuAlign="center"
             />
             <ToolbarSeparator />
             {!isLoaded ? (

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -47,7 +47,13 @@ export default function MapControlBar({
 }) {
   const controlZone = useRef(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const { themePreference, themeTitle, cycleTheme } = useThemePreference();
+  const {
+    themePreference,
+    themeTitle,
+    cycleTheme,
+    immersiveThemesEnabled,
+    selectTheme,
+  } = useThemePreference();
 
   const currentZoomOption = useMemo(
     () => resolveZoomOption(activeZoom, MAP_ZOOM_OPTIONS),
@@ -108,6 +114,8 @@ export default function MapControlBar({
         zoomDisabled={zoomDisabled}
         currentTheme={themePreference}
         themeTitle={themeTitle}
+        immersiveThemesEnabled={immersiveThemesEnabled}
+        onSelectTheme={selectTheme}
         settingsOpen={settingsOpen}
         settingsSheetId={MAP_SETTINGS_SHEET_ID}
         showSidebarToggle={showSidebarToggle}

--- a/src/config/airportMap.ts
+++ b/src/config/airportMap.ts
@@ -29,24 +29,24 @@ export const AIRPORT_MAP_PANES = {
 export const SELECTED_AIRCRAFT_TRACE_STYLE = {
   maxRenderPoints: 140,
   dark: {
-    glowColor: "var(--aircraft-trace-glow)",
+    glowColor: "var(--aviation-trace-glow)",
     glowOpacity: 0.22,
     glowWeight: 12,
-    lineColor: "var(--aircraft-trace-line)",
+    lineColor: "var(--aviation-trace-line)",
     lineOpacity: 0.94,
     lineWeight: 3.2,
-    pointColor: "var(--aircraft-trace-point)",
+    pointColor: "var(--aviation-trace-point)",
     pointFillOpacity: 0.5,
     pointRadius: 2,
   },
   light: {
-    glowColor: "var(--aircraft-trace-glow)",
+    glowColor: "var(--aviation-trace-glow)",
     glowOpacity: 0.18,
     glowWeight: 9,
-    lineColor: "var(--aircraft-trace-line)",
+    lineColor: "var(--aviation-trace-line)",
     lineOpacity: 0.82,
     lineWeight: 3,
-    pointColor: "var(--aircraft-trace-point)",
+    pointColor: "var(--aviation-trace-point)",
     pointFillOpacity: 0.34,
     pointRadius: 1.8,
   },
@@ -88,19 +88,19 @@ export const RUNWAY_APPROACH_BEAM_CONFIG = {
 export const RUNWAY_ANNOTATION_STYLE_CONFIG = {
   lineStyles: {
     dark: {
-      color: "var(--runway-annotation-line)",
+      color: "var(--aviation-runway-annotation-line)",
       weight: 3,
       opacity: 0.55,
     },
     light: {
-      color: "var(--runway-annotation-line)",
+      color: "var(--aviation-runway-annotation-line)",
       weight: 3,
       opacity: 0.42,
     },
   },
   beamColors: {
-    dark: "var(--runway-approach-beam)",
-    light: "var(--runway-approach-beam)",
+    dark: "var(--aviation-runway-approach-beam)",
+    light: "var(--aviation-runway-approach-beam)",
   },
   beamGradientStops: [
     { offset: "0%", opacityScale: 1, maxOpacity: 0.42 },

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -407,6 +407,8 @@ const en = {
     themeButtonAria: "Theme: {label} (click to switch)",
     themeLight: "Light",
     themeDark: "Dark",
+    themeSunrise: "Dawn",
+    themeSunset: "Sunset",
     runwayDirectionsAria: "Runway directions",
     loadingMapAria: "Loading map data",
     loadingAircraftAria: "Loading ADS-B aircraft data",
@@ -505,6 +507,9 @@ const en = {
     themeLight: "Light",
     themeDark: "Dark",
     themeSystem: "System",
+    themeSunrise: "Dawn",
+    themeSunset: "Sunset",
+    themeMenuLabel: "Choose theme",
     themeTitle: "Theme: {label} (click to switch)",
   },
   weather: {

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -402,6 +402,8 @@ const zhCN = {
     themeButtonAria: "主题:{label}(点击切换)",
     themeLight: "明亮",
     themeDark: "暗色",
+    themeSunrise: "黎明",
+    themeSunset: "日落",
     runwayDirectionsAria: "跑道方向",
     loadingMapAria: "正在加载地图数据",
     loadingAircraftAria: "正在加载 ADS-B 飞机数据",
@@ -499,6 +501,9 @@ const zhCN = {
     themeLight: "明亮",
     themeDark: "暗色",
     themeSystem: "系统",
+    themeSunrise: "黎明",
+    themeSunset: "日落",
+    themeMenuLabel: "选择主题",
     themeTitle: "主题:{label}(点击切换)",
   },
   weather: {

--- a/src/features/airport/map/airportMapModel.test.ts
+++ b/src/features/airport/map/airportMapModel.test.ts
@@ -4,6 +4,8 @@ import { ZOOM_AIRPORT, ZOOM_APPROACH } from "../../../utils/airportMapDisplay";
 import {
   getMapOverlayTheme,
   getVisibleAircraft,
+  isKnownMapTheme,
+  isLightMapTheme,
   resolveAirportMapInitialCenter,
   resolveAirportMapFocalCenter,
   resolveDocumentTheme,
@@ -19,7 +21,15 @@ const aircraft = [
 
 assert.equal(resolveDocumentTheme({ getAttribute: () => "light" }), "light");
 assert.equal(resolveDocumentTheme({ getAttribute: () => "dark" }), "dark");
+assert.equal(resolveDocumentTheme({ getAttribute: () => "sunrise" }), "sunrise");
+assert.equal(resolveDocumentTheme({ getAttribute: () => "sunset" }), "sunset");
 assert.equal(resolveDocumentTheme({ getAttribute: () => null }), "dark");
+assert.equal(isLightMapTheme("light"), true);
+assert.equal(isLightMapTheme("sunrise"), false);
+assert.equal(isLightMapTheme("sunset"), true);
+assert.equal(isLightMapTheme("dark"), false);
+assert.equal(isKnownMapTheme("sunrise"), true);
+assert.equal(isKnownMapTheme("unknown"), false);
 
 assert.equal(resolveAirportMapFocalCenter({ lat: null, lon: null }), null);
 assert.equal(resolveAirportMapFocalCenter({ lat: 42.3656, lon: null }), null);

--- a/src/features/airport/map/airportMapModel.ts
+++ b/src/features/airport/map/airportMapModel.ts
@@ -30,8 +30,16 @@ type VisibleAircraftOptions = AirportGroundFilterOptions & {
   zoom?: unknown;
 };
 
-export const resolveDocumentTheme = (documentElement: Pick<Element, "getAttribute"> | null | undefined) =>
-  documentElement?.getAttribute("data-theme") === "light" ? "light" : "dark";
+export const isLightMapTheme = (theme: unknown) =>
+  theme === "light" || theme === "sunset";
+
+export const isKnownMapTheme = (theme: unknown) =>
+  theme === "light" || theme === "dark" || theme === "sunrise" || theme === "sunset";
+
+export const resolveDocumentTheme = (documentElement: Pick<Element, "getAttribute"> | null | undefined) => {
+  const theme = documentElement?.getAttribute("data-theme");
+  return isKnownMapTheme(theme) ? theme : "dark";
+};
 
 export const getMapOverlayTheme = (theme: unknown) =>
   theme === "light"

--- a/src/features/airport/map/flightAwareRouteArcStyleModel.ts
+++ b/src/features/airport/map/flightAwareRouteArcStyleModel.ts
@@ -1,4 +1,5 @@
 import { SELECTED_AIRCRAFT_TRACE_STYLE } from "../../../config/airportMap";
+import { isLightMapTheme } from "./airportMapModel";
 
 const FLIGHTAWARE_ROUTE_DASH_ARRAY = "10 12";
 
@@ -10,7 +11,7 @@ export function buildFlightAwareRouteLayerStyles({
     ? Number(opacity)
     : 1;
   const traceStyle =
-    theme === "light"
+    isLightMapTheme(theme)
       ? SELECTED_AIRCRAFT_TRACE_STYLE.light
       : SELECTED_AIRCRAFT_TRACE_STYLE.dark;
   const color = traceStyle.lineColor;

--- a/src/features/airport/map/mapTileLanguageModel.test.ts
+++ b/src/features/airport/map/mapTileLanguageModel.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  buildImmersiveMapLibreStyle,
   buildProxiedMapLibreStyle,
   buildLocalizedMapLibreStyle,
   getMapLibreBaseStyleUrl,
@@ -161,4 +162,87 @@ assert.equal(
 
   assert.equal(localized.layers[0].layout.visibility, "none");
   assert.equal(localized.layers[1].layout.visibility, undefined);
+}
+
+{
+  const style = {
+    version: 8,
+    layers: [
+      {
+        id: "background",
+        type: "background",
+        paint: { "background-color": "#ffffff" },
+      },
+      {
+        id: "water",
+        type: "fill",
+        paint: { "fill-color": "#eeeeee" },
+      },
+      {
+        id: "aeroway-runway",
+        type: "line",
+        paint: { "line-color": "#dddddd", "line-width": 2 },
+      },
+      {
+        id: "highway_major_inner",
+        type: "line",
+        paint: { "line-color": "#cccccc" },
+      },
+      {
+        id: "place_city",
+        type: "symbol",
+        paint: { "text-color": "#111111", "text-halo-color": "#ffffff" },
+      },
+      {
+        id: "water_name_point_label",
+        type: "symbol",
+        paint: { "text-color": "#111111", "text-halo-color": "#ffffff" },
+      },
+    ],
+  };
+
+  const themed = buildImmersiveMapLibreStyle(style, "sunrise");
+
+  assert.notEqual(themed, style);
+  assert.equal(themed.layers[0].paint["background-color"], "#1e2758");
+  assert.equal(themed.layers[1].paint["fill-color"], "#29406f");
+  assert.equal(themed.layers[2].paint["line-color"], "#bfc7ff");
+  assert.equal(themed.layers[3].paint["line-color"], "#5f6a96");
+  assert.equal(themed.layers[4].paint["text-color"], "#eef3ff");
+  assert.equal(themed.layers[4].paint["text-halo-color"], "#18234d");
+  assert.equal(themed.layers[5].paint["text-color"], "#b9ddff");
+}
+
+{
+  const style = {
+    version: 8,
+    layers: [
+      {
+        id: "background",
+        type: "background",
+        paint: { "background-color": "#ffffff" },
+      },
+      {
+        id: "water",
+        type: "fill",
+        paint: { "fill-color": "#eeeeee" },
+      },
+      {
+        id: "highway_motorway_inner",
+        type: "line",
+        paint: { "line-color": "#cccccc" },
+      },
+    ],
+  };
+
+  const themed = buildImmersiveMapLibreStyle(style, "sunset");
+
+  assert.equal(themed.layers[0].paint["background-color"], "#f2dfc4");
+  assert.equal(themed.layers[1].paint["fill-color"], "#d8b9a1");
+  assert.equal(themed.layers[2].paint["line-color"], "#ca8750");
+}
+
+{
+  const style = { version: 8, layers: [] };
+  assert.equal(buildImmersiveMapLibreStyle(style, "light"), style);
 }

--- a/src/features/airport/map/mapTileLanguageModel.ts
+++ b/src/features/airport/map/mapTileLanguageModel.ts
@@ -47,6 +47,57 @@ type ProxiedMapStyleOptions = {
   proxyOrigin?: string;
 };
 
+const IMMERSIVE_MAP_PALETTES = Object.freeze({
+  sunrise: {
+    background: "#1e2758",
+    park: "#283f64",
+    water: "#29406f",
+    ice: "#38537f",
+    landuse: "#263360",
+    wood: "#2c4963",
+    building: "#32426a",
+    buildingOutline: "#4c5e86",
+    aeroway: "#2e3d66",
+    aerowayLine: "#bfc7ff",
+    pier: "#3b4f78",
+    path: "#4b5780",
+    minorRoad: "#3d4b74",
+    majorRoad: "#5f6a96",
+    motorway: "#7e78ad",
+    motorwayInner: "#9a94c7",
+    rail: "#68749a",
+    boundary: "#8c80aa",
+    label: "#eef3ff",
+    labelMuted: "#c8d2f3",
+    labelHalo: "#18234d",
+    waterLabel: "#b9ddff",
+  },
+  sunset: {
+    background: "#f2dfc4",
+    park: "#e1d0a4",
+    water: "#d8b9a1",
+    ice: "#f2dabb",
+    landuse: "#ead5b9",
+    wood: "#d2bf93",
+    building: "#dcc2a4",
+    buildingOutline: "#c3a17e",
+    aeroway: "#e5cfb2",
+    aerowayLine: "#7e4324",
+    pier: "#e5cfb2",
+    path: "#d9bea0",
+    minorRoad: "#e0c7a8",
+    majorRoad: "#c19166",
+    motorway: "#b96b36",
+    motorwayInner: "#ca8750",
+    rail: "#9b6742",
+    boundary: "#a66d45",
+    label: "#3d1f0e",
+    labelMuted: "#6a3b1f",
+    labelHalo: "#f9e7cf",
+    waterLabel: "#6f3c20",
+  },
+});
+
 function normalizeMapLabelLocale(locale: string) {
   return MAP_LABEL_LOCALES[locale] || MAP_LABEL_LOCALES.en;
 }
@@ -112,6 +163,21 @@ export function buildLocalizedMapLibreStyle(
   };
 }
 
+export function buildImmersiveMapLibreStyle(
+  style: MapLibreStyle,
+  theme: string,
+) {
+  const palette = IMMERSIVE_MAP_PALETTES[theme];
+  if (!palette || !style || !Array.isArray(style.layers)) return style;
+
+  return {
+    ...style,
+    layers: style.layers.map((layer) =>
+      themeMapLibreLayer(layer, palette),
+    ),
+  };
+}
+
 export function buildProxiedMapLibreStyle(
   style: MapLibreStyle,
   { tileJson }: ProxiedMapStyleOptions = {},
@@ -143,4 +209,70 @@ function isTextSymbolLayer(layer: MapLibreLayer) {
     layer.layout &&
     Object.prototype.hasOwnProperty.call(layer.layout, "text-field")
   );
+}
+
+function themeMapLibreLayer(layer: MapLibreLayer, palette: Record<string, string>) {
+  if (!layer.paint || typeof layer.paint !== "object") return layer;
+
+  const id = String(layer.id || "").toLowerCase();
+  const paint = { ...(layer.paint as Record<string, unknown>) };
+
+  if (layer.type === "background") {
+    paint["background-color"] = palette.background;
+  }
+
+  if (layer.type === "fill") {
+    const fillColor = getFillColor(id, palette);
+    if (fillColor) paint["fill-color"] = fillColor;
+    if (id.includes("building")) {
+      paint["fill-outline-color"] = palette.buildingOutline;
+    }
+  }
+
+  if (layer.type === "line") {
+    const lineColor = getLineColor(id, palette);
+    if (lineColor) paint["line-color"] = lineColor;
+  }
+
+  if (layer.type === "symbol") {
+    if (Object.prototype.hasOwnProperty.call(paint, "text-color")) {
+      paint["text-color"] = getTextColor(id, palette);
+    }
+    if (Object.prototype.hasOwnProperty.call(paint, "text-halo-color")) {
+      paint["text-halo-color"] = palette.labelHalo;
+    }
+  }
+
+  return { ...layer, paint };
+}
+
+function getFillColor(id: string, palette: Record<string, string>) {
+  if (id.includes("water")) return palette.water;
+  if (id.includes("ice") || id.includes("glacier")) return palette.ice;
+  if (id.includes("park")) return palette.park;
+  if (id.includes("wood")) return palette.wood;
+  if (id.includes("residential") || id.includes("landuse")) return palette.landuse;
+  if (id.includes("building")) return palette.building;
+  if (id.includes("aeroway")) return palette.aeroway;
+  if (id.includes("pier")) return palette.pier;
+  return null;
+}
+
+function getLineColor(id: string, palette: Record<string, string>) {
+  if (id.includes("water")) return palette.waterLabel;
+  if (id.includes("aeroway")) return palette.aerowayLine;
+  if (id.includes("motorway")) return id.includes("inner") ? palette.motorwayInner : palette.motorway;
+  if (id.includes("major")) return palette.majorRoad;
+  if (id.includes("minor")) return palette.minorRoad;
+  if (id.includes("path")) return palette.path;
+  if (id.includes("rail")) return palette.rail;
+  if (id.includes("boundary")) return palette.boundary;
+  if (id.includes("pier")) return palette.pier;
+  return null;
+}
+
+function getTextColor(id: string, palette: Record<string, string>) {
+  if (id.includes("water")) return palette.waterLabel;
+  if (id.includes("highway") || id.includes("road")) return palette.labelMuted;
+  return palette.label;
 }

--- a/src/features/airport/map/runwayAnnotationModel.ts
+++ b/src/features/airport/map/runwayAnnotationModel.ts
@@ -293,7 +293,7 @@ export function buildRunwayApproachVisualization(
   runwayMap: RunwayAnnotationRecord,
   { zoom, theme = "dark", distanceScale = 1 }: RunwayAnnotationRecord = {},
 ) {
-  if (theme === "light") {
+  if (theme === "light" || theme === "sunset") {
     return {
       kind: "approach-lines",
       data: buildRunwayApproachLineCollection(runwayMap, { zoom, distanceScale }),

--- a/src/features/app-shell/auth/useFlightAwareEnabled.ts
+++ b/src/features/app-shell/auth/useFlightAwareEnabled.ts
@@ -6,6 +6,7 @@ import {
   FEATURE_FLAGS,
   getClerkUserPrimaryEmail,
   isFeatureFlagEnabled,
+  isImmersiveThemesEnabled,
   normalizeFeatureFlags,
 } from "../feature-flags/userFeatureFlagsModel";
 
@@ -42,19 +43,15 @@ async function fetchFlagsForEmail(email) {
   return flags;
 }
 
-export function useFlightAwareEnabled() {
+export function useUserFeatureFlags() {
   const { isLoaded, isSignedIn, user } = useUser();
   const hasUser = Boolean(isLoaded && isSignedIn && user);
   const email = hasUser ? getClerkUserPrimaryEmail(user) : "";
-  const [flags, setFlags] = useState({});
-  const enabled = isFeatureFlagEnabled(
-    flags,
-    FEATURE_FLAGS.FLIGHTAWARE_ENABLED,
-  );
+  const [state, setState] = useState({ flags: {}, resolved: false });
 
   useEffect(() => {
     let cancelled = false;
-    setFlags({});
+    setState({ flags: {}, resolved: Boolean(isLoaded && !email) });
     if (!email) {
       return () => {
         cancelled = true;
@@ -63,10 +60,10 @@ export function useFlightAwareEnabled() {
 
     fetchFlagsForEmail(email)
       .then((nextFlags) => {
-        if (!cancelled) setFlags(nextFlags);
+        if (!cancelled) setState({ flags: nextFlags, resolved: true });
       })
       .catch((error) => {
-        if (!cancelled) setFlags({});
+        if (!cancelled) setState({ flags: {}, resolved: true });
         if (process.env.NODE_ENV !== "production") {
           console.warn("[flightaware-enabled] feature flag fetch failed", error);
         }
@@ -75,7 +72,23 @@ export function useFlightAwareEnabled() {
     return () => {
       cancelled = true;
     };
-  }, [email]);
+  }, [email, isLoaded]);
+
+  return {
+    email,
+    flags: state.flags,
+    hasUser,
+    resolved: state.resolved,
+    user,
+  };
+}
+
+export function useFlightAwareEnabled() {
+  const { email, flags, hasUser, user } = useUserFeatureFlags();
+  const enabled = isFeatureFlagEnabled(
+    flags,
+    FEATURE_FLAGS.FLIGHTAWARE_ENABLED,
+  );
 
   // Dev-only trace, deduped across the whole app: each consumer of the
   // hook re-renders independently, and several of them re-run on every
@@ -96,4 +109,12 @@ export function useFlightAwareEnabled() {
   }, [email, enabled, flags, hasUser, user]);
 
   return enabled;
+}
+
+export function useImmersiveThemesFeature() {
+  const { flags, resolved } = useUserFeatureFlags();
+  return {
+    enabled: isImmersiveThemesEnabled(flags),
+    resolved,
+  };
 }

--- a/src/features/app-shell/colorTokenRegistry.test.ts
+++ b/src/features/app-shell/colorTokenRegistry.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+
+import {
+  COLOR_TOKEN_GROUPS,
+  IMMERSIVE_READY_COLOR_TOKENS,
+  resolveColorTokenVar,
+} from "./colorTokenRegistry";
+
+const groupById = new Map(COLOR_TOKEN_GROUPS.map((group) => [group.id, group]));
+
+assert.equal(resolveColorTokenVar("surface", "appBackground"), "var(--atc-surface-app)");
+assert.equal(resolveColorTokenVar("text", "primary"), "var(--atc-text-primary)");
+assert.equal(resolveColorTokenVar("aviation", "traceLine"), "var(--aviation-trace-line)");
+assert.equal(resolveColorTokenVar("airspace", "controlledFill"), "var(--airspace-controlled-fill)");
+assert.equal(resolveColorTokenVar("navaidRadio", "frequencyBadge"), "var(--navaid-frequency-badge)");
+
+assert.ok(groupById.get("surface")?.tokens.some((token) => token.name === "mapGlassSurface"));
+assert.ok(groupById.get("aviation")?.tokens.some((token) => token.name === "aircraftFallbackPosition"));
+assert.ok(groupById.get("airspace")?.tokens.some((token) => token.name === "restrictedWarningFill"));
+
+assert.deepEqual(
+  IMMERSIVE_READY_COLOR_TOKENS.map((token) => token.cssVar),
+  [
+    "--immersive-sky-day-base",
+    "--immersive-sky-sunset-base",
+    "--immersive-sky-night-base",
+    "--immersive-weather-clear-accent",
+    "--immersive-weather-cloudy-accent",
+    "--immersive-weather-storm-accent",
+    "--immersive-atmosphere-glow",
+  ],
+);
+
+const allTokenVars = COLOR_TOKEN_GROUPS.flatMap((group) =>
+  group.tokens.map((token) => token.cssVar),
+);
+assert.equal(new Set(allTokenVars).size, allTokenVars.length);
+assert.ok(allTokenVars.every((cssVar) => cssVar.startsWith("--")));
+
+console.log("colorTokenRegistry.test.ts ok");

--- a/src/features/app-shell/colorTokenRegistry.ts
+++ b/src/features/app-shell/colorTokenRegistry.ts
@@ -1,0 +1,118 @@
+export type ColorTokenGroupId =
+  | "surface"
+  | "text"
+  | "border"
+  | "interaction"
+  | "aviation"
+  | "airspace"
+  | "navaidRadio";
+
+type ColorToken = {
+  name: string;
+  cssVar: string;
+  purpose: string;
+};
+
+type ColorTokenGroup = {
+  id: ColorTokenGroupId;
+  label: string;
+  tokens: ColorToken[];
+};
+
+export const COLOR_TOKEN_GROUPS: ColorTokenGroup[] = [
+  {
+    id: "surface",
+    label: "Surface",
+    tokens: [
+      { name: "appBackground", cssVar: "--atc-surface-app", purpose: "Page and map canvas background." },
+      { name: "elevatedPanel", cssVar: "--atc-surface-panel", purpose: "Sidebar and elevated panel surface." },
+      { name: "cardBackground", cssVar: "--atc-surface-card", purpose: "Default card and popover surface." },
+      { name: "translucentScrim", cssVar: "--atc-surface-scrim", purpose: "Soft overlay/scrim wash." },
+      { name: "mapGlassSurface", cssVar: "--atc-surface-map-glass", purpose: "Glass controls above the airport map." },
+    ],
+  },
+  {
+    id: "text",
+    label: "Text",
+    tokens: [
+      { name: "primary", cssVar: "--atc-text-primary", purpose: "Main copy and telemetry text." },
+      { name: "secondary", cssVar: "--atc-text-secondary", purpose: "Secondary labels and metadata." },
+      { name: "muted", cssVar: "--atc-text-muted", purpose: "Low-emphasis text." },
+      { name: "inverse", cssVar: "--atc-text-inverse", purpose: "Text on selected/active surfaces." },
+      { name: "disabled", cssVar: "--atc-text-disabled", purpose: "Unavailable controls and stale text." },
+    ],
+  },
+  {
+    id: "border",
+    label: "Border",
+    tokens: [
+      { name: "default", cssVar: "--atc-border-default", purpose: "Default dividers and card borders." },
+      { name: "subtle", cssVar: "--atc-border-subtle", purpose: "Quiet dividers in dense UI." },
+      { name: "active", cssVar: "--atc-border-active", purpose: "Selected/active outlines." },
+      { name: "focusRing", cssVar: "--atc-focus-ring", purpose: "Keyboard focus ring." },
+    ],
+  },
+  {
+    id: "interaction",
+    label: "Interaction",
+    tokens: [
+      { name: "primaryAccent", cssVar: "--atc-interaction-primary-accent", purpose: "Primary actions and key signals." },
+      { name: "accentHover", cssVar: "--atc-interaction-accent-hover", purpose: "Hover state on controls." },
+      { name: "selectedState", cssVar: "--atc-interaction-selected", purpose: "Selected cards and active choices." },
+      { name: "activeModeState", cssVar: "--atc-interaction-active-mode", purpose: "Mode controls and map tools." },
+      { name: "warningAttention", cssVar: "--atc-interaction-warning", purpose: "Warnings and attention states." },
+      { name: "danger", cssVar: "--atc-interaction-danger", purpose: "Destructive or blocked state." },
+    ],
+  },
+  {
+    id: "aviation",
+    label: "Aviation",
+    tokens: [
+      { name: "aircraftLivePosition", cssVar: "--aviation-aircraft-live-position", purpose: "Live aircraft markers." },
+      { name: "aircraftFallbackPosition", cssVar: "--aviation-aircraft-fallback-position", purpose: "Inferred/fallback aircraft markers." },
+      { name: "aircraftGroundPosition", cssVar: "--aviation-aircraft-ground-position", purpose: "Ground aircraft markers." },
+      { name: "traceLine", cssVar: "--aviation-trace-line", purpose: "Selected aircraft trace line." },
+      { name: "staleTraceLine", cssVar: "--aviation-trace-stale-line", purpose: "Older or stale trace segments." },
+      { name: "routeHintLine", cssVar: "--aviation-route-hint-line", purpose: "Flight route hints and inferred route lines." },
+      { name: "waypointTracePoint", cssVar: "--aviation-trace-point", purpose: "Trace points and route waypoints." },
+    ],
+  },
+  {
+    id: "airspace",
+    label: "Airspace",
+    tokens: [
+      { name: "controlledFill", cssVar: "--airspace-controlled-fill", purpose: "Controlled airspace fill." },
+      { name: "restrictedWarningFill", cssVar: "--airspace-restricted-warning-fill", purpose: "Restricted/warning airspace fill." },
+      { name: "border", cssVar: "--airspace-border", purpose: "General airspace borders." },
+      { name: "labelText", cssVar: "--airspace-label-text", purpose: "Airspace boundary labels." },
+      { name: "altitudeFilteredState", cssVar: "--airspace-altitude-filtered-state", purpose: "Airspace filtered by altitude context." },
+    ],
+  },
+  {
+    id: "navaidRadio",
+    label: "Navaid And Radio",
+    tokens: [
+      { name: "navaidMarker", cssVar: "--navaid-marker", purpose: "Navaid map marker signal." },
+      { name: "navaidLabel", cssVar: "--navaid-label-text", purpose: "Navaid label text." },
+      { name: "frequencyBadge", cssVar: "--navaid-frequency-badge", purpose: "ATC/frequency badges." },
+      { name: "sourceBadge", cssVar: "--navaid-source-badge", purpose: "Provider/source badges." },
+    ],
+  },
+];
+
+export const IMMERSIVE_READY_COLOR_TOKENS = [
+  { name: "skyDayBase", cssVar: "--immersive-sky-day-base" },
+  { name: "skySunsetBase", cssVar: "--immersive-sky-sunset-base" },
+  { name: "skyNightBase", cssVar: "--immersive-sky-night-base" },
+  { name: "weatherClearAccent", cssVar: "--immersive-weather-clear-accent" },
+  { name: "weatherCloudyAccent", cssVar: "--immersive-weather-cloudy-accent" },
+  { name: "weatherStormAccent", cssVar: "--immersive-weather-storm-accent" },
+  { name: "atmosphereGlow", cssVar: "--immersive-atmosphere-glow" },
+] as const;
+
+export function resolveColorTokenVar(groupId: ColorTokenGroupId, tokenName: string) {
+  const group = COLOR_TOKEN_GROUPS.find((item) => item.id === groupId);
+  const token = group?.tokens.find((item) => item.name === tokenName);
+  if (!token) return "";
+  return `var(${token.cssVar})`;
+}

--- a/src/features/app-shell/feature-flags/userFeatureFlagsModel.test.ts
+++ b/src/features/app-shell/feature-flags/userFeatureFlagsModel.test.ts
@@ -4,6 +4,7 @@ import {
   FEATURE_FLAGS,
   getClerkUserPrimaryEmail,
   isFeatureFlagEnabled,
+  isImmersiveThemesEnabled,
   normalizeFeatureFlags,
   normalizeFeatureFlagEnvironment,
   normalizeUserEmail,
@@ -51,6 +52,18 @@ assert.equal(
 );
 assert.equal(
   isFeatureFlagEnabled({ [FEATURE_FLAGS.FLIGHTAWARE_ENABLED]: "true" }, FEATURE_FLAGS.FLIGHTAWARE_ENABLED),
+  false,
+);
+assert.equal(
+  isImmersiveThemesEnabled({ [FEATURE_FLAGS.IMMERSIVE_THEMES_ENABLED]: true }),
+  true,
+);
+assert.equal(
+  isImmersiveThemesEnabled({ [FEATURE_FLAGS.FLIGHTAWARE_ENABLED]: true }),
+  true,
+);
+assert.equal(
+  isImmersiveThemesEnabled({ [FEATURE_FLAGS.FLIGHTAWARE_ENABLED]: false }),
   false,
 );
 

--- a/src/features/app-shell/feature-flags/userFeatureFlagsModel.ts
+++ b/src/features/app-shell/feature-flags/userFeatureFlagsModel.ts
@@ -1,5 +1,6 @@
 export const FEATURE_FLAGS = Object.freeze({
   FLIGHTAWARE_ENABLED: "flightAwareEnabled",
+  IMMERSIVE_THEMES_ENABLED: "immersiveThemesEnabled",
 });
 
 const FEATURE_FLAG_ENVIRONMENTS = Object.freeze({
@@ -59,4 +60,12 @@ export function normalizeFeatureFlags(flags: unknown) {
 
 export function isFeatureFlagEnabled(flags: unknown, flagKey: string) {
   return normalizeFeatureFlags(flags)[flagKey] === true;
+}
+
+export function isImmersiveThemesEnabled(flags: unknown) {
+  const normalizedFlags = normalizeFeatureFlags(flags);
+  return (
+    normalizedFlags[FEATURE_FLAGS.IMMERSIVE_THEMES_ENABLED] === true ||
+    normalizedFlags[FEATURE_FLAGS.FLIGHTAWARE_ENABLED] === true
+  );
 }

--- a/src/features/app-shell/themePreference.test.ts
+++ b/src/features/app-shell/themePreference.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+
+import {
+  THEME_DARK,
+  THEME_LIGHT,
+  THEME_SUNRISE,
+  THEME_SUNSET,
+  THEME_SYSTEM,
+} from "../../utils/theme";
+import { getThemeIconKey, getThemeTitle } from "./themePreference";
+
+assert.equal(getThemeTitle(THEME_LIGHT), "Theme: Light (click to switch)");
+assert.equal(getThemeTitle(THEME_DARK), "Theme: Dark (click to switch)");
+assert.equal(getThemeTitle(THEME_SYSTEM), "Theme: System (click to switch)");
+assert.equal(getThemeTitle(THEME_SUNRISE), "Theme: Dawn (click to switch)");
+assert.equal(getThemeTitle(THEME_SUNSET), "Theme: Sunset (click to switch)");
+
+assert.equal(getThemeIconKey(THEME_LIGHT), "sun");
+assert.equal(getThemeIconKey(THEME_DARK), "moon");
+assert.equal(getThemeIconKey(THEME_SYSTEM), "monitor");
+assert.equal(getThemeIconKey(THEME_SUNRISE), "sunrise");
+assert.equal(getThemeIconKey(THEME_SUNSET), "sunset");
+
+console.log("theme preference tests passed");

--- a/src/features/app-shell/themePreference.ts
+++ b/src/features/app-shell/themePreference.ts
@@ -1,6 +1,8 @@
 import {
   THEME_DARK,
   THEME_LIGHT,
+  THEME_SUNRISE,
+  THEME_SUNSET,
   THEME_SYSTEM,
   sanitizeTheme,
 } from "../../utils/theme";
@@ -9,6 +11,8 @@ export const getThemeTitle = (theme) => {
   const safeTheme = sanitizeTheme(theme);
   if (safeTheme === THEME_LIGHT) return "Theme: Light (click to switch)";
   if (safeTheme === THEME_DARK) return "Theme: Dark (click to switch)";
+  if (safeTheme === THEME_SUNRISE) return "Theme: Dawn (click to switch)";
+  if (safeTheme === THEME_SUNSET) return "Theme: Sunset (click to switch)";
   return "Theme: System (click to switch)";
 };
 
@@ -16,5 +20,7 @@ export const getThemeIconKey = (theme) => {
   const safeTheme = sanitizeTheme(theme);
   if (safeTheme === THEME_LIGHT) return "sun";
   if (safeTheme === THEME_DARK) return "moon";
+  if (safeTheme === THEME_SUNRISE) return "sunrise";
+  if (safeTheme === THEME_SUNSET) return "sunset";
   return "monitor";
 };

--- a/src/features/app-shell/useThemePreference.ts
+++ b/src/features/app-shell/useThemePreference.ts
@@ -5,12 +5,16 @@ import {
   THEME_SYSTEM,
   applyThemePreference,
   initThemePreference,
+  isImmersiveTheme,
   nextTheme,
+  sanitizeTheme,
   writeStoredTheme,
 } from "../../utils/theme";
+import { useImmersiveThemesFeature } from "./auth/useFlightAwareEnabled";
 import { getThemeIconKey, getThemeTitle } from "./themePreference";
 
 export function useThemePreference() {
+  const immersiveThemesFeature = useImmersiveThemesFeature();
   const [themePreference, setThemePreference] = useState(THEME_SYSTEM);
   const mediaQueryList = useRef(null);
   const themePreferenceRef = useRef(THEME_SYSTEM);
@@ -44,10 +48,10 @@ export function useThemePreference() {
     return () => mediaQueryList.current?.removeEventListener("change", listener);
   }, []);
 
-  const cycleTheme = useCallback(() => {
-    const next = nextTheme(themePreferenceRef.current);
-    themePreferenceRef.current = next;
+  const applySelectedTheme = useCallback((theme) => {
+    const next = sanitizeTheme(theme);
     setThemePreference(next);
+    themePreferenceRef.current = next;
     writeStoredTheme(next);
     applyThemePreference({
       theme: next,
@@ -55,13 +59,37 @@ export function useThemePreference() {
     });
   }, []);
 
+  const selectTheme = useCallback((theme) => {
+    const next = sanitizeTheme(theme);
+    if (isImmersiveTheme(next) && !immersiveThemesFeature.enabled) return false;
+    applySelectedTheme(next);
+    return true;
+  }, [applySelectedTheme, immersiveThemesFeature.enabled]);
+
+  useEffect(() => {
+    if (!immersiveThemesFeature.resolved) return;
+    if (!isImmersiveTheme(themePreferenceRef.current)) return;
+    if (immersiveThemesFeature.enabled) return;
+    applySelectedTheme(THEME_SYSTEM);
+  }, [
+    applySelectedTheme,
+    immersiveThemesFeature.enabled,
+    immersiveThemesFeature.resolved,
+  ]);
+
+  const cycleTheme = useCallback(() => {
+    selectTheme(nextTheme(themePreferenceRef.current));
+  }, [selectTheme]);
+
   return useMemo(
     () => ({
       themePreference,
       themeTitle: getThemeTitle(themePreference),
       themeIconKey: getThemeIconKey(themePreference),
       cycleTheme,
+      immersiveThemesEnabled: immersiveThemesFeature.enabled,
+      selectTheme,
     }),
-    [cycleTheme, themePreference],
+    [cycleTheme, immersiveThemesFeature.enabled, selectTheme, themePreference],
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -678,6 +678,198 @@
     --sidebar-ring: var(--atc-accent);
 }
 
+:root[data-theme="sunrise"] {
+    /* Dawn: blue-violet night sky with a low orange horizon glow. */
+    --theme-primary-bright: oklch(0.82 0.07 258);
+    --theme-primary-deep: oklch(0.68 0.08 254);
+    --theme-primary-ink: oklch(0.2 0.055 262);
+    --theme-sidebar-bg: oklch(0.21 0.05 262);
+    --theme-sidebar-card: oklch(0.265 0.05 258);
+    --primary-bright: var(--theme-primary-bright);
+    --primary-deep: var(--theme-primary-deep);
+    --primary-ink: var(--theme-primary-ink);
+    --atc-bg: oklch(0.2 0.052 264);
+    --atc-card: oklch(0.255 0.05 260);
+    --atc-elev: oklch(0.32 0.055 258);
+    --atc-high: oklch(0.4 0.066 254);
+    --atc-accent: var(--primary-bright);
+    --atc-orange: var(--primary-bright);
+    --atc-mint: oklch(0.75 0.08 205);
+    --atc-red: oklch(0.69 0.17 25);
+    --atc-text: oklch(0.92 0.022 244);
+    --atc-dim: color-mix(in oklab, var(--atc-text) 68%, transparent);
+    --atc-faint: color-mix(in oklab, var(--atc-text) 46%, transparent);
+    --atc-line: color-mix(in oklab, var(--atc-text) 10%, transparent);
+    --atc-line-strong: color-mix(in oklab, var(--atc-text) 20%, transparent);
+    --atc-click-bg: var(--primary-ink);
+    --atc-click-fg: var(--primary-bright);
+    --atc-focus-bg: oklch(0.93 0.018 244);
+    --atc-focus-fg: oklch(0.13 0.05 264);
+    --traffic-level-color: oklch(0.75 0.035 244);
+    --aviation-map-label-shadow: #18234d;
+    --aviation-map-attribution: rgba(220,232,255,0.38);
+    --aviation-map-range-background: rgba(13,18,53,0.46);
+    --aviation-map-range-text: #dce8ff;
+    --aviation-map-range-label: rgba(220,232,255,0.7);
+    --aviation-range-ring-minor: rgba(220,232,255,0.12);
+    --aviation-range-ring-major: rgba(220,232,255,0.24);
+    --aviation-range-ring-band: rgba(220,232,255,0.06);
+    --airspace-blocked-stroke: oklch(0.73 0.17 25);
+    --airspace-restricted-stroke: oklch(0.76 0.14 42);
+    --airspace-permission-stroke: oklch(0.82 0.13 78);
+    --airspace-caution-stroke: oklch(0.83 0.12 96);
+    --aviation-trace-line: var(--primary-bright);
+    --aviation-trace-glow: color-mix(in oklab, var(--primary-bright) 84%, oklch(0.74 0.16 300));
+    --aviation-trace-point: var(--primary-bright);
+    --aviation-runway-annotation-line: #bfc7ff;
+    --aviation-runway-approach-line: rgba(191,199,255,0.72);
+    --aviation-runway-approach-beam: #bfc7ff;
+    --aviation-nearby-runway-line: #bfc7ff;
+    --aircraft-departure: oklch(0.78 0.035 244);
+    --aircraft-arrival: oklch(0.78 0.035 244);
+    --aircraft-unknown: oklch(0.78 0.035 244);
+    --aircraft-ground: oklch(0.66 0.04 244);
+    --aviation-logo-plate: #111943;
+    --glass-card-top: color-mix(in oklab, var(--atc-high) 34%, transparent);
+    --glass-card-bottom: color-mix(in oklab, var(--atc-bg) 56%, transparent);
+    --glass-card-glint-strong: color-mix(in oklab, var(--primary-bright) 16%, transparent);
+    --glass-card-glint-soft: color-mix(in oklab, oklch(0.7 0.13 285) 12%, transparent);
+    --glass-card-border: color-mix(in oklab, var(--primary-bright) 18%, var(--atc-text) 8%);
+    --glass-card-inset: color-mix(in oklab, var(--atc-text) 14%, transparent);
+    --atc-toolbar-surface: color-mix(in oklab, var(--atc-card) 82%, oklch(0.32 0.08 268 / 0.24));
+    --atc-control-hover-bg: color-mix(in oklab, var(--primary-bright) 12%, var(--atc-elev));
+    --atc-control-hover-bg-strong: color-mix(in oklab, var(--primary-bright) 18%, var(--atc-elev));
+    --atc-control-selected-bg: color-mix(in oklab, var(--primary-bright) 18%, transparent);
+    --atc-menu-panel-shadow:
+        0 18px 44px color-mix(in oklab, var(--primary-bright) 18%, transparent),
+        0 4px 12px color-mix(in oklab, var(--atc-text) 8%, transparent);
+    --app-panel-shadow:
+        0 24px 58px color-mix(in oklab, var(--primary-bright) 16%, transparent),
+        0 8px 22px color-mix(in oklab, var(--atc-text) 7%, transparent),
+        0 1px 3px color-mix(in oklab, var(--atc-text) 5%, transparent);
+    --app-map-sidebar-shadow:
+        18px 0 48px color-mix(in oklab, var(--primary-bright) 18%, transparent),
+        3px 0 12px color-mix(in oklab, var(--atc-text) 8%, transparent),
+        var(--app-panel-shadow);
+    --app-card-shadow:
+        0 12px 28px color-mix(in oklab, var(--primary-bright) 12%, transparent),
+        inset 0 1px 0 color-mix(in oklab, var(--atc-text) 8%, transparent);
+    --app-floating-shadow:
+        0 20px 48px color-mix(in oklab, var(--primary-bright) 16%, transparent),
+        0 7px 18px color-mix(in oklab, var(--atc-text) 6%, transparent),
+        0 1px 2px color-mix(in oklab, var(--atc-text) 5%, transparent);
+    --app-floating-edge-shadow: color-mix(in oklab, var(--primary-bright) 28%, transparent);
+    --app-toolbar-shadow:
+        0 14px 28px color-mix(in oklab, var(--primary-bright) 18%, transparent),
+        0 4px 10px color-mix(in oklab, var(--atc-text) 8%, transparent),
+        0 1px 2px color-mix(in oklab, var(--atc-text) 6%, transparent);
+    --preview-card-shadow: var(--app-floating-shadow);
+    --sidebar-tile-bottom-glow: linear-gradient(
+        to top,
+        color-mix(in oklab, var(--primary-bright) 44%, transparent) 0%,
+        color-mix(in oklab, var(--primary-bright) 24%, transparent) 18%,
+        color-mix(in oklab, white 12%, transparent) 48%,
+        transparent 82%
+    );
+    --sidebar-tile-edge-glow: color-mix(in oklab, var(--primary-bright) 58%, white);
+    --immersive-sky-day-base: var(--atc-bg);
+    --immersive-sky-sunset-base: color-mix(in oklab, var(--atc-bg) 70%, var(--primary-bright));
+    --immersive-atmosphere-glow: color-mix(in oklab, var(--primary-bright) 26%, transparent);
+}
+
+:root[data-theme="sunset"] {
+    /* Sunset: warm orange paper while keeping operational contrast intact. */
+    --theme-primary-bright: oklch(0.68 0.13 55);
+    --theme-primary-deep: oklch(0.38 0.09 46);
+    --theme-primary-ink: oklch(0.985 0.008 72);
+    --theme-sidebar-bg: oklch(0.952 0.027 72);
+    --theme-sidebar-card: oklch(0.988 0.014 76);
+    --primary-bright: var(--theme-primary-bright);
+    --primary-deep: var(--theme-primary-deep);
+    --primary-ink: var(--theme-primary-ink);
+    --atc-bg: oklch(0.95 0.028 72);
+    --atc-card: oklch(0.989 0.014 76);
+    --atc-elev: oklch(0.895 0.034 68);
+    --atc-high: oklch(0.8 0.052 60);
+    --atc-accent: oklch(0.34 0.075 48);
+    --atc-orange: var(--primary-bright);
+    --atc-mint: oklch(0.58 0.065 164);
+    --atc-red: oklch(0.5 0.17 26);
+    --atc-text: oklch(0.19 0.018 52);
+    --atc-focus-bg: oklch(0.986 0.011 72);
+    --atc-focus-fg: oklch(0.16 0.018 52);
+    --traffic-level-color: oklch(0.42 0.03 50);
+    --aviation-map-label-shadow: rgba(249,242,229,0.95);
+    --aviation-map-attribution: rgba(47,30,17,0.45);
+    --aviation-map-range-background: rgba(252,247,236,0.48);
+    --aviation-map-range-text: #2f1e11;
+    --aviation-map-range-label: rgba(47,30,17,0.7);
+    --aviation-range-ring-minor: rgba(64,38,18,0.115);
+    --aviation-range-ring-major: rgba(64,38,18,0.21);
+    --aviation-range-ring-band: rgba(64,38,18,0.055);
+    --airspace-blocked-stroke: oklch(0.43 0.16 25);
+    --airspace-restricted-stroke: oklch(0.47 0.13 38);
+    --airspace-permission-stroke: oklch(0.43 0.1 72);
+    --airspace-caution-stroke: oklch(0.45 0.11 88);
+    --aviation-trace-line: #2f1e11;
+    --aviation-trace-glow: oklch(0.5 0.105 48);
+    --aviation-trace-point: #2f1e11;
+    --aviation-runway-annotation-line: #412716;
+    --aviation-runway-approach-line: rgba(65,39,22,0.64);
+    --aviation-runway-approach-beam: oklch(0.46 0.1 48);
+    --aviation-nearby-runway-line: #4a2d18;
+    --aircraft-departure: oklch(0.39 0.03 50);
+    --aircraft-arrival: oklch(0.39 0.03 50);
+    --aircraft-unknown: oklch(0.39 0.03 50);
+    --aircraft-ground: oklch(0.53 0.025 50);
+    --aviation-logo-plate: #f8f0df;
+    --glass-card-top: color-mix(in oklab, var(--atc-card) 64%, transparent);
+    --glass-card-bottom: color-mix(in oklab, oklch(0.84 0.06 58) 46%, transparent);
+    --glass-card-glint-strong: color-mix(in oklab, oklch(0.99 0.018 72) 48%, transparent);
+    --glass-card-glint-soft: color-mix(in oklab, var(--primary-bright) 16%, transparent);
+    --glass-card-border: color-mix(in oklab, var(--primary-bright) 22%, var(--atc-text) 8%);
+    --glass-card-inset: color-mix(in oklab, oklch(0.99 0.018 72) 40%, transparent);
+    --atc-toolbar-surface: color-mix(in oklab, var(--atc-card) 76%, oklch(0.82 0.075 55 / 0.36));
+    --atc-control-hover-bg: color-mix(in oklab, var(--primary-bright) 15%, var(--atc-elev));
+    --atc-control-hover-bg-strong: color-mix(in oklab, var(--primary-bright) 23%, var(--atc-elev));
+    --atc-control-selected-bg: color-mix(in oklab, var(--primary-bright) 18%, transparent);
+    --atc-menu-panel-shadow:
+        0 18px 44px color-mix(in oklab, oklch(0.68 0.13 55) 24%, transparent),
+        0 4px 12px color-mix(in oklab, var(--atc-text) 9%, transparent);
+    --app-panel-shadow:
+        0 24px 58px color-mix(in oklab, oklch(0.68 0.13 55) 20%, transparent),
+        0 8px 22px color-mix(in oklab, var(--atc-text) 8%, transparent),
+        0 1px 3px color-mix(in oklab, var(--atc-text) 5%, transparent);
+    --app-map-sidebar-shadow:
+        18px 0 50px color-mix(in oklab, oklch(0.68 0.13 55) 22%, transparent),
+        3px 0 12px color-mix(in oklab, var(--atc-text) 8%, transparent),
+        var(--app-panel-shadow);
+    --app-card-shadow:
+        0 12px 28px color-mix(in oklab, oklch(0.68 0.13 55) 16%, transparent),
+        inset 0 1px 0 color-mix(in oklab, white 38%, transparent);
+    --app-floating-shadow:
+        0 20px 48px color-mix(in oklab, oklch(0.68 0.13 55) 20%, transparent),
+        0 7px 18px color-mix(in oklab, var(--atc-text) 7%, transparent),
+        0 1px 2px color-mix(in oklab, var(--atc-text) 5%, transparent);
+    --app-floating-edge-shadow: color-mix(in oklab, oklch(0.68 0.13 55) 38%, transparent);
+    --app-toolbar-shadow:
+        0 14px 28px color-mix(in oklab, oklch(0.68 0.13 55) 26%, transparent),
+        0 4px 10px color-mix(in oklab, var(--atc-text) 9%, transparent),
+        0 1px 2px color-mix(in oklab, var(--atc-text) 6%, transparent);
+    --preview-card-shadow: var(--app-floating-shadow);
+    --sidebar-tile-bottom-glow: linear-gradient(
+        to top,
+        color-mix(in oklab, var(--primary-bright) 48%, transparent) 0%,
+        color-mix(in oklab, var(--primary-bright) 26%, transparent) 18%,
+        color-mix(in oklab, white 10%, transparent) 48%,
+        transparent 82%
+    );
+    --sidebar-tile-edge-glow: color-mix(in oklab, var(--primary-bright) 62%, white);
+    --immersive-sky-day-base: var(--atc-bg);
+    --immersive-sky-sunset-base: color-mix(in oklab, var(--atc-bg) 70%, var(--primary-bright));
+    --immersive-atmosphere-glow: color-mix(in oklab, var(--primary-bright) 22%, transparent);
+}
+
 :root[data-theme="dark"] {
     /* Dark: premium near-black travel app shell with bright active state. */
     --primary-bright: oklch(0.94 0.004 100);
@@ -969,6 +1161,16 @@ body {
     mix-blend-mode: multiply;
 }
 
+:root[data-theme="sunrise"] .atc-tile-base {
+    filter: saturate(1.04) contrast(1) brightness(1.02);
+    mix-blend-mode: normal;
+}
+
+:root[data-theme="sunset"] .atc-tile-base {
+    filter: saturate(1.04) contrast(0.98) brightness(1);
+    mix-blend-mode: normal;
+}
+
 .runway-end-label {
     align-items: center;
     background: color-mix(in oklab, var(--atc-surface-card) 88%, transparent);
@@ -1084,7 +1286,9 @@ body {
     mix-blend-mode: screen;
 }
 
-:root[data-theme="light"] .runway-approach-beam {
+:root[data-theme="light"] .runway-approach-beam,
+:root[data-theme="sunrise"] .runway-approach-beam,
+:root[data-theme="sunset"] .runway-approach-beam {
     filter: blur(2.4px);
     mix-blend-mode: multiply;
 }
@@ -2862,6 +3066,10 @@ body {
     --map-label-glow: oklch(0.12 0.004 100);
 }
 
+:root[data-theme="sunrise"] {
+    --map-label-glow: rgba(13, 18, 53, 0.72);
+}
+
 .leaflet-marker-icon {
     transition: none;
 }
@@ -3026,6 +3234,20 @@ body {
     stroke-dasharray: 10 12 !important;
 }
 
+:root[data-theme="sunrise"] .aircraft-label {
+    text-shadow:
+        0 1px 2px rgba(13, 18, 53, 0.7),
+        0 0 1px rgba(13, 18, 53, 0.85);
+}
+
+:root[data-theme="sunrise"] .aircraft-nose-beam {
+    display: none;
+}
+
+:root[data-theme="sunrise"] .aircraft-trace--flightaware-route-glow {
+    opacity: 0.2;
+}
+
 .aircraft-trace-point {
     filter: drop-shadow(
         0 0 7px color-mix(in oklab, var(--atc-accent) 24%, transparent)
@@ -3092,14 +3314,28 @@ body {
     text-transform: uppercase;
 }
 
-:root[data-theme="light"] .aircraft-trace--glow {
+:root[data-theme="light"] .aircraft-trace--glow,
+:root[data-theme="sunset"] .aircraft-trace--glow {
     filter: blur(2.5px);
     mix-blend-mode: multiply;
 }
 
-:root[data-theme="light"] .aircraft-trace-point {
+:root[data-theme="sunrise"] .aircraft-trace--glow {
+    filter: blur(1.8px);
+    mix-blend-mode: screen;
+    opacity: 0.32;
+}
+
+:root[data-theme="light"] .aircraft-trace-point,
+:root[data-theme="sunset"] .aircraft-trace-point {
     filter: drop-shadow(
         0 0 4px color-mix(in oklab, var(--atc-accent) 12%, transparent)
+    );
+}
+
+:root[data-theme="sunrise"] .aircraft-trace-point {
+    filter: drop-shadow(
+        0 0 2px color-mix(in oklab, var(--atc-accent) 14%, transparent)
     );
 }
 
@@ -6035,6 +6271,99 @@ body {
     z-index: 0;
 }
 
+.airport-map-kit .airport-map-stage::before,
+.airport-map-kit .airport-map-stage::after {
+    content: "";
+    inset: 0;
+    pointer-events: none;
+    position: absolute;
+}
+
+.airport-map-kit .airport-map-stage::before {
+    z-index: 12;
+}
+
+.airport-map-kit .airport-map-stage::after {
+    z-index: 13;
+}
+
+:root[data-theme="sunrise"] .airport-map-kit .airport-map-stage::before {
+    background:
+        linear-gradient(
+            180deg,
+            rgba(9, 13, 48, 0.34) 0%,
+            rgba(35, 39, 103, 0.28) 32%,
+            rgba(117, 106, 180, 0.18) 56%,
+            rgba(255, 188, 91, 0.06) 80%,
+            transparent 100%
+        ),
+        radial-gradient(
+            ellipse at 50% 104%,
+            rgba(255, 206, 112, 0.18) 0%,
+            rgba(235, 132, 56, 0.08) 28%,
+            rgba(111, 91, 172, 0.08) 52%,
+            transparent 72%
+        );
+    mix-blend-mode: screen;
+    opacity: 0.82;
+}
+
+:root[data-theme="sunrise"] .airport-map-kit .airport-map-stage::after {
+    -webkit-backdrop-filter: saturate(1.08) contrast(0.98);
+    backdrop-filter: saturate(1.08) contrast(0.98);
+    background:
+        linear-gradient(
+            0deg,
+            rgba(255, 198, 96, 0.08) 0%,
+            rgba(255, 198, 96, 0.04) 16%,
+            transparent 36%
+        ),
+        radial-gradient(
+            ellipse at 18% 64%,
+            rgba(189, 194, 255, 0.24),
+            transparent 42%
+        );
+    mix-blend-mode: soft-light;
+    opacity: 0.72;
+}
+
+:root[data-theme="sunset"] .airport-map-kit .airport-map-stage::before {
+    background:
+        linear-gradient(
+            180deg,
+            rgba(255, 194, 94, 0.22) 0%,
+            rgba(255, 137, 31, 0.2) 38%,
+            rgba(115, 49, 24, 0.12) 100%
+        ),
+        radial-gradient(
+            ellipse at 46% 102%,
+            rgba(255, 218, 110, 0.42) 0%,
+            rgba(245, 121, 31, 0.28) 34%,
+            transparent 66%
+        );
+    mix-blend-mode: soft-light;
+    opacity: 0.72;
+}
+
+:root[data-theme="sunset"] .airport-map-kit .airport-map-stage::after {
+    -webkit-backdrop-filter: saturate(1.05) contrast(0.97);
+    backdrop-filter: saturate(1.05) contrast(0.97);
+    background:
+        radial-gradient(
+            ellipse at 82% 22%,
+            rgba(255, 235, 171, 0.16),
+            transparent 38%
+        ),
+        linear-gradient(
+            90deg,
+            rgba(255, 178, 76, 0.08),
+            transparent 44%,
+            rgba(111, 45, 19, 0.08)
+        );
+    mix-blend-mode: overlay;
+    opacity: 0.62;
+}
+
 :root[data-theme="dark"] .airport-map-kit .airport-map-stage {
     border-color: color-mix(in oklab, var(--atc-line-strong) 64%, transparent);
     box-shadow:
@@ -6287,6 +6616,12 @@ body {
         text-shadow:
             0 0 3px var(--map-label-glow),
             0 0 6px var(--map-label-glow);
+    }
+
+    :root[data-theme="sunrise"] .airport-map-kit .aircraft-label {
+        text-shadow:
+            0 1px 2px rgba(13, 18, 53, 0.7),
+            0 0 1px rgba(13, 18, 53, 0.85);
     }
 
     .airport-map-kit .nearby-airport-marker-dot {

--- a/src/style.css
+++ b/src/style.css
@@ -445,6 +445,40 @@
     --atc-focus-bg: oklch(0.985 0.003 100);
     --atc-focus-fg: oklch(0.16 0.006 100);
     --atc-focus-edge: var(--atc-orange);
+    --atc-surface-app: var(--atc-bg);
+    --atc-surface-panel: var(--atc-elev);
+    --atc-surface-card: var(--atc-card);
+    --atc-surface-scrim: color-mix(in oklab, var(--atc-bg) 72%, transparent);
+    --atc-surface-map-glass: color-mix(in oklab, var(--atc-card) 88%, transparent);
+    --atc-surface-preview-card: color-mix(in oklab, var(--atc-card) 96%, var(--atc-bg));
+    --atc-surface-row-rest: color-mix(in oklab, var(--atc-bg) 38%, transparent);
+    --atc-surface-icon-wash: color-mix(in oklab, var(--atc-text) 8%, transparent);
+    --atc-text-primary: var(--atc-text);
+    --atc-text-secondary: var(--atc-dim);
+    --atc-text-muted: var(--atc-faint);
+    --atc-text-inverse: var(--atc-click-fg);
+    --atc-text-disabled: color-mix(in oklab, var(--atc-text) 30%, transparent);
+    --atc-border-default: var(--atc-line);
+    --atc-border-subtle: color-mix(in oklab, var(--atc-line) 60%, transparent);
+    --atc-border-active: var(--atc-click-border);
+    --atc-focus-ring: var(--atc-focus-edge);
+    --atc-interaction-primary-accent: var(--atc-accent);
+    --atc-interaction-accent-hover: color-mix(in oklab, var(--atc-elev) 55%, transparent);
+    --atc-interaction-selected: var(--atc-click-bg);
+    --atc-interaction-active-mode: var(--atc-click-bg);
+    --atc-interaction-warning: var(--atc-orange);
+    --atc-interaction-danger: var(--atc-red);
+    --atc-action-primary-border: color-mix(in oklab, var(--primary-bright) 82%, var(--primary-ink));
+    --atc-action-primary-shadow:
+        0 8px 16px color-mix(in oklab, var(--primary-bright) 16%, transparent),
+        inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 28%, transparent);
+    --atc-action-focus-ring: color-mix(in oklab, var(--primary-bright) 72%, white);
+    --atc-preview-accent-wash: linear-gradient(
+        135deg,
+        color-mix(in oklab, var(--atc-orange) 10%, transparent),
+        transparent 48%
+    );
+    --atc-preview-card-inset: inset 0 1px 0 color-mix(in oklab, var(--atc-text) 8%, transparent);
     --glass-card-top: color-mix(in oklab, var(--atc-bg) 50%, transparent);
     --glass-card-bottom: color-mix(in oklab, var(--atc-elev) 50%, transparent);
     --glass-card-glint-strong: color-mix(in oklab, var(--atc-bg) 40%, transparent);
@@ -452,14 +486,22 @@
     --glass-card-border: color-mix(in oklab, var(--atc-text) 13%, transparent);
     --glass-card-inset: color-mix(in oklab, var(--atc-bg) 32%, transparent);
     --traffic-level-color: oklch(0.46 0.006 100);
-    --map-label-shadow: rgba(245,243,238,0.95);
-    --map-attribution: rgba(26,26,24,0.45);
-    --map-range-background: rgba(250,249,245,0.45);
-    --map-range-text: #1a1a18;
-    --map-range-label: rgba(26,26,24,0.7);
-    --airport-range-ring-minor: rgba(18,21,26,0.11);
-    --airport-range-ring-major: rgba(18,21,26,0.20);
-    --airport-range-ring-band: rgba(18,21,26,0.05);
+    --aviation-map-label-shadow: rgba(245,243,238,0.95);
+    --aviation-map-attribution: rgba(26,26,24,0.45);
+    --aviation-map-range-background: rgba(250,249,245,0.45);
+    --aviation-map-range-text: #1a1a18;
+    --aviation-map-range-label: rgba(26,26,24,0.7);
+    --aviation-range-ring-minor: rgba(18,21,26,0.11);
+    --aviation-range-ring-major: rgba(18,21,26,0.20);
+    --aviation-range-ring-band: rgba(18,21,26,0.05);
+    --map-label-shadow: var(--aviation-map-label-shadow);
+    --map-attribution: var(--aviation-map-attribution);
+    --map-range-background: var(--aviation-map-range-background);
+    --map-range-text: var(--aviation-map-range-text);
+    --map-range-label: var(--aviation-map-range-label);
+    --airport-range-ring-minor: var(--aviation-range-ring-minor);
+    --airport-range-ring-major: var(--aviation-range-ring-major);
+    --airport-range-ring-band: var(--aviation-range-ring-band);
     --airspace-blocked-stroke: oklch(0.39 0.16 27);
     --airspace-blocked-fill: color-mix(in oklab, var(--airspace-blocked-stroke) 8%, transparent);
     --airspace-blocked-focus-fill: color-mix(in oklab, var(--airspace-blocked-stroke) 24%, transparent);
@@ -485,13 +527,27 @@
     --airspace-unknown-fill: color-mix(in oklab, var(--atc-text) 3.5%, transparent);
     --airspace-unknown-focus-fill: color-mix(in oklab, var(--atc-text) 14%, transparent);
     --airspace-boundary-label: color-mix(in oklab, var(--atc-text) 52%, transparent);
-    --aircraft-trace-line: #1a1a18;
-    --aircraft-trace-glow: #55534e;
-    --aircraft-trace-point: #1a1a18;
-    --runway-annotation-line: #1a1a18;
-    --runway-approach-line: rgba(26,26,24,0.62);
-    --runway-approach-beam: #2f2f2b;
-    --nearby-runway-line: #24231f;
+    --airspace-restricted-warning-fill: var(--airspace-restricted-fill);
+    --airspace-border: var(--airspace-controlled-stroke);
+    --airspace-label-text: var(--airspace-boundary-label);
+    --airspace-altitude-filtered-state: var(--airspace-info-fill);
+    --aviation-trace-line: #1a1a18;
+    --aviation-trace-glow: #55534e;
+    --aviation-trace-point: #1a1a18;
+    --aviation-trace-stale-line: color-mix(in oklab, var(--aviation-trace-line) 54%, transparent);
+    --aviation-route-hint-line: var(--aviation-trace-line);
+    --aviation-aircraft-shadow: rgba(0,0,0,0.95);
+    --aviation-runway-annotation-line: #1a1a18;
+    --aviation-runway-approach-line: rgba(26,26,24,0.62);
+    --aviation-runway-approach-beam: #2f2f2b;
+    --aviation-nearby-runway-line: #24231f;
+    --aircraft-trace-line: var(--aviation-trace-line);
+    --aircraft-trace-glow: var(--aviation-trace-glow);
+    --aircraft-trace-point: var(--aviation-trace-point);
+    --runway-annotation-line: var(--aviation-runway-annotation-line);
+    --runway-approach-line: var(--aviation-runway-approach-line);
+    --runway-approach-beam: var(--aviation-runway-approach-beam);
+    --nearby-runway-line: var(--aviation-nearby-runway-line);
 
     /* Single grey for every aircraft regardless of departure/arrival —
        the airport is the only thing painted yellow on the map. */
@@ -499,6 +555,30 @@
     --aircraft-arrival: oklch(0.42 0.006 100);
     --aircraft-unknown: oklch(0.42 0.006 100);
     --aircraft-ground: oklch(0.55 0.006 100);
+    --aviation-aircraft-live-position: var(--aircraft-departure);
+    --aviation-aircraft-fallback-position: var(--aircraft-unknown);
+    --aviation-aircraft-ground-position: var(--aircraft-ground);
+    --aviation-logo-plate: #f5f3ee;
+    --navaid-marker: var(--atc-accent);
+    --navaid-label-text: var(--atc-accent);
+    --navaid-label-muted: color-mix(in oklab, var(--navaid-label-text) 72%, var(--atc-dim));
+    --navaid-label-surface: color-mix(in oklab, var(--atc-card) 90%, transparent);
+    --navaid-label-border: color-mix(in oklab, var(--navaid-marker) 34%, transparent);
+    --navaid-frequency-badge: var(--atc-card);
+    --navaid-source-badge: var(--atc-elev);
+    --watcher-candidate-marker-border: color-mix(in oklab, var(--primary-bright) 54%, var(--atc-line));
+    --watcher-candidate-marker-surface: color-mix(in oklab, var(--atc-card) 92%, transparent);
+    --watcher-candidate-marker-fg: var(--primary-bright);
+    --watcher-candidate-marker-shadow: 0 8px 24px rgba(0,0,0,0.28);
+    /* Immersive Mode can later remap these by local time/weather without
+       changing component-level color references. */
+    --immersive-sky-day-base: var(--atc-bg);
+    --immersive-sky-sunset-base: color-mix(in oklab, var(--atc-bg) 82%, var(--atc-orange));
+    --immersive-sky-night-base: color-mix(in oklab, var(--atc-bg) 86%, black);
+    --immersive-weather-clear-accent: var(--atc-mint);
+    --immersive-weather-cloudy-accent: var(--atc-high);
+    --immersive-weather-storm-accent: var(--atc-red);
+    --immersive-atmosphere-glow: color-mix(in oklab, var(--atc-orange) 18%, transparent);
 
     /* Tone tokens — composed from theme colors via color-mix.
        Defined once in :root because their inputs are themeable;
@@ -632,6 +712,40 @@
     --atc-focus-bg: oklch(0.95 0.005 100);
     --atc-focus-fg: oklch(0.13 0.004 100);
     --atc-focus-edge: var(--atc-orange);
+    --atc-surface-app: var(--atc-bg);
+    --atc-surface-panel: var(--atc-elev);
+    --atc-surface-card: var(--atc-card);
+    --atc-surface-scrim: color-mix(in oklab, var(--atc-bg) 74%, transparent);
+    --atc-surface-map-glass: color-mix(in oklab, var(--atc-card) 84%, transparent);
+    --atc-surface-preview-card: color-mix(in oklab, var(--atc-card) 96%, var(--atc-bg));
+    --atc-surface-row-rest: color-mix(in oklab, var(--atc-bg) 38%, transparent);
+    --atc-surface-icon-wash: color-mix(in oklab, var(--atc-text) 8%, transparent);
+    --atc-text-primary: var(--atc-text);
+    --atc-text-secondary: var(--atc-dim);
+    --atc-text-muted: var(--atc-faint);
+    --atc-text-inverse: var(--atc-click-fg);
+    --atc-text-disabled: color-mix(in oklab, var(--atc-text) 28%, transparent);
+    --atc-border-default: var(--atc-line);
+    --atc-border-subtle: color-mix(in oklab, var(--atc-line) 62%, transparent);
+    --atc-border-active: var(--atc-click-border);
+    --atc-focus-ring: var(--atc-focus-edge);
+    --atc-interaction-primary-accent: var(--atc-accent);
+    --atc-interaction-accent-hover: color-mix(in oklab, var(--atc-high) 42%, transparent);
+    --atc-interaction-selected: var(--atc-click-bg);
+    --atc-interaction-active-mode: var(--atc-click-bg);
+    --atc-interaction-warning: var(--atc-orange);
+    --atc-interaction-danger: var(--atc-red);
+    --atc-action-primary-border: color-mix(in oklab, var(--primary-bright) 82%, var(--primary-ink));
+    --atc-action-primary-shadow:
+        0 8px 16px color-mix(in oklab, var(--primary-bright) 16%, transparent),
+        inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 28%, transparent);
+    --atc-action-focus-ring: color-mix(in oklab, var(--primary-bright) 72%, white);
+    --atc-preview-accent-wash: linear-gradient(
+        135deg,
+        color-mix(in oklab, var(--atc-orange) 10%, transparent),
+        transparent 48%
+    );
+    --atc-preview-card-inset: inset 0 1px 0 color-mix(in oklab, var(--atc-text) 8%, transparent);
     --glass-card-top: color-mix(in oklab, var(--atc-high) 30%, transparent);
     --glass-card-bottom: color-mix(in oklab, var(--atc-bg) 44%, transparent);
     --glass-card-glint-strong: color-mix(in oklab, var(--atc-text) 12%, transparent);
@@ -639,14 +753,22 @@
     --glass-card-border: color-mix(in oklab, var(--atc-text) 14%, transparent);
     --glass-card-inset: color-mix(in oklab, var(--atc-text) 15%, transparent);
     --traffic-level-color: oklch(0.72 0.006 100);
-    --map-label-shadow: #1a1a18;
-    --map-attribution: rgba(245,243,238,0.3);
-    --map-range-background: rgba(8,12,20,0.4);
-    --map-range-text: #f5f3ee;
-    --map-range-label: rgba(245,243,238,0.7);
-    --airport-range-ring-minor: rgba(255,255,255,0.11);
-    --airport-range-ring-major: rgba(255,255,255,0.20);
-    --airport-range-ring-band: rgba(255,255,255,0.05);
+    --aviation-map-label-shadow: #1a1a18;
+    --aviation-map-attribution: rgba(245,243,238,0.3);
+    --aviation-map-range-background: rgba(8,12,20,0.4);
+    --aviation-map-range-text: #f5f3ee;
+    --aviation-map-range-label: rgba(245,243,238,0.7);
+    --aviation-range-ring-minor: rgba(255,255,255,0.11);
+    --aviation-range-ring-major: rgba(255,255,255,0.20);
+    --aviation-range-ring-band: rgba(255,255,255,0.05);
+    --map-label-shadow: var(--aviation-map-label-shadow);
+    --map-attribution: var(--aviation-map-attribution);
+    --map-range-background: var(--aviation-map-range-background);
+    --map-range-text: var(--aviation-map-range-text);
+    --map-range-label: var(--aviation-map-range-label);
+    --airport-range-ring-minor: var(--aviation-range-ring-minor);
+    --airport-range-ring-major: var(--aviation-range-ring-major);
+    --airport-range-ring-band: var(--aviation-range-ring-band);
     --airspace-blocked-stroke: oklch(0.74 0.18 27);
     --airspace-blocked-fill: color-mix(in oklab, var(--airspace-blocked-stroke) 10%, transparent);
     --airspace-blocked-focus-fill: color-mix(in oklab, var(--airspace-blocked-stroke) 30%, transparent);
@@ -672,19 +794,55 @@
     --airspace-unknown-fill: color-mix(in oklab, var(--atc-text) 5%, transparent);
     --airspace-unknown-focus-fill: color-mix(in oklab, var(--atc-text) 18%, transparent);
     --airspace-boundary-label: color-mix(in oklab, var(--atc-text) 64%, transparent);
-    --aircraft-trace-line: var(--primary-bright);
-    --aircraft-trace-glow: var(--primary-bright);
-    --aircraft-trace-point: var(--primary-bright);
-    --runway-annotation-line: #d8bd83;
-    --runway-approach-line: rgba(216,189,131,0.78);
-    --runway-approach-beam: #d8bd83;
-    --nearby-runway-line: var(--primary-bright);
+    --airspace-restricted-warning-fill: var(--airspace-restricted-fill);
+    --airspace-border: var(--airspace-controlled-stroke);
+    --airspace-label-text: var(--airspace-boundary-label);
+    --airspace-altitude-filtered-state: var(--airspace-info-fill);
+    --aviation-trace-line: var(--primary-bright);
+    --aviation-trace-glow: var(--primary-bright);
+    --aviation-trace-point: var(--primary-bright);
+    --aviation-trace-stale-line: color-mix(in oklab, var(--aviation-trace-line) 54%, transparent);
+    --aviation-route-hint-line: var(--aviation-trace-line);
+    --aviation-aircraft-shadow: rgba(0,0,0,0.95);
+    --aviation-runway-annotation-line: #d8bd83;
+    --aviation-runway-approach-line: rgba(216,189,131,0.78);
+    --aviation-runway-approach-beam: #d8bd83;
+    --aviation-nearby-runway-line: var(--primary-bright);
+    --aircraft-trace-line: var(--aviation-trace-line);
+    --aircraft-trace-glow: var(--aviation-trace-glow);
+    --aircraft-trace-point: var(--aviation-trace-point);
+    --runway-annotation-line: var(--aviation-runway-annotation-line);
+    --runway-approach-line: var(--aviation-runway-approach-line);
+    --runway-approach-beam: var(--aviation-runway-approach-beam);
+    --nearby-runway-line: var(--aviation-nearby-runway-line);
 
     /* Dark theme: same single grey for every aircraft. */
     --aircraft-departure: oklch(0.62 0.006 100);
     --aircraft-arrival: oklch(0.62 0.006 100);
     --aircraft-unknown: oklch(0.62 0.006 100);
     --aircraft-ground: oklch(0.74 0.006 100);
+    --aviation-aircraft-live-position: var(--aircraft-departure);
+    --aviation-aircraft-fallback-position: var(--aircraft-unknown);
+    --aviation-aircraft-ground-position: var(--aircraft-ground);
+    --aviation-logo-plate: #f5f3ee;
+    --navaid-marker: var(--atc-accent);
+    --navaid-label-text: var(--atc-accent);
+    --navaid-label-muted: color-mix(in oklab, var(--navaid-label-text) 72%, var(--atc-dim));
+    --navaid-label-surface: color-mix(in oklab, var(--atc-card) 90%, transparent);
+    --navaid-label-border: color-mix(in oklab, var(--navaid-marker) 34%, transparent);
+    --navaid-frequency-badge: var(--atc-card);
+    --navaid-source-badge: var(--atc-elev);
+    --watcher-candidate-marker-border: color-mix(in oklab, var(--primary-bright) 54%, var(--atc-line));
+    --watcher-candidate-marker-surface: color-mix(in oklab, var(--atc-card) 92%, transparent);
+    --watcher-candidate-marker-fg: var(--primary-bright);
+    --watcher-candidate-marker-shadow: 0 8px 24px rgba(0,0,0,0.28);
+    --immersive-sky-day-base: var(--atc-bg);
+    --immersive-sky-sunset-base: color-mix(in oklab, var(--atc-bg) 72%, var(--atc-orange));
+    --immersive-sky-night-base: color-mix(in oklab, var(--atc-bg) 86%, black);
+    --immersive-weather-clear-accent: var(--atc-mint);
+    --immersive-weather-cloudy-accent: var(--atc-high);
+    --immersive-weather-storm-accent: var(--atc-red);
+    --immersive-atmosphere-glow: color-mix(in oklab, var(--atc-orange) 22%, transparent);
 
     --atc-radius-pill: 999px;
     --atc-radius-panel: 18px;
@@ -813,11 +971,11 @@ body {
 
 .runway-end-label {
     align-items: center;
-    background: color-mix(in oklab, var(--atc-card) 88%, transparent);
-    border: 1px solid color-mix(in oklab, var(--atc-accent) 54%, transparent);
+    background: color-mix(in oklab, var(--atc-surface-card) 88%, transparent);
+    border: 1px solid color-mix(in oklab, var(--atc-interaction-primary-accent) 54%, transparent);
     border-radius: 4px;
     box-shadow: 0 6px 16px rgb(0 0 0 / 0.24);
-    color: var(--atc-accent);
+    color: var(--atc-interaction-primary-accent);
     display: flex;
     font-family: var(--font-mono);
     font-size: 10px;
@@ -836,10 +994,10 @@ body {
 }
 
 .runway-end-label--light {
-    background: color-mix(in oklab, var(--atc-card) 92%, transparent);
-    border-color: color-mix(in oklab, var(--atc-accent) 62%, transparent);
+    background: color-mix(in oklab, var(--atc-surface-card) 92%, transparent);
+    border-color: color-mix(in oklab, var(--atc-interaction-primary-accent) 62%, transparent);
     box-shadow: 0 5px 14px rgb(15 23 42 / 0.16);
-    color: var(--atc-accent);
+    color: var(--atc-interaction-primary-accent);
     text-shadow: none;
 }
 
@@ -859,14 +1017,14 @@ body {
 }
 
 .airport-range-ring-label--dark {
-    color: rgb(255 255 255 / 0.62);
+    color: color-mix(in oklab, var(--aviation-map-range-text) 62%, transparent);
     text-shadow:
         0 1px 2px rgb(0 0 0 / 0.55),
         0 0 6px rgb(0 0 0 / 0.32);
 }
 
 .airport-range-ring-label--light {
-    color: rgb(18 21 26 / 0.62);
+    color: color-mix(in oklab, var(--aviation-map-range-text) 62%, transparent);
     text-shadow:
         0 1px 2px rgb(255 255 255 / 0.6),
         0 0 4px rgb(255 255 255 / 0.4);
@@ -878,15 +1036,15 @@ body {
 }
 
 .airport-range-ring-label--major.airport-range-ring-label--dark {
-    color: rgb(255 255 255 / 0.86);
+    color: color-mix(in oklab, var(--aviation-map-range-text) 86%, transparent);
 }
 
 .airport-range-ring-label--major.airport-range-ring-label--light {
-    color: rgb(18 21 26 / 0.86);
+    color: color-mix(in oklab, var(--aviation-map-range-text) 86%, transparent);
 }
 
 .airspace-boundary-label {
-    fill: var(--airspace-boundary-label);
+    fill: var(--airspace-label-text);
     font-family: var(--font-mono);
     font-size: 10px;
     font-weight: 700;
@@ -904,7 +1062,7 @@ body {
     fill: none;
     opacity: 0.46;
     pointer-events: none;
-    stroke: var(--airspace-boundary-label);
+    stroke: var(--airspace-label-text);
     stroke-dasharray: 0.5 9;
     stroke-linecap: round;
     stroke-linejoin: round;
@@ -953,7 +1111,7 @@ body {
     border: 0;
     box-shadow: none;
     box-sizing: border-box;
-    color: var(--atc-accent);
+    color: var(--navaid-marker);
     display: block;
     height: 8px;
     left: 0;
@@ -971,11 +1129,11 @@ body {
 
 .navaid-label__body {
     align-items: center;
-    background: color-mix(in oklab, var(--atc-card) 90%, transparent);
-    border: 1px solid color-mix(in oklab, var(--atc-accent) 34%, transparent);
+    background: var(--navaid-label-surface);
+    border: 1px solid var(--navaid-label-border);
     border-radius: 4px;
     box-shadow: 0 5px 14px rgb(0 0 0 / 0.18);
-    color: var(--atc-accent);
+    color: var(--navaid-label-text);
     display: inline-flex;
     font-family: var(--font-mono);
     gap: 3px;
@@ -995,7 +1153,7 @@ body {
 }
 
 .navaid-label__body small {
-    color: color-mix(in oklab, var(--atc-accent) 72%, var(--atc-muted));
+    color: var(--navaid-label-muted);
     font-size: 6px;
     font-weight: 700;
     letter-spacing: 0;
@@ -1006,7 +1164,7 @@ body {
 }
 
 .navaid-label-icon--light .navaid-label__body {
-    background: color-mix(in oklab, var(--atc-card) 94%, transparent);
+    background: color-mix(in oklab, var(--atc-surface-card) 94%, transparent);
     box-shadow: 0 4px 12px rgb(15 23 42 / 0.12);
     text-shadow: none;
 }
@@ -1029,11 +1187,11 @@ body {
 
 .navaid-count-marker {
     align-items: center;
-    background: color-mix(in oklab, var(--atc-card) 88%, transparent);
-    border: 1px solid color-mix(in oklab, var(--atc-accent) 42%, transparent);
+    background: color-mix(in oklab, var(--navaid-frequency-badge) 88%, transparent);
+    border: 1px solid color-mix(in oklab, var(--navaid-marker) 42%, transparent);
     border-radius: 999px;
     box-shadow: 0 8px 22px rgb(0 0 0 / 0.18);
-    color: var(--atc-accent);
+    color: var(--navaid-label-text);
     display: inline-flex;
     font-family: var(--font-mono);
     gap: 3px;
@@ -1056,7 +1214,7 @@ body {
 }
 
 .navaid-count-marker span {
-    color: color-mix(in oklab, var(--atc-accent) 72%, var(--atc-muted));
+    color: var(--navaid-label-muted);
     font-size: 7px;
     font-weight: 800;
     letter-spacing: 0;

--- a/src/utils/theme.test.ts
+++ b/src/utils/theme.test.ts
@@ -3,10 +3,13 @@ import assert from 'node:assert/strict'
 import {
   THEME_DARK,
   THEME_LIGHT,
+  THEME_SUNRISE,
+  THEME_SUNSET,
   THEME_SYSTEM,
   applyThemePreference,
   initThemePreference,
   nextTheme,
+  isImmersiveTheme,
   sanitizeTheme,
   writeStoredTheme,
 } from './theme'
@@ -46,11 +49,18 @@ globalThis.document = {
 } as Document
 
 assert.equal(sanitizeTheme('light'), THEME_LIGHT)
+assert.equal(sanitizeTheme('sunrise'), THEME_SUNRISE)
+assert.equal(sanitizeTheme('sunset'), THEME_SUNSET)
 assert.equal(sanitizeTheme('wat'), THEME_SYSTEM)
 
 assert.equal(nextTheme(THEME_LIGHT), THEME_DARK)
 assert.equal(nextTheme(THEME_DARK), THEME_SYSTEM)
 assert.equal(nextTheme(THEME_SYSTEM), THEME_LIGHT)
+assert.equal(nextTheme(THEME_SUNRISE), THEME_LIGHT)
+assert.equal(nextTheme(THEME_SUNSET), THEME_LIGHT)
+assert.equal(isImmersiveTheme(THEME_SUNRISE), true)
+assert.equal(isImmersiveTheme(THEME_SUNSET), true)
+assert.equal(isImmersiveTheme(THEME_LIGHT), false)
 
 const storage = createStorage({ theme: 'wat' })
 assert.equal(
@@ -91,9 +101,20 @@ assert.equal(lightResult.preference, THEME_LIGHT)
 assert.equal(lightResult.resolvedTheme, THEME_LIGHT)
 assert.equal(lightRoot.attrs.get('data-theme'), THEME_LIGHT)
 
+const sunriseRoot = createRoot()
+const sunriseResult = applyThemePreference({
+  theme: THEME_SUNRISE,
+  root: sunriseRoot,
+  mediaQueryList: { matches: true },
+})
+assert.equal(sunriseResult.preference, THEME_SUNRISE)
+assert.equal(sunriseResult.resolvedTheme, THEME_SUNRISE)
+assert.equal(sunriseRoot.attrs.get('data-theme'), THEME_SUNRISE)
+
 // applyThemePreference writes the RESOLVED theme to the cookie even
 // when the preference is "system" — that's what kills the SSR dark
-// flash for system-preference users on the next page load.
+// flash for system-preference users on the next page load. Concrete
+// non-system themes write themselves so SSR can render their token palette.
 cookieJar.value = ''
 applyThemePreference({
   theme: THEME_SYSTEM,
@@ -101,6 +122,14 @@ applyThemePreference({
   mediaQueryList: { matches: false },
 })
 assert.ok(cookieJar.value.startsWith('theme=light;'), `expected resolved light cookie, got "${cookieJar.value}"`)
+
+cookieJar.value = ''
+applyThemePreference({
+  theme: THEME_SUNSET,
+  root: createRoot(),
+  mediaQueryList: { matches: false },
+})
+assert.ok(cookieJar.value.startsWith('theme=sunset;'), `expected resolved sunset cookie, got "${cookieJar.value}"`)
 
 cookieJar.value = ''
 writeStoredTheme(THEME_SYSTEM, storage)

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -2,9 +2,16 @@ const THEME_KEY = 'theme'
 const THEME_LIGHT = 'light'
 const THEME_DARK = 'dark'
 const THEME_SYSTEM = 'system'
+const THEME_SUNRISE = 'sunrise'
+const THEME_SUNSET = 'sunset'
 const FALLBACK_THEME = THEME_SYSTEM
 
-type ThemePreference = typeof THEME_LIGHT | typeof THEME_DARK | typeof THEME_SYSTEM
+type ThemePreference =
+  | typeof THEME_LIGHT
+  | typeof THEME_DARK
+  | typeof THEME_SYSTEM
+  | typeof THEME_SUNRISE
+  | typeof THEME_SUNSET
 type ThemeStorage = {
   getItem(key: string): unknown
   setItem(key: string, value: string): void
@@ -12,7 +19,28 @@ type ThemeStorage = {
 type ThemeRoot = Pick<Element, "setAttribute">
 type ThemeMediaQueryList = Pick<MediaQueryList, "matches">
 
-const THEMES: ThemePreference[] = [THEME_LIGHT, THEME_DARK, THEME_SYSTEM]
+const THEMES: ThemePreference[] = [
+  THEME_LIGHT,
+  THEME_DARK,
+  THEME_SYSTEM,
+  THEME_SUNRISE,
+  THEME_SUNSET,
+]
+const SWITCHABLE_THEMES: ThemePreference[] = [
+  THEME_LIGHT,
+  THEME_DARK,
+  THEME_SYSTEM,
+]
+const CONCRETE_THEMES: ThemePreference[] = [
+  THEME_LIGHT,
+  THEME_DARK,
+  THEME_SUNRISE,
+  THEME_SUNSET,
+]
+const IMMERSIVE_THEMES: ThemePreference[] = [
+  THEME_SUNRISE,
+  THEME_SUNSET,
+]
 
 const getSystemTheme = (mediaQueryList: ThemeMediaQueryList = window.matchMedia('(prefers-color-scheme: dark)')) =>
   mediaQueryList.matches ? THEME_DARK : THEME_LIGHT
@@ -20,16 +48,22 @@ const getSystemTheme = (mediaQueryList: ThemeMediaQueryList = window.matchMedia(
 const sanitizeTheme = (theme: unknown): ThemePreference =>
   THEMES.includes(theme as ThemePreference) ? (theme as ThemePreference) : FALLBACK_THEME
 
+const isConcreteTheme = (theme: unknown): theme is Exclude<ThemePreference, typeof THEME_SYSTEM> =>
+  CONCRETE_THEMES.includes(theme as ThemePreference)
+
+const isImmersiveTheme = (theme: unknown): theme is typeof THEME_SUNRISE | typeof THEME_SUNSET =>
+  IMMERSIVE_THEMES.includes(theme as ThemePreference)
+
 const readStoredTheme = (storage: ThemeStorage = window.localStorage) => sanitizeTheme(storage.getItem(THEME_KEY))
 
 const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
 
-// The cookie carries the RESOLVED theme (light/dark), never "system".
+// The cookie carries the RESOLVED theme, never "system".
 // SSR can then render the right data-theme directly even when the user
 // runs on system preference — no flash on cold loads / hard refreshes.
 const writeResolvedThemeCookie = (resolvedTheme: unknown) => {
   if (typeof document === 'undefined') return
-  if (resolvedTheme !== THEME_LIGHT && resolvedTheme !== THEME_DARK) return
+  if (!isConcreteTheme(resolvedTheme)) return
   document.cookie = `${THEME_KEY}=${resolvedTheme}; Path=/; Max-Age=${THEME_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`
 }
 
@@ -71,16 +105,21 @@ const initThemePreference = ({
 
 const nextTheme = (theme: unknown) => {
   const safeTheme = sanitizeTheme(theme)
-  const currentIndex = THEMES.indexOf(safeTheme)
-  return THEMES[(currentIndex + 1) % THEMES.length]
+  const currentIndex = SWITCHABLE_THEMES.indexOf(safeTheme)
+  if (currentIndex === -1) return THEME_LIGHT
+  return SWITCHABLE_THEMES[(currentIndex + 1) % SWITCHABLE_THEMES.length]
 }
 
 export {
   THEME_LIGHT,
   THEME_DARK,
+  THEME_SUNRISE,
+  THEME_SUNSET,
   THEME_SYSTEM,
   applyThemePreference,
   initThemePreference,
+  isConcreteTheme,
+  isImmersiveTheme,
   nextTheme,
   sanitizeTheme,
   writeStoredTheme,

--- a/supabase/migrations/20260603190000_backfill_immersive_theme_flags.sql
+++ b/supabase/migrations/20260603190000_backfill_immersive_theme_flags.sql
@@ -1,0 +1,14 @@
+update public.user_feature_flags
+set
+  flags = jsonb_set(
+    coalesce(flags, '{}'::jsonb),
+    '{immersiveThemesEnabled}',
+    'true'::jsonb,
+    true
+  ),
+  updated_at = timezone('utc', now())
+where flags->>'flightAwareEnabled' = 'true'
+  and coalesce(flags->>'immersiveThemesEnabled', 'false') <> 'true';
+
+comment on table public.user_feature_flags is
+  'Server-read feature flags keyed by Clerk primary email and environment. Example flags: {"flightAwareEnabled": true, "immersiveThemesEnabled": true}.';


### PR DESCRIPTION
## Summary
- Added a semantic color-token registry for surface, text, border, interaction, aviation, airspace, navaid/radio, and immersive-ready token groups.
- Added CSS token aliases that preserve the current light/dark look while giving future Immersive Mode a stable palette layer.
- Migrated high-impact map/settings/aircraft preview paths away from one-off color expressions toward semantic tokens.

## Validation
- /opt/homebrew/bin/pnpm lint (passes with existing VirtualNearbyList React Compiler warning)
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm build
- Local browser: home page, /airport/KBOS desktop map/settings, /aircraft/AAL732 tracking route, Radio navaid labels, Watcher spotting markers
- Mobile smoke: /airport/KBOS at 390x844 with map, aircraft, airspace labels, no horizontal overflow