### PR TITLE
[codex] Refine aircraft global light shadows

### DIFF
--- a/src/components/map/Aircraft3DOverlay.tsx
+++ b/src/components/map/Aircraft3DOverlay.tsx
@@ -13,6 +13,7 @@ import {
 import {
   resolveAircraft3DAttitudeRotation,
   resolveAircraft3DEdgeTone,
+  resolveAircraft3DLightVector,
   resolveAircraft3DLandingLightIntensity,
   resolveAircraft3DLightingProfile,
   resolveAircraft3DMaterialProfile,
@@ -68,6 +69,7 @@ type AircraftRenderGroup = THREE.Group & {
     beaconMaterials?: THREE.MeshBasicMaterial[];
     emphasisOpacity?: number;
     lightMaterials?: THREE.Material[];
+    localMinutes?: unknown;
     modelRoot?: THREE.Group;
     modelSignature?: string;
     pendingModelSignature?: string;
@@ -367,12 +369,23 @@ function createMeshMaterial({
 
 function getEdgeLightVector(
   materialProfile: ReturnType<typeof resolveAircraft3DMaterialProfile>,
+  lightVector?: ReturnType<typeof resolveAircraft3DLightVector>,
 ) {
-  const vector = materialProfile.edgeLightVector;
+  const vector = lightVector
+    ? {
+        x: lightVector.localX,
+        y: lightVector.localY,
+        z: lightVector.localZ,
+      }
+    : materialProfile.edgeLightVector;
+  const resolveComponent = (value: unknown, fallback: number) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : fallback;
+  };
   return new THREE.Vector3(
-    Number(vector.x) || -0.42,
-    Number(vector.y) || -0.7,
-    Number(vector.z) || 0.58,
+    resolveComponent(vector.x, -0.42),
+    resolveComponent(vector.y, -0.7),
+    resolveComponent(vector.z, 0.58),
   ).normalize();
 }
 
@@ -433,17 +446,19 @@ function resolveSegmentLightDot({
 function createDirectionalEdgeGeometry({
   geometry,
   materialProfile,
+  lightVector,
   phase,
   selected,
 }: {
   geometry: THREE.BufferGeometry;
+  lightVector?: ReturnType<typeof resolveAircraft3DLightVector>;
   materialProfile: ReturnType<typeof resolveAircraft3DMaterialProfile>;
   phase: string;
   selected: boolean;
 }) {
   const edgeGeometry = new THREE.EdgesGeometry(geometry, 16);
   const position = edgeGeometry.getAttribute("position") as THREE.BufferAttribute;
-  const lightVector = getEdgeLightVector(materialProfile);
+  const edgeLightVector = getEdgeLightVector(materialProfile, lightVector);
   const colors: number[] = [];
   const baseOpacity = Math.max(materialProfile.edgeOpacity, 0.001);
 
@@ -451,7 +466,7 @@ function createDirectionalEdgeGeometry({
     const lightDot = resolveSegmentLightDot({
       edgeGeometry,
       index,
-      lightVector,
+      lightVector: edgeLightVector,
     });
     const tone = resolveAircraft3DEdgeTone({ phase, selected, lightDot });
     const color = new THREE.Color(tone.color).multiplyScalar(
@@ -807,8 +822,16 @@ function buildModelGroup({
   const materialProfile =
     resolveAircraft3DMaterialProfile({ phase, selected }) ||
     resolveAircraft3DMaterialProfile({ phase: "day", selected });
+  const heading = resolveAircraftHeading(aircraft);
+  const lightVector = resolveAircraft3DLightVector({
+    heading,
+    localMinutes,
+    phase,
+  });
   const shadowPresentation = resolveAircraft3DShadowPresentation({
     altitude: aircraft?.altitude,
+    heading,
+    localMinutes,
     onGround: aircraft?.onGround,
     phase,
     selected,
@@ -872,6 +895,7 @@ function buildModelGroup({
     const edges = new THREE.LineSegments(
       createDirectionalEdgeGeometry({
         geometry,
+        lightVector,
         materialProfile,
         phase,
         selected,
@@ -960,11 +984,14 @@ async function refreshModelForGroup({
     immersiveModeActive: true,
     velocity: aircraft?.velocity,
   });
+  const headingBucket =
+    Math.round(resolveAircraftHeading(aircraft) / 15) * 15;
   const signature = [
     source.name,
     phase,
     selected ? "selected" : "normal",
     localMinutes == null ? "" : String(Math.round(Number(localMinutes) || 0)),
+    String(((headingBucket % 360) + 360) % 360),
     aircraft?.onGround ? "ground" : "air",
     aircraft?.movement || "",
     contrail ? "contrail" : "clean",
@@ -1013,11 +1040,18 @@ function updateGroupScale(group: AircraftRenderGroup, aircraft: any, selected: b
   group.scale.setScalar(scalar);
 }
 
-function updateShadow(group: AircraftRenderGroup, aircraft: any, phase: string) {
+function updateShadow(
+  group: AircraftRenderGroup,
+  aircraft: any,
+  phase: string,
+  localMinutes?: unknown,
+) {
   const shadow = group.userData.shadow;
   if (!shadow) return;
   const presentation = resolveAircraft3DShadowPresentation({
     altitude: aircraft?.altitude,
+    heading: resolveAircraftHeading(aircraft),
+    localMinutes,
     onGround: aircraft?.onGround,
     phase,
     selected: Boolean(group.userData.selected),
@@ -1028,15 +1062,30 @@ function updateShadow(group: AircraftRenderGroup, aircraft: any, phase: string) 
   material.opacity = presentation.opacity * (group.userData.emphasisOpacity ?? 1);
 }
 
-function syncLighting(state: AircraftOverlayState, phase: string) {
+function syncLighting(
+  state: AircraftOverlayState,
+  phase: string,
+  localMinutes?: unknown,
+) {
   const profile = resolveAircraft3DLightingProfile({ phase });
+  const lightVector = resolveAircraft3DLightVector({ localMinutes, phase });
   state.profile = profile;
   state.ambientLight.color.set(profile.ambientColor);
   state.ambientLight.intensity = profile.ambientIntensity;
   state.keyLight.color.set(profile.keyLightColor);
   state.keyLight.intensity = profile.keyLightIntensity;
+  state.keyLight.position.set(
+    lightVector.x * 70,
+    lightVector.y * 70,
+    Math.max(18, lightVector.z * 82),
+  );
   state.rimLight.color.set(profile.rimLightColor);
   state.rimLight.intensity = profile.rimLightIntensity;
+  state.rimLight.position.set(
+    -lightVector.x * 42,
+    -lightVector.y * 42,
+    Math.max(38, 68 - lightVector.z * 18),
+  );
 }
 
 function updateGroupAttitude(group: AircraftRenderGroup, aircraft: any) {
@@ -1073,7 +1122,7 @@ function syncAircraftGroups({
   trafficFilter,
   typeFilter,
 }: Aircraft3DOverlayProps & { state: AircraftOverlayState }) {
-  syncLighting(state, immersivePhase || "day");
+  syncLighting(state, immersivePhase || "day", immersiveLocalMinutes);
   const ids = new Set<string>();
   const selectionActive = Boolean(
     selectedAircraftId &&
@@ -1104,6 +1153,7 @@ function syncAircraftGroups({
     });
     group.userData.aircraft = item;
     group.userData.emphasisOpacity = emphasis.opacity;
+    group.userData.localMinutes = immersiveLocalMinutes;
     group.userData.phase = immersivePhase || "day";
     group.userData.selected = selected;
     group.visible = emphasis.opacity > 0.03;
@@ -1172,7 +1222,12 @@ function renderFrame(state: AircraftOverlayState) {
     group.rotation.z = THREE.MathUtils.degToRad(resolveAircraftHeading(aircraft));
     updateGroupScale(group, aircraft, Boolean(group.userData.selected));
     updateModelAttitude(group);
-    updateShadow(group, aircraft, group.userData.phase || "day");
+    updateShadow(
+      group,
+      aircraft,
+      group.userData.phase || "day",
+      group.userData.localMinutes,
+    );
 
     const pulse = 0.62 + Math.sin(now / 180) * 0.38;
     for (const material of group.userData.beaconMaterials || []) {
@@ -1217,11 +1272,22 @@ export default function Aircraft3DOverlay({
     camera.lookAt(0, 0, 0);
 
     const profile = resolveAircraft3DLightingProfile({ phase: immersivePhase });
+    const initialLightVector = resolveAircraft3DLightVector({
+      phase: immersivePhase,
+    });
     const ambientLight = new THREE.AmbientLight(profile.ambientColor, profile.ambientIntensity);
     const keyLight = new THREE.DirectionalLight(profile.keyLightColor, profile.keyLightIntensity);
-    keyLight.position.set(-24, -42, 70);
+    keyLight.position.set(
+      initialLightVector.x * 70,
+      initialLightVector.y * 70,
+      Math.max(18, initialLightVector.z * 82),
+    );
     const rimLight = new THREE.DirectionalLight(profile.rimLightColor, profile.rimLightIntensity);
-    rimLight.position.set(38, 30, 52);
+    rimLight.position.set(
+      -initialLightVector.x * 42,
+      -initialLightVector.y * 42,
+      Math.max(38, 68 - initialLightVector.z * 18),
+    );
     scene.add(ambientLight, keyLight, rimLight);
 
     const state: AircraftOverlayState = {

--- a/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import {
   resolveAircraft3DAttitudeRotation,
+  resolveAircraft3DLightVector,
   resolveAircraft3DLandingLightIntensity,
   resolveAircraft3DLightingProfile,
   resolveAircraft3DMaterialProfile,
@@ -172,7 +173,70 @@ assert.ok(dayCruiseShadow.opacity >= 0.08);
 assert.ok(selectedDayCruiseShadow.opacity > dayCruiseShadow.opacity);
 assert.ok(dayCruiseShadow.opacity > nightCruiseShadow.opacity);
 assert.ok(morningSurfaceShadow.scaleX > dayCruiseShadow.scaleX);
-assert.ok(dayCruiseShadow.positionY < 12.8);
+assert.ok(Math.abs(dayCruiseShadow.positionX) < 2);
+
+const sunriseLight = resolveAircraft3DLightVector({
+  localMinutes: 360,
+  phase: "morning",
+});
+const noonLight = resolveAircraft3DLightVector({
+  localMinutes: 720,
+  phase: "day",
+});
+const sunsetLight = resolveAircraft3DLightVector({
+  localMinutes: 1080,
+  phase: "sunset",
+});
+const runwayLight = resolveAircraft3DLightVector({
+  localMinutes: 22 * 60,
+  phase: "night",
+});
+assert.equal(sunriseLight.source, "sun");
+assert.ok(sunriseLight.x > 0.75);
+assert.ok(noonLight.z > sunriseLight.z);
+assert.ok(Math.abs(noonLight.x) < 0.08);
+assert.ok(sunsetLight.x < -0.75);
+assert.equal(runwayLight.source, "runway");
+assert.ok(runwayLight.z < sunriseLight.z);
+
+const morningHighShadow = resolveAircraft3DShadowPresentation({
+  altitude: 32_000,
+  localMinutes: 360,
+  phase: "morning",
+});
+const morningLowShadow = resolveAircraft3DShadowPresentation({
+  altitude: 2_000,
+  localMinutes: 360,
+  phase: "morning",
+});
+const sunsetHighShadow = resolveAircraft3DShadowPresentation({
+  altitude: 32_000,
+  localMinutes: 1080,
+  phase: "sunset",
+});
+const noonHighShadow = resolveAircraft3DShadowPresentation({
+  altitude: 32_000,
+  localMinutes: 720,
+  phase: "day",
+});
+const eastboundMorningShadow = resolveAircraft3DShadowPresentation({
+  altitude: 32_000,
+  heading: 90,
+  localMinutes: 360,
+  phase: "morning",
+});
+const runwayShadow = resolveAircraft3DShadowPresentation({
+  altitude: 32_000,
+  localMinutes: 22 * 60,
+  phase: "night",
+});
+assert.ok(morningHighShadow.positionX < -4);
+assert.ok(sunsetHighShadow.positionX > 4);
+assert.ok(Math.abs(morningHighShadow.positionX) > Math.abs(morningLowShadow.positionX));
+assert.ok(Math.abs(noonHighShadow.positionX) < Math.abs(morningHighShadow.positionX));
+assert.ok(Math.abs(eastboundMorningShadow.positionY) > Math.abs(eastboundMorningShadow.positionX));
+assert.ok(runwayShadow.opacity < morningHighShadow.opacity);
+assert.ok(Math.hypot(runwayShadow.positionX, runwayShadow.positionY) < 6);
 
 const dayShadowEdge = resolveAircraft3DEdgeTone({
   phase: "day",

--- a/src/features/aircraft/icons/aircraftIcon3DModel.ts
+++ b/src/features/aircraft/icons/aircraftIcon3DModel.ts
@@ -10,11 +10,17 @@ type AircraftContrailOptions = Aircraft3DOverlayOptions & {
 };
 
 type Aircraft3DLightingOptions = {
+  localMinutes?: unknown;
   phase?: unknown;
+};
+
+type Aircraft3DLightVectorOptions = Aircraft3DLightingOptions & {
+  heading?: unknown;
 };
 
 type Aircraft3DShadowOptions = Aircraft3DLightingOptions & {
   altitude?: unknown;
+  heading?: unknown;
   onGround?: boolean;
   selected?: boolean;
 };
@@ -51,6 +57,7 @@ type Aircraft3DAttitudeOptions = {
 const CONTRAIL_MIN_ALTITUDE_FT = 32_000;
 const CONTRAIL_MIN_SPEED_KT = 240;
 const AIRCRAFT_ORIGINAL_ICON_SIZE_PX = 18;
+const MINUTES_PER_DAY = 24 * 60;
 const FAMILY_VISUAL_SCALE: Record<string, number> = {
   balloon: 0.92,
   jet: 1,
@@ -68,6 +75,55 @@ const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max);
 
 const round2 = (value: number) => Math.round(value * 100) / 100;
+const round3 = (value: number) => Math.round(value * 1000) / 1000;
+
+const normalizeMinutes = (value: unknown) => {
+  if (value == null || value === "") return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return (
+    ((Math.round(numeric) % MINUTES_PER_DAY) + MINUTES_PER_DAY) %
+    MINUTES_PER_DAY
+  );
+};
+
+const normalizeVector3 = ({
+  x,
+  y,
+  z,
+}: {
+  x: number;
+  y: number;
+  z: number;
+}) => {
+  const length = Math.hypot(x, y, z);
+  if (length <= 0.0001) {
+    return { x: 0, y: 0, z: 1 };
+  }
+  return {
+    x: x / length,
+    y: y / length,
+    z: z / length,
+  };
+};
+
+const rotateScreenVectorToLocal = ({
+  heading,
+  x,
+  y,
+}: {
+  heading: unknown;
+  x: number;
+  y: number;
+}) => {
+  const headingRad = ((toFiniteNumber(heading) ?? 0) * Math.PI) / 180;
+  const cos = Math.cos(-headingRad);
+  const sin = Math.sin(-headingRad);
+  return {
+    x: x * cos - y * sin,
+    y: x * sin + y * cos,
+  };
+};
 
 const hexToRgb = (hex: string) => {
   const normalized = hex.replace("#", "");
@@ -112,6 +168,91 @@ export const shouldRenderAircraftContrail = ({
       altitudeFt >= CONTRAIL_MIN_ALTITUDE_FT &&
       velocityKt >= CONTRAIL_MIN_SPEED_KT,
   );
+};
+
+const resolveDaylightProgress = (phase: string, localMinutes: unknown) => {
+  const minutes = normalizeMinutes(localMinutes);
+  if (minutes != null && minutes >= 300 && minutes <= 1140) {
+    return clamp((minutes - 300) / 840, 0, 1);
+  }
+
+  switch (phase) {
+    case "dawn":
+      return 0.08;
+    case "morning":
+      return 0.22;
+    case "afternoon":
+      return 0.62;
+    case "sunset":
+      return 0.86;
+    case "dusk":
+      return 0.96;
+    case "day":
+    default:
+      return 0.5;
+  }
+};
+
+const isDaylightAircraftPhase = (phase: string) =>
+  phase === "dawn" ||
+  phase === "morning" ||
+  phase === "day" ||
+  phase === "afternoon" ||
+  phase === "sunset" ||
+  phase === "dusk";
+
+export const resolveAircraft3DLightVector = ({
+  heading = 0,
+  localMinutes = null,
+  phase = "day",
+}: Aircraft3DLightVectorOptions = {}) => {
+  const phaseKey = String(phase || "day");
+  const nightLightingActive = isImmersiveNightLightingActive({
+    localMinutes,
+    phase: phaseKey,
+  });
+
+  if (nightLightingActive) {
+    const global = normalizeVector3({ x: 0.44, y: 0.62, z: 0.28 });
+    const local = rotateScreenVectorToLocal({
+      heading,
+      x: global.x,
+      y: global.y,
+    });
+    return {
+      localX: round3(local.x),
+      localY: round3(local.y),
+      localZ: round3(global.z),
+      source: "runway" as const,
+      x: round3(global.x),
+      y: round3(global.y),
+      z: round3(global.z),
+    };
+  }
+
+  const progress = resolveDaylightProgress(phaseKey, localMinutes);
+  const sunArc = Math.sin(progress * Math.PI);
+  const horizontal = Math.cos(progress * Math.PI);
+  const global = normalizeVector3({
+    x: horizontal,
+    y: 0,
+    z: 0.22 + sunArc * 0.9,
+  });
+  const local = rotateScreenVectorToLocal({
+    heading,
+    x: global.x,
+    y: global.y,
+  });
+
+  return {
+    localX: round3(local.x),
+    localY: round3(local.y),
+    localZ: round3(global.z),
+    source: "sun" as const,
+    x: round3(global.x),
+    y: round3(global.y),
+    z: round3(global.z),
+  };
 };
 
 export const resolveAircraft3DLightingProfile = ({
@@ -181,18 +322,40 @@ export const resolveAircraft3DLightingProfile = ({
 
 export const resolveAircraft3DShadowPresentation = ({
   altitude = null,
+  heading = 0,
+  localMinutes = null,
   onGround = false,
   phase = "day",
   selected = false,
 }: Aircraft3DShadowOptions = {}) => {
   const phaseKey = String(phase || "day");
-  const daylightPhase =
-    phaseKey === "morning" || phaseKey === "day" || phaseKey === "afternoon";
+  const daylightPhase = isDaylightAircraftPhase(phaseKey);
   const altitudeFt = onGround
     ? 0
     : clamp(toFiniteNumber(altitude) ?? 0, 0, 42_000);
   const altitudeRatio = altitudeFt / 42_000;
   const profile = resolveAircraft3DLightingProfile({ phase: phaseKey });
+  const light = resolveAircraft3DLightVector({
+    heading,
+    localMinutes,
+    phase: phaseKey,
+  });
+  const lightHorizontal = Math.hypot(light.localX, light.localY);
+
+  if (light.source === "runway") {
+    const selectedBoost = selected ? 1.18 : 1;
+    const opacity = round2(
+      clamp((0.028 + (1 - altitudeRatio) * 0.012) * selectedBoost, 0.022, 0.052),
+    );
+    const offsetDistance = 1.4 + Math.pow(altitudeRatio, 0.72) * 3.4;
+    return {
+      opacity,
+      positionX: round2(-light.localX * offsetDistance),
+      positionY: round2(-light.localY * offsetDistance),
+      scaleX: round2(0.82 + altitudeRatio * 0.08),
+      scaleY: round2(0.58 + altitudeRatio * 0.06),
+    };
+  }
 
   const selectedBoost = selected
     ? daylightPhase
@@ -201,29 +364,39 @@ export const resolveAircraft3DShadowPresentation = ({
     : daylightPhase
       ? 1.02
       : 0.92;
-  const altitudeFade = altitudeRatio * (daylightPhase ? 0.045 : 0.08);
+  const altitudeFade = altitudeRatio * (daylightPhase ? 0.04 : 0.06);
   const opacityFloor =
-    phaseKey === "night" ? 0.05 : daylightPhase ? 0.082 : 0.055;
+    phaseKey === "night" ? 0.032 : daylightPhase ? 0.078 : 0.052;
   const opacity = round2(
-    Math.max(opacityFloor, profile.shadowOpacity * selectedBoost - altitudeFade),
+    Math.max(
+      opacityFloor,
+      profile.shadowOpacity *
+        selectedBoost *
+        (0.78 + lightHorizontal * 0.26) -
+        altitudeFade,
+    ),
   );
 
   if (daylightPhase) {
+    const offsetDistance =
+      lightHorizontal * (1.2 + Math.pow(altitudeRatio, 0.78) * 13.6);
+    const lowSunStretch = clamp(lightHorizontal, 0, 1);
     return {
       opacity,
-      positionX: round2(2.2 + altitudeRatio * 5.1),
-      positionY: round2(3 + altitudeRatio * 7.8),
-      scaleX: round2(0.98 - altitudeRatio * 0.16),
-      scaleY: round2(0.74 - altitudeRatio * 0.08),
+      positionX: round2(-light.localX * offsetDistance),
+      positionY: round2(-light.localY * offsetDistance),
+      scaleX: round2(0.78 + lowSunStretch * 0.42 - altitudeRatio * 0.12),
+      scaleY: round2(0.52 + lowSunStretch * 0.24 - altitudeRatio * 0.06),
     };
   }
 
+  const offsetDistance = 2 + Math.pow(altitudeRatio, 0.78) * 7.4;
   return {
     opacity,
-    positionX: round2(2.5 + altitudeRatio * 7),
-    positionY: round2(3.5 + altitudeRatio * 10),
-    scaleX: round2(0.9 + altitudeRatio * 0.32),
-    scaleY: round2(0.72 + altitudeRatio * 0.18),
+    positionX: round2(-light.localX * offsetDistance),
+    positionY: round2(-light.localY * offsetDistance),
+    scaleX: round2(0.84 + altitudeRatio * 0.18),
+    scaleY: round2(0.62 + altitudeRatio * 0.1),
   };
 };
 


### PR DESCRIPTION
## Summary
- Add a shared aircraft 3D light-vector model that moves daylight from east to west in north-up map coordinates and switches night rendering to a low runway-light source.
- Drive 3D aircraft shadows, edge highlights, and Three.js key/rim light positions from that shared vector, including altitude-based ground projection and heading-aware local rotation.
- Cover sunrise/noon/sunset/runway-light shadow behavior with focused aircraft 3D model assertions.

## Validation
- `git diff --check`
- `/opt/homebrew/bin/pnpm test src/features/aircraft/icons/aircraftIcon3DModel.test.ts` (108 test files passed)
- `/opt/homebrew/bin/pnpm lint` (0 errors; existing `VirtualNearbyList.tsx` TanStack Virtual warning)
- `/opt/homebrew/bin/pnpm build`
- Local browser verification on `http://localhost:3000/airport/PHNL`, `KBOS`, and `EDDF` in immersive mode: 3D canvas present, day/sunset/night phases confirmed, labels/status fonts applied, and screenshots eyeballed.
