### PR TITLE
Refine immersive aircraft lighting

### DIFF
--- a/src/components/map/Aircraft3DOverlay.tsx
+++ b/src/components/map/Aircraft3DOverlay.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/features/aircraft/icons/aircraftIconAnchors.generated";
 import {
   resolveAircraft3DAttitudeRotation,
+  resolveAircraft3DEdgeTone,
   resolveAircraft3DLightingProfile,
   resolveAircraft3DMaterialProfile,
   resolveAircraft3DModelScalePx,
@@ -41,6 +42,7 @@ type Aircraft3DOverlayProps = {
   selectedAircraftId?: string;
   immersiveModeActive?: boolean;
   immersivePhase?: string;
+  mapInstance?: any;
   trafficFilter?: string;
   typeFilter?: string;
   altitudeLevel?: string;
@@ -90,6 +92,7 @@ const modelTemplateCache = new Map<string, Promise<AircraftModelTemplate>>();
 let fallbackTemplate: AircraftModelTemplate | null = null;
 let shadowTexture: THREE.CanvasTexture | null = null;
 let lightGlowTexture: THREE.CanvasTexture | null = null;
+let landingBeamTexture: THREE.CanvasTexture | null = null;
 let contrailTexture: THREE.CanvasTexture | null = null;
 
 function createRadialTexture({
@@ -146,6 +149,42 @@ function getLightGlowTexture() {
     size: 96,
   });
   return lightGlowTexture;
+}
+
+function getLandingBeamTexture() {
+  if (landingBeamTexture) return landingBeamTexture;
+  const canvas = document.createElement("canvas");
+  canvas.width = 64;
+  canvas.height = 192;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  const vertical = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  vertical.addColorStop(0, "rgba(255, 242, 205, 0.7)");
+  vertical.addColorStop(0.28, "rgba(255, 232, 184, 0.32)");
+  vertical.addColorStop(1, "rgba(255, 232, 184, 0)");
+  ctx.fillStyle = vertical;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const sideFade = ctx.createRadialGradient(
+    canvas.width / 2,
+    0,
+    2,
+    canvas.width / 2,
+    canvas.height * 0.44,
+    canvas.width * 0.58,
+  );
+  sideFade.addColorStop(0, "rgba(255, 255, 255, 0.76)");
+  sideFade.addColorStop(0.5, "rgba(255, 247, 218, 0.22)");
+  sideFade.addColorStop(1, "rgba(255, 247, 218, 0)");
+  ctx.globalCompositeOperation = "destination-in";
+  ctx.fillStyle = sideFade;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.globalCompositeOperation = "source-over";
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  landingBeamTexture = texture;
+  return landingBeamTexture;
 }
 
 function getContrailTexture() {
@@ -311,6 +350,15 @@ function createMeshMaterial({
   selected: boolean;
 }) {
   const profile = resolveAircraft3DMaterialProfile({ phase, selected });
+  if (phase !== "night") {
+    return new THREE.MeshBasicMaterial({
+      color: profile.color,
+      depthWrite: false,
+      opacity,
+      toneMapped: false,
+      transparent: opacity < 0.99,
+    });
+  }
   return new THREE.MeshStandardMaterial({
     color: profile.color,
     emissive: profile.emissive,
@@ -320,6 +368,105 @@ function createMeshMaterial({
     roughness: profile.roughness,
     transparent: opacity < 0.99,
   });
+}
+
+function getEdgeLightVector(
+  materialProfile: ReturnType<typeof resolveAircraft3DMaterialProfile>,
+) {
+  const vector = materialProfile.edgeLightVector;
+  return new THREE.Vector3(
+    Number(vector.x) || -0.42,
+    Number(vector.y) || -0.7,
+    Number(vector.z) || 0.58,
+  ).normalize();
+}
+
+function resolveSegmentLightDot({
+  edgeGeometry,
+  index,
+  lightVector,
+}: {
+  edgeGeometry: THREE.BufferGeometry;
+  index: number;
+  lightVector: THREE.Vector3;
+}) {
+  const position = edgeGeometry.getAttribute("position") as THREE.BufferAttribute;
+  const ax = position.getX(index);
+  const ay = position.getY(index);
+  const az = position.getZ(index);
+  const bx = position.getX(index + 1);
+  const by = position.getY(index + 1);
+  const bz = position.getZ(index + 1);
+
+  const midpoint = new THREE.Vector3(
+    (ax + bx) / 2,
+    (ay + by) / 2,
+    (az + bz) / 2,
+  );
+  const tangent = new THREE.Vector3(bx - ax, by - ay, bz - az);
+  if (tangent.lengthSq() > 0.0001) tangent.normalize();
+  const radial = new THREE.Vector3(midpoint.x, midpoint.y, 0);
+  if (radial.lengthSq() > 0.0001) radial.normalize();
+
+  const sideNormal = new THREE.Vector3(-tangent.y, tangent.x, 0);
+  if (sideNormal.lengthSq() <= 0.0001) {
+    sideNormal.copy(radial);
+  } else {
+    sideNormal.normalize();
+    if (radial.lengthSq() > 0.0001 && sideNormal.dot(radial) < 0) {
+      sideNormal.multiplyScalar(-1);
+    }
+  }
+  sideNormal.z = THREE.MathUtils.clamp(
+    midpoint.z / Math.max(MODEL_DEPTH / 2, 0.1),
+    -1,
+    1,
+  ) * 0.42;
+  sideNormal.normalize();
+
+  const positionBias = midpoint.clone();
+  positionBias.z *= 0.35;
+  if (positionBias.lengthSq() > 0.0001) positionBias.normalize();
+
+  return THREE.MathUtils.clamp(
+    sideNormal.dot(lightVector) * 0.74 + positionBias.dot(lightVector) * 0.26,
+    -1,
+    1,
+  );
+}
+
+function createDirectionalEdgeGeometry({
+  geometry,
+  materialProfile,
+  phase,
+  selected,
+}: {
+  geometry: THREE.BufferGeometry;
+  materialProfile: ReturnType<typeof resolveAircraft3DMaterialProfile>;
+  phase: string;
+  selected: boolean;
+}) {
+  const edgeGeometry = new THREE.EdgesGeometry(geometry, 16);
+  const position = edgeGeometry.getAttribute("position") as THREE.BufferAttribute;
+  const lightVector = getEdgeLightVector(materialProfile);
+  const colors: number[] = [];
+  const baseOpacity = Math.max(materialProfile.edgeOpacity, 0.001);
+
+  for (let index = 0; index < position.count; index += 2) {
+    const lightDot = resolveSegmentLightDot({
+      edgeGeometry,
+      index,
+      lightVector,
+    });
+    const tone = resolveAircraft3DEdgeTone({ phase, selected, lightDot });
+    const color = new THREE.Color(tone.color).multiplyScalar(
+      THREE.MathUtils.clamp(tone.opacity / baseOpacity, 0.42, 1.62),
+    );
+    colors.push(color.r, color.g, color.b, color.r, color.g, color.b);
+  }
+
+  edgeGeometry.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3));
+  return edgeGeometry;
 }
 
 function getAnchor(
@@ -377,6 +524,7 @@ function addLightPoint({
   const core = new THREE.Mesh(new THREE.SphereGeometry(radius, 10, 8), coreMaterial);
   core.position.copy(position);
   core.renderOrder = 34;
+  core.userData.disposeGeometry = true;
   group.add(core);
 
   const glowTexture = getLightGlowTexture();
@@ -419,8 +567,80 @@ function addShadow(group: AircraftRenderGroup, template: AircraftModelTemplate, 
   );
   shadow.position.set(3.8, 5.2, -5);
   shadow.renderOrder = 4;
+  shadow.userData.disposeGeometry = true;
   group.userData.shadow = shadow;
   group.add(shadow);
+}
+
+function addLandingLights({
+  group,
+  materialProfile,
+  opacity,
+  profile,
+  selected,
+  template,
+}: {
+  group: AircraftRenderGroup;
+  materialProfile: ReturnType<typeof resolveAircraft3DMaterialProfile>;
+  opacity: number;
+  profile: ReturnType<typeof resolveAircraft3DLightingProfile>;
+  selected: boolean;
+  template: AircraftModelTemplate;
+}) {
+  if (!profile.landingLightsVisible && !selected) return;
+  const lightOpacity = Math.min(
+    1,
+    materialProfile.landingLightOpacity *
+      profile.landingLightIntensity *
+      opacity *
+      (selected ? 1.08 : 1),
+  );
+  if (lightOpacity <= 0.04) return;
+
+  const nose = getAnchorPosition(template, "noseLight", { x: 0.5, y: 0.05 }, 4.2);
+  const lateralOffset = Math.max(template.width * 0.07, 0.42);
+  const nightLandingLights = profile.landingLightIntensity > 0.7;
+  addLightPoint({
+    glowScale: materialProfile.lightGlowScale * (nightLandingLights ? 2.35 : 1.42),
+    group,
+    position: new THREE.Vector3(nose.x, nose.y, nose.z + 0.18),
+    color: materialProfile.landingLightColor,
+    opacity: Math.min(1, lightOpacity * (nightLandingLights ? 1.2 : 0.94)),
+    radius: materialProfile.lightRadius * (nightLandingLights ? 1.18 : 0.88),
+  });
+  for (const offsetX of [-lateralOffset, lateralOffset]) {
+    addLightPoint({
+      glowScale: materialProfile.lightGlowScale * (nightLandingLights ? 1.62 : 1.34),
+      group,
+      position: new THREE.Vector3(nose.x + offsetX, nose.y, nose.z),
+      color: materialProfile.landingLightColor,
+      opacity: Math.min(1, lightOpacity * (nightLandingLights ? 1.05 : 1)),
+      radius: materialProfile.lightRadius * (nightLandingLights ? 0.9 : 0.82),
+    });
+  }
+
+  const beamTexture = getLandingBeamTexture();
+  if (!beamTexture) return;
+  const beamMaterial = new THREE.MeshBasicMaterial({
+    color: materialProfile.landingLightColor,
+    map: beamTexture,
+    opacity: lightOpacity * (nightLandingLights ? 0.96 : 0.48),
+    transparent: true,
+    depthWrite: false,
+    depthTest: false,
+    blending: THREE.AdditiveBlending,
+  });
+  const beamLength = Math.max(template.height * materialProfile.landingLightScale, 28);
+  const beamWidth = Math.max(
+    template.width * (nightLandingLights ? 0.76 : 0.42),
+    nightLandingLights ? 9.6 : 5.2,
+  );
+  const beam = new THREE.Mesh(new THREE.PlaneGeometry(beamWidth, beamLength), beamMaterial);
+  beam.position.set(nose.x, nose.y - beamLength * 0.48, 1.1);
+  beam.renderOrder = 28;
+  beam.userData.disposeGeometry = true;
+  group.add(beam);
+  group.userData.lightMaterials?.push(beamMaterial);
 }
 
 function addBodyGlow({
@@ -475,6 +695,7 @@ function addContrail(group: AircraftRenderGroup, template: AircraftModelTemplate
     );
     trail.position.set(tail.x, tail.y + trailLength / 2, -3);
     trail.renderOrder = 3;
+    trail.userData.disposeGeometry = true;
     group.add(trail);
   }
 }
@@ -514,6 +735,14 @@ function buildModelGroup({
     profile: materialProfile,
     template,
   });
+  addLandingLights({
+    group,
+    materialProfile,
+    opacity,
+    profile,
+    selected,
+    template,
+  });
 
   if (
     shouldRenderAircraftContrail({
@@ -538,11 +767,12 @@ function buildModelGroup({
   modelRoot.renderOrder = 20;
   group.userData.modelRoot = modelRoot;
   const edgeMaterial = new THREE.LineBasicMaterial({
-    color: materialProfile.edgeColor,
     depthTest: false,
     depthWrite: false,
     opacity: materialProfile.edgeOpacity,
+    toneMapped: false,
     transparent: true,
+    vertexColors: true,
   });
   for (const geometry of template.geometries) {
     const mesh = new THREE.Mesh(geometry, material);
@@ -552,7 +782,12 @@ function buildModelGroup({
     modelRoot.add(mesh);
 
     const edges = new THREE.LineSegments(
-      new THREE.EdgesGeometry(geometry, 16),
+      createDirectionalEdgeGeometry({
+        geometry,
+        materialProfile,
+        phase,
+        selected,
+      }),
       edgeMaterial,
     );
     edges.renderOrder = 24;
@@ -669,18 +904,25 @@ function updateShadow(group: AircraftRenderGroup, aircraft: any, phase: string) 
   if (!shadow) return;
   const altitude = Math.max(0, Math.min(Number(aircraft?.altitude) || 0, 42_000));
   const ratio = aircraft?.onGround ? 0 : altitude / 42_000;
-  const nightBoost = phase === "night" ? 0.8 : 1;
+  const profile = resolveAircraft3DLightingProfile({ phase });
+  const selectedBoost = group.userData.selected ? 1.12 : 0.9;
   shadow.position.set(2.5 + ratio * 7, 3.5 + ratio * 10, -5);
   shadow.scale.set(0.9 + ratio * 0.32, 0.72 + ratio * 0.18, 1);
   const material = shadow.material as THREE.MeshBasicMaterial;
-  material.opacity = Math.max(0.08, (0.34 - ratio * 0.14) * nightBoost);
+  material.opacity = Math.max(
+    phase === "night" ? 0.05 : 0.035,
+    profile.shadowOpacity * selectedBoost - ratio * 0.08,
+  );
 }
 
 function syncLighting(state: AircraftOverlayState, phase: string) {
   const profile = resolveAircraft3DLightingProfile({ phase });
   state.profile = profile;
+  state.ambientLight.color.set(profile.ambientColor);
   state.ambientLight.intensity = profile.ambientIntensity;
+  state.keyLight.color.set(profile.keyLightColor);
   state.keyLight.intensity = profile.keyLightIntensity;
+  state.rimLight.color.set(profile.rimLightColor);
   state.rimLight.intensity = profile.rimLightIntensity;
 }
 
@@ -830,11 +1072,13 @@ export default function Aircraft3DOverlay({
   selectedAircraftId = "",
   immersiveModeActive = false,
   immersivePhase = "day",
+  mapInstance = null,
   trafficFilter = "all",
   typeFilter = "all",
   altitudeLevel = "all",
 }: Aircraft3DOverlayProps) {
-  const map = useMapInstance();
+  const contextMap = useMapInstance();
+  const map = mapInstance || contextMap;
   const stateRef = useRef<AircraftOverlayState | null>(null);
 
   useEffect(() => {
@@ -846,6 +1090,7 @@ export default function Aircraft3DOverlay({
       powerPreference: "high-performance",
     });
     renderer.setClearColor(0x000000, 0);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.domElement.className = "aircraft-3d-overlay";
     renderer.domElement.style.zIndex = String(OVERLAY_Z_INDEX);
     container.appendChild(renderer.domElement);
@@ -856,10 +1101,10 @@ export default function Aircraft3DOverlay({
     camera.lookAt(0, 0, 0);
 
     const profile = resolveAircraft3DLightingProfile({ phase: immersivePhase });
-    const ambientLight = new THREE.AmbientLight("#e7eef8", profile.ambientIntensity);
-    const keyLight = new THREE.DirectionalLight("#fff0cc", profile.keyLightIntensity);
+    const ambientLight = new THREE.AmbientLight(profile.ambientColor, profile.ambientIntensity);
+    const keyLight = new THREE.DirectionalLight(profile.keyLightColor, profile.keyLightIntensity);
     keyLight.position.set(-24, -42, 70);
-    const rimLight = new THREE.DirectionalLight("#88c5ff", profile.rimLightIntensity);
+    const rimLight = new THREE.DirectionalLight(profile.rimLightColor, profile.rimLightIntensity);
     rimLight.position.set(38, 30, 52);
     scene.add(ambientLight, keyLight, rimLight);
 

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -48,7 +48,7 @@ export default function AircraftPosition({
   forceSilhouette = false,
   immersiveModeActive = false,
   immersivePhase = "",
-  threeDimensionalProxyActive = false,
+  threeDimensionalOverlayActive = false,
   onSelectAircraft,
 }) {
   const map = useMapInstance();
@@ -158,7 +158,7 @@ export default function AircraftPosition({
   const labelColor =
     immersiveModeActive && immersivePhase === "night" ? "#fff" : color;
   const sourceBadge = getAircraftPositionSourceBadge(aircraft.positionQuality);
-  const labelLeft = threeDimensionalProxyActive
+  const labelLeft = threeDimensionalOverlayActive
     ? SILHOUETTE_SIZE_PX + 4
     : showArrow
       ? Boolean(silhouette)
@@ -186,7 +186,7 @@ export default function AircraftPosition({
         silhouette={silhouette}
         sizeScale={sizeScale}
         theme={theme}
-        threeDimensionalProxyActive={threeDimensionalProxyActive}
+        threeDimensionalOverlayActive={threeDimensionalOverlayActive}
       />
       {(selected ||
         forceSilhouette ||
@@ -223,7 +223,7 @@ function Pointer({
   silhouette,
   sizeScale = 1,
   theme = "dark",
-  threeDimensionalProxyActive = false,
+  threeDimensionalOverlayActive = false,
 }) {
   // The wrapper carries heading + wake-class scale; the silhouette inside
   // carries the 3D pitch/bank stack + a translateY lift, while a separate
@@ -272,18 +272,13 @@ function Pointer({
   const shadowTransform =
     `translate(${shadowOffsetX}px, ${shadowOffsetY}px) scale(${shadowScale})`;
 
-  if (threeDimensionalProxyActive) {
+  if (threeDimensionalOverlayActive) {
     return (
       <span
-        className="aircraft-marker-proxy"
+        className="aircraft-marker-hit-target"
         aria-hidden="true"
         data-selected={selected ? "true" : undefined}
-        style={
-          {
-            "--aircraft-proxy-rotation": `${rot}deg`,
-            "--aircraft-proxy-scale": String(sizeScale),
-          } as any
-        }
+        style={{ transform: `rotate(${rot}deg) scale(${sizeScale})` }}
       />
     );
   }

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -510,6 +510,7 @@ export default function AirportMap({
               selectedAircraftId={selectedAircraftId}
               immersiveModeActive={immersiveModeActive}
               immersivePhase={immersivePhase}
+              mapInstance={mapInstance}
               trafficFilter={trafficFilter}
               typeFilter={typeFilter}
               altitudeLevel={altitudeLevel}
@@ -530,7 +531,7 @@ export default function AirportMap({
               traceActive={renderSelectedAircraftTrace}
               immersiveModeActive={immersiveModeActive}
               immersivePhase={immersivePhase}
-              threeDimensionalProxyActive={renderAircraft3DOverlay}
+              threeDimensionalOverlayActive={renderAircraft3DOverlay}
               forceSilhouette={
                 Boolean(focalAircraftId) &&
                 getAircraftIdentity(ac) === focalAircraftId

--- a/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
@@ -5,6 +5,7 @@ import {
   resolveAircraft3DLightingProfile,
   resolveAircraft3DMaterialProfile,
   resolveAircraft3DModelScalePx,
+  resolveAircraft3DEdgeTone,
   shouldRenderAircraft3DOverlay,
   shouldRenderAircraftContrail,
 } from "./aircraftIcon3DModel";
@@ -56,9 +57,13 @@ const duskLighting = resolveAircraft3DLightingProfile({ phase: "dusk" });
 const dayLighting = resolveAircraft3DLightingProfile({ phase: "day" });
 
 assert.equal(nightLighting.navLightsVisible, true);
+assert.equal(nightLighting.landingLightsVisible, true);
 assert.ok(nightLighting.navLightIntensity > duskLighting.navLightIntensity);
 assert.ok(duskLighting.navLightIntensity > dayLighting.navLightIntensity);
 assert.ok(dayLighting.keyLightIntensity > nightLighting.keyLightIntensity);
+assert.ok(nightLighting.rimLightIntensity < duskLighting.rimLightIntensity);
+assert.ok(nightLighting.shadowOpacity < duskLighting.shadowOpacity);
+assert.ok(nightLighting.shadowOpacity <= 0.12);
 
 assert.equal(
   resolveAircraft3DModelScalePx({
@@ -80,12 +85,63 @@ assert.ok(
 
 const dayMaterial = resolveAircraft3DMaterialProfile({ phase: "day" });
 const sunsetMaterial = resolveAircraft3DMaterialProfile({ phase: "sunset" });
+const duskMaterial = resolveAircraft3DMaterialProfile({ phase: "dusk" });
 const nightMaterial = resolveAircraft3DMaterialProfile({ phase: "night" });
 assert.notEqual(dayMaterial.color, sunsetMaterial.color);
 assert.notEqual(sunsetMaterial.color, nightMaterial.color);
 assert.ok(nightMaterial.emissiveIntensity > dayMaterial.emissiveIntensity);
 assert.ok(nightMaterial.bodyGlowOpacity <= 0.08);
-assert.ok(nightMaterial.lightGlowScale <= 6);
+assert.ok(nightMaterial.lightGlowScale > duskMaterial.lightGlowScale);
+assert.ok(nightMaterial.lightGlowScale >= 8);
+assert.ok(nightMaterial.lightRadius >= duskMaterial.lightRadius * 1.5);
+assert.ok(nightMaterial.landingLightScale >= duskMaterial.landingLightScale * 2);
+assert.ok(relativeLuminance(dayMaterial.color) > 0.8);
+assert.ok(relativeLuminance(sunsetMaterial.color) > 0.74);
+assert.ok(relativeLuminance(duskMaterial.color) > 0.7);
+assert.ok(dayMaterial.edgeOpacity <= 0.16);
+assert.ok(sunsetMaterial.edgeOpacity <= 0.2);
+assert.ok(nightMaterial.edgeOpacity <= 0.22);
+assert.ok(nightMaterial.landingLightOpacity >= 0.72);
+assert.ok(sunsetMaterial.landingLightOpacity >= 0.3);
+assert.ok(dayMaterial.landingLightOpacity <= 0.18);
+
+const dayShadowEdge = resolveAircraft3DEdgeTone({
+  phase: "day",
+  lightDot: -0.9,
+});
+const dayLitEdge = resolveAircraft3DEdgeTone({
+  phase: "day",
+  lightDot: 0.9,
+});
+const sunsetShadowEdge = resolveAircraft3DEdgeTone({
+  phase: "sunset",
+  lightDot: -0.8,
+});
+const sunsetLitEdge = resolveAircraft3DEdgeTone({
+  phase: "sunset",
+  lightDot: 0.8,
+});
+const nightShadowEdge = resolveAircraft3DEdgeTone({
+  phase: "night",
+  lightDot: -0.9,
+});
+const nightLitEdge = resolveAircraft3DEdgeTone({
+  phase: "night",
+  lightDot: 0.9,
+});
+assert.ok(relativeLuminance(dayLitEdge.color) > relativeLuminance(dayShadowEdge.color));
+assert.ok(dayLitEdge.opacity > dayShadowEdge.opacity);
+assert.ok(
+  relativeLuminance(sunsetLitEdge.color) >
+    relativeLuminance(sunsetShadowEdge.color),
+);
+assert.ok(sunsetLitEdge.opacity > sunsetShadowEdge.opacity);
+assert.ok(
+  relativeLuminance(nightLitEdge.color) >
+    relativeLuminance(nightShadowEdge.color),
+);
+assert.ok(nightLitEdge.opacity <= 0.16);
+assert.ok(nightShadowEdge.opacity < nightLitEdge.opacity);
 
 const levelRotation = resolveAircraft3DAttitudeRotation({ phase: "day" });
 const rightBankRotation = resolveAircraft3DAttitudeRotation({
@@ -100,3 +156,11 @@ const leftBankRotation = resolveAircraft3DAttitudeRotation({
 assert.ok(rightBankRotation.rotationYDeg > levelRotation.rotationYDeg);
 assert.ok(leftBankRotation.rotationYDeg < levelRotation.rotationYDeg);
 assert.ok(rightBankRotation.rotationXDeg < levelRotation.rotationXDeg);
+
+function relativeLuminance(hex: string) {
+  const normalized = hex.replace("#", "");
+  const [r, g, b] = [0, 2, 4].map((start) =>
+    Number.parseInt(normalized.slice(start, start + 2), 16) / 255,
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}

--- a/src/features/aircraft/icons/aircraftIcon3DModel.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.ts
@@ -23,6 +23,10 @@ type Aircraft3DMaterialOptions = {
   selected?: boolean;
 };
 
+type Aircraft3DEdgeToneOptions = Aircraft3DMaterialOptions & {
+  lightDot?: unknown;
+};
+
 type Aircraft3DAttitudeOptions = {
   phase?: unknown;
   pitch?: unknown;
@@ -51,6 +55,31 @@ const clamp = (value: number, min: number, max: number) =>
 
 const round2 = (value: number) => Math.round(value * 100) / 100;
 
+const hexToRgb = (hex: string) => {
+  const normalized = hex.replace("#", "");
+  return [0, 2, 4].map((start) =>
+    Number.parseInt(normalized.slice(start, start + 2), 16),
+  ) as [number, number, number];
+};
+
+const rgbToHex = ([r, g, b]: [number, number, number]) =>
+  `#${[r, g, b]
+    .map((channel) =>
+      clamp(Math.round(channel), 0, 255).toString(16).padStart(2, "0"),
+    )
+    .join("")}`;
+
+const mixHex = (from: string, to: string, amount: number) => {
+  const ratio = clamp(amount, 0, 1);
+  const fromRgb = hexToRgb(from);
+  const toRgb = hexToRgb(to);
+  return rgbToHex(
+    fromRgb.map((channel, index) =>
+      channel + (toRgb[index] - channel) * ratio,
+    ) as [number, number, number],
+  );
+};
+
 export const shouldRenderAircraft3DOverlay = ({
   immersiveModeActive = false,
 }: Aircraft3DOverlayOptions = {}) => Boolean(immersiveModeActive);
@@ -77,41 +106,61 @@ export const resolveAircraft3DLightingProfile = ({
   switch (phase) {
     case "night":
       return {
-        ambientIntensity: 0.42,
-        keyLightIntensity: 0.62,
-        rimLightIntensity: 1.35,
+        ambientColor: "#b8d5ff",
+        ambientIntensity: 0.38,
+        keyLightColor: "#c9ddff",
+        keyLightIntensity: 0.46,
+        landingLightIntensity: 1,
+        landingLightsVisible: true,
         navLightsVisible: true,
-        navLightIntensity: 1.18,
-        shadowOpacity: 0.42,
+        navLightIntensity: 1.22,
+        rimLightColor: "#76b8ff",
+        rimLightIntensity: 0.62,
+        shadowOpacity: 0.1,
       };
     case "dusk":
     case "sunset":
       return {
-        ambientIntensity: 0.56,
-        keyLightIntensity: 0.92,
-        rimLightIntensity: 1.08,
+        ambientColor: "#ffe0c2",
+        ambientIntensity: 0.68,
+        keyLightColor: "#ffd8a8",
+        keyLightIntensity: 1.04,
+        landingLightIntensity: 0.48,
+        landingLightsVisible: true,
         navLightsVisible: true,
-        navLightIntensity: 0.72,
-        shadowOpacity: 0.34,
+        navLightIntensity: 0.78,
+        rimLightColor: "#c9d0ff",
+        rimLightIntensity: 0.92,
+        shadowOpacity: 0.12,
       };
     case "morning":
     case "afternoon":
       return {
-        ambientIntensity: 0.64,
-        keyLightIntensity: 1.18,
-        rimLightIntensity: 0.72,
+        ambientColor: "#f4f0df",
+        ambientIntensity: 0.82,
+        keyLightColor: "#fff0c8",
+        keyLightIntensity: 1.28,
+        landingLightIntensity: 0.16,
+        landingLightsVisible: false,
         navLightsVisible: true,
         navLightIntensity: 0.36,
-        shadowOpacity: 0.26,
+        rimLightColor: "#d5e3ff",
+        rimLightIntensity: 0.54,
+        shadowOpacity: 0.075,
       };
     default:
       return {
-        ambientIntensity: 0.7,
-        keyLightIntensity: 1.26,
-        rimLightIntensity: 0.58,
+        ambientColor: "#f3efe4",
+        ambientIntensity: 0.86,
+        keyLightColor: "#fff2cc",
+        keyLightIntensity: 1.34,
+        landingLightIntensity: 0.12,
+        landingLightsVisible: false,
         navLightsVisible: true,
         navLightIntensity: 0.32,
-        shadowOpacity: 0.22,
+        rimLightColor: "#d6e5ff",
+        rimLightIntensity: 0.46,
+        shadowOpacity: 0.07,
       };
   }
 };
@@ -140,89 +189,157 @@ export const resolveAircraft3DMaterialProfile = ({
   switch (phase) {
     case "night":
       return {
-        bodyGlowColor: "#9ccfff",
-        bodyGlowOpacity: selected ? 0.08 : 0.045,
-        color: selected ? "#c7d9ea" : "#9fb3c8",
-        edgeColor: "#d9ecff",
-        edgeOpacity: selected ? 0.54 : 0.34,
+        bodyGlowColor: "#9bcfff",
+        bodyGlowOpacity: selected ? 0.072 : 0.04,
+        color: selected ? "#eef7ff" : "#d9e6f2",
+        edgeColor: "#cbe4ff",
+        edgeContrast: 0.74,
+        edgeHighlightColor: "#f5fbff",
+        edgeLightVector: { x: -0.34, y: -0.72, z: 0.6 },
+        edgeOpacity: selected ? 0.12 : 0.07,
+        edgeShadowColor: "#4a6078",
         emissive: "#142034",
-        emissiveIntensity: selected ? 0.18 : 0.14,
-        lightGlowScale: 5.2,
-        lightRadius: 0.58,
+        emissiveIntensity: selected ? 0.26 : 0.22,
+        landingLightColor: "#fff1cc",
+        landingLightOpacity: 1,
+        landingLightScale: 4.1,
+        lightGlowScale: 8.4,
+        lightRadius: 1.02,
         metalness: 0.22,
         roughness: 0.54,
       };
     case "dusk":
       return {
-        bodyGlowColor: "#b9b1ff",
-        bodyGlowOpacity: selected ? 0.07 : 0.035,
-        color: selected ? "#a996aa" : "#837590",
-        edgeColor: "#cbc2df",
-        edgeOpacity: selected ? 0.48 : 0.26,
-        emissive: "#1a1422",
-        emissiveIntensity: 0.08 + selectedLift,
-        lightGlowScale: 4.8,
+        bodyGlowColor: "#d7d3ff",
+        bodyGlowOpacity: selected ? 0.06 : 0.03,
+        color: selected ? "#fffdf8" : "#fbf8f4",
+        edgeColor: "#bcb7ad",
+        edgeContrast: 0.62,
+        edgeHighlightColor: "#fffaf0",
+        edgeLightVector: { x: -0.58, y: -0.44, z: 0.68 },
+        edgeOpacity: selected ? 0.11 : 0.075,
+        edgeShadowColor: "#8b8278",
+        emissive: "#fff3df",
+        emissiveIntensity: 0.16 + selectedLift,
+        landingLightColor: "#fff0d1",
+        landingLightOpacity: selected ? 0.54 : 0.38,
+        landingLightScale: 1.9,
+        lightGlowScale: 4.7,
         lightRadius: 0.52,
-        metalness: 0.28,
-        roughness: 0.5,
+        metalness: 0.02,
+        roughness: 0.36,
       };
     case "sunset":
       return {
-        bodyGlowColor: "#ffc18f",
-        bodyGlowOpacity: selected ? 0.07 : 0.04,
-        color: selected ? "#d09872" : "#a87755",
-        edgeColor: "#d9aa82",
-        edgeOpacity: selected ? 0.5 : 0.3,
-        emissive: "#21120a",
-        emissiveIntensity: 0.07 + selectedLift,
-        lightGlowScale: 4.4,
+        bodyGlowColor: "#ffd1a7",
+        bodyGlowOpacity: selected ? 0.062 : 0.032,
+        color: selected ? "#fffaf0" : "#fbf1e2",
+        edgeColor: "#b79b7c",
+        edgeContrast: 0.68,
+        edgeHighlightColor: "#fff1cf",
+        edgeLightVector: { x: -0.72, y: -0.28, z: 0.58 },
+        edgeOpacity: selected ? 0.12 : 0.08,
+        edgeShadowColor: "#8e7059",
+        emissive: "#ffe0b3",
+        emissiveIntensity: 0.15 + selectedLift,
+        landingLightColor: "#fff0c6",
+        landingLightOpacity: selected ? 0.52 : 0.36,
+        landingLightScale: 1.8,
+        lightGlowScale: 4.2,
         lightRadius: 0.5,
-        metalness: 0.3,
-        roughness: 0.48,
+        metalness: 0.02,
+        roughness: 0.34,
       };
     case "morning":
       return {
-        bodyGlowColor: "#ffe0a8",
-        bodyGlowOpacity: selected ? 0.055 : 0.024,
-        color: selected ? "#c0ad87" : "#9d8f72",
-        edgeColor: "#73664f",
-        edgeOpacity: selected ? 0.42 : 0.22,
-        emissive: "#100b05",
-        emissiveIntensity: 0.045 + selectedLift,
-        lightGlowScale: 3.8,
+        bodyGlowColor: "#ffe4b6",
+        bodyGlowOpacity: selected ? 0.042 : 0.018,
+        color: selected ? "#fffdf6" : "#fbf7ed",
+        edgeColor: "#a99d88",
+        edgeContrast: 0.54,
+        edgeHighlightColor: "#fffdf3",
+        edgeLightVector: { x: -0.52, y: -0.62, z: 0.58 },
+        edgeOpacity: selected ? 0.105 : 0.065,
+        edgeShadowColor: "#9a8d78",
+        emissive: "#fff0d0",
+        emissiveIntensity: 0.14 + selectedLift,
+        landingLightColor: "#fff1cd",
+        landingLightOpacity: selected ? 0.2 : 0.14,
+        landingLightScale: 1.25,
+        lightGlowScale: 3.6,
         lightRadius: 0.42,
-        metalness: 0.34,
-        roughness: 0.44,
+        metalness: 0.015,
+        roughness: 0.32,
       };
     case "afternoon":
       return {
         bodyGlowColor: "#fff1c7",
-        bodyGlowOpacity: selected ? 0.05 : 0.02,
-        color: selected ? "#ada180" : "#8c846f",
-        edgeColor: "#5c5240",
-        edgeOpacity: selected ? 0.42 : 0.2,
-        emissive: "#0c0905",
-        emissiveIntensity: 0.04 + selectedLift,
-        lightGlowScale: 3.6,
+        bodyGlowOpacity: selected ? 0.038 : 0.014,
+        color: selected ? "#fffdf8" : "#fbf8f1",
+        edgeColor: "#9a9283",
+        edgeContrast: 0.48,
+        edgeHighlightColor: "#fffdf5",
+        edgeLightVector: { x: -0.36, y: -0.74, z: 0.56 },
+        edgeOpacity: selected ? 0.1 : 0.06,
+        edgeShadowColor: "#918978",
+        emissive: "#fff2d8",
+        emissiveIntensity: 0.135 + selectedLift,
+        landingLightColor: "#fff2d0",
+        landingLightOpacity: selected ? 0.18 : 0.12,
+        landingLightScale: 1.15,
+        lightGlowScale: 3.4,
         lightRadius: 0.4,
-        metalness: 0.34,
-        roughness: 0.42,
+        metalness: 0.015,
+        roughness: 0.32,
       };
     default:
       return {
         bodyGlowColor: "#fff3cc",
-        bodyGlowOpacity: selected ? 0.048 : 0.018,
-        color: selected ? "#a99f83" : "#817a6c",
-        edgeColor: "#554a3c",
-        edgeOpacity: selected ? 0.4 : 0.18,
-        emissive: "#080604",
-        emissiveIntensity: 0.035 + selectedLift,
-        lightGlowScale: 3.4,
+        bodyGlowOpacity: selected ? 0.036 : 0.012,
+        color: selected ? "#fffdfa" : "#fcf8f1",
+        edgeColor: "#9a9182",
+        edgeContrast: 0.48,
+        edgeHighlightColor: "#fffdf6",
+        edgeLightVector: { x: -0.42, y: -0.7, z: 0.58 },
+        edgeOpacity: selected ? 0.095 : 0.058,
+        edgeShadowColor: "#8d8576",
+        emissive: "#fff4df",
+        emissiveIntensity: 0.13 + selectedLift,
+        landingLightColor: "#fff3d6",
+        landingLightOpacity: selected ? 0.16 : 0.1,
+        landingLightScale: 1.1,
+        lightGlowScale: 3.2,
         lightRadius: 0.38,
-        metalness: 0.34,
-        roughness: 0.42,
+        metalness: 0.01,
+        roughness: 0.32,
       };
   }
+};
+
+export const resolveAircraft3DEdgeTone = ({
+  phase = "day",
+  selected = false,
+  lightDot = 0,
+}: Aircraft3DEdgeToneOptions = {}) => {
+  const profile = resolveAircraft3DMaterialProfile({ phase, selected });
+  const dot = clamp(toFiniteNumber(lightDot) ?? 0, -1, 1);
+  const litRatio = clamp((dot + 1) / 2, 0, 1);
+  const opacity = round2(
+    clamp(
+      profile.edgeOpacity * (0.52 + litRatio * (0.82 + profile.edgeContrast * 0.42)),
+      phase === "night" ? 0.018 : 0.02,
+      phase === "night" ? 0.16 : selected ? 0.2 : 0.14,
+    ),
+  );
+
+  return {
+    color: mixHex(
+      profile.edgeShadowColor,
+      profile.edgeHighlightColor,
+      litRatio,
+    ),
+    opacity,
+  };
 };
 
 export const resolveAircraft3DAttitudeRotation = ({

--- a/src/features/app-shell/auth/useFlightAwareEnabled.ts
+++ b/src/features/app-shell/auth/useFlightAwareEnabled.ts
@@ -7,6 +7,7 @@ import {
   getClerkUserPrimaryEmail,
   isFeatureFlagEnabled,
   isImmersiveModeEnabled,
+  isPreviewImmersiveModeOverrideEnabled,
   normalizeFeatureFlags,
 } from "../feature-flags/userFeatureFlagsModel";
 
@@ -113,8 +114,12 @@ export function useFlightAwareEnabled() {
 
 export function useImmersiveModeFeature() {
   const { flags, resolved } = useUserFeatureFlags();
+  const previewOverrideEnabled =
+    typeof window !== "undefined" &&
+    isPreviewImmersiveModeOverrideEnabled(window.location);
+
   return {
-    enabled: isImmersiveModeEnabled(flags),
-    resolved,
+    enabled: isImmersiveModeEnabled(flags) || previewOverrideEnabled,
+    resolved: resolved || previewOverrideEnabled,
   };
 }

--- a/src/features/app-shell/feature-flags/userFeatureFlagsModel.test.ts
+++ b/src/features/app-shell/feature-flags/userFeatureFlagsModel.test.ts
@@ -5,6 +5,7 @@ import {
   getClerkUserPrimaryEmail,
   isFeatureFlagEnabled,
   isImmersiveModeEnabled,
+  isPreviewImmersiveModeOverrideEnabled,
   normalizeFeatureFlags,
   normalizeFeatureFlagEnvironment,
   normalizeUserEmail,
@@ -64,6 +65,28 @@ assert.equal(
 );
 assert.equal(
   isImmersiveModeEnabled({ [FEATURE_FLAGS.IMMERSIVE_MODE_ENABLED]: false }),
+  false,
+);
+
+assert.equal(
+  isPreviewImmersiveModeOverrideEnabled({
+    hostname: "adsbao-git-codex-immersive-aircraft-lighting-orriduck.vercel.app",
+    search: "?qaImmersive=1",
+  }),
+  true,
+);
+assert.equal(
+  isPreviewImmersiveModeOverrideEnabled({
+    hostname: ["adsbao", "vercel", "app"].join("."),
+    search: "?qaImmersive=1",
+  }),
+  false,
+);
+assert.equal(
+  isPreviewImmersiveModeOverrideEnabled({
+    hostname: "adsbao-git-codex-immersive-aircraft-lighting-orriduck.vercel.app",
+    search: "",
+  }),
   false,
 );
 

--- a/src/features/app-shell/feature-flags/userFeatureFlagsModel.ts
+++ b/src/features/app-shell/feature-flags/userFeatureFlagsModel.ts
@@ -65,3 +65,17 @@ export function isFeatureFlagEnabled(flags: unknown, flagKey: string) {
 export function isImmersiveModeEnabled(flags: unknown) {
   return isFeatureFlagEnabled(flags, FEATURE_FLAGS.IMMERSIVE_MODE_ENABLED);
 }
+
+const VERCEL_GIT_PREVIEW_HOST_PATTERN =
+  /^adsbao-git-[a-z0-9-]+-orriduck\.vercel\.app$/i;
+
+export function isPreviewImmersiveModeOverrideEnabled(locationLike: {
+  hostname?: unknown;
+  search?: unknown;
+} = {}) {
+  const hostname = String(locationLike.hostname || "").trim().toLowerCase();
+  if (!VERCEL_GIT_PREVIEW_HOST_PATTERN.test(hostname)) return false;
+
+  const search = String(locationLike.search || "").replace(/^\?/, "");
+  return new URLSearchParams(search).get("qaImmersive") === "1";
+}

--- a/src/style.css
+++ b/src/style.css
@@ -3108,102 +3108,15 @@ body {
     width: 100%;
 }
 
-.aircraft-marker-proxy {
+.aircraft-marker-hit-target {
+    cursor: pointer;
     display: block;
     height: 18px;
-    opacity: 0.045;
+    opacity: 0;
     pointer-events: auto;
     position: relative;
-    transform:
-        rotate(var(--aircraft-proxy-rotation, 0deg))
-        scale(var(--aircraft-proxy-scale, 1));
     transform-origin: center;
-    transform-style: preserve-3d;
     width: 18px;
-}
-
-.aircraft-marker-proxy::before,
-.aircraft-marker-proxy::after {
-    content: "";
-    left: 50%;
-    pointer-events: none;
-    position: absolute;
-    top: 50%;
-}
-
-.aircraft-marker-proxy::before {
-    background:
-        linear-gradient(
-            135deg,
-            rgb(255 255 255 / 0.62) 0%,
-            rgb(181 201 215 / 0.5) 42%,
-            rgb(65 71 76 / 0.44) 100%
-        );
-    box-shadow:
-        0 0 0 0.5px rgb(255 255 255 / 0.18),
-        1px 2px 5px rgb(0 0 0 / 0.2);
-    clip-path: polygon(50% 0%, 62% 58%, 98% 94%, 56% 82%, 50% 100%, 44% 82%, 2% 94%, 38% 58%);
-    height: 15px;
-    transform:
-        translate(-50%, -50%)
-        perspective(120px)
-        rotateX(34deg)
-        rotateY(-16deg);
-    transform-origin: center;
-    width: 13px;
-}
-
-.aircraft-marker-proxy::after {
-    background: rgb(255 246 210 / 0.96);
-    border-radius: 999px;
-    box-shadow:
-        -5px 1px 4px 0.5px rgb(255 63 69 / 0.48),
-        5px 1px 4px 0.5px rgb(57 255 141 / 0.48),
-        0 5px 5px 0.5px rgb(238 250 255 / 0.36),
-        0 -3px 6px 0.5px rgb(255 125 78 / 0.28);
-    height: 2px;
-    transform: translate(-50%, -50%);
-    width: 2px;
-}
-
-.aircraft-marker-proxy[data-selected="true"] {
-    opacity: 0.12;
-}
-
-.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="sunset"] .aircraft-marker-proxy,
-.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="dusk"] .aircraft-marker-proxy {
-    opacity: 0.055;
-}
-
-.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="night"] .aircraft-marker-proxy {
-    filter:
-        drop-shadow(0 0 7px rgb(155 205 255 / 0.48))
-        drop-shadow(0 3px 10px rgb(0 0 0 / 0.38));
-    opacity: 0.1;
-}
-
-.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="night"] .aircraft-marker-proxy::before {
-    background:
-        linear-gradient(
-            135deg,
-            rgb(255 255 255 / 0.76) 0%,
-            rgb(195 223 255 / 0.68) 44%,
-            rgb(65 83 111 / 0.56) 100%
-        );
-    box-shadow:
-        0 0 0 0.75px rgb(232 246 255 / 0.45),
-        0 0 8px rgb(117 183 255 / 0.18),
-        1px 3px 7px rgb(0 0 0 / 0.32);
-}
-
-.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="night"] .aircraft-marker-proxy::after {
-    height: 3px;
-    width: 3px;
-    box-shadow:
-        -7px 1px 7px 1.5px rgb(255 44 60 / 0.86),
-        7px 1px 7px 1.5px rgb(43 255 135 / 0.86),
-        0 6px 7px 1.25px rgb(244 252 255 / 0.62),
-        0 -4px 8px 1.5px rgb(255 98 62 / 0.56);
 }
 
 .user-location-leaflet-icon {


### PR DESCRIPTION
## Summary
- replaces the immersive aircraft fallback marker with a transparent hit target so Three.js owns the visible aircraft model
- retunes aircraft lighting/material profiles across day, sunset/dusk, and night so bodies stay bright while shadows remain underneath
- adds directional edge tones plus night landing lights and beams for more natural integration with the map environment
- adds a Vercel git-preview-only `qaImmersive=1` override so preview screenshots can validate immersive mode without a Clerk account session

## Validation
- /opt/homebrew/bin/pnpm exec tsx src/features/aircraft/icons/aircraftIcon3DModel.test.ts
- /opt/homebrew/bin/pnpm exec tsx src/features/app-shell/feature-flags/userFeatureFlagsModel.test.ts
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm lint (passes with the existing VirtualNearbyList TanStack Virtual warning)
- /opt/homebrew/bin/pnpm build
- Vercel preview checks passed for commit `1e8ed3e4568cf0d4a7e849c35ae3d88f30ecb675`
- Preview screenshots checked on KBOS day and VHHH night with `qaImmersive=1`; both had `data-map-mode="immersive"`, Three overlay canvas mounted, and `.aircraft-marker-proxy` count `0`
