### PR TITLE
[codex] Tune RKSI immersive night aircraft lights

### DIFF
--- a/src/components/map/Aircraft3DOverlay.tsx
+++ b/src/components/map/Aircraft3DOverlay.tsx
@@ -13,6 +13,7 @@ import {
 import {
   resolveAircraft3DAttitudeRotation,
   resolveAircraft3DEdgeTone,
+  resolveAircraft3DLandingLightIntensity,
   resolveAircraft3DLightingProfile,
   resolveAircraft3DMaterialProfile,
   resolveAircraft3DModelScalePx,
@@ -498,16 +499,22 @@ function getAnchorPosition(
 }
 
 function addLightPoint({
+  flare = false,
   glowScale,
+  glowStrength = 1,
   group,
+  haloStrength = 1,
   position,
   color,
   opacity,
   radius,
   pulse = false,
 }: {
+  flare?: boolean;
   glowScale: number;
+  glowStrength?: number;
   group: AircraftRenderGroup;
+  haloStrength?: number;
   position: THREE.Vector3;
   color: string;
   opacity: number;
@@ -515,8 +522,10 @@ function addLightPoint({
   pulse?: boolean;
 }) {
   const coreMaterial = new THREE.MeshBasicMaterial({
+    blending: THREE.AdditiveBlending,
     color,
     opacity,
+    toneMapped: false,
     transparent: true,
     depthWrite: false,
     depthTest: false,
@@ -529,10 +538,32 @@ function addLightPoint({
 
   const glowTexture = getLightGlowTexture();
   if (glowTexture) {
+    const haloSize = Math.max(radius * glowScale, radius * 3.2);
+    const haloMaterial = new THREE.MeshBasicMaterial({
+      blending: THREE.AdditiveBlending,
+      color,
+      map: glowTexture,
+      opacity: opacity * 0.72 * haloStrength,
+      side: THREE.DoubleSide,
+      toneMapped: false,
+      transparent: true,
+      depthWrite: false,
+      depthTest: false,
+    });
+    const halo = new THREE.Mesh(
+      new THREE.PlaneGeometry(haloSize, haloSize),
+      haloMaterial,
+    );
+    halo.position.copy(position);
+    halo.renderOrder = 32;
+    halo.userData.disposeGeometry = true;
+    group.add(halo);
+    group.userData.lightMaterials?.push(haloMaterial);
+
     const glowMaterial = new THREE.SpriteMaterial({
       color,
       map: glowTexture,
-      opacity: opacity * 0.58,
+      opacity: opacity * 0.58 * glowStrength,
       transparent: true,
       depthWrite: false,
       depthTest: false,
@@ -544,6 +575,35 @@ function addLightPoint({
     glow.renderOrder = 33;
     group.add(glow);
     group.userData.lightMaterials?.push(glowMaterial);
+
+    const flareBase = radius * glowScale;
+    if (flare && opacity > 0.42 && flareBase >= 9) {
+      for (const flare of [
+        { x: 1.7, y: 0.34, opacity: 0.24 },
+        { x: 0.42, y: 1.18, opacity: 0.16 },
+      ]) {
+        const flareMaterial = new THREE.MeshBasicMaterial({
+          blending: THREE.AdditiveBlending,
+          color,
+          map: glowTexture,
+          opacity: opacity * flare.opacity,
+          side: THREE.DoubleSide,
+          toneMapped: false,
+          transparent: true,
+          depthWrite: false,
+          depthTest: false,
+        });
+        const flareSprite = new THREE.Mesh(
+          new THREE.PlaneGeometry(flareBase * flare.x, flareBase * flare.y),
+          flareMaterial,
+        );
+        flareSprite.position.copy(position);
+        flareSprite.renderOrder = 35;
+        flareSprite.userData.disposeGeometry = true;
+        group.add(flareSprite);
+        group.userData.lightMaterials?.push(flareMaterial);
+      }
+    }
   }
 
   if (pulse) group.userData.beaconMaterials?.push(coreMaterial);
@@ -573,25 +633,36 @@ function addShadow(group: AircraftRenderGroup, template: AircraftModelTemplate, 
 }
 
 function addLandingLights({
+  aircraft,
   group,
   materialProfile,
   opacity,
+  phase,
   profile,
   selected,
   template,
 }: {
+  aircraft: any;
   group: AircraftRenderGroup;
   materialProfile: ReturnType<typeof resolveAircraft3DMaterialProfile>;
   opacity: number;
+  phase: string;
   profile: ReturnType<typeof resolveAircraft3DLightingProfile>;
   selected: boolean;
   template: AircraftModelTemplate;
 }) {
   if (!profile.landingLightsVisible && !selected) return;
+  const operationalIntensity = resolveAircraft3DLandingLightIntensity({
+    altitude: aircraft?.altitude,
+    onGround: aircraft?.onGround,
+    phase,
+    selected,
+  });
   const lightOpacity = Math.min(
     1,
     materialProfile.landingLightOpacity *
       profile.landingLightIntensity *
+      operationalIntensity *
       opacity *
       (selected ? 1.08 : 1),
   );
@@ -599,41 +670,53 @@ function addLandingLights({
 
   const nose = getAnchorPosition(template, "noseLight", { x: 0.5, y: 0.05 }, 4.2);
   const lateralOffset = Math.max(template.width * 0.07, 0.42);
-  const nightLandingLights = profile.landingLightIntensity > 0.7;
+  const nightLandingLights =
+    profile.landingLightIntensity * operationalIntensity > 0.72;
   addLightPoint({
-    glowScale: materialProfile.lightGlowScale * (nightLandingLights ? 2.35 : 1.42),
+    flare: false,
+    glowScale: materialProfile.lightGlowScale * (nightLandingLights ? 0.9 : 1.42),
+    glowStrength: nightLandingLights ? 0.42 : 1,
     group,
+    haloStrength: nightLandingLights ? 0.32 : 1,
     position: new THREE.Vector3(nose.x, nose.y, nose.z + 0.18),
     color: materialProfile.landingLightColor,
-    opacity: Math.min(1, lightOpacity * (nightLandingLights ? 1.2 : 0.94)),
-    radius: materialProfile.lightRadius * (nightLandingLights ? 1.18 : 0.88),
+    opacity: Math.min(1, lightOpacity * (nightLandingLights ? 0.96 : 0.94)),
+    radius: materialProfile.lightRadius * (nightLandingLights ? 0.34 : 0.88),
   });
   for (const offsetX of [-lateralOffset, lateralOffset]) {
     addLightPoint({
-      glowScale: materialProfile.lightGlowScale * (nightLandingLights ? 1.62 : 1.34),
+      flare: false,
+      glowScale: materialProfile.lightGlowScale * (nightLandingLights ? 0.7 : 1.34),
+      glowStrength: nightLandingLights ? 0.34 : 1,
       group,
+      haloStrength: nightLandingLights ? 0.26 : 1,
       position: new THREE.Vector3(nose.x + offsetX, nose.y, nose.z),
       color: materialProfile.landingLightColor,
-      opacity: Math.min(1, lightOpacity * (nightLandingLights ? 1.05 : 1)),
-      radius: materialProfile.lightRadius * (nightLandingLights ? 0.9 : 0.82),
+      opacity: Math.min(1, lightOpacity * (nightLandingLights ? 0.82 : 1)),
+      radius: materialProfile.lightRadius * (nightLandingLights ? 0.28 : 0.82),
     });
   }
 
   const beamTexture = getLandingBeamTexture();
   if (!beamTexture) return;
   const beamMaterial = new THREE.MeshBasicMaterial({
+    blending: THREE.AdditiveBlending,
     color: materialProfile.landingLightColor,
     map: beamTexture,
-    opacity: lightOpacity * (nightLandingLights ? 0.96 : 0.48),
+    opacity: Math.min(1, lightOpacity * (nightLandingLights ? 0.68 : 0.48)),
+    side: THREE.DoubleSide,
+    toneMapped: false,
     transparent: true,
     depthWrite: false,
     depthTest: false,
-    blending: THREE.AdditiveBlending,
   });
-  const beamLength = Math.max(template.height * materialProfile.landingLightScale, 28);
+  const beamLength = Math.max(
+    template.height * materialProfile.landingLightScale,
+    nightLandingLights ? 42 : 28,
+  );
   const beamWidth = Math.max(
-    template.width * (nightLandingLights ? 0.76 : 0.42),
-    nightLandingLights ? 9.6 : 5.2,
+    template.width * (nightLandingLights ? 0.52 : 0.42),
+    nightLandingLights ? 7.4 : 5.2,
   );
   const beam = new THREE.Mesh(new THREE.PlaneGeometry(beamWidth, beamLength), beamMaterial);
   beam.position.set(nose.x, nose.y - beamLength * 0.48, 1.1);
@@ -736,9 +819,11 @@ function buildModelGroup({
     template,
   });
   addLandingLights({
+    aircraft,
     group,
     materialProfile,
     opacity,
+    phase,
     profile,
     selected,
     template,
@@ -798,35 +883,48 @@ function buildModelGroup({
 
   if (profile.navLightsVisible || selected) {
     const lightOpacity = Math.min(1, profile.navLightIntensity * (selected ? 1.12 : 1));
-    const lightRadius = materialProfile.lightRadius;
-    const lightGlowScale = materialProfile.lightGlowScale;
+    const nightNavLights = phase === "night";
+    const lightRadius = materialProfile.lightRadius * (nightNavLights ? 0.46 : 1);
+    const lightGlowScale = materialProfile.lightGlowScale * (nightNavLights ? 0.72 : 1);
     addLightPoint({
+      flare: nightNavLights,
       glowScale: lightGlowScale,
+      glowStrength: nightNavLights ? 0.9 : 1,
       group,
+      haloStrength: nightNavLights ? 0.68 : 1,
       position: getAnchorPosition(template, "leftWingTip", { x: 0.05, y: 0.52 }),
       color: "#ff4e4e",
       opacity: lightOpacity,
       radius: lightRadius,
     });
     addLightPoint({
+      flare: nightNavLights,
       glowScale: lightGlowScale,
+      glowStrength: nightNavLights ? 0.9 : 1,
       group,
+      haloStrength: nightNavLights ? 0.68 : 1,
       position: getAnchorPosition(template, "rightWingTip", { x: 0.95, y: 0.52 }),
       color: "#50ff9b",
       opacity: lightOpacity,
       radius: lightRadius,
     });
     addLightPoint({
+      flare: false,
       glowScale: lightGlowScale,
+      glowStrength: nightNavLights ? 0.82 : 1,
       group,
+      haloStrength: nightNavLights ? 0.58 : 1,
       position: getAnchorPosition(template, "tailLight", { x: 0.5, y: 0.96 }),
       color: "#f6fbff",
       opacity: Math.min(1, lightOpacity * 0.9),
       radius: lightRadius * 0.82,
     });
     addLightPoint({
+      flare: nightNavLights,
       glowScale: lightGlowScale,
+      glowStrength: nightNavLights ? 0.84 : 1,
       group,
+      haloStrength: nightNavLights ? 0.58 : 1,
       position: getAnchorPosition(template, "antiCollisionBeacon", { x: 0.5, y: 0.5 }, 3.8),
       color: "#ff6d4d",
       opacity: Math.min(1, lightOpacity * 0.92),

--- a/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import {
   resolveAircraft3DAttitudeRotation,
+  resolveAircraft3DLandingLightIntensity,
   resolveAircraft3DLightingProfile,
   resolveAircraft3DMaterialProfile,
   resolveAircraft3DModelScalePx,
@@ -95,6 +96,33 @@ assert.ok(nightMaterial.lightGlowScale > duskMaterial.lightGlowScale);
 assert.ok(nightMaterial.lightGlowScale >= 8);
 assert.ok(nightMaterial.lightRadius >= duskMaterial.lightRadius * 1.5);
 assert.ok(nightMaterial.landingLightScale >= duskMaterial.landingLightScale * 2);
+assert.ok(
+  nightLighting.navLightIntensity >= duskLighting.navLightIntensity * 1.8,
+);
+assert.ok(nightMaterial.bodyGlowOpacity >= duskMaterial.bodyGlowOpacity * 1.8);
+assert.ok(nightMaterial.lightGlowScale >= duskMaterial.lightGlowScale * 2.6);
+assert.ok(nightMaterial.lightRadius >= duskMaterial.lightRadius * 2.4);
+assert.ok(nightMaterial.landingLightScale >= duskMaterial.landingLightScale * 2.8);
+assert.ok(
+  resolveAircraft3DLandingLightIntensity({
+    altitude: 2_900,
+    phase: "night",
+  }) > 0.85,
+);
+assert.ok(
+  resolveAircraft3DLandingLightIntensity({
+    altitude: 41_000,
+    phase: "night",
+  }) < 0.08,
+);
+assert.ok(
+  resolveAircraft3DLandingLightIntensity({
+    altitude: 41_000,
+    phase: "night",
+    selected: true,
+  }) < 0.12,
+);
+assert.ok(nightLighting.navLightIntensity > 1.2);
 assert.ok(relativeLuminance(dayMaterial.color) > 0.8);
 assert.ok(relativeLuminance(sunsetMaterial.color) > 0.74);
 assert.ok(relativeLuminance(duskMaterial.color) > 0.7);

--- a/src/features/aircraft/icons/aircraftIcon3DModel.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.ts
@@ -23,6 +23,11 @@ type Aircraft3DMaterialOptions = {
   selected?: boolean;
 };
 
+type Aircraft3DLandingLightOptions = Aircraft3DMaterialOptions & {
+  altitude?: unknown;
+  onGround?: boolean;
+};
+
 type Aircraft3DEdgeToneOptions = Aircraft3DMaterialOptions & {
   lightDot?: unknown;
 };
@@ -107,15 +112,15 @@ export const resolveAircraft3DLightingProfile = ({
     case "night":
       return {
         ambientColor: "#b8d5ff",
-        ambientIntensity: 0.38,
+        ambientIntensity: 0.3,
         keyLightColor: "#c9ddff",
-        keyLightIntensity: 0.46,
-        landingLightIntensity: 1,
+        keyLightIntensity: 0.42,
+        landingLightIntensity: 1.15,
         landingLightsVisible: true,
         navLightsVisible: true,
-        navLightIntensity: 1.22,
+        navLightIntensity: 1.48,
         rimLightColor: "#76b8ff",
-        rimLightIntensity: 0.62,
+        rimLightIntensity: 0.78,
         shadowOpacity: 0.1,
       };
     case "dusk":
@@ -165,6 +170,24 @@ export const resolveAircraft3DLightingProfile = ({
   }
 };
 
+export const resolveAircraft3DLandingLightIntensity = ({
+  altitude = null,
+  onGround = false,
+  phase = "day",
+  selected = false,
+}: Aircraft3DLandingLightOptions = {}) => {
+  const phaseKey = String(phase || "day");
+  const altitudeFt = toFiniteNumber(altitude);
+  if (phaseKey !== "night") return selected ? 0.36 : 1;
+  if (onGround) return 1;
+  if (altitudeFt == null) return selected ? 0.18 : 0.42;
+
+  const approachRatio = clamp((18_000 - altitudeFt) / 15_000, 0, 1);
+  const approachIntensity = Math.pow(approachRatio, 1.34);
+  const selectedFloor = selected ? 0.08 : 0.03;
+  return round2(Math.max(selectedFloor, approachIntensity));
+};
+
 export const resolveAircraft3DModelScalePx = ({
   family = "jet",
   sizeScale = 1,
@@ -190,21 +213,21 @@ export const resolveAircraft3DMaterialProfile = ({
     case "night":
       return {
         bodyGlowColor: "#9bcfff",
-        bodyGlowOpacity: selected ? 0.072 : 0.04,
-        color: selected ? "#eef7ff" : "#d9e6f2",
+        bodyGlowOpacity: selected ? 0.096 : 0.06,
+        color: selected ? "#eff9ff" : "#cbd7e2",
         edgeColor: "#cbe4ff",
-        edgeContrast: 0.74,
-        edgeHighlightColor: "#f5fbff",
+        edgeContrast: 0.86,
+        edgeHighlightColor: "#f8fdff",
         edgeLightVector: { x: -0.34, y: -0.72, z: 0.6 },
-        edgeOpacity: selected ? 0.12 : 0.07,
-        edgeShadowColor: "#4a6078",
-        emissive: "#142034",
-        emissiveIntensity: selected ? 0.26 : 0.22,
+        edgeOpacity: selected ? 0.1 : 0.055,
+        edgeShadowColor: "#26364a",
+        emissive: "#0b1422",
+        emissiveIntensity: selected ? 0.23 : 0.18,
         landingLightColor: "#fff1cc",
         landingLightOpacity: 1,
-        landingLightScale: 4.1,
-        lightGlowScale: 8.4,
-        lightRadius: 1.02,
+        landingLightScale: 5.5,
+        lightGlowScale: 12.8,
+        lightRadius: 1.32,
         metalness: 0.22,
         roughness: 0.54,
       };


### PR DESCRIPTION
## Summary
- Split immersive night lighting into small navigation/beacon lights versus altitude-gated landing/head lights.
- Keep low-altitude aircraft with a small headlight core and narrow beam while preventing high-altitude traffic from becoming large glowing blobs.
- Strengthen night rim/material contrast so aircraft edges respond to the scene lighting without reverting to old 2D markers.

## Validation
- /opt/homebrew/bin/pnpm exec tsx src/features/aircraft/icons/aircraftIcon3DModel.test.ts
- /opt/homebrew/bin/pnpm lint
- /opt/homebrew/bin/pnpm build
- /opt/homebrew/bin/pnpm test
- Local RKSI immersive night smoke with mocked aircraft: data-map-mode="immersive", phase="night", canvas3d=1, markerProxy=0.