### PR TITLE
Refine immersive night lighting

### DIFF
--- a/src/components/map/Aircraft3DOverlay.tsx
+++ b/src/components/map/Aircraft3DOverlay.tsx
@@ -43,6 +43,7 @@ type Aircraft3DOverlayProps = {
   selectedAircraftId?: string;
   immersiveModeActive?: boolean;
   immersivePhase?: string;
+  immersiveLocalMinutes?: unknown;
   mapInstance?: any;
   trafficFilter?: string;
   typeFilter?: string;
@@ -351,17 +352,9 @@ function createMeshMaterial({
   selected: boolean;
 }) {
   const profile = resolveAircraft3DMaterialProfile({ phase, selected });
-  if (phase !== "night") {
-    return new THREE.MeshBasicMaterial({
-      color: profile.color,
-      depthWrite: false,
-      opacity,
-      toneMapped: false,
-      transparent: opacity < 0.99,
-    });
-  }
   return new THREE.MeshStandardMaterial({
     color: profile.color,
+    depthWrite: false,
     emissive: profile.emissive,
     emissiveIntensity: profile.emissiveIntensity,
     metalness: profile.metalness,
@@ -635,6 +628,7 @@ function addShadow(group: AircraftRenderGroup, template: AircraftModelTemplate, 
 function addLandingLights({
   aircraft,
   group,
+  localMinutes,
   materialProfile,
   opacity,
   phase,
@@ -644,6 +638,7 @@ function addLandingLights({
 }: {
   aircraft: any;
   group: AircraftRenderGroup;
+  localMinutes?: unknown;
   materialProfile: ReturnType<typeof resolveAircraft3DMaterialProfile>;
   opacity: number;
   phase: string;
@@ -654,6 +649,7 @@ function addLandingLights({
   if (!profile.landingLightsVisible && !selected) return;
   const operationalIntensity = resolveAircraft3DLandingLightIntensity({
     altitude: aircraft?.altitude,
+    localMinutes,
     onGround: aircraft?.onGround,
     phase,
     selected,
@@ -786,6 +782,7 @@ function addContrail(group: AircraftRenderGroup, template: AircraftModelTemplate
 function buildModelGroup({
   aircraft,
   group,
+  localMinutes,
   opacity,
   phase,
   profile,
@@ -794,6 +791,7 @@ function buildModelGroup({
 }: {
   aircraft: any;
   group: AircraftRenderGroup;
+  localMinutes?: unknown;
   opacity: number;
   phase: string;
   profile: ReturnType<typeof resolveAircraft3DLightingProfile>;
@@ -821,6 +819,7 @@ function buildModelGroup({
   addLandingLights({
     aircraft,
     group,
+    localMinutes,
     materialProfile,
     opacity,
     phase,
@@ -937,6 +936,7 @@ function buildModelGroup({
 async function refreshModelForGroup({
   aircraft,
   group,
+  localMinutes,
   opacity,
   phase,
   profile,
@@ -944,6 +944,7 @@ async function refreshModelForGroup({
 }: {
   aircraft: any;
   group: AircraftRenderGroup;
+  localMinutes?: unknown;
   opacity: number;
   phase: string;
   profile: ReturnType<typeof resolveAircraft3DLightingProfile>;
@@ -959,6 +960,7 @@ async function refreshModelForGroup({
     source.name,
     phase,
     selected ? "selected" : "normal",
+    localMinutes == null ? "" : String(Math.round(Number(localMinutes) || 0)),
     aircraft?.onGround ? "ground" : "air",
     aircraft?.movement || "",
     contrail ? "contrail" : "clean",
@@ -971,6 +973,7 @@ async function refreshModelForGroup({
     buildModelGroup({
       aircraft,
       group,
+      localMinutes,
       opacity,
       phase,
       profile,
@@ -980,7 +983,16 @@ async function refreshModelForGroup({
   }
   const template = await loadAircraftModelTemplate(source.name, source.src);
   if (group.userData.pendingModelSignature !== signature) return;
-  buildModelGroup({ aircraft, group, opacity, phase, profile, selected, template });
+  buildModelGroup({
+    aircraft,
+    group,
+    localMinutes,
+    opacity,
+    phase,
+    profile,
+    selected,
+    template,
+  });
   group.userData.modelSignature = signature;
 }
 
@@ -1051,6 +1063,7 @@ function updateModelAttitude(group: AircraftRenderGroup) {
 function syncAircraftGroups({
   aircraft,
   altitudeLevel,
+  immersiveLocalMinutes,
   immersivePhase,
   selectedAircraftId,
   state,
@@ -1111,6 +1124,7 @@ function syncAircraftGroups({
     refreshModelForGroup({
       aircraft: item,
       group,
+      localMinutes: immersiveLocalMinutes,
       opacity: emphasis.opacity,
       phase: immersivePhase || "day",
       profile: state.profile,
@@ -1170,6 +1184,7 @@ export default function Aircraft3DOverlay({
   selectedAircraftId = "",
   immersiveModeActive = false,
   immersivePhase = "day",
+  immersiveLocalMinutes = null,
   mapInstance = null,
   trafficFilter = "all",
   typeFilter = "all",
@@ -1254,6 +1269,7 @@ export default function Aircraft3DOverlay({
       aircraft,
       altitudeLevel,
       immersiveModeActive,
+      immersiveLocalMinutes,
       immersivePhase,
       selectedAircraftId,
       state,
@@ -1264,6 +1280,7 @@ export default function Aircraft3DOverlay({
     aircraft,
     altitudeLevel,
     immersiveModeActive,
+    immersiveLocalMinutes,
     immersivePhase,
     selectedAircraftId,
     trafficFilter,

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -155,8 +155,16 @@ export default function AircraftPosition({
   });
   const rot = Math.round(aircraft.track || 0);
   const label = (aircraft.callsign || aircraft.icao24 || "").trim();
-  const labelColor =
-    immersiveModeActive && immersivePhase === "night" ? "#fff" : color;
+  const immersiveLightLabel =
+    immersivePhase === "night" ||
+    immersivePhase === "dusk" ||
+    immersivePhase === "sunset" ||
+    immersivePhase === "dawn";
+  const labelColor = immersiveModeActive
+    ? immersiveLightLabel
+      ? "#f7fbff"
+      : "#253047"
+    : color;
   const sourceBadge = getAircraftPositionSourceBadge(aircraft.positionQuality);
   const labelLeft = threeDimensionalOverlayActive
     ? SILHOUETTE_SIZE_PX + 4

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -16,6 +16,7 @@ import AircraftPosition from "./AircraftPosition";
 import UserLocationMarker from "./UserLocationMarker";
 import SelectedAircraftTrace from "./SelectedAircraftTrace";
 import RunwayAnnotationLayer from "./RunwayAnnotationLayer";
+import { resolveRunwayAnnotationVisibility } from "../../features/airport/map/runwayAnnotationModel";
 import { AIRPORT_MAP_FALLBACK_CENTER } from "../../config/airportMap";
 import MapAttribution from "./MapAttribution";
 import MapLoadingOverlay, {
@@ -384,6 +385,12 @@ export default function AirportMap({
   const overlayTheme = getMapOverlayTheme(currentTheme);
   const mapStyleTheme = immersiveModeActive ? "immersive" : currentTheme;
   const showBaseMapLabels = immersiveModeActive ? false : showMapLabels;
+  const runwayAnnotationVisibility = resolveRunwayAnnotationVisibility({
+    immersiveModeActive,
+    immersiveLocalMinutes,
+    immersivePhase,
+    showRunwayBeams,
+  });
   const nearbyAirportLayerDisplay = resolveNearbyAirportLayerDisplay({
     nearbyAirports,
     immersiveModeActive,
@@ -482,10 +489,10 @@ export default function AirportMap({
           />
           <RunwayAnnotationLayer
             runwayMap={runwayMap}
-            theme={currentTheme}
+            theme={immersiveModeActive ? "night" : currentTheme}
             zoom={zoom}
-            showBeams={!immersiveModeActive && showRunwayBeams}
-            showBadges={!immersiveModeActive}
+            showBeams={runwayAnnotationVisibility.showBeams}
+            showBadges={runwayAnnotationVisibility.showBadges}
           />
           <CandidateWatchingSpotsLayer
             enabled={!immersiveModeActive && showCandidateWatchingSpots}
@@ -510,6 +517,7 @@ export default function AirportMap({
               selectedAircraftId={selectedAircraftId}
               immersiveModeActive={immersiveModeActive}
               immersivePhase={immersivePhase}
+              immersiveLocalMinutes={immersiveLocalMinutes}
               mapInstance={mapInstance}
               trafficFilter={trafficFilter}
               typeFilter={typeFilter}

--- a/src/components/map/RunwayAnnotationLayer.tsx
+++ b/src/components/map/RunwayAnnotationLayer.tsx
@@ -13,6 +13,7 @@ import {
   buildRunwayApproachVisualization,
   buildRunwayCenterlineCollection,
   buildRunwayEndLabels,
+  buildRunwayLightCollection,
 } from "../../features/airport/map/runwayAnnotationModel";
 
 const escapeHtml = (value: unknown) =>
@@ -42,6 +43,12 @@ const runwayLabelIcon = (ident: string, theme: string) =>
     iconSize: [34, 18],
     iconAnchor: [17, 22],
   });
+
+const runwayLightRadius = (feature: Record<string, any>) => {
+  const progress = Number(feature?.properties?.progress);
+  if (progress === 0 || progress === 1) return 1.55;
+  return 1.12;
+};
 
 const isLeafletLayer = (layer: unknown): layer is L.Layer =>
   Boolean(
@@ -97,6 +104,25 @@ const buildApproachLayer = ({ kind, data, map, theme }: Record<string, any>) => 
   return { layer, beamLayer: layer, beamRenderer };
 };
 
+const buildRunwayLightLayer = ({ data }: Record<string, any>) =>
+  L.geoJSON(data as any, {
+    interactive: false,
+    pointToLayer(feature, latlng) {
+      return L.circleMarker(latlng, {
+        bubblingMouseEvents: false,
+        className: "runway-light-dot",
+        color: "var(--runway-light-core)",
+        fill: true,
+        fillColor: "var(--runway-light)",
+        fillOpacity: 0.84,
+        opacity: 0.88,
+        radius: runwayLightRadius(feature as Record<string, any>),
+        stroke: true,
+        weight: 0.45,
+      });
+    },
+  } as any);
+
 export default function RunwayAnnotationLayer({
   runwayMap,
   theme = "dark",
@@ -140,6 +166,14 @@ export default function RunwayAnnotationLayer({
       if (isLeafletLayer(built.layer)) sublayers.unshift(built.layer);
       beamLayer = isLeafletLayer(built.beamLayer) ? built.beamLayer : null;
       beamRenderer = built.beamRenderer;
+
+      if (theme === "night") {
+        const runwayLights = buildRunwayLightCollection(runwayMap);
+        if (runwayLights.features.length) {
+          const lightLayer = buildRunwayLightLayer({ data: runwayLights });
+          if (isLeafletLayer(lightLayer)) sublayers.push(lightLayer);
+        }
+      }
     }
 
     if (showBadges) {

--- a/src/config/airportMap.ts
+++ b/src/config/airportMap.ts
@@ -92,6 +92,11 @@ export const RUNWAY_ANNOTATION_STYLE_CONFIG = {
       weight: 3,
       opacity: 0.55,
     },
+    night: {
+      color: "var(--runway-night-line)",
+      weight: 1.6,
+      opacity: 0.52,
+    },
     light: {
       color: "var(--aviation-runway-annotation-line)",
       weight: 3,
@@ -100,6 +105,7 @@ export const RUNWAY_ANNOTATION_STYLE_CONFIG = {
   },
   beamColors: {
     dark: "var(--aviation-runway-approach-beam)",
+    night: "var(--runway-night-beam)",
     light: "var(--aviation-runway-approach-beam)",
   },
   beamGradientStops: [

--- a/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
@@ -111,6 +111,20 @@ assert.ok(
 );
 assert.ok(
   resolveAircraft3DLandingLightIntensity({
+    altitude: 2_900,
+    localMinutes: 20 * 60 + 59,
+    phase: "dusk",
+  }) < 0.35,
+);
+assert.ok(
+  resolveAircraft3DLandingLightIntensity({
+    altitude: 2_900,
+    localMinutes: 21 * 60,
+    phase: "dusk",
+  }) > 0.85,
+);
+assert.ok(
+  resolveAircraft3DLandingLightIntensity({
     altitude: 41_000,
     phase: "night",
   }) < 0.08,
@@ -126,6 +140,8 @@ assert.ok(nightLighting.navLightIntensity > 1.2);
 assert.ok(relativeLuminance(dayMaterial.color) > 0.8);
 assert.ok(relativeLuminance(sunsetMaterial.color) > 0.74);
 assert.ok(relativeLuminance(duskMaterial.color) > 0.7);
+assert.ok(relativeLuminance(duskMaterial.color) < relativeLuminance(dayMaterial.color));
+assert.ok(colorDistance(dayMaterial.color, duskMaterial.color) > 25);
 assert.ok(dayMaterial.edgeOpacity <= 0.16);
 assert.ok(sunsetMaterial.edgeOpacity <= 0.2);
 assert.ok(nightMaterial.edgeOpacity <= 0.22);
@@ -191,4 +207,21 @@ function relativeLuminance(hex: string) {
     Number.parseInt(normalized.slice(start, start + 2), 16) / 255,
   );
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function colorDistance(left: string, right: string) {
+  const leftRgb = rgb(left);
+  const rightRgb = rgb(right);
+  return Math.hypot(
+    leftRgb[0] - rightRgb[0],
+    leftRgb[1] - rightRgb[1],
+    leftRgb[2] - rightRgb[2],
+  );
+}
+
+function rgb(hex: string) {
+  const normalized = hex.replace("#", "");
+  return [0, 2, 4].map((start) =>
+    Number.parseInt(normalized.slice(start, start + 2), 16),
+  );
 }

--- a/src/features/aircraft/icons/aircraftIcon3DModel.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.ts
@@ -1,3 +1,5 @@
+import { isImmersiveNightLightingActive } from "../../airport/immersive/immersiveLightingModel";
+
 type Aircraft3DOverlayOptions = {
   immersiveModeActive?: boolean;
 };
@@ -25,6 +27,7 @@ type Aircraft3DMaterialOptions = {
 
 type Aircraft3DLandingLightOptions = Aircraft3DMaterialOptions & {
   altitude?: unknown;
+  localMinutes?: unknown;
   onGround?: boolean;
 };
 
@@ -172,13 +175,26 @@ export const resolveAircraft3DLightingProfile = ({
 
 export const resolveAircraft3DLandingLightIntensity = ({
   altitude = null,
+  localMinutes = null,
   onGround = false,
   phase = "day",
   selected = false,
 }: Aircraft3DLandingLightOptions = {}) => {
   const phaseKey = String(phase || "day");
   const altitudeFt = toFiniteNumber(altitude);
-  if (phaseKey !== "night") return selected ? 0.36 : 1;
+  const nightLightingActive = isImmersiveNightLightingActive({
+    localMinutes,
+    phase: phaseKey,
+  });
+  if (!nightLightingActive) {
+    if (phaseKey === "dusk" || phaseKey === "sunset") {
+      const approachRatio =
+        altitudeFt == null ? 0.24 : clamp((7_000 - altitudeFt) / 5_000, 0, 1);
+      const duskIntensity = approachRatio * (selected ? 0.34 : 0.28);
+      return round2(Math.max(selected ? 0.12 : 0.04, duskIntensity));
+    }
+    return selected ? 0.22 : 0.08;
+  }
   if (onGround) return 1;
   if (altitudeFt == null) return selected ? 0.18 : 0.42;
 
@@ -233,17 +249,17 @@ export const resolveAircraft3DMaterialProfile = ({
       };
     case "dusk":
       return {
-        bodyGlowColor: "#d7d3ff",
-        bodyGlowOpacity: selected ? 0.06 : 0.03,
-        color: selected ? "#fffdf8" : "#fbf8f4",
-        edgeColor: "#bcb7ad",
-        edgeContrast: 0.62,
-        edgeHighlightColor: "#fffaf0",
+        bodyGlowColor: "#b7c2ff",
+        bodyGlowOpacity: selected ? 0.058 : 0.032,
+        color: selected ? "#eef2fb" : "#d9d8e6",
+        edgeColor: "#9ea5bf",
+        edgeContrast: 0.66,
+        edgeHighlightColor: "#f5f7ff",
         edgeLightVector: { x: -0.58, y: -0.44, z: 0.68 },
         edgeOpacity: selected ? 0.11 : 0.075,
-        edgeShadowColor: "#8b8278",
-        emissive: "#fff3df",
-        emissiveIntensity: 0.16 + selectedLift,
+        edgeShadowColor: "#68708a",
+        emissive: "#d8ddff",
+        emissiveIntensity: 0.12 + selectedLift,
         landingLightColor: "#fff0d1",
         landingLightOpacity: selected ? 0.54 : 0.38,
         landingLightScale: 1.9,
@@ -256,15 +272,15 @@ export const resolveAircraft3DMaterialProfile = ({
       return {
         bodyGlowColor: "#ffd1a7",
         bodyGlowOpacity: selected ? 0.062 : 0.032,
-        color: selected ? "#fffaf0" : "#fbf1e2",
-        edgeColor: "#b79b7c",
+        color: selected ? "#fff1df" : "#efd8bf",
+        edgeColor: "#b68f70",
         edgeContrast: 0.68,
         edgeHighlightColor: "#fff1cf",
         edgeLightVector: { x: -0.72, y: -0.28, z: 0.58 },
         edgeOpacity: selected ? 0.12 : 0.08,
-        edgeShadowColor: "#8e7059",
+        edgeShadowColor: "#805d49",
         emissive: "#ffe0b3",
-        emissiveIntensity: 0.15 + selectedLift,
+        emissiveIntensity: 0.11 + selectedLift,
         landingLightColor: "#fff0c6",
         landingLightOpacity: selected ? 0.52 : 0.36,
         landingLightScale: 1.8,
@@ -277,7 +293,7 @@ export const resolveAircraft3DMaterialProfile = ({
       return {
         bodyGlowColor: "#ffe4b6",
         bodyGlowOpacity: selected ? 0.042 : 0.018,
-        color: selected ? "#fffdf6" : "#fbf7ed",
+        color: selected ? "#fffaf0" : "#f8f1de",
         edgeColor: "#a99d88",
         edgeContrast: 0.54,
         edgeHighlightColor: "#fffdf3",
@@ -285,7 +301,7 @@ export const resolveAircraft3DMaterialProfile = ({
         edgeOpacity: selected ? 0.105 : 0.065,
         edgeShadowColor: "#9a8d78",
         emissive: "#fff0d0",
-        emissiveIntensity: 0.14 + selectedLift,
+        emissiveIntensity: 0.09 + selectedLift,
         landingLightColor: "#fff1cd",
         landingLightOpacity: selected ? 0.2 : 0.14,
         landingLightScale: 1.25,
@@ -298,7 +314,7 @@ export const resolveAircraft3DMaterialProfile = ({
       return {
         bodyGlowColor: "#fff1c7",
         bodyGlowOpacity: selected ? 0.038 : 0.014,
-        color: selected ? "#fffdf8" : "#fbf8f1",
+        color: selected ? "#fffaf2" : "#f7f0df",
         edgeColor: "#9a9283",
         edgeContrast: 0.48,
         edgeHighlightColor: "#fffdf5",
@@ -306,7 +322,7 @@ export const resolveAircraft3DMaterialProfile = ({
         edgeOpacity: selected ? 0.1 : 0.06,
         edgeShadowColor: "#918978",
         emissive: "#fff2d8",
-        emissiveIntensity: 0.135 + selectedLift,
+        emissiveIntensity: 0.085 + selectedLift,
         landingLightColor: "#fff2d0",
         landingLightOpacity: selected ? 0.18 : 0.12,
         landingLightScale: 1.15,
@@ -319,7 +335,7 @@ export const resolveAircraft3DMaterialProfile = ({
       return {
         bodyGlowColor: "#fff3cc",
         bodyGlowOpacity: selected ? 0.036 : 0.012,
-        color: selected ? "#fffdfa" : "#fcf8f1",
+        color: selected ? "#fffdf8" : "#f8f6ef",
         edgeColor: "#9a9182",
         edgeContrast: 0.48,
         edgeHighlightColor: "#fffdf6",
@@ -327,7 +343,7 @@ export const resolveAircraft3DMaterialProfile = ({
         edgeOpacity: selected ? 0.095 : 0.058,
         edgeShadowColor: "#8d8576",
         emissive: "#fff4df",
-        emissiveIntensity: 0.13 + selectedLift,
+        emissiveIntensity: 0.08 + selectedLift,
         landingLightColor: "#fff3d6",
         landingLightOpacity: selected ? 0.16 : 0.1,
         landingLightScale: 1.1,

--- a/src/features/airport/immersive/immersiveLightingModel.test.ts
+++ b/src/features/airport/immersive/immersiveLightingModel.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+
+import { isImmersiveNightLightingActive } from "./immersiveLightingModel";
+
+assert.equal(
+  isImmersiveNightLightingActive({ localMinutes: 20 * 60 + 59 }),
+  false,
+);
+assert.equal(
+  isImmersiveNightLightingActive({ localMinutes: 21 * 60 }),
+  true,
+);
+assert.equal(
+  isImmersiveNightLightingActive({ localMinutes: 4 * 60 + 59 }),
+  true,
+);
+assert.equal(
+  isImmersiveNightLightingActive({ localMinutes: 5 * 60 }),
+  false,
+);
+assert.equal(
+  isImmersiveNightLightingActive({ localMinutes: null, phase: "night" }),
+  true,
+);
+assert.equal(
+  isImmersiveNightLightingActive({ localMinutes: null, phase: "dusk" }),
+  false,
+);
+
+console.log("immersiveLightingModel.test.ts ok");

--- a/src/features/airport/immersive/immersiveLightingModel.ts
+++ b/src/features/airport/immersive/immersiveLightingModel.ts
@@ -1,0 +1,25 @@
+const MINUTES_PER_DAY = 24 * 60;
+const AIRPORT_LIGHTS_START_MINUTES = 21 * 60;
+const AIRPORT_LIGHTS_END_MINUTES = 5 * 60;
+
+function normalizeMinutes(value: unknown) {
+  if (value == null || value === "") return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return ((Math.round(numeric) % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+}
+
+export function isImmersiveNightLightingActive({
+  localMinutes = null,
+  phase = "",
+}: {
+  localMinutes?: unknown;
+  phase?: unknown;
+} = {}) {
+  const minutes = normalizeMinutes(localMinutes);
+  if (minutes == null) return String(phase || "") === "night";
+  return (
+    minutes >= AIRPORT_LIGHTS_START_MINUTES ||
+    minutes < AIRPORT_LIGHTS_END_MINUTES
+  );
+}

--- a/src/features/airport/map/runwayAnnotationModel.test.ts
+++ b/src/features/airport/map/runwayAnnotationModel.test.ts
@@ -4,6 +4,8 @@ import {
   buildRunwayApproachVisualization,
   buildRunwayCenterlineCollection,
   buildRunwayEndLabels,
+  buildRunwayLightCollection,
+  resolveRunwayAnnotationVisibility,
 } from "./runwayAnnotationModel";
 import {
   ZOOM_AIRPORT,
@@ -19,6 +21,7 @@ const runwayMap = {
   runways: [
     {
       id: "04R/22L",
+      widthFt: 150,
       ends: [
         { ident: "04R", lat: 42.35404, lon: -71.010352 },
         { ident: "22L", lat: 42.377344, lon: -70.999076 },
@@ -133,4 +136,59 @@ assert.equal(lightVisualization.kind, "approach-lines");
 assert.deepEqual(
   lightVisualization.data.features.map((feature) => feature.geometry.type),
   ["LineString", "LineString"],
+);
+
+const nightVisualization = buildRunwayApproachVisualization(runwayMap, {
+  theme: "night",
+  zoom: ZOOM_AIRPORT,
+});
+assert.equal(nightVisualization.kind, "approach-beams");
+
+const runwayLights = buildRunwayLightCollection(runwayMap);
+assert.equal(runwayLights.features.length, 32);
+assert.deepEqual(
+  [...new Set(runwayLights.features.map((feature) => feature.properties.side))],
+  ["left", "right"],
+);
+assert.equal(runwayLights.features[0].properties.progress, 0);
+assert.equal(runwayLights.features.at(-1).properties.progress, 1);
+assert.ok(
+  metersBetween(
+    runwayLights.features[0].geometry.coordinates,
+    runwayMap.runways[0].centerline.geometry.coordinates[0],
+  ) >= 20,
+);
+assert.ok(
+  metersBetween(
+    runwayLights.features[0].geometry.coordinates,
+    runwayMap.runways[0].centerline.geometry.coordinates[0],
+  ) <= 26,
+);
+
+assert.deepEqual(
+  resolveRunwayAnnotationVisibility({
+    immersiveModeActive: true,
+    immersiveLocalMinutes: 20 * 60 + 59,
+    immersivePhase: "dusk",
+    showRunwayBeams: true,
+  }),
+  { showBeams: false, showBadges: false },
+);
+assert.deepEqual(
+  resolveRunwayAnnotationVisibility({
+    immersiveModeActive: true,
+    immersiveLocalMinutes: 21 * 60,
+    immersivePhase: "night",
+    showRunwayBeams: false,
+  }),
+  { showBeams: true, showBadges: false },
+);
+assert.deepEqual(
+  resolveRunwayAnnotationVisibility({
+    immersiveModeActive: false,
+    immersiveLocalMinutes: 21 * 60,
+    immersivePhase: "night",
+    showRunwayBeams: false,
+  }),
+  { showBeams: false, showBadges: true },
 );

--- a/src/features/airport/map/runwayAnnotationModel.ts
+++ b/src/features/airport/map/runwayAnnotationModel.ts
@@ -1,13 +1,20 @@
 import { RUNWAY_APPROACH_BEAM_CONFIG } from "../../../config/airportMap";
 import { ZOOM_APPROACH } from "../../../utils/airportMapDisplay";
+import { isImmersiveNightLightingActive } from "../immersive/immersiveLightingModel";
 import { shouldShowRunwayEndLabelsForZoom } from "./airportMapZoomFeatures";
 
 const METERS_PER_DEGREE_LATITUDE = 111_320;
 const STATUTE_MILE_METERS = 1_609.344;
+const FEET_TO_METERS = 0.3048;
+const RUNWAY_LIGHT_SPACING_METERS = 180;
+const DEFAULT_RUNWAY_WIDTH_METERS = 45;
+const MIN_RUNWAY_LIGHT_WIDTH_METERS = 18;
+const MAX_RUNWAY_LIGHT_WIDTH_METERS = 80;
 
 const shouldShowRunwayEndLabels = shouldShowRunwayEndLabelsForZoom;
 
 type RunwayAnnotationRecord = Record<string, any>;
+type Coordinate2D = [number, number];
 
 const metersPerDegreeLongitude = (latitude: number) =>
   METERS_PER_DEGREE_LATITUDE * Math.cos((latitude * Math.PI) / 180);
@@ -15,6 +22,11 @@ const metersPerDegreeLongitude = (latitude: number) =>
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 const interpolate = (from: number, to: number, progress: number) => from + (to - from) * progress;
+
+const isCoordinate2D = (value: unknown): value is Coordinate2D =>
+  Array.isArray(value) &&
+  Number.isFinite(value[0]) &&
+  Number.isFinite(value[1]);
 
 const runwayBeamProfileForZoom = (zoom: unknown) => {
   const numericZoom = Number.isFinite(Number(zoom)) ? Number(zoom) : ZOOM_APPROACH;
@@ -83,6 +95,103 @@ const coordinateFromVectorMeters = ({ end, vector, distance }: RunwayAnnotationR
   end.lon + (vector.x * distance) / vector.lonMeters,
   end.lat + (vector.y * distance) / METERS_PER_DEGREE_LATITUDE,
 ];
+
+const metersBetweenCoordinates = (
+  [startLon, startLat]: Coordinate2D,
+  [endLon, endLat]: Coordinate2D,
+) => {
+  const lonMeters = metersPerDegreeLongitude((startLat + endLat) / 2);
+  const dx = (endLon - startLon) * lonMeters;
+  const dy = (endLat - startLat) * METERS_PER_DEGREE_LATITUDE;
+  return Math.hypot(dx, dy);
+};
+
+const lineCoordinateAtProgress = (
+  start: Coordinate2D,
+  end: Coordinate2D,
+  progress: number,
+) => [
+  start[0] + (end[0] - start[0]) * progress,
+  start[1] + (end[1] - start[1]) * progress,
+] as Coordinate2D;
+
+const runwayVectorFromCoordinates = (start: Coordinate2D, end: Coordinate2D) => {
+  const lonMeters = metersPerDegreeLongitude((start[1] + end[1]) / 2);
+  const dx = (end[0] - start[0]) * lonMeters;
+  const dy = (end[1] - start[1]) * METERS_PER_DEGREE_LATITUDE;
+  const length = Math.hypot(dx, dy);
+  if (!Number.isFinite(length) || length <= 0) return null;
+
+  return {
+    x: dx / length,
+    y: dy / length,
+    lonMeters,
+    length,
+  };
+};
+
+const offsetCoordinate = (
+  coordinate: Coordinate2D,
+  vector: RunwayAnnotationRecord,
+  lateralDistanceMeters: number,
+) => {
+  const perpendicularX = -vector.y;
+  const perpendicularY = vector.x;
+  return [
+    coordinate[0] + (perpendicularX * lateralDistanceMeters) / vector.lonMeters,
+    coordinate[1] + (perpendicularY * lateralDistanceMeters) / METERS_PER_DEGREE_LATITUDE,
+  ] as Coordinate2D;
+};
+
+const runwayWidthMeters = (runway: RunwayAnnotationRecord) => {
+  const widthMeters = Number(runway?.widthFt) * FEET_TO_METERS;
+  if (!Number.isFinite(widthMeters) || widthMeters <= 0) {
+    return DEFAULT_RUNWAY_WIDTH_METERS;
+  }
+  return clamp(
+    widthMeters,
+    MIN_RUNWAY_LIGHT_WIDTH_METERS,
+    MAX_RUNWAY_LIGHT_WIDTH_METERS,
+  );
+};
+
+const runwayLightFeaturesForRunway = (runway: RunwayAnnotationRecord) => {
+  const coordinates = runway?.centerline?.geometry?.coordinates || [];
+  const start = coordinates[0];
+  const end = coordinates.at(-1);
+  if (!isCoordinate2D(start) || !isCoordinate2D(end)) {
+    return [];
+  }
+
+  const vector = runwayVectorFromCoordinates(start, end);
+  if (!vector) return [];
+  const lightCount = Math.max(
+    2,
+    Math.min(36, Math.floor(vector.length / RUNWAY_LIGHT_SPACING_METERS)),
+  );
+  const halfWidthMeters = runwayWidthMeters(runway) / 2;
+
+  return [-1, 1].flatMap((side) =>
+    Array.from({ length: lightCount + 1 }, (_, index) => {
+      const progress = index / lightCount;
+      const center = lineCoordinateAtProgress(start, end, progress);
+      const coordinate = offsetCoordinate(center, vector, halfWidthMeters * side);
+      return {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: coordinate,
+        },
+        properties: {
+          runwayId: runway.id,
+          lightIndex: index,
+          progress,
+          side: side < 0 ? "left" : "right",
+        },
+      };
+    }),
+  );
+};
 
 const rotateVector = (vector: RunwayAnnotationRecord, degrees: number) => {
   const radians = (degrees * Math.PI) / 180;
@@ -302,6 +411,40 @@ export function buildRunwayApproachVisualization(
   return {
     kind: "approach-beams",
     data: buildRunwayApproachBeamCollection(runwayMap, { zoom, distanceScale }),
+  };
+}
+
+export function resolveRunwayAnnotationVisibility({
+  immersiveModeActive = false,
+  immersiveLocalMinutes = null,
+  immersivePhase = "",
+  showRunwayBeams = true,
+}: RunwayAnnotationRecord = {}) {
+  if (!immersiveModeActive) {
+    return {
+      showBeams: Boolean(showRunwayBeams),
+      showBadges: true,
+    };
+  }
+
+  return {
+    showBeams: isImmersiveNightLightingActive({
+      localMinutes: immersiveLocalMinutes,
+      phase: immersivePhase,
+    }),
+    showBadges: false,
+  };
+}
+
+export function buildRunwayLightCollection(runwayMap: RunwayAnnotationRecord) {
+  return {
+    type: "FeatureCollection",
+    properties: {
+      airport: runwayMap?.airport || "",
+      source: runwayMap?.source || "Runway geometry",
+      cycle: runwayMap?.cycle || "",
+    },
+    features: (runwayMap?.runways || []).flatMap(runwayLightFeaturesForRunway),
   };
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -540,6 +540,11 @@
     --aviation-runway-annotation-line: #1a1a18;
     --aviation-runway-approach-line: rgba(26,26,24,0.62);
     --aviation-runway-approach-beam: #2f2f2b;
+    --aviation-runway-light-core: #fff0a8;
+    --aviation-runway-light: #ffd36a;
+    --aviation-runway-light-glow: rgba(255, 207, 93, 0.36);
+    --aviation-runway-night-line: rgba(255, 211, 106, 0.48);
+    --aviation-runway-night-beam: #ffd36a;
     --aviation-nearby-runway-line: #24231f;
     --aircraft-trace-line: var(--aviation-trace-line);
     --aircraft-trace-glow: var(--aviation-trace-glow);
@@ -547,6 +552,11 @@
     --runway-annotation-line: var(--aviation-runway-annotation-line);
     --runway-approach-line: var(--aviation-runway-approach-line);
     --runway-approach-beam: var(--aviation-runway-approach-beam);
+    --runway-light-core: var(--aviation-runway-light-core);
+    --runway-light: var(--aviation-runway-light);
+    --runway-light-glow: var(--aviation-runway-light-glow);
+    --runway-night-line: var(--aviation-runway-night-line);
+    --runway-night-beam: var(--aviation-runway-night-beam);
     --nearby-runway-line: var(--aviation-nearby-runway-line);
 
     /* Single grey for every aircraft regardless of departure/arrival —
@@ -1286,11 +1296,23 @@ body {
     mix-blend-mode: screen;
 }
 
+.runway-light-dot {
+    filter:
+        drop-shadow(0 0 1.5px var(--runway-light-glow))
+        drop-shadow(0 0 4px var(--runway-light-glow));
+    mix-blend-mode: screen;
+}
+
 :root[data-theme="light"] .runway-approach-beam,
 :root[data-theme="sunrise"] .runway-approach-beam,
 :root[data-theme="sunset"] .runway-approach-beam {
     filter: blur(2.4px);
     mix-blend-mode: multiply;
+}
+
+.airport-map-stage[data-map-mode="immersive"] .runway-approach-beam {
+    filter: blur(3.2px);
+    mix-blend-mode: screen;
 }
 
 /* Light-theme approach: dashed extended centerline replaces the dark
@@ -3264,6 +3286,12 @@ body {
         0 1px 2px rgb(0 0 0 / 0.72),
         0 0 8px rgb(0 0 0 / 0.82),
         0 0 14px rgb(23 37 67 / 0.58);
+}
+
+:root[data-theme="sunrise"] .airport-map-stage[data-map-mode="immersive"] .aircraft-label,
+.airport-map-stage[data-map-mode="immersive"][data-immersive-phase] .aircraft-label,
+.airport-map-stage[data-map-mode="immersive"] .aircraft-label {
+    text-shadow: none;
 }
 
 :root[data-theme="sunrise"] .aircraft-nose-beam {


### PR DESCRIPTION
## Summary
- Enables immersive runway lighting around the airport night window (21:00 through before 05:00), with yellow runway approach beams and small runway edge light points.
- Refines aircraft 3D material and landing-light behavior so dusk/day colors react to time, high-altitude aircraft keep nav lights, and landing lights do not blast the map outside the night window.
- Removes immersive callsign label shadows and keeps labels phase-aware for light/dark readability.

## Validation
- `/opt/homebrew/bin/pnpm test` (108 test files passed)
- `/opt/homebrew/bin/pnpm lint` (passes with existing VirtualNearbyList React Compiler warning)
- `/opt/homebrew/bin/pnpm build`
- `git diff --check`
- Local browser: `http://localhost:3000/airport/EDDF?locale=zh-CN` verified night phase, 3D canvas, 8 runway beams, 170 yellow runway light dots, and callsign text-shadow `none`. Screenshot: `/tmp/eddf-local-yellow-runway-final.png`
- Vercel preview: `https://adsbao-git-codex-immersive-evening-lighting-orriduck.vercel.app/airport/EDDF?locale=zh-CN` after enabling immersive mode in map settings verified night phase, 3D canvas, 8 runway beams, 170 yellow runway light dots, and callsign text-shadow `none`. Screenshot: `/tmp/eddf-preview-yellow-runway-final.png`
