### PR TITLE
[codex] Make immersive mode public

### DIFF
--- a/src/app/api/dao/userMapSettings.dao.test.ts
+++ b/src/app/api/dao/userMapSettings.dao.test.ts
@@ -275,14 +275,11 @@ function createFakeSupabaseClient({
     createClientImpl,
   });
 
-  const readRow = await repository.readSettingsByEmail("owner@example.com", {
-    immersiveModeEnabled: true,
-  });
+  const readRow = await repository.readSettingsByEmail("owner@example.com");
   assert.equal(readRow.settings.selectedMode, MAP_MODE_IDS.IMMERSIVE);
 
   await repository.upsertSettingsByEmail({
     email: "owner@example.com",
-    immersiveModeEnabled: true,
     settings: {
       selectedMode: MAP_MODE_IDS.IMMERSIVE,
       baseMode: MAP_MODE_IDS.IMMERSIVE,

--- a/src/app/api/dao/userMapSettings.dao.ts
+++ b/src/app/api/dao/userMapSettings.dao.ts
@@ -36,9 +36,6 @@ function createUserMapSettingsRepository({
       const normalizedEnvironment = normalizeFeatureFlagEnvironment(
         options.environment || defaultEnvironment,
       );
-      const settingsOptions = {
-        immersiveModeEnabled: options.immersiveModeEnabled === true,
-      };
 
       const { data, error } = await client
         .from(USER_MAP_SETTINGS_TABLE)
@@ -58,7 +55,7 @@ function createUserMapSettingsRepository({
         settings: normalizeMapSettings({
           ...data.settings,
           hasSelectedMode: data.has_selected_mode,
-        }, settingsOptions),
+        }),
         updatedAt: data.updated_at || "",
       };
     },
@@ -66,7 +63,6 @@ function createUserMapSettingsRepository({
     async upsertSettingsByEmail({
       email,
       environment,
-      immersiveModeEnabled,
       settings,
     }: UserMapSettingsRecord = {}) {
       const normalizedEmail = normalizeUserEmail(email);
@@ -76,12 +72,10 @@ function createUserMapSettingsRepository({
       );
       const existingRow = await this.readSettingsByEmail(normalizedEmail, {
         environment: normalizedEnvironment,
-        immersiveModeEnabled,
       });
       const normalizedSettings = mergeMapSettings({
         settings: existingRow?.settings || DEFAULT_MAP_SETTINGS,
         updates: settings,
-        immersiveModeEnabled: immersiveModeEnabled === true,
       });
       const updatedAt = normalizedSettings.updatedAt || new Date().toISOString();
 
@@ -113,7 +107,7 @@ function createUserMapSettingsRepository({
         settings: normalizeMapSettings({
           ...data.settings,
           hasSelectedMode: data.has_selected_mode,
-        }, { immersiveModeEnabled: immersiveModeEnabled === true }),
+        }),
         updatedAt: data.updated_at || "",
       };
     },

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -30,7 +30,6 @@ export default function ExplorerMapMenu({
     showCandidateWatchingSpots,
     mapSettings,
     mapSettingsSaveStatus,
-    immersiveModeEnabled,
     setMapZoom,
     applyMapMode,
     toggleSidebar,
@@ -58,7 +57,6 @@ export default function ExplorerMapMenu({
         showCandidateWatchingSpots={showCandidateWatchingSpots}
         mapSettings={mapSettings}
         mapSettingsSaveStatus={mapSettingsSaveStatus}
-        immersiveModeEnabled={immersiveModeEnabled}
         userLocationActive={userLocationActive}
         userLocationAudioActive={userLocationAudioActive}
         userLocationPending={userLocationPending}

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -29,7 +29,6 @@ import {
   readStoredMapSettings,
   writeStoredMapSettings,
 } from "@/features/airport/map-settings/mapSettingsStorage";
-import { useImmersiveModeFeature } from "@/features/app-shell/auth/useFlightAwareEnabled";
 import {
   getAirportSidebarMode,
   getAirportSidebarOpenForMode,
@@ -68,11 +67,11 @@ function toggleValue(value) {
   return !value;
 }
 
-function applyMapSettingsToUiState(state, settings, options = {}) {
-  const normalizedSettings = normalizeMapSettings(settings, options);
-  const layers = mapSettingsToExplorerLayers(normalizedSettings, options);
+function applyMapSettingsToUiState(state, settings) {
+  const normalizedSettings = normalizeMapSettings(settings);
+  const layers = mapSettingsToExplorerLayers(normalizedSettings);
   const userLocationPreferences =
-    mapSettingsToUserLocationPreferences(normalizedSettings, options);
+    mapSettingsToUserLocationPreferences(normalizedSettings);
   return {
     ...state,
     ...layers,
@@ -85,16 +84,14 @@ function applyMapSettingsToUiState(state, settings, options = {}) {
   };
 }
 
-function applyManualLayerToggle(state, layerKey, value, options = {}) {
+function applyManualLayerToggle(state, layerKey, value) {
   return applyMapSettingsToUiState(
     state,
     buildCustomMapSettings({
       settings: state.mapSettings,
       layerKey,
       value,
-      ...options,
     }),
-    options,
   );
 }
 
@@ -127,42 +124,33 @@ function airportExplorerUiReducer(state, action) {
         state,
         MAP_LAYER_KEYS.MAP_LABELS,
         toggleValue(state.showMapLabels),
-        { immersiveModeEnabled: action.immersiveModeEnabled },
       );
     case "toggleRunwayBeams":
       return applyManualLayerToggle(
         state,
         MAP_LAYER_KEYS.APPROACH_BEAMS,
         toggleValue(state.showRunwayBeams),
-        { immersiveModeEnabled: action.immersiveModeEnabled },
       );
     case "toggleNavaidMarkers":
       return applyManualLayerToggle(
         state,
         MAP_LAYER_KEYS.NAVAID_MARKERS,
         toggleValue(state.showNavaidMarkers),
-        { immersiveModeEnabled: action.immersiveModeEnabled },
       );
     case "toggleAirspaces":
       return applyManualLayerToggle(
         state,
         MAP_LAYER_KEYS.AIRSPACES,
         toggleValue(state.showAirspaces),
-        { immersiveModeEnabled: action.immersiveModeEnabled },
       );
     case "toggleCandidateWatchingSpots":
       return applyManualLayerToggle(
         state,
         MAP_LAYER_KEYS.CANDIDATE_WATCHING_SPOTS,
         toggleValue(state.showCandidateWatchingSpots),
-        { immersiveModeEnabled: action.immersiveModeEnabled },
       );
     case "applyMapMode":
-      if (
-        !isSelectableMapModeId(action.modeId, {
-          immersiveModeEnabled: action.immersiveModeEnabled,
-        })
-      ) {
+      if (!isSelectableMapModeId(action.modeId)) {
         return state;
       }
       return applyMapSettingsToUiState(
@@ -170,14 +158,10 @@ function airportExplorerUiReducer(state, action) {
         buildPresetMapSettings({
           modeId: action.modeId,
           audioEnabled: state.mapSettings?.audioEnabled,
-          immersiveModeEnabled: action.immersiveModeEnabled,
         }),
-        { immersiveModeEnabled: action.immersiveModeEnabled },
       );
     case "hydrateMapSettings":
-      return applyMapSettingsToUiState(state, action.settings, {
-        immersiveModeEnabled: action.immersiveModeEnabled,
-      });
+      return applyMapSettingsToUiState(state, action.settings);
     case "setUserLocationPreferences": {
       const userLocationEnabled = action.userLocationEnabled === true;
       const userLocationAudioEnabled =
@@ -186,7 +170,6 @@ function airportExplorerUiReducer(state, action) {
         settings: state.mapSettings,
         layerKey: MAP_LAYER_KEYS.USER_LOCATION,
         value: userLocationEnabled,
-        immersiveModeEnabled: action.immersiveModeEnabled,
       });
       return applyMapSettingsToUiState(
         state,
@@ -194,9 +177,7 @@ function airportExplorerUiReducer(state, action) {
           settings: locationSettings,
           layerKey: MAP_LAYER_KEYS.USER_LOCATION_AUDIO,
           value: userLocationAudioEnabled,
-          immersiveModeEnabled: action.immersiveModeEnabled,
         }),
-        { immersiveModeEnabled: action.immersiveModeEnabled },
       );
     }
     case "setTrafficFilter":
@@ -318,8 +299,6 @@ function airportExplorerUiReducer(state, action) {
 
 export function ExplorerUiProvider({ children }) {
   const { isLoaded, isSignedIn } = useUser();
-  const immersiveModeFeature = useImmersiveModeFeature();
-  const immersiveModeEnabled = immersiveModeFeature.enabled;
   const hasHydratedMapSettingsRef = useRef(false);
   const persistedMapSettingsRef = useRef("");
   const [mapSettingsSaveStatus, setMapSettingsSaveStatus] = useState("idle");
@@ -366,14 +345,13 @@ export function ExplorerUiProvider({ children }) {
   }, []);
 
   useEffect(() => {
-    if (!isLoaded || !immersiveModeFeature.resolved) return undefined;
+    if (!isLoaded) return undefined;
     let cancelled = false;
-    const options = { immersiveModeEnabled };
 
     const hydrateMapSettings = async () => {
       hasHydratedMapSettingsRef.current = false;
       setMapSettingsSaveStatus("idle");
-      const cachedSettings = readStoredMapSettings(options);
+      const cachedSettings = readStoredMapSettings();
       let userSettings = null;
 
       if (isSignedIn) {
@@ -384,7 +362,7 @@ export function ExplorerUiProvider({ children }) {
           if (response.ok) {
             const payload = await response.json();
             userSettings = payload?.settings
-              ? normalizeMapSettings(payload.settings, options)
+              ? normalizeMapSettings(payload.settings)
               : null;
           }
         } catch {
@@ -397,19 +375,17 @@ export function ExplorerUiProvider({ children }) {
         signedIn: isSignedIn,
         userSettings,
         cachedSettings,
-        immersiveModeEnabled,
       });
       if (hydratedSettings.settings) {
         dispatch({
           type: "hydrateMapSettings",
           settings: hydratedSettings.settings,
-          immersiveModeEnabled,
         });
       }
 
       const effectiveSettings = hydratedSettings.settings
         ? hydratedSettings.settings
-        : normalizeMapSettings(DEFAULT_MAP_SETTINGS, options);
+        : normalizeMapSettings(DEFAULT_MAP_SETTINGS);
       if (isSignedIn && hydratedSettings.source === "cache") {
         persistedMapSettingsRef.current = "";
       } else {
@@ -424,8 +400,6 @@ export function ExplorerUiProvider({ children }) {
       cancelled = true;
     };
   }, [
-    immersiveModeEnabled,
-    immersiveModeFeature.resolved,
     isLoaded,
     isSignedIn,
   ]);
@@ -433,19 +407,16 @@ export function ExplorerUiProvider({ children }) {
   useEffect(() => {
     if (
       !isLoaded ||
-      !immersiveModeFeature.resolved ||
       !hasHydratedMapSettingsRef.current
     ) {
       return undefined;
     }
-    const nextSettings = normalizeMapSettings(mapSettings, {
-      immersiveModeEnabled,
-    });
+    const nextSettings = normalizeMapSettings(mapSettings);
     const serialized = JSON.stringify(nextSettings);
     if (serialized === persistedMapSettingsRef.current) return undefined;
 
     if (!isSignedIn) {
-      writeStoredMapSettings(nextSettings, { immersiveModeEnabled });
+      writeStoredMapSettings(nextSettings);
       persistedMapSettingsRef.current = serialized;
       return undefined;
     }
@@ -466,7 +437,7 @@ export function ExplorerUiProvider({ children }) {
         if (!response.ok) throw new Error("save failed");
         const payload = await response.json();
         const savedSettings = payload?.settings
-          ? normalizeMapSettings(payload.settings, { immersiveModeEnabled })
+          ? normalizeMapSettings(payload.settings)
           : nextSettings;
         const savedSerialized = JSON.stringify(savedSettings);
         if (cancelled) return;
@@ -475,7 +446,6 @@ export function ExplorerUiProvider({ children }) {
           dispatch({
             type: "hydrateMapSettings",
             settings: savedSettings,
-            immersiveModeEnabled,
           });
         }
         setMapSettingsSaveStatus("saved");
@@ -491,8 +461,6 @@ export function ExplorerUiProvider({ children }) {
       controller.abort();
     };
   }, [
-    immersiveModeEnabled,
-    immersiveModeFeature.resolved,
     isLoaded,
     isSignedIn,
     mapSettings,
@@ -511,31 +479,28 @@ export function ExplorerUiProvider({ children }) {
   }, []);
 
   const toggleMapLabels = useCallback(() => {
-    dispatch({ type: "toggleMapLabels", immersiveModeEnabled });
-  }, [immersiveModeEnabled]);
+    dispatch({ type: "toggleMapLabels" });
+  }, []);
 
   const toggleRunwayBeams = useCallback(() => {
-    dispatch({ type: "toggleRunwayBeams", immersiveModeEnabled });
-  }, [immersiveModeEnabled]);
+    dispatch({ type: "toggleRunwayBeams" });
+  }, []);
 
   const toggleNavaidMarkers = useCallback(() => {
-    dispatch({ type: "toggleNavaidMarkers", immersiveModeEnabled });
-  }, [immersiveModeEnabled]);
+    dispatch({ type: "toggleNavaidMarkers" });
+  }, []);
 
   const toggleAirspaces = useCallback(() => {
-    dispatch({ type: "toggleAirspaces", immersiveModeEnabled });
-  }, [immersiveModeEnabled]);
+    dispatch({ type: "toggleAirspaces" });
+  }, []);
 
   const toggleCandidateWatchingSpots = useCallback(() => {
-    dispatch({
-      type: "toggleCandidateWatchingSpots",
-      immersiveModeEnabled,
-    });
-  }, [immersiveModeEnabled]);
+    dispatch({ type: "toggleCandidateWatchingSpots" });
+  }, []);
 
   const applyMapMode = useCallback((modeId) => {
-    dispatch({ type: "applyMapMode", modeId, immersiveModeEnabled });
-  }, [immersiveModeEnabled]);
+    dispatch({ type: "applyMapMode", modeId });
+  }, []);
 
   const setUserLocationPreferences = useCallback(
     ({ userLocationEnabled, userLocationAudioEnabled = false }) => {
@@ -543,10 +508,9 @@ export function ExplorerUiProvider({ children }) {
         type: "setUserLocationPreferences",
         userLocationEnabled,
         userLocationAudioEnabled,
-        immersiveModeEnabled,
       });
     },
-    [immersiveModeEnabled],
+    [],
   );
 
   const setTrafficFilter = useCallback((trafficFilter) => {
@@ -612,8 +576,7 @@ export function ExplorerUiProvider({ children }) {
   const fitToTraceSignal = state.fitToTraceSignal;
   const mapFollowsAircraft = state.mapFollowsAircraft;
   const immersiveModeActive =
-    mapSettings?.selectedMode === MAP_MODE_IDS.IMMERSIVE &&
-    immersiveModeEnabled;
+    mapSettings?.selectedMode === MAP_MODE_IDS.IMMERSIVE;
 
   const value = useMemo(
     () => ({
@@ -633,7 +596,6 @@ export function ExplorerUiProvider({ children }) {
       mapSettings,
       mapSettingsSaveStatus,
       immersiveModeActive,
-      immersiveModeEnabled,
       trafficFilter,
       typeFilter,
       altitudeLevel,
@@ -686,7 +648,6 @@ export function ExplorerUiProvider({ children }) {
       mapSettings,
       mapSettingsSaveStatus,
       immersiveModeActive,
-      immersiveModeEnabled,
       trafficFilter,
       typeFilter,
       altitudeLevel,

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -92,13 +92,12 @@ export default function MapSettingsSheet({
   onToggleUserLocation = null,
   onToggleUserLocationAudio = null,
   mapSettingsSaveStatus = "idle",
-  immersiveModeEnabled = false,
 }) {
   const { t } = useI18n();
   const { isLoaded, isSignedIn } = useUser();
-  const settings = normalizeMapSettings(mapSettings, { immersiveModeEnabled });
+  const settings = normalizeMapSettings(mapSettings);
   const modeOptions = [
-    ...getSelectableMapModeOptions({ immersiveModeEnabled }),
+    ...getSelectableMapModeOptions(),
     CUSTOM_MAP_MODE_OPTION,
   ];
   const state = {

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -28,7 +28,6 @@ export default function MapControlBar({
   userLocationAudioActive = false,
   userLocationPending = false,
   userLocationNotice = "",
-  immersiveModeEnabled = false,
   showSidebarToggle = true,
   onZoom,
   onToggleMapLabels,
@@ -90,7 +89,6 @@ export default function MapControlBar({
         userLocationAudioActive={userLocationAudioActive}
         userLocationPending={userLocationPending}
         userLocationNotice={userLocationNotice}
-        immersiveModeEnabled={immersiveModeEnabled}
         onSelectMapMode={onSelectMapMode}
         onToggleMapLabels={onToggleMapLabels}
         onToggleBeams={onToggleRunwayBeams}

--- a/src/features/airport/map-settings/mapSettingsModel.test.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.test.ts
@@ -147,13 +147,7 @@ import {
 
 {
   assert.equal(
-    getSelectableMapModeOptions({ immersiveModeEnabled: false }).some(
-      (mode) => mode.id === MAP_MODE_IDS.IMMERSIVE,
-    ),
-    false,
-  );
-  assert.equal(
-    getSelectableMapModeOptions({ immersiveModeEnabled: true }).some(
+    getSelectableMapModeOptions().some(
       (mode) => mode.id === MAP_MODE_IDS.IMMERSIVE,
     ),
     true,
@@ -161,18 +155,14 @@ import {
 }
 
 {
-  const locked = buildPresetMapSettings({ modeId: MAP_MODE_IDS.IMMERSIVE });
-  assert.equal(locked.selectedMode, MAP_MODE_IDS.CONTROLLER);
-
   const immersive = buildPresetMapSettings({
     modeId: MAP_MODE_IDS.IMMERSIVE,
-    immersiveModeEnabled: true,
     now: "2026-06-02T15:08:00.000Z",
   });
 
   assert.equal(immersive.selectedMode, MAP_MODE_IDS.IMMERSIVE);
   assert.deepEqual(
-    mapSettingsToExplorerLayers(immersive, { immersiveModeEnabled: true }),
+    mapSettingsToExplorerLayers(immersive),
     {
       showMapLabels: false,
       showRunwayBeams: false,
@@ -184,14 +174,6 @@ import {
   assert.equal(
     normalizeMapSettings(
       { selectedMode: MAP_MODE_IDS.IMMERSIVE, baseMode: MAP_MODE_IDS.IMMERSIVE },
-      { immersiveModeEnabled: false },
-    ).selectedMode,
-    MAP_MODE_IDS.CONTROLLER,
-  );
-  assert.equal(
-    normalizeMapSettings(
-      { selectedMode: MAP_MODE_IDS.IMMERSIVE, baseMode: MAP_MODE_IDS.IMMERSIVE },
-      { immersiveModeEnabled: true },
     ).selectedMode,
     MAP_MODE_IDS.IMMERSIVE,
   );
@@ -210,7 +192,6 @@ import {
       baseMode: MAP_MODE_IDS.IMMERSIVE,
       hasSelectedMode: true,
     },
-    immersiveModeEnabled: true,
   });
 
   assert.equal(
@@ -230,7 +211,6 @@ import {
       baseMode: MAP_MODE_IDS.IMMERSIVE,
       hasSelectedMode: true,
     },
-    immersiveModeEnabled: true,
   });
 
   assert.equal(

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -135,32 +135,24 @@ function isPresetMapModeId(value) {
   return PRESET_MODE_ID_SET.has(value);
 }
 
-function isImmersiveModeEnabled(options: MapSettingsOptions = {}) {
-  return options?.immersiveModeEnabled === true;
-}
-
-export function isSelectableMapModeId(value, options: MapSettingsOptions = {}) {
+export function isSelectableMapModeId(value) {
   if (!isPresetMapModeId(value) || DISABLED_MAP_MODE_ID_SET.has(value)) {
     return false;
   }
-  if (value === MAP_MODE_IDS.IMMERSIVE) return isImmersiveModeEnabled(options);
   return true;
 }
 
-export function getSelectableMapModeOptions(options: MapSettingsOptions = {}) {
-  return MAP_MODE_OPTIONS.filter((mode) =>
-    isSelectableMapModeId(mode.id, options),
-  );
+export function getSelectableMapModeOptions() {
+  return MAP_MODE_OPTIONS.filter((mode) => isSelectableMapModeId(mode.id));
 }
 
 function getMapSettingsBaseMode(
   settings: MapSettingsRecord = {},
-  options: MapSettingsOptions = {},
 ) {
   const selectedMode = settings?.selectedMode;
   const baseMode = settings?.baseMode;
-  if (isSelectableMapModeId(selectedMode, options)) return selectedMode;
-  if (isSelectableMapModeId(baseMode, options)) return baseMode;
+  if (isSelectableMapModeId(selectedMode)) return selectedMode;
+  if (isSelectableMapModeId(baseMode)) return baseMode;
   return DEFAULT_MAP_SETTINGS.baseMode;
 }
 
@@ -182,22 +174,13 @@ function normalizeMapLayerOverrides(layerOverrides: unknown) {
 
 export function normalizeMapSettings(
   settings: MapSettingsRecord = {},
-  options: MapSettingsOptions = {},
 ) {
-  if (
-    !isImmersiveModeEnabled(options) &&
-    (settings?.selectedMode === MAP_MODE_IDS.IMMERSIVE ||
-      settings?.baseMode === MAP_MODE_IDS.IMMERSIVE)
-  ) {
-    return DEFAULT_MAP_SETTINGS;
-  }
-
   const selectedMode = isMapModeId(settings?.selectedMode)
     ? settings.selectedMode
     : DEFAULT_MAP_SETTINGS.selectedMode;
-  const baseMode = isSelectableMapModeId(settings?.baseMode, options)
+  const baseMode = isSelectableMapModeId(settings?.baseMode)
     ? settings.baseMode
-    : isSelectableMapModeId(selectedMode, options)
+    : isSelectableMapModeId(selectedMode)
       ? selectedMode
       : DEFAULT_MAP_SETTINGS.baseMode;
 
@@ -216,14 +199,12 @@ export function resolveMapSettingsHydration({
   signedIn = false,
   userSettings = null,
   cachedSettings = null,
-  immersiveModeEnabled = false,
 }: MapSettingsOptions = {}) {
-  const options = { immersiveModeEnabled };
   const normalizedUserSettings = userSettings
-    ? normalizeMapSettings(userSettings, options)
+    ? normalizeMapSettings(userSettings)
     : null;
   const normalizedCachedSettings = cachedSettings
-    ? normalizeMapSettings(cachedSettings, options)
+    ? normalizeMapSettings(cachedSettings)
     : null;
 
   if (signedIn && normalizedUserSettings) {
@@ -242,10 +223,8 @@ function hasOwnSetting(settings: MapSettingsRecord, key: string) {
 export function mergeMapSettings({
   settings = DEFAULT_MAP_SETTINGS,
   updates = {},
-  immersiveModeEnabled = false,
 }: MapSettingsOptions = {}) {
-  const options = { immersiveModeEnabled };
-  const normalized = normalizeMapSettings(settings, options);
+  const normalized = normalizeMapSettings(settings);
   const updateRecord =
     updates && typeof updates === "object" && !Array.isArray(updates)
       ? updates
@@ -268,7 +247,7 @@ export function mergeMapSettings({
       : normalized.selectedMode;
   const baseMode =
     hasOwnSetting(updateRecord, "baseMode") &&
-    isSelectableMapModeId(updateRecord.baseMode, options)
+    isSelectableMapModeId(updateRecord.baseMode)
       ? updateRecord.baseMode
       : normalized.baseMode;
 
@@ -290,15 +269,14 @@ export function mergeMapSettings({
       hasOwnSetting(updateRecord, "updated_at")
         ? updateRecord.updatedAt || updateRecord.updated_at || ""
         : normalized.updatedAt,
-  }, options);
+  });
 }
 
 function resolveMapSettingsLayers(
   settings: MapSettingsRecord = DEFAULT_MAP_SETTINGS,
-  options: MapSettingsOptions = {},
 ) {
-  const normalized = normalizeMapSettings(settings, options);
-  const preset = getMapModePreset(getMapSettingsBaseMode(normalized, options));
+  const normalized = normalizeMapSettings(settings);
+  const preset = getMapModePreset(getMapSettingsBaseMode(normalized));
   return {
     ...preset.layers,
     ...normalized.layerOverrides,
@@ -309,10 +287,8 @@ export function buildPresetMapSettings({
   modeId,
   audioEnabled = false,
   now = new Date().toISOString(),
-  immersiveModeEnabled = false,
 }: MapSettingsOptions = {}) {
-  const options = { immersiveModeEnabled };
-  if (!isSelectableMapModeId(modeId, options)) {
+  if (!isSelectableMapModeId(modeId)) {
     return normalizeMapSettings(DEFAULT_MAP_SETTINGS);
   }
   const preset = getMapModePreset(modeId);
@@ -331,10 +307,8 @@ export function buildCustomMapSettings({
   layerKey,
   value,
   now = new Date().toISOString(),
-  immersiveModeEnabled = false,
 }: MapSettingsOptions = {}) {
-  const options = { immersiveModeEnabled };
-  const normalized = normalizeMapSettings(settings, options);
+  const normalized = normalizeMapSettings(settings);
   if (!LAYER_KEY_SET.has(layerKey) || typeof value !== "boolean") {
     return normalized;
   }
@@ -342,7 +316,7 @@ export function buildCustomMapSettings({
   return {
     ...normalized,
     selectedMode: MAP_MODE_IDS.CUSTOM,
-    baseMode: getMapSettingsBaseMode(normalized, options),
+    baseMode: getMapSettingsBaseMode(normalized),
     layerOverrides: {
       ...normalized.layerOverrides,
       [layerKey]: value,
@@ -355,15 +329,13 @@ export function buildMapSettingsFromLayerState({
   settings = DEFAULT_MAP_SETTINGS,
   layers = {},
   now = new Date().toISOString(),
-  immersiveModeEnabled = false,
 }: MapSettingsOptions = {}) {
-  const options = { immersiveModeEnabled };
-  const normalized = normalizeMapSettings(settings, options);
-  const baseMode = getMapSettingsBaseMode(normalized, options);
+  const normalized = normalizeMapSettings(settings);
+  const baseMode = getMapSettingsBaseMode(normalized);
   const baseLayers = getMapModePreset(baseMode).layers;
   const layerOverrides = normalizeMapLayerOverrides(layers);
   const nextLayers = {
-    ...resolveMapSettingsLayers(normalized, options),
+    ...resolveMapSettingsLayers(normalized),
     ...layerOverrides,
   };
   const custom = PERSISTED_MAP_LAYER_KEYS.some(
@@ -381,9 +353,8 @@ export function buildMapSettingsFromLayerState({
 
 export function mapSettingsToExplorerLayers(
   settings: MapSettingsRecord = DEFAULT_MAP_SETTINGS,
-  options: MapSettingsOptions = {},
 ) {
-  const layers = resolveMapSettingsLayers(settings, options);
+  const layers = resolveMapSettingsLayers(settings);
   return {
     showMapLabels: layers[MAP_LAYER_KEYS.MAP_LABELS],
     showRunwayBeams: layers[MAP_LAYER_KEYS.APPROACH_BEAMS],
@@ -395,9 +366,8 @@ export function mapSettingsToExplorerLayers(
 
 export function mapSettingsToUserLocationPreferences(
   settings: MapSettingsRecord = DEFAULT_MAP_SETTINGS,
-  options: MapSettingsOptions = {},
 ) {
-  const layers = resolveMapSettingsLayers(settings, options);
+  const layers = resolveMapSettingsLayers(settings);
   const enabled = layers[MAP_LAYER_KEYS.USER_LOCATION] === true;
   return {
     userLocationEnabled: enabled,

--- a/src/features/airport/map-settings/mapSettingsStorage.test.ts
+++ b/src/features/airport/map-settings/mapSettingsStorage.test.ts
@@ -29,18 +29,12 @@ try {
       baseMode: MAP_MODE_IDS.IMMERSIVE,
       hasSelectedMode: true,
     },
-    { immersiveModeEnabled: true },
   );
 
   assert.equal(
-    readStoredMapSettings({ immersiveModeEnabled: true })?.selectedMode,
+    readStoredMapSettings()?.selectedMode,
     MAP_MODE_IDS.IMMERSIVE,
-    "cache should preserve immersive settings when the feature is enabled",
-  );
-  assert.equal(
-    readStoredMapSettings({ immersiveModeEnabled: false })?.selectedMode,
-    MAP_MODE_IDS.CONTROLLER,
-    "cache should still normalize unsupported immersive settings away",
+    "cache should preserve immersive settings without a feature flag",
   );
 } finally {
   if (typeof originalWindow === "undefined") {

--- a/src/features/airport/map-settings/mapSettingsStorage.ts
+++ b/src/features/airport/map-settings/mapSettingsStorage.ts
@@ -7,23 +7,23 @@ import {
 
 const MAP_SETTINGS_STORAGE_KEY = "adsbao:airport-map-settings:v1";
 
-export function readStoredMapSettings(options = {}) {
+export function readStoredMapSettings() {
   if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(MAP_SETTINGS_STORAGE_KEY);
     if (!raw) return null;
-    return normalizeMapSettings(JSON.parse(raw), options);
+    return normalizeMapSettings(JSON.parse(raw));
   } catch {
     return null;
   }
 }
 
-export function writeStoredMapSettings(settings = DEFAULT_MAP_SETTINGS, options = {}) {
+export function writeStoredMapSettings(settings = DEFAULT_MAP_SETTINGS) {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(
       MAP_SETTINGS_STORAGE_KEY,
-      JSON.stringify(normalizeMapSettings(settings, options)),
+      JSON.stringify(normalizeMapSettings(settings)),
     );
   } catch {
     // Browser storage can be unavailable; the current in-memory settings still apply.

--- a/src/features/airport/map-settings/userMapSettings.server.test.ts
+++ b/src/features/airport/map-settings/userMapSettings.server.test.ts
@@ -20,7 +20,7 @@ const user = {
     featureFlagsRepository: {
       async readFlagsByEmail(email, options) {
         calls.push({ type: "flags", email, options });
-        return { flags: { immersiveModeEnabled: true } };
+        throw new Error("immersive mode should not read feature flags");
       },
     },
     repository: {
@@ -40,14 +40,9 @@ const user = {
   assert.equal(settings.selectedMode, MAP_MODE_IDS.IMMERSIVE);
   assert.deepEqual(calls, [
     {
-      type: "flags",
-      email: "owner@example.com",
-      options: { environment: "preview" },
-    },
-    {
       type: "settings",
       email: "owner@example.com",
-      options: { immersiveModeEnabled: true },
+      options: undefined,
     },
   ]);
 }
@@ -59,7 +54,7 @@ const user = {
     env: { VERCEL_ENV: "preview" },
     featureFlagsRepository: {
       async readFlagsByEmail() {
-        return { flags: { immersiveModeEnabled: true } };
+        throw new Error("immersive mode should not read feature flags");
       },
     },
     repository: {
@@ -76,7 +71,7 @@ const user = {
   });
 
   assert.equal(calls[0].email, "owner@example.com");
-  assert.equal(calls[0].immersiveModeEnabled, true);
+  assert.equal("immersiveModeEnabled" in calls[0], false);
   assert.equal(calls[0].settings.selectedMode, MAP_MODE_IDS.IMMERSIVE);
 }
 

--- a/src/features/airport/map-settings/userMapSettings.server.ts
+++ b/src/features/airport/map-settings/userMapSettings.server.ts
@@ -3,33 +3,18 @@ import {
 } from "../../../app/api/dao/userMapSettings.dao";
 import {
   getClerkUserPrimaryEmail,
-  isImmersiveModeEnabled,
 } from "../../app-shell/feature-flags/userFeatureFlagsModel";
-import {
-  resolveFeatureFlagsForUser,
-} from "../../app-shell/feature-flags/userFeatureFlags.server";
 type UserMapSettingsServerRecord = Record<string, any>;
 
 export async function resolveMapSettingsForUser({
   user,
-  env = process.env,
-  featureFlagsRepository,
   repository = createUserMapSettingsRepositoryFromEnv(),
 }: UserMapSettingsServerRecord = {}) {
   const email = getClerkUserPrimaryEmail(user);
   if (!email || !repository) return null;
-  const immersiveModeEnabled = isImmersiveModeEnabled(
-    await resolveFeatureFlagsForUser({
-      user,
-      env,
-      repository: featureFlagsRepository,
-    }),
-  );
 
   try {
-    const row = await repository.readSettingsByEmail(email, {
-      immersiveModeEnabled,
-    });
+    const row = await repository.readSettingsByEmail(email);
     return row?.settings || null;
   } catch (error: any) {
     console.warn(`[map-settings] Supabase read failed for ${email}:`, error.message);
@@ -39,24 +24,14 @@ export async function resolveMapSettingsForUser({
 
 export async function persistMapSettingsForUser({
   user,
-  env = process.env,
-  featureFlagsRepository,
   settings,
   repository = createUserMapSettingsRepositoryFromEnv(),
 }: UserMapSettingsServerRecord = {}) {
   const email = getClerkUserPrimaryEmail(user);
   if (!email || !repository) return null;
-  const immersiveModeEnabled = isImmersiveModeEnabled(
-    await resolveFeatureFlagsForUser({
-      user,
-      env,
-      repository: featureFlagsRepository,
-    }),
-  );
 
   const row = await repository.upsertSettingsByEmail({
     email,
-    immersiveModeEnabled,
     settings,
   });
   return row?.settings || null;

--- a/src/features/app-shell/auth/useFlightAwareEnabled.ts
+++ b/src/features/app-shell/auth/useFlightAwareEnabled.ts
@@ -6,8 +6,6 @@ import {
   FEATURE_FLAGS,
   getClerkUserPrimaryEmail,
   isFeatureFlagEnabled,
-  isImmersiveModeEnabled,
-  isPreviewImmersiveModeOverrideEnabled,
   normalizeFeatureFlags,
 } from "../feature-flags/userFeatureFlagsModel";
 
@@ -110,16 +108,4 @@ export function useFlightAwareEnabled() {
   }, [email, enabled, flags, hasUser, user]);
 
   return enabled;
-}
-
-export function useImmersiveModeFeature() {
-  const { flags, resolved } = useUserFeatureFlags();
-  const previewOverrideEnabled =
-    typeof window !== "undefined" &&
-    isPreviewImmersiveModeOverrideEnabled(window.location);
-
-  return {
-    enabled: isImmersiveModeEnabled(flags) || previewOverrideEnabled,
-    resolved: resolved || previewOverrideEnabled,
-  };
 }

--- a/src/features/app-shell/feature-flags/userFeatureFlagsModel.test.ts
+++ b/src/features/app-shell/feature-flags/userFeatureFlagsModel.test.ts
@@ -4,8 +4,6 @@ import {
   FEATURE_FLAGS,
   getClerkUserPrimaryEmail,
   isFeatureFlagEnabled,
-  isImmersiveModeEnabled,
-  isPreviewImmersiveModeOverrideEnabled,
   normalizeFeatureFlags,
   normalizeFeatureFlagEnvironment,
   normalizeUserEmail,
@@ -56,37 +54,7 @@ assert.equal(
   false,
 );
 assert.equal(
-  isImmersiveModeEnabled({ [FEATURE_FLAGS.IMMERSIVE_MODE_ENABLED]: true }),
-  true,
-);
-assert.equal(
-  isImmersiveModeEnabled({ [FEATURE_FLAGS.FLIGHTAWARE_ENABLED]: true }),
-  false,
-);
-assert.equal(
-  isImmersiveModeEnabled({ [FEATURE_FLAGS.IMMERSIVE_MODE_ENABLED]: false }),
-  false,
-);
-
-assert.equal(
-  isPreviewImmersiveModeOverrideEnabled({
-    hostname: "adsbao-git-codex-immersive-aircraft-lighting-orriduck.vercel.app",
-    search: "?qaImmersive=1",
-  }),
-  true,
-);
-assert.equal(
-  isPreviewImmersiveModeOverrideEnabled({
-    hostname: ["adsbao", "vercel", "app"].join("."),
-    search: "?qaImmersive=1",
-  }),
-  false,
-);
-assert.equal(
-  isPreviewImmersiveModeOverrideEnabled({
-    hostname: "adsbao-git-codex-immersive-aircraft-lighting-orriduck.vercel.app",
-    search: "",
-  }),
+  Object.prototype.hasOwnProperty.call(FEATURE_FLAGS, "IMMERSIVE_MODE_ENABLED"),
   false,
 );
 

--- a/src/features/app-shell/feature-flags/userFeatureFlagsModel.ts
+++ b/src/features/app-shell/feature-flags/userFeatureFlagsModel.ts
@@ -1,6 +1,5 @@
 export const FEATURE_FLAGS = Object.freeze({
   FLIGHTAWARE_ENABLED: "flightAwareEnabled",
-  IMMERSIVE_MODE_ENABLED: "immersiveModeEnabled",
 });
 
 const FEATURE_FLAG_ENVIRONMENTS = Object.freeze({
@@ -60,22 +59,4 @@ export function normalizeFeatureFlags(flags: unknown) {
 
 export function isFeatureFlagEnabled(flags: unknown, flagKey: string) {
   return normalizeFeatureFlags(flags)[flagKey] === true;
-}
-
-export function isImmersiveModeEnabled(flags: unknown) {
-  return isFeatureFlagEnabled(flags, FEATURE_FLAGS.IMMERSIVE_MODE_ENABLED);
-}
-
-const VERCEL_GIT_PREVIEW_HOST_PATTERN =
-  /^adsbao-git-[a-z0-9-]+-orriduck\.vercel\.app$/i;
-
-export function isPreviewImmersiveModeOverrideEnabled(locationLike: {
-  hostname?: unknown;
-  search?: unknown;
-} = {}) {
-  const hostname = String(locationLike.hostname || "").trim().toLowerCase();
-  if (!VERCEL_GIT_PREVIEW_HOST_PATTERN.test(hostname)) return false;
-
-  const search = String(locationLike.search || "").replace(/^\?/, "");
-  return new URLSearchParams(search).get("qaImmersive") === "1";
 }

--- a/supabase/migrations/20260604193000_remove_immersive_mode_feature_flag.sql
+++ b/supabase/migrations/20260604193000_remove_immersive_mode_feature_flag.sql
@@ -1,0 +1,6 @@
+update public.user_feature_flags
+set flags = flags - 'immersiveModeEnabled'
+where flags ? 'immersiveModeEnabled';
+
+comment on table public.user_feature_flags is
+  'Server-read feature flags keyed by Clerk primary email and environment. Example flags: {"flightAwareEnabled": true}.';


### PR DESCRIPTION
## Summary
- Remove immersive mode from the internal feature flag model and hook surface.
- Make immersive mode selectable, persisted, and hydrated without a feature flag gate.
- Add a Supabase migration to remove the old immersiveModeEnabled flag key from stored user feature flags.

## Validation
- /opt/homebrew/bin/pnpm lint
- /opt/homebrew/bin/pnpm build
- /opt/homebrew/bin/pnpm test
- Local browser smoke on KBOS: opened map settings, selected 沉浸模式, verified data-map-mode="immersive" and no 2D aircraft marker proxies.