### PR TITLE
[codex] Refine immersive aircraft visuals

### DIFF
--- a/src/components/map/Aircraft3DOverlay.tsx
+++ b/src/components/map/Aircraft3DOverlay.tsx
@@ -17,6 +17,7 @@ import {
   resolveAircraft3DLightingProfile,
   resolveAircraft3DMaterialProfile,
   resolveAircraft3DModelScalePx,
+  resolveAircraft3DShadowPresentation,
   shouldRenderAircraftContrail,
 } from "@/features/aircraft/icons/aircraftIcon3DModel";
 import {
@@ -803,13 +804,16 @@ function buildModelGroup({
   group.userData.lightMaterials = [];
   group.userData.beaconMaterials = [];
 
-  const shadowOpacity = selected
-    ? profile.shadowOpacity * 1.3
-    : profile.shadowOpacity * 0.86;
   const materialProfile =
     resolveAircraft3DMaterialProfile({ phase, selected }) ||
     resolveAircraft3DMaterialProfile({ phase: "day", selected });
-  addShadow(group, template, shadowOpacity * opacity);
+  const shadowPresentation = resolveAircraft3DShadowPresentation({
+    altitude: aircraft?.altitude,
+    onGround: aircraft?.onGround,
+    phase,
+    selected,
+  });
+  addShadow(group, template, shadowPresentation.opacity * opacity);
   addBodyGlow({
     group,
     opacity,
@@ -1012,17 +1016,16 @@ function updateGroupScale(group: AircraftRenderGroup, aircraft: any, selected: b
 function updateShadow(group: AircraftRenderGroup, aircraft: any, phase: string) {
   const shadow = group.userData.shadow;
   if (!shadow) return;
-  const altitude = Math.max(0, Math.min(Number(aircraft?.altitude) || 0, 42_000));
-  const ratio = aircraft?.onGround ? 0 : altitude / 42_000;
-  const profile = resolveAircraft3DLightingProfile({ phase });
-  const selectedBoost = group.userData.selected ? 1.12 : 0.9;
-  shadow.position.set(2.5 + ratio * 7, 3.5 + ratio * 10, -5);
-  shadow.scale.set(0.9 + ratio * 0.32, 0.72 + ratio * 0.18, 1);
+  const presentation = resolveAircraft3DShadowPresentation({
+    altitude: aircraft?.altitude,
+    onGround: aircraft?.onGround,
+    phase,
+    selected: Boolean(group.userData.selected),
+  });
+  shadow.position.set(presentation.positionX, presentation.positionY, -5);
+  shadow.scale.set(presentation.scaleX, presentation.scaleY, 1);
   const material = shadow.material as THREE.MeshBasicMaterial;
-  material.opacity = Math.max(
-    phase === "night" ? 0.05 : 0.035,
-    profile.shadowOpacity * selectedBoost - ratio * 0.08,
-  );
+  material.opacity = presentation.opacity * (group.userData.emphasisOpacity ?? 1);
 }
 
 function syncLighting(state: AircraftOverlayState, phase: string) {

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -155,15 +155,8 @@ export default function AircraftPosition({
   });
   const rot = Math.round(aircraft.track || 0);
   const label = (aircraft.callsign || aircraft.icao24 || "").trim();
-  const immersiveLightLabel =
-    immersivePhase === "night" ||
-    immersivePhase === "dusk" ||
-    immersivePhase === "sunset" ||
-    immersivePhase === "dawn";
   const labelColor = immersiveModeActive
-    ? immersiveLightLabel
-      ? "#f7fbff"
-      : "#253047"
+    ? "var(--aircraft-label-immersive-color)"
     : color;
   const sourceBadge = getAircraftPositionSourceBadge(aircraft.positionQuality);
   const labelLeft = threeDimensionalOverlayActive

--- a/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
@@ -6,6 +6,7 @@ import {
   resolveAircraft3DLightingProfile,
   resolveAircraft3DMaterialProfile,
   resolveAircraft3DModelScalePx,
+  resolveAircraft3DShadowPresentation,
   resolveAircraft3DEdgeTone,
   shouldRenderAircraft3DOverlay,
   shouldRenderAircraftContrail,
@@ -148,6 +149,30 @@ assert.ok(nightMaterial.edgeOpacity <= 0.22);
 assert.ok(nightMaterial.landingLightOpacity >= 0.72);
 assert.ok(sunsetMaterial.landingLightOpacity >= 0.3);
 assert.ok(dayMaterial.landingLightOpacity <= 0.18);
+
+const dayCruiseShadow = resolveAircraft3DShadowPresentation({
+  altitude: 39_000,
+  phase: "day",
+});
+const selectedDayCruiseShadow = resolveAircraft3DShadowPresentation({
+  altitude: 39_000,
+  phase: "day",
+  selected: true,
+});
+const nightCruiseShadow = resolveAircraft3DShadowPresentation({
+  altitude: 39_000,
+  phase: "night",
+});
+const morningSurfaceShadow = resolveAircraft3DShadowPresentation({
+  altitude: 0,
+  phase: "morning",
+  onGround: true,
+});
+assert.ok(dayCruiseShadow.opacity >= 0.08);
+assert.ok(selectedDayCruiseShadow.opacity > dayCruiseShadow.opacity);
+assert.ok(dayCruiseShadow.opacity > nightCruiseShadow.opacity);
+assert.ok(morningSurfaceShadow.scaleX > dayCruiseShadow.scaleX);
+assert.ok(dayCruiseShadow.positionY < 12.8);
 
 const dayShadowEdge = resolveAircraft3DEdgeTone({
   phase: "day",

--- a/src/features/aircraft/icons/aircraftIcon3DModel.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.ts
@@ -13,6 +13,12 @@ type Aircraft3DLightingOptions = {
   phase?: unknown;
 };
 
+type Aircraft3DShadowOptions = Aircraft3DLightingOptions & {
+  altitude?: unknown;
+  onGround?: boolean;
+  selected?: boolean;
+};
+
 type Aircraft3DModelScaleOptions = {
   altitude?: unknown;
   family?: unknown;
@@ -154,7 +160,7 @@ export const resolveAircraft3DLightingProfile = ({
         navLightIntensity: 0.36,
         rimLightColor: "#d5e3ff",
         rimLightIntensity: 0.54,
-        shadowOpacity: 0.075,
+        shadowOpacity: 0.13,
       };
     default:
       return {
@@ -168,9 +174,57 @@ export const resolveAircraft3DLightingProfile = ({
         navLightIntensity: 0.32,
         rimLightColor: "#d6e5ff",
         rimLightIntensity: 0.46,
-        shadowOpacity: 0.07,
+        shadowOpacity: 0.14,
       };
   }
+};
+
+export const resolveAircraft3DShadowPresentation = ({
+  altitude = null,
+  onGround = false,
+  phase = "day",
+  selected = false,
+}: Aircraft3DShadowOptions = {}) => {
+  const phaseKey = String(phase || "day");
+  const daylightPhase =
+    phaseKey === "morning" || phaseKey === "day" || phaseKey === "afternoon";
+  const altitudeFt = onGround
+    ? 0
+    : clamp(toFiniteNumber(altitude) ?? 0, 0, 42_000);
+  const altitudeRatio = altitudeFt / 42_000;
+  const profile = resolveAircraft3DLightingProfile({ phase: phaseKey });
+
+  const selectedBoost = selected
+    ? daylightPhase
+      ? 1.24
+      : 1.14
+    : daylightPhase
+      ? 1.02
+      : 0.92;
+  const altitudeFade = altitudeRatio * (daylightPhase ? 0.045 : 0.08);
+  const opacityFloor =
+    phaseKey === "night" ? 0.05 : daylightPhase ? 0.082 : 0.055;
+  const opacity = round2(
+    Math.max(opacityFloor, profile.shadowOpacity * selectedBoost - altitudeFade),
+  );
+
+  if (daylightPhase) {
+    return {
+      opacity,
+      positionX: round2(2.2 + altitudeRatio * 5.1),
+      positionY: round2(3 + altitudeRatio * 7.8),
+      scaleX: round2(0.98 - altitudeRatio * 0.16),
+      scaleY: round2(0.74 - altitudeRatio * 0.08),
+    };
+  }
+
+  return {
+    opacity,
+    positionX: round2(2.5 + altitudeRatio * 7),
+    positionY: round2(3.5 + altitudeRatio * 10),
+    scaleX: round2(0.9 + altitudeRatio * 0.32),
+    scaleY: round2(0.72 + altitudeRatio * 0.18),
+  };
 };
 
 export const resolveAircraft3DLandingLightIntensity = ({

--- a/src/style.css
+++ b/src/style.css
@@ -3082,6 +3082,16 @@ body {
 
 :root {
     --map-label-glow: rgba(250, 249, 245, 0.95);
+    --aircraft-label-immersive-color: #263244;
+    --aircraft-label-immersive-shadow:
+        0 1px 1px rgb(255 255 255 / 0.58),
+        0 0 7px rgb(255 255 255 / 0.48),
+        0 1px 8px rgb(34 45 54 / 0.16);
+    --map-source-immersive-color: #29323d;
+    --map-source-immersive-muted: #46505c;
+    --map-source-immersive-shadow:
+        0 1px 1px rgb(255 255 255 / 0.6),
+        0 0 8px rgb(255 255 255 / 0.42);
 }
 
 :root[data-theme="dark"] {
@@ -3090,6 +3100,34 @@ body {
 
 :root[data-theme="sunrise"] {
     --map-label-glow: rgba(13, 18, 53, 0.72);
+}
+
+.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="dawn"],
+.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="dusk"],
+.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="night"] {
+    --aircraft-label-immersive-color: #f7fbff;
+    --aircraft-label-immersive-shadow:
+        0 1px 2px rgb(0 0 0 / 0.74),
+        0 0 9px rgb(0 0 0 / 0.86),
+        0 0 15px rgb(23 37 67 / 0.6);
+    --map-source-immersive-color: #f4f8ff;
+    --map-source-immersive-muted: #d4deec;
+    --map-source-immersive-shadow:
+        0 1px 2px rgb(0 0 0 / 0.78),
+        0 0 12px rgb(0 0 0 / 0.72);
+}
+
+.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="sunset"] {
+    --aircraft-label-immersive-color: #342315;
+    --aircraft-label-immersive-shadow:
+        0 1px 1px rgb(255 239 210 / 0.68),
+        0 0 7px rgb(255 230 190 / 0.5),
+        0 1px 8px rgb(95 45 20 / 0.2);
+    --map-source-immersive-color: #35251b;
+    --map-source-immersive-muted: #5d4b3c;
+    --map-source-immersive-shadow:
+        0 1px 1px rgb(255 238 209 / 0.62),
+        0 0 9px rgb(255 221 178 / 0.38);
 }
 
 .leaflet-marker-icon {
@@ -3279,19 +3317,6 @@ body {
     text-shadow:
         0 1px 2px rgba(13, 18, 53, 0.7),
         0 0 1px rgba(13, 18, 53, 0.85);
-}
-
-.airport-map-stage[data-map-mode="immersive"][data-immersive-phase="night"] .aircraft-label {
-    text-shadow:
-        0 1px 2px rgb(0 0 0 / 0.72),
-        0 0 8px rgb(0 0 0 / 0.82),
-        0 0 14px rgb(23 37 67 / 0.58);
-}
-
-:root[data-theme="sunrise"] .airport-map-stage[data-map-mode="immersive"] .aircraft-label,
-.airport-map-stage[data-map-mode="immersive"][data-immersive-phase] .aircraft-label,
-.airport-map-stage[data-map-mode="immersive"] .aircraft-label {
-    text-shadow: none;
 }
 
 :root[data-theme="sunrise"] .aircraft-nose-beam {
@@ -6790,4 +6815,57 @@ body {
         pointer-events: none;
     }
 
+}
+
+.airport-map-stage[data-map-mode="immersive"] .aircraft-label {
+    font-family: var(--font-display);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0;
+    line-height: 1;
+    text-shadow: var(--aircraft-label-immersive-shadow);
+}
+
+.airport-map-kit .airport-map-stage[data-map-mode="immersive"] .aircraft-label {
+    font-size: 9px;
+}
+
+.airport-map-stage[data-map-mode="immersive"] [aria-label="Map data sources"] {
+    color: var(--map-source-immersive-color);
+    filter: drop-shadow(0 5px 10px color-mix(in oklab, var(--atc-bg) 38%, transparent));
+    font-family: var(--font-display);
+    text-shadow: var(--map-source-immersive-shadow);
+}
+
+.airport-map-stage[data-map-mode="immersive"] [aria-label="Map data sources"] :where(span) {
+    color: var(--map-source-immersive-color);
+    font-weight: 800;
+    letter-spacing: 0;
+    line-height: 1.02;
+    text-shadow: inherit;
+}
+
+.airport-map-stage[data-map-mode="immersive"] [aria-label="Map data sources"] > span:first-child {
+    font-size: 9px;
+}
+
+.airport-map-stage[data-map-mode="immersive"] [aria-label="Map data sources"] > span:last-child :where(span) {
+    color: var(--map-source-immersive-muted);
+    font-size: 8px;
+    font-weight: 700;
+}
+
+.airport-map-stage[data-map-mode="immersive"] [aria-label="Map data sources"] [aria-hidden="true"] {
+    background: var(--map-source-immersive-muted);
+    box-shadow: 0 0 7px color-mix(in oklab, var(--map-source-immersive-muted) 24%, transparent);
+}
+
+@media (max-width: 767px) {
+    .airport-map-stage[data-map-mode="immersive"] .aircraft-label {
+        font-size: 10px;
+    }
+
+    .airport-map-stage[data-map-mode="immersive"] [aria-label="Map data sources"] > span:first-child {
+        font-size: 10px;
+    }
 }


### PR DESCRIPTION
## Summary
- strengthen daytime immersive 3D aircraft ground shadows with a tested presentation model
- move immersive aircraft label color from hard-coded JSX to phase-aware CSS tokens
- adapt map source/status text typography and contrast across immersive day, sunset, and night phases

## Validation
- `git diff --check`
- `/opt/homebrew/bin/pnpm test src/features/aircraft/icons/aircraftIcon3DModel.test.ts` (runner reported 108 test files passed)
- `/opt/homebrew/bin/pnpm lint` (one existing `VirtualNearbyList.tsx` TanStack Virtual warning)
- `/opt/homebrew/bin/pnpm build`
- local browser: `http://localhost:3000/airport/KBOS` immersive `sunset`, 3D canvas present, aircraft labels/status text use sunset tokens
- local browser: 390px viewport on `http://localhost:3000/airport/KBOS`, aircraft labels/status text stay readable
- local browser: `http://localhost:3000/airport/PHNL` immersive `day`, 3D canvas present, day-phase aircraft labels/status text use day tokens
