### PR TITLE
Refine map visuals and airport markers

### DIFF
--- a/src/app/api/proxy/map-style/[theme]/route.ts
+++ b/src/app/api/proxy/map-style/[theme]/route.ts
@@ -9,6 +9,7 @@ import {
 import {
   buildLocalizedMapLibreStyle,
   buildProxiedMapLibreStyle,
+  buildReadableTerrainMapLibreStyle,
   getMapLibreBaseStyleUrl,
 } from "@/features/airport/map/mapTileLanguageModel";
 import { isKnownMapTheme } from "@/features/airport/map/airportMapModel";
@@ -62,7 +63,10 @@ export async function GET(request, { params }) {
   }
 
   const style = buildLocalizedMapLibreStyle(
-    buildProxiedMapLibreStyle(upstreamStyle),
+    buildReadableTerrainMapLibreStyle(
+      buildProxiedMapLibreStyle(upstreamStyle),
+      { theme: baseTheme },
+    ),
     { locale, showLabels },
   );
 

--- a/src/components/aircraft/trace/SelectedAircraftTraceContext.tsx
+++ b/src/components/aircraft/trace/SelectedAircraftTraceContext.tsx
@@ -23,6 +23,7 @@ const EMPTY_TRACE = {
   tracePoints: [],
   loading: false,
   traceFetchLoading: false,
+  fullTrace: false,
 };
 
 const SelectedAircraftTraceContext = createContext({
@@ -30,7 +31,7 @@ const SelectedAircraftTraceContext = createContext({
   traces: [],
 });
 
-function deriveTrace(aircraft, hookResult) {
+function deriveTrace(aircraft, hookResult, { fullTrace = false } = {}) {
   return {
     aircraftHex: aircraft ? getAircraftIdentity(aircraft) || null : null,
     movement:
@@ -38,6 +39,7 @@ function deriveTrace(aircraft, hookResult) {
     tracePoints: hookResult.tracePoints,
     loading: hookResult.loading,
     traceFetchLoading: hookResult.traceFetchLoading,
+    fullTrace: Boolean(fullTrace),
   };
 }
 
@@ -72,8 +74,8 @@ export function SelectedAircraftTraceProvider({
     [primaryAircraft, primaryHook],
   );
   const focal = useMemo(
-    () => deriveTrace(focalAircraft, focalHook),
-    [focalAircraft, focalHook],
+    () => deriveTrace(focalAircraft, focalHook, { fullTrace: fullTraceForFocal }),
+    [focalAircraft, focalHook, fullTraceForFocal],
   );
 
   const traces = useMemo(() => {

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -17,6 +17,7 @@ import {
   resolveAirportExplorerSelection,
   resolveAirportProfile,
 } from "@/features/airport/explorer/airportExplorerModel";
+import { resolveSpottingMetricZoomState } from "@/features/airport/explorer/airportExplorerUiModel";
 import { useAirportExplorerData } from "@/features/airport/explorer/useAirportExplorerData";
 import { useNearbyAirports } from "@/hooks/useNearbyAirports";
 import { SelectedAircraftTraceProvider } from "../../aircraft/trace/SelectedAircraftTraceContext";
@@ -34,7 +35,7 @@ import { useCandidateWatchingSpots } from "@/features/airport/watcher/useCandida
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUserLocationAircraftAudio } from "@/hooks/useUserLocationAircraftAudio";
 import { MAP_MODE_IDS } from "@/features/airport/map-settings/mapSettingsModel";
-import { ZOOM_DETAIL } from "@/utils/airportMapDisplay";
+import { ZOOM_APPROACH, ZOOM_DETAIL } from "@/utils/airportMapDisplay";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -94,6 +95,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
   const [userLocationNotice, setUserLocationNotice] = useState("");
   const userLocationWatchIdRef = useRef<number | null>(null);
   const autoUserLocationAttemptKeyRef = useRef("");
+  const spottingPreviousZoomRef = useRef<number | null>(null);
   const airportProfile = useMemo(
     () => resolveAirportProfile({ icao, airport }),
     [icao, airport],
@@ -387,10 +389,20 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     userLocationAudioActive,
   ]);
 
-  const openSpottingDetail = useCallback(() => {
-    applyMapMode(MAP_MODE_IDS.SPOTTING);
-    setMapZoom(ZOOM_DETAIL);
-  }, [applyMapMode, setMapZoom]);
+  const openSpottingDetail = useCallback((activeView = "") => {
+    const zoomUpdate = resolveSpottingMetricZoomState({
+      activeView,
+      currentZoom: mapZoom,
+      previousZoom: spottingPreviousZoomRef.current,
+      detailZoom: ZOOM_DETAIL,
+      fallbackZoom: ZOOM_APPROACH,
+    });
+    spottingPreviousZoomRef.current = zoomUpdate.nextPreviousZoom;
+    if (activeView !== "spotting") {
+      applyMapMode(MAP_MODE_IDS.SPOTTING);
+    }
+    setMapZoom(zoomUpdate.nextZoom);
+  }, [applyMapMode, mapZoom, setMapZoom]);
 
   const criticalLoadingSettled = areCriticalLoadingRequestsSettled({
     aircraftPositionsSettled: traffic.aircraftPositionsSettled,

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -4,7 +4,11 @@ import {
   ChevronRight,
   LocateFixed,
 } from "lucide-react";
-import { airportDisplayName, airportSubtitle } from "@/utils/airport";
+import {
+  airportDisplayCode,
+  airportDisplayName,
+  airportSubtitle,
+} from "@/utils/airport";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useAirportDiscoveryNearby } from "@/features/airport/search/useAirportDiscoveryNearby";
 import {
@@ -174,7 +178,7 @@ function NearbyPromptRow({ status, errorMessage, onRequest }) {
 
 function AirportDiscoveryAirportRow({ airport, onOpen }) {
   const { locale, t } = useI18n();
-  const code = airport.iata || airport.icao || airport.code;
+  const code = airportDisplayCode(airport);
   const label = airport.discoveryLabelKey ? t(airport.discoveryLabelKey) : "";
 
   return (

--- a/src/components/airport/search/AirportRow.tsx
+++ b/src/components/airport/search/AirportRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import { airportDisplayName, airportSubtitle } from "@/utils/airport";
+import { airportDisplayCode, airportDisplayName, airportSubtitle } from "@/utils/airport";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 
 export default function AirportRow({
@@ -23,7 +23,7 @@ export default function AirportRow({
         onClick={() => onOpen(airport)}
       >
         <span className="endf-tab endf-tab--code">
-          <span>{airport.iata || airport.icao || airport.code}</span>
+          <span>{airportDisplayCode(airport)}</span>
         </span>
         <span className="min-w-0">
           <strong className="block truncate text-[13px] font-semibold text-atc-text">

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -28,7 +28,7 @@ import {
 import {
   resolveFlightTrackingDisplayContext,
 } from "@/features/aircraft/tracking/flightTrackingDisplayModel";
-import { buildGreatCirclePath } from "@/features/aviation/flight-routes/greatCircleRouteModel";
+import { buildFlightAwareRouteArcPath } from "@/features/aviation/flight-routes/flightRouteArcModel";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled";
 import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel";
 import { mergeTrackedAircraftIntoNearby } from "@/features/airport/explorer/airportExplorerModel";
@@ -660,23 +660,17 @@ function FlightExplorerContent({ callsign }) {
   }, [focalKey, selectedAircraftId, setSelectedAircraftId, showNearbyContext]);
 
   const focalRoutePath = useMemo(() => {
-    const route = enrichedTrackedAircraft?.flightRoute;
-    if (
-      !routeEndpointAirportsOnly ||
-      !route ||
-      focalLat == null ||
-      focalLon == null
-    ) {
-      return [];
-    }
-    return buildGreatCirclePath({
+    return buildFlightAwareRouteArcPath({
+      route: enrichedTrackedAircraft?.flightRoute,
+      routeProvider,
+      routeEndpointAirportsOnly,
       from: { lat: focalLat, lon: focalLon },
-      to: route.destination,
     });
   }, [
     enrichedTrackedAircraft?.flightRoute,
     focalLat,
     focalLon,
+    routeProvider,
     routeEndpointAirportsOnly,
   ]);
 

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -141,7 +141,7 @@ export default function AircraftPosition({
     forceSilhouette || (showArrow && !aircraft.onGround)
       ? resolveAircraftIcon(aircraft)
       : null;
-  // Wake-class scale (A1–0.90 → A5–1.10). Applied to the moving marker
+  // Wake-class scale (A1–0.70 → A5–1.45). Applied to the moving marker
   // glyphs so heavies read larger than light traffic; falls back to 1× for
   // unknown / out-of-range categories. The slow-traffic dot stays unscaled
   // because at that point we're encoding "minimal indicator", not class.
@@ -172,8 +172,6 @@ export default function AircraftPosition({
         rot={rot}
         roll={attitude.roll}
         pitch={attitude.pitch}
-        altitude={aircraft.altitude}
-        onGround={aircraft.onGround}
         selected={selected}
         showArrow={showArrow}
         silhouette={silhouette}
@@ -195,21 +193,11 @@ export default function AircraftPosition({
   );
 }
 
-// Altitude reference points (ft) used to map ADS-B altitude to a 0..1
-// ratio. Anything at or above CRUISE_FT looks fully "high" — its shadow
-// is the longest cast and the faintest blur. Surface-level traffic
-// (onGround or near 0 ft) gets a tight, dark shadow practically touching
-// the silhouette.
-const SHADOW_GROUND_FT = 0;
-const SHADOW_CRUISE_FT = 38_000;
-
 function Pointer({
   color,
   rot,
   roll = 0,
   pitch = 0,
-  altitude = null,
-  onGround = false,
   selected = false,
   showArrow,
   silhouette,
@@ -217,56 +205,19 @@ function Pointer({
   theme = "dark",
 }) {
   // The wrapper carries heading + wake-class scale; the silhouette inside
-  // carries the 3D pitch/bank stack + a translateY lift, while a separate
-  // shadow element stays planted in the wrapper's plane. The visual story:
-  // the shadow is "the ground", the silhouette flies above it on climb and
-  // touches it on descent. perspective(280px) sits close enough that
-  // ±12°/±35° read as visibly tilted (vs. 540px which is near-orthographic).
+  // carries the 3D pitch/bank stack + a translateY lift. perspective(280px)
+  // sits close enough that ±12°/±35° read as visibly tilted.
   const wrapperTransform = `rotate(${rot}deg) scale(${sizeScale})`;
   // Pitch still drives a small lift on the silhouette so the climb/descent
-  // posture reads at a glance, but the *shadow* is now decoupled from
-  // verticalRate and tracks absolute altitude instead.
+  // posture reads at a glance without drawing a ground projection.
   const pitchLiftPx = (-(pitch / 12) * 4).toFixed(2);
   const silhouetteTransform =
     `translateY(${pitchLiftPx}px) perspective(280px) ` +
     `rotateX(${pitch}deg) rotateY(${roll}deg)`;
 
-  // Ground shadow keyed off absolute altitude (or onGround). Higher = the
-  // shadow trails farther from the aircraft (longer cast), gets fainter
-  // and more diffuse; lower = tight, dark, near-coincident with the
-  // silhouette. The offset is in the wrapper's pre-rotation frame so the
-  // shadow trails the same screen-direction regardless of heading — top-
-  // left light-source convention shared with the rest of the surface
-  // shadows in the design system. The shadow uses the same SVG mask as
-  // the silhouette so what hits the basemap is the actual aircraft
-  // outline, not a generic blob.
-  const altClamped = onGround
-    ? SHADOW_GROUND_FT
-    : Math.min(
-        Math.max(Number(altitude) || SHADOW_GROUND_FT, SHADOW_GROUND_FT),
-        SHADOW_CRUISE_FT,
-      );
-  const altRatio = (altClamped - SHADOW_GROUND_FT) /
-    (SHADOW_CRUISE_FT - SHADOW_GROUND_FT);
-  const shadowOffsetX = (1 + altRatio * 6).toFixed(2);
-  const shadowOffsetY = (1 + altRatio * 9).toFixed(2);
-  // Floor blur at 5px and ceiling opacity at 0.5 so even surface-level
-  // traffic reads as a soft cast, not a duplicated silhouette. The mask
-  // still gives the shadow the aircraft outline, but at this much blur it
-  // reads as a tinted halo of the right shape rather than a double image.
-  const shadowBlur = (5 + altRatio * 5).toFixed(2);
-  const shadowOpacity = (0.5 - altRatio * 0.25).toFixed(2);
-  // Shadow is meaningfully smaller than the aircraft (game-art convention
-  // for altitude). Surface-level traffic gets ~0.85× — close to the real
-  // outline; cruise gets ~0.70× — a small distant cast.
-  const shadowScale = (0.85 - altRatio * 0.15).toFixed(3);
-  const shadowTransform =
-    `translate(${shadowOffsetX}px, ${shadowOffsetY}px) scale(${shadowScale})`;
-
   if (showArrow && silhouette) {
     // Wrapper carries the heading rotation so the dark-theme nose beam
-    // orbits with it. Shadow + silhouette share the same SVG mask so the
-    // projection is the real aircraft outline, not a generic ellipse.
+    // orbits with it.
     const maskUrl = `url(${silhouette.src})`;
     const maskStyle = {
       position: "absolute",
@@ -293,19 +244,6 @@ function Pointer({
           transform: wrapperTransform,
         }}
       >
-        {selected ? (
-          <div
-            className="aircraft-shadow"
-            aria-hidden="true"
-            style={{
-              ...maskStyle,
-              backgroundColor: "var(--aviation-aircraft-shadow)",
-              opacity: shadowOpacity,
-              filter: `blur(${shadowBlur}px)`,
-              transform: shadowTransform,
-            } as any}
-          />
-        ) : null}
         <div
           className="aircraft-silhouette"
           style={{
@@ -331,24 +269,6 @@ function Pointer({
           position: "relative",
         }}
       >
-        {selected ? (
-          <svg
-            className="aircraft-shadow"
-            aria-hidden="true"
-            width={SILHOUETTE_SIZE_PX}
-            height={SILHOUETTE_SIZE_PX}
-            viewBox="0 0 24 24"
-            style={{
-              position: "absolute",
-              inset: 0,
-              opacity: shadowOpacity,
-              filter: `blur(${shadowBlur}px)`,
-              transform: shadowTransform,
-            }}
-          >
-            <path d="M12 2L16 20L12 17L8 20Z" fill="var(--aviation-aircraft-shadow)" />
-          </svg>
-        ) : null}
         <svg
           width={SILHOUETTE_SIZE_PX}
           height={SILHOUETTE_SIZE_PX}

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -420,7 +420,7 @@ export default function AirportMap({
           <AirspaceLayer
             airspaces={renderedAirspaces}
             visible={showAirspaces}
-            showBoundaryLabels={!fullTraceContext}
+            showBoundaryLabels={false}
             selectedAirspaceId={selectedAirspaceId}
             onSelectAirspace={onSelectAirspace}
           />

--- a/src/components/map/AirportMarker.tsx
+++ b/src/components/map/AirportMarker.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../features/airport/map/airportMapZoomFeatures";
 import { getDistanceNm } from "../../utils/aircraftTrafficIntent";
 import { AirportLabelBadge } from "@/components/ui/AirportLabelBadge";
+import { airportDisplayCode } from "@/utils/airport";
 
 export default function AirportMarker({
   lat,
@@ -71,7 +72,7 @@ export default function AirportMarker({
 
   if (!container) return null;
 
-  const code = (airport?.iata || icao || "").trim();
+  const code = airportDisplayCode({ ...airport, icao });
   const details = [];
   if (showAreaCount) {
     details.push({

--- a/src/components/map/AirspaceLayer.tsx
+++ b/src/components/map/AirspaceLayer.tsx
@@ -7,6 +7,7 @@ import {
   buildAirspaceOverlayAnimationPlan,
   buildAirspaceOverlayFeatures,
   resolveAirspaceInitialOpacity,
+  resolveAirspaceInteriorPattern,
   resolveAirspaceOverlayFocusStyle,
   resolveAirspaceOverlayStyle,
 } from "@/features/airport/map/airspaceOverlayModel";
@@ -31,7 +32,7 @@ let boundaryLabelSequence = 0;
 export default function AirspaceLayer({
   airspaces = [],
   visible = true,
-  showBoundaryLabels = true,
+  showBoundaryLabels = false,
   selectedAirspaceId = "",
   onSelectAirspace = null,
 }: {
@@ -45,6 +46,7 @@ export default function AirspaceLayer({
   const layerRef = useRef<L.GeoJSON | null>(null);
   const boundaryLabelsRef = useRef<SVGTextElement[]>([]);
   const boundaryEdgesRef = useRef<SVGElement[]>([]);
+  const interiorHatchesRef = useRef<SVGElement[]>([]);
   const labelFrameRef = useRef(0);
   const animationFrameRef = useRef(0);
   const hasAnimatedInitialEnterRef = useRef(false);
@@ -69,9 +71,12 @@ export default function AirspaceLayer({
     boundaryLabelsRef.current = [];
     boundaryEdgesRef.current.forEach((edge) => edge.remove());
     boundaryEdgesRef.current = [];
+    interiorHatchesRef.current.forEach((hatch) => hatch.remove());
+    interiorHatchesRef.current = [];
     safeRemoveFromMap(layerRef.current, map);
     const boundaryLabels: SVGTextElement[] = [];
     const boundaryEdges: SVGElement[] = [];
+    const interiorHatches: SVGElement[] = [];
     const animateInitialEnter =
       visibleRef.current && !hasAnimatedInitialEnterRef.current;
     const initialOpacity = resolveAirspaceInitialOpacity({
@@ -111,6 +116,7 @@ export default function AirspaceLayer({
       polygonLayer,
       boundaryLabels,
       boundaryEdges,
+      interiorHatches,
       selectedAirspaceIdRef.current,
       initialOpacity,
     );
@@ -123,6 +129,14 @@ export default function AirspaceLayer({
         ),
       );
       boundaryEdgesRef.current = boundaryEdges;
+      interiorHatches.push(
+        ...attachInteriorHatches(
+          polygonLayer,
+          selectedAirspaceIdRef.current,
+          initialOpacity,
+        ),
+      );
+      interiorHatchesRef.current = interiorHatches;
       boundaryLabels.push(
         ...attachBoundaryLabels(
           polygonLayer,
@@ -137,6 +151,7 @@ export default function AirspaceLayer({
           layerGroup: polygonLayer,
           labels: boundaryLabels,
           edges: boundaryEdges,
+          hatches: interiorHatches,
           selectedAirspaceId: selectedAirspaceIdRef.current,
           visible: true,
           animationFrameRef,
@@ -151,6 +166,8 @@ export default function AirspaceLayer({
       boundaryLabelsRef.current = [];
       boundaryEdges.forEach((edge) => edge.remove());
       boundaryEdgesRef.current = [];
+      interiorHatches.forEach((hatch) => hatch.remove());
+      interiorHatchesRef.current = [];
       safeRemoveFromMap(polygonLayer, map);
       layerRef.current = null;
     };
@@ -173,6 +190,7 @@ export default function AirspaceLayer({
       layerGroup: polygonLayer,
       labels: boundaryLabelsRef.current,
       edges: boundaryEdgesRef.current,
+      hatches: interiorHatchesRef.current,
       selectedAirspaceId,
       visible,
       animationFrameRef,
@@ -202,6 +220,7 @@ function animateAirspaceGroupOpacity({
   layerGroup,
   labels,
   edges,
+  hatches,
   selectedAirspaceId,
   visible,
   animationFrameRef,
@@ -209,6 +228,7 @@ function animateAirspaceGroupOpacity({
   layerGroup: L.GeoJSON;
   labels: SVGTextElement[];
   edges: SVGElement[];
+  hatches: SVGElement[];
   selectedAirspaceId: string;
   visible: boolean;
   animationFrameRef: MutableRefObject<number>;
@@ -228,6 +248,7 @@ function animateAirspaceGroupOpacity({
       layerGroup,
       labels,
       edges,
+      hatches,
       selectedAirspaceId,
       visible ? 1 : 0,
     );
@@ -236,6 +257,7 @@ function animateAirspaceGroupOpacity({
 
   const labelGroups = groupLabelsByLayerIndex(labels);
   const edgeGroups = groupLabelsByLayerIndex(edges);
+  const hatchGroups = groupLabelsByLayerIndex(hatches);
   const startedAt = window.performance.now();
   const targetOpacity = visible ? 1 : 0;
   const animations = plan.steps.map((step) => {
@@ -244,6 +266,7 @@ function animateAirspaceGroupOpacity({
       layer,
       labels: labelGroups.get(step.index) || [],
       edges: edgeGroups.get(step.index) || [],
+      hatches: hatchGroups.get(step.index) || [],
       delayMs: step.delayMs,
       fromOpacity: readAirspaceLayerOpacityScale(layer, visible ? 0 : 1),
     };
@@ -266,6 +289,7 @@ function animateAirspaceGroupOpacity({
         animation.layer,
         animation.labels,
         animation.edges,
+        animation.hatches,
         selectedAirspaceId,
         opacityScale,
       );
@@ -277,6 +301,7 @@ function animateAirspaceGroupOpacity({
         layerGroup,
         labels,
         edges,
+        hatches,
         selectedAirspaceId,
         targetOpacity,
       );
@@ -294,16 +319,19 @@ function applyAirspaceGroupOpacity(
   layerGroup: L.GeoJSON,
   labels: SVGTextElement[],
   edges: SVGElement[],
+  hatches: SVGElement[],
   selectedAirspaceId: string,
   opacityScale: number,
 ) {
   const labelGroups = groupLabelsByLayerIndex(labels);
   const edgeGroups = groupLabelsByLayerIndex(edges);
+  const hatchGroups = groupLabelsByLayerIndex(hatches);
   getAirspaceFeatureLayers(layerGroup).forEach((layer, index) => {
     applyAirspaceFeatureOpacity(
       layer,
       labelGroups.get(index) || [],
       edgeGroups.get(index) || [],
+      hatchGroups.get(index) || [],
       selectedAirspaceId,
       opacityScale,
     );
@@ -314,6 +342,7 @@ function applyAirspaceFeatureOpacity(
   layer: any,
   labels: SVGTextElement[],
   edges: SVGElement[],
+  hatches: SVGElement[],
   selectedAirspaceId: string,
   opacityScale: number,
 ) {
@@ -323,6 +352,7 @@ function applyAirspaceFeatureOpacity(
   layer.__airspaceOpacityScale = opacityScale;
   labels.forEach((label) => setBoundaryLabelState(label, selectedAirspaceId, opacityScale));
   edges.forEach((edge) => setBoundaryEdgeState(edge, selectedAirspaceId, opacityScale));
+  hatches.forEach((hatch) => setInteriorHatchState(hatch, selectedAirspaceId, opacityScale));
 }
 
 function getAirspaceFeatureLayers(layerGroup: L.GeoJSON) {
@@ -476,6 +506,75 @@ function attachBoundaryEdges(
   return edges;
 }
 
+function attachInteriorHatches(
+  layerGroup: L.GeoJSON,
+  selectedAirspaceId = "",
+  opacityScale = 1,
+): SVGElement[] {
+  const hatches: SVGElement[] = [];
+
+  let layerIndex = 0;
+  layerGroup.eachLayer((layer: any) => {
+    const currentLayerIndex = layerIndex;
+    layerIndex += 1;
+    const pattern = resolveAirspaceInteriorPattern(layer.feature);
+    if (!pattern.enabled) return;
+
+    const path = typeof layer.getElement === "function"
+      ? layer.getElement()
+      : null;
+    const svg = path?.ownerSVGElement;
+    if (!path || !svg || typeof path.getBBox !== "function") return;
+
+    const bbox = path.getBBox();
+    if (!Number.isFinite(bbox.width) || !Number.isFinite(bbox.height)) return;
+    if (bbox.width <= 0 || bbox.height <= 0) return;
+
+    const pathId = path.id || `airspace-boundary-${boundaryLabelSequence += 1}`;
+    path.id = pathId;
+    const clipId = `airspace-interior-hatch-clip-${boundaryLabelSequence += 1}`;
+    const defs = ensureSvgDefs(svg);
+    const clipPath = document.createElementNS(SVG_NS, "clipPath");
+    clipPath.id = clipId;
+    const clipUse = document.createElementNS(SVG_NS, "use");
+    clipUse.setAttribute("href", `#${pathId}`);
+    clipUse.setAttributeNS(XLINK_NS, "xlink:href", `#${pathId}`);
+    clipPath.appendChild(clipUse);
+    defs.appendChild(clipPath);
+
+    const group = document.createElementNS(SVG_NS, "g");
+    group.dataset.airspaceLayerIndex = String(currentLayerIndex);
+    group.dataset.airspaceFeatureId = String(layer.feature?.properties?.id || "");
+    group.dataset.airspacePatternOpacity = String(pattern.opacity);
+    group.classList.add("airspace-interior-hatch");
+    group.setAttribute("clip-path", `url(#${clipId})`);
+    group.setAttribute("pointer-events", "none");
+
+    const spacing = 21;
+    const padding = Math.max(bbox.width, bbox.height) + spacing;
+    const startX = bbox.x - padding;
+    const endX = bbox.x + bbox.width + padding;
+    const y1 = bbox.y + bbox.height + spacing;
+    const y2 = bbox.y - spacing;
+    for (let x = startX; x <= endX; x += spacing) {
+      const line = document.createElementNS(SVG_NS, "line");
+      line.classList.add("airspace-interior-hatch__line");
+      line.setAttribute("x1", String(x));
+      line.setAttribute("y1", String(y1));
+      line.setAttribute("x2", String(x + bbox.height + spacing));
+      line.setAttribute("y2", String(y2));
+      line.setAttribute("stroke", pattern.color);
+      group.appendChild(line);
+    }
+
+    setInteriorHatchState(group, selectedAirspaceId, opacityScale);
+    svg.appendChild(group);
+    hatches.push(group, clipPath);
+  });
+
+  return hatches;
+}
+
 function setBoundaryLabelState(
   label: SVGTextElement,
   selectedAirspaceId: string,
@@ -498,6 +597,19 @@ function setBoundaryEdgeState(
     edge.dataset.airspaceFeatureId === selectedAirspaceId;
   edge.classList.toggle("airspace-boundary-edge--focused", isFocused);
   edge.style.opacity = String((isFocused ? 0.78 : 0.46) * opacityScale);
+}
+
+function setInteriorHatchState(
+  hatch: SVGElement,
+  selectedAirspaceId: string,
+  opacityScale: number,
+) {
+  const isFocused =
+    Boolean(selectedAirspaceId) &&
+    hatch.dataset.airspaceFeatureId === selectedAirspaceId;
+  hatch.classList.toggle("airspace-interior-hatch--focused", isFocused);
+  const baseOpacity = Number(hatch.dataset.airspacePatternOpacity) || 0;
+  hatch.style.opacity = String((isFocused ? baseOpacity + 0.12 : baseOpacity) * opacityScale);
 }
 
 function boundaryLabelLines(

--- a/src/components/map/MapLoadingOverlay.tsx
+++ b/src/components/map/MapLoadingOverlay.tsx
@@ -140,7 +140,6 @@ export default function MapLoadingOverlay({
     >
       <div key={playbackCycle} className="adsb-loading-grid" aria-hidden="true">
         <span className="adsb-loading-grid__matrix" />
-        <span className="adsb-loading-grid__scan" />
       </div>
     </div>
   );

--- a/src/components/map/MapTileLayers.tsx
+++ b/src/components/map/MapTileLayers.tsx
@@ -7,10 +7,11 @@ import { useMapInstance } from "./MapContext";
 import {
   shouldAttemptMapLibreTiles,
   shouldLogMapTileLayerFailure,
+  shouldSuppressMapLibreTileError,
 } from "@/features/airport/map/mapTileLayerModel";
 import { isLightMapTheme } from "@/features/airport/map/airportMapModel";
 
-const MAP_STYLE_THEME_REVISION = "light-dark-v1";
+const MAP_STYLE_THEME_REVISION = "terrain-readable-v9";
 
 export default function MapTileLayers({
   theme = "dark",
@@ -57,6 +58,7 @@ export default function MapTileLayers({
             className: "atc-maplibre-base",
           } as any);
           nextLayer.addTo(map);
+          attachMapLibreErrorHandler(nextLayer);
           layerRef.current = nextLayer;
           layerRef.current.getContainer()?.classList.add("atc-tile-base");
           setSelectionOpacity(layerRef.current, theme, selectionActiveRef.current);
@@ -163,6 +165,16 @@ function setSelectionOpacity(layer, theme, selectionActive) {
     return;
   }
   container.style.opacity = "1";
+}
+
+function attachMapLibreErrorHandler(layer: any) {
+  const maplibreMap = layer?.getMaplibreMap?.();
+  if (!maplibreMap || typeof maplibreMap.on !== "function") return;
+
+  maplibreMap.on("error", (event) => {
+    if (shouldSuppressMapLibreTileError(event)) return;
+    console.error("[airport-map] map tile error", event?.error || event);
+  });
 }
 
 function hasWebGlContext() {

--- a/src/components/map/NearbyAirportLayer.tsx
+++ b/src/components/map/NearbyAirportLayer.tsx
@@ -14,7 +14,6 @@ import {
   buildRunwayEndLabels,
 } from "../../features/airport/map/runwayAnnotationModel";
 import { shouldShowNearbyAirportRunwaysForZoom } from "../../features/airport/map/airportMapZoomFeatures";
-import { airportLabelBadgeHtml } from "@/components/ui/AirportLabelBadge";
 
 const escapeHtml = (value: unknown) =>
   String(value || "")
@@ -24,7 +23,8 @@ const escapeHtml = (value: unknown) =>
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
 
-const airportLabel = (airport: Record<string, any>) => airport.iata || airport.icao || "";
+const airportLabel = (airport: Record<string, any>) =>
+  airport.iata || airport.icao || airport.code || "";
 
 const markerHtml = (airport: Record<string, any>) => {
   const code = airportLabel(airport);
@@ -34,17 +34,16 @@ const markerHtml = (airport: Record<string, any>) => {
   // Two parts: the dot sits exactly on the airport position; the label
   // stack (code pill + distance pill) is offset down-left so the runway
   // / centerline at the airport stays visible underneath.
-  const badge = airportLabelBadgeHtml({
-    code,
-    className: "nearby-airport-marker-label",
-    // Distance shown as "DIST 14NM" — label is the noun ("DIST"), value
-    // is the magnitude with unit suffix concatenated so the unit reads
-    // as part of the number, not as a separate caption.
-    details:
-      distance != null
-        ? [{ key: "dist", variant: "near", label: "DIST", value: `${distance}NM` }]
-        : [],
-  });
+  const distanceHtml =
+    distance != null
+      ? `<span class="nearby-airport-marker-badge__meta">${escapeHtml(distance)}NM</span>`
+      : "";
+  const badge = `
+    <span class="nearby-airport-marker-label nearby-airport-marker-badge">
+      <span class="nearby-airport-marker-badge__code">${escapeHtml(code)}</span>
+      ${distanceHtml}
+    </span>
+  `;
   return `
     <div class="nearby-airport-marker notranslate" translate="no">
       <span class="nearby-airport-marker-dot"></span>

--- a/src/components/map/SelectedAircraftTrace.tsx
+++ b/src/components/map/SelectedAircraftTrace.tsx
@@ -175,6 +175,7 @@ export default function SelectedAircraftTrace({ theme = "dark" }) {
             movement={trace.movement}
             tracePoints={trace.tracePoints}
             opacity={typeof trace.opacity === "number" ? trace.opacity : 1}
+            fullTrace={Boolean(trace.fullTrace)}
           />
         ) : null,
       )}
@@ -188,6 +189,7 @@ function SingleAircraftTrace({
   movement,
   tracePoints,
   opacity = 1,
+  fullTrace = false,
 }) {
   const { t } = useI18n();
   const map = useMapInstance();
@@ -243,8 +245,14 @@ function SingleAircraftTrace({
     return computeTraceGeometry({
       tracePoints: committedTrace.tracePoints,
       maxRenderPoints: SELECTED_AIRCRAFT_TRACE_STYLE.maxRenderPoints,
+      fullTrace,
     });
-  }, [aircraftHex, committedTrace.aircraftHex, committedTrace.tracePoints]);
+  }, [
+    aircraftHex,
+    committedTrace.aircraftHex,
+    committedTrace.tracePoints,
+    fullTrace,
+  ]);
 
   const traceRevealKey = useMemo(
     () =>

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -64,8 +64,9 @@ export default function AirportSidebar({
   }, [activeView, atcFrequencies.length]);
 
   const handleSpottingView = () => {
+    const previousView = activeView;
     setActiveView("spotting");
-    onOpenSpotting?.();
+    onOpenSpotting?.(previousView);
   };
 
   const header = (

--- a/src/features/aircraft/trace/traceGeometry.test.ts
+++ b/src/features/aircraft/trace/traceGeometry.test.ts
@@ -70,4 +70,27 @@ import { computeTraceGeometry } from "./traceGeometry";
   );
 }
 
+{
+  const base = 1_700_000_000_000 - (1_700_000_000_000 % 600_000);
+  const tracePoints = Array.from({ length: 32 }, (_, minute) => ({
+    lat: 42 + minute * 0.03,
+    lon: -71 + minute * 0.02,
+    timestampMs: base + minute * 60_000,
+    altitude: 2_000 + minute * 100,
+  }));
+
+  const geometry = computeTraceGeometry({
+    tracePoints,
+    maxRenderPoints: 80,
+    fullTrace: true,
+  });
+
+  assert.ok(geometry, "full trace should still produce geometry");
+  assert.deepEqual(
+    geometry.labelPoints.map((point) => (point.timestampMs - base) / 60_000),
+    [0, 10, 20, 30],
+    "full trace labels should land at ten-minute intervals",
+  );
+}
+
 console.log("traceGeometry.test.ts ok");

--- a/src/features/aircraft/trace/traceGeometry.ts
+++ b/src/features/aircraft/trace/traceGeometry.ts
@@ -12,6 +12,7 @@ import { getDistanceNm } from "../../../utils/aircraftTrafficIntent";
 
 const DEFAULT_TRACE_MAX_LABELS = 5;
 const DEFAULT_TRACE_LABEL_MIN_DISTANCE_NM = 2;
+const FULL_TRACE_LABEL_INTERVAL_MS = 10 * 60 * 1000;
 
 function buildTraceSamplePoints(points) {
   const usable = points.slice(0, -1);
@@ -53,10 +54,35 @@ function buildTraceLabelPoints(
   return selected.reverse();
 }
 
+function buildFullTraceLabelPoints(
+  points,
+  { intervalMs = FULL_TRACE_LABEL_INTERVAL_MS } = {},
+) {
+  const usable = points.slice(0, -1);
+  if (usable.length === 0) return [];
+
+  const selected = [];
+  let lastLabelTimestampMs = null;
+  for (const point of usable) {
+    const timestampMs = Number(point?.timestampMs);
+    if (!Number.isFinite(timestampMs)) continue;
+    if (
+      lastLabelTimestampMs != null &&
+      timestampMs - lastLabelTimestampMs < intervalMs
+    ) {
+      continue;
+    }
+    selected.push(point);
+    lastLabelTimestampMs = timestampMs;
+  }
+  return selected;
+}
+
 export function computeTraceGeometry({
   tracePoints = [],
   maxRenderPoints,
   curveSteps = 5,
+  fullTrace = false,
 }) {
   if (!Array.isArray(tracePoints) || tracePoints.length < 2) return null;
 
@@ -76,7 +102,9 @@ export function computeTraceGeometry({
         id: `segment-${index}`,
         curve,
         samplePoints: buildTraceSamplePoints(sampled),
-        labelPoints: buildTraceLabelPoints(sampled),
+        labelPoints: fullTrace
+          ? buildFullTraceLabelPoints(segment.points)
+          : buildTraceLabelPoints(sampled),
       };
     })
     .filter(Boolean);

--- a/src/features/airport/explorer/airportExplorerUiModel.test.ts
+++ b/src/features/airport/explorer/airportExplorerUiModel.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
-import { DEFAULT_AIRPORT_EXPLORER_UI_STATE } from "./airportExplorerUiModel";
+import {
+  DEFAULT_AIRPORT_EXPLORER_UI_STATE,
+  resolveSpottingMetricZoomState,
+} from "./airportExplorerUiModel";
 
 assert.equal(
   DEFAULT_AIRPORT_EXPLORER_UI_STATE.showMapLabels,
@@ -18,5 +21,50 @@ assert.equal(
   DEFAULT_AIRPORT_EXPLORER_UI_STATE.showAirspaces,
   true,
 );
+
+{
+  const update = resolveSpottingMetricZoomState({
+    activeView: "traffic",
+    currentZoom: 10,
+    previousZoom: null,
+    detailZoom: 13,
+    fallbackZoom: 10,
+  });
+
+  assert.deepEqual(update, {
+    nextZoom: 13,
+    nextPreviousZoom: 10,
+  });
+}
+
+{
+  const update = resolveSpottingMetricZoomState({
+    activeView: "spotting",
+    currentZoom: 13,
+    previousZoom: 10,
+    detailZoom: 13,
+    fallbackZoom: 10,
+  });
+
+  assert.deepEqual(update, {
+    nextZoom: 10,
+    nextPreviousZoom: null,
+  });
+}
+
+{
+  const update = resolveSpottingMetricZoomState({
+    activeView: "spotting",
+    currentZoom: 13,
+    previousZoom: null,
+    detailZoom: 13,
+    fallbackZoom: 10,
+  });
+
+  assert.deepEqual(update, {
+    nextZoom: 10,
+    nextPreviousZoom: null,
+  });
+}
 
 console.log("airportExplorerUiModel.test.ts ok");

--- a/src/features/airport/explorer/airportExplorerUiModel.ts
+++ b/src/features/airport/explorer/airportExplorerUiModel.ts
@@ -9,3 +9,30 @@ export const DEFAULT_AIRPORT_EXPLORER_UI_STATE = {
   showAirspaces: true,
   ...DEFAULT_AIRCRAFT_FILTERS,
 };
+
+const finiteZoomOr = (value: unknown, fallback: number) => {
+  if (value == null || value === "") return fallback;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+export function resolveSpottingMetricZoomState({
+  activeView = "",
+  currentZoom = ZOOM_APPROACH,
+  previousZoom = null,
+  detailZoom,
+  fallbackZoom = ZOOM_APPROACH,
+}: Record<string, any> = {}) {
+  const fallback = finiteZoomOr(fallbackZoom, ZOOM_APPROACH);
+  if (activeView === "spotting") {
+    return {
+      nextZoom: finiteZoomOr(previousZoom, fallback),
+      nextPreviousZoom: null,
+    };
+  }
+
+  return {
+    nextZoom: finiteZoomOr(detailZoom, fallback),
+    nextPreviousZoom: finiteZoomOr(currentZoom, fallback),
+  };
+}

--- a/src/features/airport/map/airspaceOverlayModel.test.ts
+++ b/src/features/airport/map/airspaceOverlayModel.test.ts
@@ -4,6 +4,7 @@ import {
   buildAirspaceOverlayAnimationPlan,
   buildAirspaceOverlayFeatures,
   resolveAirspaceInitialOpacity,
+  resolveAirspaceInteriorPattern,
   resolveAirspaceOverlayFocusStyle,
   resolveAirspaceOverlayStyle,
 } from "./airspaceOverlayModel";
@@ -162,6 +163,33 @@ const polygon = {
   assert.equal(focusedControlledStyle.fillOpacity, 1);
   assert.equal(focusedControlledStyle.opacity, 1);
   assert.equal(focusedControlledStyle.weight, Number(controlledStyle.weight) + 0.8);
+}
+
+{
+  const blockedPattern = resolveAirspaceInteriorPattern({
+    properties: { accessLevel: "blocked" },
+  });
+  assert.deepEqual(blockedPattern, {
+    enabled: true,
+    color: "var(--airspace-blocked-stroke)",
+    opacity: 0.7,
+  });
+
+  const restrictedPattern = resolveAirspaceInteriorPattern({
+    properties: { accessLevel: "restricted" },
+  });
+  assert.deepEqual(restrictedPattern, {
+    enabled: true,
+    color: "var(--airspace-restricted-stroke)",
+    opacity: 0.64,
+  });
+
+  assert.equal(
+    resolveAirspaceInteriorPattern({
+      properties: { accessLevel: "controlled" },
+    }).enabled,
+    false,
+  );
 }
 
 console.log("airspaceOverlayModel.test.ts ok");

--- a/src/features/airport/map/airspaceOverlayModel.ts
+++ b/src/features/airport/map/airspaceOverlayModel.ts
@@ -180,3 +180,27 @@ export function resolveAirspaceOverlayFocusStyle(feature: AirspaceOverlayRecord 
     weight: Number(style.weight || 1.5) + 0.8,
   };
 }
+
+export function resolveAirspaceInteriorPattern(feature: AirspaceOverlayRecord = {}) {
+  const level = String(feature.properties?.accessLevel || "unknown");
+  const token = tokenForLevel(level);
+  if (level === "blocked") {
+    return {
+      enabled: true,
+      color: `var(--airspace-${token}-stroke)`,
+      opacity: 0.7,
+    };
+  }
+  if (level === "restricted") {
+    return {
+      enabled: true,
+      color: `var(--airspace-${token}-stroke)`,
+      opacity: 0.64,
+    };
+  }
+  return {
+    enabled: false,
+    color: `var(--airspace-${token}-stroke)`,
+    opacity: 0,
+  };
+}

--- a/src/features/airport/map/mapTileLanguageModel.test.ts
+++ b/src/features/airport/map/mapTileLanguageModel.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  buildReadableTerrainMapLibreStyle,
   buildProxiedMapLibreStyle,
   buildLocalizedMapLibreStyle,
   getMapLibreBaseStyleUrl,
@@ -161,4 +162,153 @@ assert.equal(
 
   assert.equal(localized.layers[0].layout.visibility, "none");
   assert.equal(localized.layers[1].layout.visibility, undefined);
+}
+
+{
+  const style = {
+    version: 8,
+    layers: [
+      {
+        id: "background",
+        type: "background",
+        paint: { "background-color": "rgb(12,12,12)" },
+      },
+      {
+        id: "water",
+        type: "fill",
+        paint: { "fill-color": "rgb(27,27,29)" },
+      },
+      {
+        id: "landcover_wood",
+        type: "fill",
+        paint: {
+          "fill-color": "rgb(32,32,32)",
+          "fill-pattern": "wood-pattern",
+          "fill-opacity": 0.8,
+        },
+      },
+      {
+        id: "road_major",
+        type: "line",
+        paint: { "line-color": "rgb(40,40,40)" },
+      },
+    ],
+  };
+
+  const themed = buildReadableTerrainMapLibreStyle(style, { theme: "dark" });
+  const background = themed.layers.find((layer) => layer.id === "background");
+  const water = themed.layers.find((layer) => layer.id === "water");
+  const wood = themed.layers.find((layer) => layer.id === "landcover_wood");
+  const road = themed.layers.find((layer) => layer.id === "road_major");
+
+  assert.equal(background.paint["background-color"], "#30382f");
+  assert.equal(water.paint["fill-color"], "#50676b");
+  assert.equal(wood.paint["fill-color"], "#43523d");
+  assert.equal(wood.paint["fill-opacity"], 0.58);
+  assert.equal(wood.paint["fill-pattern"], undefined);
+  assert.equal(road.paint["line-color"], "#565a55");
+}
+
+{
+  const style = {
+    version: 8,
+    layers: [
+      {
+        id: "background",
+        type: "background",
+        paint: { "background-color": "rgb(242,243,240)" },
+      },
+      {
+        id: "park",
+        type: "fill",
+        paint: { "fill-color": "rgb(230,233,229)" },
+      },
+      {
+        id: "water",
+        type: "fill",
+        paint: { "fill-color": "rgb(194,200,202)" },
+      },
+      {
+        id: "landcover_wood",
+        type: "fill",
+        paint: {
+          "fill-color": "rgb(220,224,220)",
+          "fill-opacity": 1,
+        },
+      },
+    ],
+  };
+
+  const themed = buildReadableTerrainMapLibreStyle(style, { theme: "light" });
+  const background = themed.layers.find((layer) => layer.id === "background");
+  const park = themed.layers.find((layer) => layer.id === "park");
+  const water = themed.layers.find((layer) => layer.id === "water");
+  const wood = themed.layers.find((layer) => layer.id === "landcover_wood");
+
+  assert.equal(background.paint["background-color"], "#e7efe0");
+  assert.equal(park.paint["fill-color"], "#d2e2ca");
+  assert.equal(water.paint["fill-color"], "#b9d7df");
+  assert.equal(wood.paint["fill-opacity"], 0.72);
+}
+
+{
+  const style = {
+    version: 8,
+    sources: {
+      ne2_shaded: { type: "raster" },
+      openmaptiles: { type: "vector" },
+    },
+    layers: [
+      {
+        id: "background",
+        type: "background",
+        paint: { "background-color": "#000" },
+      },
+      {
+        id: "water",
+        type: "fill",
+        source: "openmaptiles",
+        "source-layer": "water",
+        paint: { "fill-color": "#111" },
+      },
+      {
+        id: "highway_minor",
+        type: "line",
+        source: "openmaptiles",
+        "source-layer": "transportation",
+        paint: { "line-color": "#222" },
+      },
+    ],
+  };
+
+  const themed = buildReadableTerrainMapLibreStyle(style, { theme: "light" });
+  const ids = themed.layers.map((layer) => layer.id);
+
+  assert.ok(ids.includes("adsbao_terrain_hillshade"));
+  assert.ok(ids.includes("adsbao_terrain_landcover"));
+  assert.ok(ids.includes("adsbao_terrain_landuse"));
+  assert.ok(
+    ids.indexOf("water") < ids.indexOf("adsbao_terrain_topo"),
+    "topographic terrain should render above base surface fills",
+  );
+  assert.ok(
+    ids.indexOf("adsbao_terrain_topo") < ids.indexOf("highway_minor"),
+    "topographic terrain should render below map linework",
+  );
+
+  const hillshade = themed.layers.find((layer) => layer.id === "adsbao_terrain_hillshade");
+  const topo = themed.layers.find((layer) => layer.id === "adsbao_terrain_topo");
+  const landcover = themed.layers.find((layer) => layer.id === "adsbao_terrain_landcover");
+  const landuse = themed.layers.find((layer) => layer.id === "adsbao_terrain_landuse");
+  assert.equal(themed.sources.adsbao_terrain_dem.type, "raster-dem");
+  assert.equal(themed.sources.adsbao_terrain_dem.encoding, "terrarium");
+  assert.equal(themed.sources.adsbao_terrain_topo.type, "raster");
+  assert.equal(hillshade.type, "hillshade");
+  assert.equal(hillshade.source, "adsbao_terrain_dem");
+  assert.equal(hillshade.paint["hillshade-exaggeration"], 1);
+  assert.equal(topo.type, "raster");
+  assert.equal(topo.paint["raster-saturation"], -0.18);
+  assert.equal(topo.paint["raster-opacity"], 0.94);
+  assert.equal(landcover["source-layer"], "landcover");
+  assert.equal(landuse["source-layer"], "landuse");
 }

--- a/src/features/airport/map/mapTileLanguageModel.ts
+++ b/src/features/airport/map/mapTileLanguageModel.ts
@@ -10,6 +10,7 @@ const MAP_LABEL_LOCALES = Object.freeze({
 
 type MapLibreLayer = {
   type?: string;
+  paint?: Record<string, unknown>;
   layout?: {
     visibility?: string;
     [key: string]: unknown;
@@ -46,6 +47,109 @@ type ProxiedMapStyleOptions = {
   tileJson?: TileJson;
   proxyOrigin?: string;
 };
+
+type ReadableTerrainStyleOptions = {
+  theme?: string;
+};
+
+type TerrainPalette = {
+  background: string;
+  water: string;
+  waterLabel: string;
+  waterLabelHalo: string;
+  terrain: string;
+  terrainOpacity: number;
+  terrainSecondary: string;
+  terrainSecondaryOpacity: number;
+  residential: string;
+  building: string;
+  buildingOutline: string;
+  road: string;
+  roadCasing: string;
+  aeroway: string;
+  boundary: string;
+  label: string;
+  labelHalo: string;
+  hillshadeExaggeration: number;
+  hillshadeShadow: string;
+  hillshadeHighlight: string;
+  hillshadeAccent: string;
+  topoOpacity: number;
+  topoSaturation: number;
+  topoBrightnessMin: number;
+  topoBrightnessMax: number;
+  topoContrast: number;
+};
+
+const TERRAIN_DEM_SOURCE_ID = "adsbao_terrain_dem";
+const TERRAIN_TOPO_SOURCE_ID = "adsbao_terrain_topo";
+
+const TERRAIN_LAYER_IDS = Object.freeze([
+  "adsbao_terrain_hillshade",
+  "adsbao_terrain_topo",
+  "adsbao_terrain_landuse",
+  "adsbao_terrain_landcover",
+]);
+
+const READABLE_TERRAIN_PALETTES: Record<"dark" | "light", TerrainPalette> =
+  Object.freeze({
+    dark: Object.freeze({
+      background: "#30382f",
+      water: "#50676b",
+      waterLabel: "#8fa5aa",
+      waterLabelHalo: "#272d28",
+      terrain: "#43523d",
+      terrainOpacity: 0.58,
+      terrainSecondary: "#384137",
+      terrainSecondaryOpacity: 0.48,
+      residential: "#31362f",
+      building: "#373a34",
+      buildingOutline: "#4c5148",
+      road: "#646a61",
+      roadCasing: "#484f47",
+      aeroway: "#42443f",
+      boundary: "#5d625c",
+      label: "#b1b6ad",
+      labelHalo: "#242a24",
+      hillshadeExaggeration: 1,
+      hillshadeShadow: "rgba(1, 3, 1, 0.92)",
+      hillshadeHighlight: "rgba(180, 194, 166, 0.82)",
+      hillshadeAccent: "rgba(82, 99, 74, 0.68)",
+      topoOpacity: 0.78,
+      topoSaturation: -0.35,
+      topoBrightnessMin: 0.04,
+      topoBrightnessMax: 0.88,
+      topoContrast: 0.18,
+    }),
+    light: Object.freeze({
+      background: "#e7efe0",
+      water: "#b9d7df",
+      waterLabel: "#5b7479",
+      waterLabelHalo: "#f4f3ec",
+      terrain: "#d2e2ca",
+      terrainOpacity: 0.72,
+      terrainSecondary: "#dfe7d8",
+      terrainSecondaryOpacity: 0.6,
+      residential: "#e8e8df",
+      building: "#e2e0d7",
+      buildingOutline: "#d3d1c8",
+      road: "#bfc2b8",
+      roadCasing: "#d9d9cf",
+      aeroway: "#e6e1d7",
+      boundary: "#b9b9ad",
+      label: "#30332d",
+      labelHalo: "#f5f4ed",
+      hillshadeExaggeration: 1,
+      hillshadeShadow: "rgba(96, 101, 91, 0.76)",
+      hillshadeHighlight: "rgba(255, 255, 250, 0.86)",
+      hillshadeAccent: "rgba(118, 130, 108, 0.56)",
+      topoOpacity: 0.94,
+      topoSaturation: -0.18,
+      topoBrightnessMin: 0,
+      topoBrightnessMax: 1,
+      topoContrast: 0.18,
+    }),
+  });
 
 function normalizeMapLabelLocale(locale: string) {
   return MAP_LABEL_LOCALES[locale] || MAP_LABEL_LOCALES.en;
@@ -137,10 +241,317 @@ export function buildProxiedMapLibreStyle(
   };
 }
 
+export function buildReadableTerrainMapLibreStyle(
+  style: MapLibreStyle,
+  { theme = "dark" }: ReadableTerrainStyleOptions = {},
+) {
+  if (!style || !Array.isArray(style.layers)) return style;
+
+  const palette =
+    theme === "light"
+      ? READABLE_TERRAIN_PALETTES.light
+      : READABLE_TERRAIN_PALETTES.dark;
+
+  return {
+    ...style,
+    sources: injectReadableTerrainSources(style.sources || {}),
+    layers: injectReadableTerrainLayers(style.layers.map((layer) => {
+      const paint = resolveTerrainLayerPaint(layer, palette);
+      return paint ? { ...layer, paint } : layer;
+    }), style, palette),
+  };
+}
+
+function injectReadableTerrainSources(
+  sources: Record<string, MapLibreSource>,
+) {
+  return {
+    ...sources,
+    [TERRAIN_DEM_SOURCE_ID]: {
+      type: "raster-dem",
+      tiles: [
+        "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png",
+      ],
+      tileSize: 256,
+      maxzoom: 15,
+      encoding: "terrarium",
+      attribution:
+        '<a href="https://github.com/tilezen/joerd/tree/master/docs/attribution.md">Terrain Tiles</a>',
+    },
+    [TERRAIN_TOPO_SOURCE_ID]: {
+      type: "raster",
+      tiles: [
+        "https://a.tile.opentopomap.org/{z}/{x}/{y}.png",
+        "https://b.tile.opentopomap.org/{z}/{x}/{y}.png",
+        "https://c.tile.opentopomap.org/{z}/{x}/{y}.png",
+      ],
+      tileSize: 256,
+      maxzoom: 15,
+      attribution:
+        '<a href="https://opentopomap.org">OpenTopoMap</a>',
+    },
+  };
+}
+
+function injectReadableTerrainLayers(
+  layers: MapLibreLayer[],
+  style: MapLibreStyle,
+  palette: TerrainPalette,
+) {
+  const cleanedLayers = layers.filter(
+    (layer) => !TERRAIN_LAYER_IDS.includes(String(layer?.id || "")),
+  );
+  const terrainLayers = buildReadableTerrainLayers(style, palette);
+  if (terrainLayers.length === 0) return cleanedLayers;
+
+  const insertIndex = resolveReadableTerrainInsertIndex(cleanedLayers);
+  return [
+    ...cleanedLayers.slice(0, insertIndex),
+    ...terrainLayers,
+    ...cleanedLayers.slice(insertIndex),
+  ];
+}
+
+function resolveReadableTerrainInsertIndex(layers: MapLibreLayer[]) {
+  const lineworkIndex = layers.findIndex((layer) => {
+    const id = String(layer?.id || "");
+    const sourceLayer = String(layer?.["source-layer"] || "");
+    return (
+      layer?.type === "line" &&
+      (sourceLayer === "transportation" ||
+        sourceLayer === "aeroway" ||
+        isLayerId(id, "road") ||
+        isLayerId(id, "highway") ||
+        isLayerId(id, "tunnel") ||
+        isLayerId(id, "railway") ||
+        isLayerId(id, "aeroway"))
+    );
+  });
+  if (lineworkIndex >= 0) return lineworkIndex;
+
+  const symbolIndex = layers.findIndex((layer) => layer?.type === "symbol");
+  if (symbolIndex >= 0) return symbolIndex;
+
+  const lastSurfaceIndex = layers.reduce((lastIndex, layer, index) => {
+    return ["background", "fill", "raster", "hillshade"].includes(
+      String(layer?.type || ""),
+    )
+      ? index
+      : lastIndex;
+  }, -1);
+  return lastSurfaceIndex >= 0 ? lastSurfaceIndex + 1 : 0;
+}
+
+function buildReadableTerrainLayers(
+  style: MapLibreStyle,
+  palette: TerrainPalette,
+) {
+  const sources = style?.sources || {};
+  const layers: MapLibreLayer[] = [];
+
+  if (sources.openmaptiles) {
+    layers.push(
+      {
+        id: "adsbao_terrain_landuse",
+        type: "fill",
+        source: "openmaptiles",
+        "source-layer": "landuse",
+        filter: polygonClassFilter([
+          "park",
+          "forest",
+          "farmland",
+          "farm",
+          "grass",
+          "meadow",
+          "recreation_ground",
+          "nature_reserve",
+          "cemetery",
+          "allotments",
+          "orchard",
+          "vineyard",
+        ]),
+        paint: {
+          "fill-color": palette.terrainSecondary,
+          "fill-opacity": palette.terrainSecondaryOpacity,
+        },
+      },
+      {
+        id: "adsbao_terrain_landcover",
+        type: "fill",
+        source: "openmaptiles",
+        "source-layer": "landcover",
+        filter: polygonClassFilter([
+          "wood",
+          "forest",
+          "grass",
+          "scrub",
+          "wetland",
+          "heath",
+          "meadow",
+          "farmland",
+        ]),
+        paint: {
+          "fill-color": palette.terrain,
+          "fill-opacity": palette.terrainOpacity,
+        },
+      },
+    );
+  }
+
+  layers.push({
+    id: "adsbao_terrain_hillshade",
+    type: "hillshade",
+    source: TERRAIN_DEM_SOURCE_ID,
+    paint: {
+      "hillshade-exaggeration": palette.hillshadeExaggeration,
+      "hillshade-shadow-color": palette.hillshadeShadow,
+      "hillshade-highlight-color": palette.hillshadeHighlight,
+      "hillshade-accent-color": palette.hillshadeAccent,
+      "hillshade-illumination-direction": 315,
+    },
+  });
+  layers.push({
+    id: "adsbao_terrain_topo",
+    type: "raster",
+    source: TERRAIN_TOPO_SOURCE_ID,
+    paint: {
+      "raster-opacity": palette.topoOpacity,
+      "raster-saturation": palette.topoSaturation,
+      "raster-contrast": palette.topoContrast,
+      "raster-brightness-min": palette.topoBrightnessMin,
+      "raster-brightness-max": palette.topoBrightnessMax,
+      "raster-fade-duration": 0,
+    },
+  });
+
+  return layers;
+}
+
+function polygonClassFilter(values: string[]) {
+  return [
+    "all",
+    [
+      "match",
+      ["geometry-type"],
+      ["MultiPolygon", "Polygon"],
+      true,
+      false,
+    ],
+    [
+      "any",
+      ["match", ["get", "class"], values, true, false],
+      ["match", ["get", "subclass"], values, true, false],
+    ],
+  ];
+}
+
 function isTextSymbolLayer(layer: MapLibreLayer) {
   return (
     layer?.type === "symbol" &&
     layer.layout &&
     Object.prototype.hasOwnProperty.call(layer.layout, "text-field")
   );
+}
+
+function resolveTerrainLayerPaint(
+  layer: MapLibreLayer,
+  palette: TerrainPalette,
+) {
+  const id = String(layer?.id || "");
+  const paint = { ...(layer.paint || {}) };
+  let changed = false;
+
+  const setPaint = (key: string, value: unknown) => {
+    paint[key] = value;
+    changed = true;
+  };
+  const deletePaint = (key: string) => {
+    if (!Object.prototype.hasOwnProperty.call(paint, key)) return;
+    delete paint[key];
+    changed = true;
+  };
+
+  if (layer.type === "background") {
+    setPaint("background-color", palette.background);
+  }
+
+  if (isLayerId(id, "water")) {
+    setPaintForType(layer, setPaint, {
+      fill: ["fill-color", palette.water],
+      line: ["line-color", palette.water],
+      symbol: ["text-color", palette.waterLabel],
+    });
+    if (layer.type === "symbol") setPaint("text-halo-color", palette.waterLabelHalo);
+  }
+
+  if (isLayerId(id, "park") || isLayerId(id, "wood") || isLayerId(id, "forest")) {
+    setPaint("fill-color", palette.terrain);
+    if (layer.type === "fill") setPaint("fill-opacity", palette.terrainOpacity);
+    deletePaint("fill-pattern");
+  }
+
+  if (
+    (isLayerId(id, "landcover") || isLayerId(id, "landuse")) &&
+    !isLayerId(id, "wood") &&
+    !isLayerId(id, "forest") &&
+    !isLayerId(id, "park")
+  ) {
+    const fillColor = isLayerId(id, "residential")
+      ? palette.residential
+      : palette.terrainSecondary;
+    setPaint("fill-color", fillColor);
+    if (layer.type === "fill") setPaint("fill-opacity", palette.terrainSecondaryOpacity);
+    deletePaint("fill-pattern");
+  }
+
+  if (isLayerId(id, "building")) {
+    setPaint("fill-color", palette.building);
+    setPaint("fill-outline-color", palette.buildingOutline);
+  }
+
+  if (isLayerId(id, "road") || isLayerId(id, "highway")) {
+    setPaintForType(layer, setPaint, {
+      fill: ["fill-color", palette.roadCasing],
+      line: ["line-color", isLayerId(id, "casing") ? palette.roadCasing : palette.road],
+    });
+  }
+
+  if (isLayerId(id, "aeroway") || isLayerId(id, "airport")) {
+    setPaintForType(layer, setPaint, {
+      fill: ["fill-color", palette.aeroway],
+      line: ["line-color", palette.aeroway],
+      symbol: ["text-color", palette.label],
+    });
+    if (layer.type === "symbol") setPaint("text-halo-color", palette.labelHalo);
+  }
+
+  if (isLayerId(id, "boundary")) {
+    setPaintForType(layer, setPaint, {
+      line: ["line-color", palette.boundary],
+    });
+  }
+
+  if (
+    layer.type === "symbol" &&
+    (isLayerId(id, "place") || isLayerId(id, "label"))
+  ) {
+    setPaint("text-color", palette.label);
+    setPaint("text-halo-color", palette.labelHalo);
+  }
+
+  return changed ? paint : null;
+}
+
+function setPaintForType(
+  layer: MapLibreLayer,
+  setPaint: (key: string, value: unknown) => void,
+  values: Partial<Record<string, [string, unknown]>>,
+) {
+  const value = layer.type ? values[layer.type] : null;
+  if (!value) return;
+  setPaint(value[0], value[1]);
+}
+
+function isLayerId(id: string, needle: string) {
+  return id.toLowerCase().includes(needle);
 }

--- a/src/features/airport/map/mapTileLayerModel.test.ts
+++ b/src/features/airport/map/mapTileLayerModel.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   shouldAttemptMapLibreTiles,
   shouldLogMapTileLayerFailure,
+  shouldSuppressMapLibreTileError,
 } from "./mapTileLayerModel";
 
 assert.equal(
@@ -37,6 +38,21 @@ assert.equal(
 assert.equal(
   shouldLogMapTileLayerFailure(new Error("OpenFreeMap style request failed: 503")),
   true,
+);
+
+assert.equal(
+  shouldSuppressMapLibreTileError({
+    error: new Error(
+      "AJAXError: Failed to fetch (0): https://tiles.openfreemap.org/planet/20260531_080002_pt/9/153/194.pbf",
+    ),
+  }),
+  true,
+);
+assert.equal(
+  shouldSuppressMapLibreTileError({
+    error: new Error("Style image missing: aircraft-icon"),
+  }),
+  false,
 );
 
 console.log("mapTileLayerModel.test.ts ok");

--- a/src/features/airport/map/mapTileLayerModel.ts
+++ b/src/features/airport/map/mapTileLayerModel.ts
@@ -4,6 +4,13 @@ const RECOVERABLE_FAILURE_PATTERNS = [
   /maplibre/i,
 ];
 
+const RECOVERABLE_TILE_ERROR_PATTERNS = [
+  /AJAXError:\s*Failed to fetch/i,
+  /Failed to fetch.*\.(pbf|png|jpg|jpeg|webp)/i,
+  /tiles\.openfreemap\.org/i,
+  /elevation-tiles-prod/i,
+];
+
 export function shouldAttemptMapLibreTiles({
   userAgent = "",
   webGlAvailable = true,
@@ -16,4 +23,10 @@ export function shouldAttemptMapLibreTiles({
 export function shouldLogMapTileLayerFailure(error) {
   const message = error?.message || String(error || "");
   return !RECOVERABLE_FAILURE_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function shouldSuppressMapLibreTileError(event = {}) {
+  const error = event?.error || event;
+  const message = error?.message || String(error || "");
+  return RECOVERABLE_TILE_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }

--- a/src/features/aviation/flight-routes/flightRouteArcModel.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteArcModel.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+
+import { ROUTE_PROVIDER } from "../sourceDisplayModel";
+import {
+  buildFlightAwareRouteArcPath,
+  shouldShowFlightAwareRouteArc,
+} from "./flightRouteArcModel";
+
+const flightAwareRoute = {
+  source: "flightaware",
+  origin: { icao: "KBOS", lat: 42.3656, lon: -71.0096 },
+  destination: { icao: "OMDB", lat: 25.2532, lon: 55.3657 },
+};
+
+{
+  assert.equal(
+    shouldShowFlightAwareRouteArc({
+      route: { ...flightAwareRoute, source: "adsbdb" },
+      routeProvider: ROUTE_PROVIDER.FLIGHTAWARE,
+      routeEndpointAirportsOnly: false,
+    }),
+    true,
+  );
+
+  const path = buildFlightAwareRouteArcPath({
+    route: flightAwareRoute,
+    routeProvider: ROUTE_PROVIDER.FLIGHTAWARE,
+    routeEndpointAirportsOnly: false,
+    from: { lat: 42.36, lon: -70.72 },
+    segments: 8,
+  });
+
+  assert.equal(path.length, 9);
+  assert.deepEqual(path[0], [42.36, -70.72]);
+  assert.deepEqual(path.at(-1), [25.2532, 55.3657]);
+}
+
+{
+  assert.equal(
+    shouldShowFlightAwareRouteArc({
+      route: { ...flightAwareRoute, source: "adsbdb" },
+      routeProvider: ROUTE_PROVIDER.ADSBDB,
+      routeEndpointAirportsOnly: false,
+    }),
+    false,
+  );
+
+  assert.deepEqual(
+    buildFlightAwareRouteArcPath({
+      route: { ...flightAwareRoute, source: "adsbdb" },
+      routeProvider: ROUTE_PROVIDER.ADSBDB,
+      routeEndpointAirportsOnly: false,
+      from: { lat: 42.36, lon: -70.72 },
+    }),
+    [],
+  );
+}
+
+{
+  assert.equal(
+    shouldShowFlightAwareRouteArc({
+      route: { ...flightAwareRoute, source: "adsbdb" },
+      routeProvider: ROUTE_PROVIDER.ADSBDB,
+      routeEndpointAirportsOnly: true,
+    }),
+    true,
+  );
+}
+
+console.log("flightRouteArcModel.test.ts ok");

--- a/src/features/aviation/flight-routes/flightRouteArcModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteArcModel.ts
@@ -1,0 +1,55 @@
+import { ROUTE_PROVIDER } from "../sourceDisplayModel";
+import { buildGreatCirclePath } from "./greatCircleRouteModel";
+
+type FlightRouteArcOptions = {
+  route?: Record<string, any> | null;
+  routeProvider?: unknown;
+  routeEndpointAirportsOnly?: unknown;
+};
+
+type FlightRouteArcPathOptions = FlightRouteArcOptions & {
+  from?: Record<string, any> | null;
+  segments?: unknown;
+};
+
+function hasDestination(route: Record<string, any> | null | undefined) {
+  return Boolean(route?.destination);
+}
+
+export function shouldShowFlightAwareRouteArc({
+  route = null,
+  routeProvider = "",
+  routeEndpointAirportsOnly = false,
+}: FlightRouteArcOptions = {}) {
+  if (!hasDestination(route)) return false;
+
+  const normalizedProvider = String(routeProvider || "").trim().toLowerCase();
+  return (
+    normalizedProvider === ROUTE_PROVIDER.FLIGHTAWARE ||
+    Boolean(routeEndpointAirportsOnly)
+  );
+}
+
+export function buildFlightAwareRouteArcPath({
+  route = null,
+  routeProvider = "",
+  routeEndpointAirportsOnly = false,
+  from = null,
+  segments = 32,
+}: FlightRouteArcPathOptions = {}) {
+  if (
+    !shouldShowFlightAwareRouteArc({
+      route,
+      routeProvider,
+      routeEndpointAirportsOnly,
+    })
+  ) {
+    return [];
+  }
+
+  return buildGreatCirclePath({
+    from,
+    to: route?.destination,
+    segments,
+  });
+}

--- a/src/style.css
+++ b/src/style.css
@@ -536,7 +536,6 @@
     --aviation-trace-point: #1a1a18;
     --aviation-trace-stale-line: color-mix(in oklab, var(--aviation-trace-line) 54%, transparent);
     --aviation-route-hint-line: var(--aviation-trace-line);
-    --aviation-aircraft-shadow: rgba(0,0,0,0.95);
     --aviation-runway-annotation-line: #1a1a18;
     --aviation-runway-approach-line: rgba(26,26,24,0.62);
     --aviation-runway-approach-beam: #2f2f2b;
@@ -803,7 +802,6 @@
     --aviation-trace-point: var(--primary-bright);
     --aviation-trace-stale-line: color-mix(in oklab, var(--aviation-trace-line) 54%, transparent);
     --aviation-route-hint-line: var(--aviation-trace-line);
-    --aviation-aircraft-shadow: rgba(0,0,0,0.95);
     --aviation-runway-annotation-line: #d8bd83;
     --aviation-runway-approach-line: rgba(216,189,131,0.78);
     --aviation-runway-approach-beam: #d8bd83;
@@ -1066,6 +1064,21 @@ body {
     opacity: 0.78;
     stroke-dasharray: 0.5 7;
     stroke-width: 10px;
+}
+
+.airspace-interior-hatch {
+    opacity: 0.64;
+    pointer-events: none;
+}
+
+.airspace-interior-hatch__line {
+    stroke-linecap: butt;
+    stroke-linejoin: miter;
+    stroke-width: 2.2px;
+}
+
+.airspace-interior-hatch--focused .airspace-interior-hatch__line {
+    stroke-width: 2.6px;
 }
 
 .airspace-boundary-label--focused {
@@ -1540,9 +1553,7 @@ body {
 
 .adsb-loading-grid::before,
 .adsb-loading-grid::after,
-.adsb-loading-grid__matrix,
-.adsb-loading-grid__matrix::after,
-.adsb-loading-grid__scan {
+.adsb-loading-grid__matrix {
     position: absolute;
 }
 
@@ -1582,90 +1593,8 @@ body {
     opacity: 0.86;
 }
 
-.adsb-loading-grid__matrix::after {
-    background-image:
-        radial-gradient(
-            circle,
-            color-mix(in oklab, var(--endf-yellow) 78%, transparent) 0 1.6px,
-            transparent 1.95px
-        ),
-        radial-gradient(
-            circle,
-            color-mix(in oklab, var(--atc-accent) 48%, transparent) 0 1.35px,
-            transparent 1.85px
-        );
-    background-position:
-        0 0,
-        9px 9px;
-    background-size:
-        18px 18px,
-        18px 18px;
-    content: "";
-    inset: 0;
-    opacity: 0.54;
-    -webkit-mask-image: linear-gradient(
-        90deg,
-        transparent,
-        oklch(1% 0.01 100) 42%,
-        transparent 76%
-    );
-    mask-image: linear-gradient(
-        90deg,
-        transparent,
-        oklch(1% 0.01 100) 42%,
-        transparent 76%
-    );
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-size: min(18vw, 220px) 100%;
-    mask-size: min(18vw, 220px) 100%;
-    animation: adsb-grid-highlight 2.45s cubic-bezier(0.25, 1, 0.5, 1) infinite;
-}
-
-.adsb-loading-grid__scan {
-    background:
-        linear-gradient(
-            90deg,
-            transparent,
-            color-mix(in oklab, var(--endf-yellow) 18%, transparent) 38%,
-            color-mix(in oklab, var(--endf-yellow) 70%, transparent) 48%,
-            color-mix(in oklab, var(--atc-accent) 24%, transparent) 58%,
-            transparent 100%
-        );
-    box-shadow: 0 0 24px color-mix(in oklab, var(--endf-yellow) 12%, transparent);
-    inset: 0 auto 0 0;
-    opacity: 0.42;
-    transform: translateX(-120%);
-    width: min(16vw, 180px);
-    animation: adsb-grid-scan 2.45s cubic-bezier(0.25, 1, 0.5, 1) infinite;
-}
-
 .adsb-loading-overlay.is-exiting .adsb-loading-grid {
     animation: adsb-loading-grid-fade-out 1.1s ease forwards;
-}
-
-@keyframes adsb-grid-scan {
-    0%,
-    10% {
-        transform: translateX(-120%);
-    }
-    74%,
-    100% {
-        transform: translateX(calc(100vw + 120%));
-    }
-}
-
-@keyframes adsb-grid-highlight {
-    0%,
-    10% {
-        -webkit-mask-position: calc(-1 * min(18vw, 220px)) 0;
-        mask-position: calc(-1 * min(18vw, 220px)) 0;
-    }
-    74%,
-    100% {
-        -webkit-mask-position: calc(100% + min(18vw, 220px)) 0;
-        mask-position: calc(100% + min(18vw, 220px)) 0;
-    }
 }
 
 @keyframes adsb-loading-fade-out {
@@ -2968,17 +2897,11 @@ body {
     }
 }
 
-/* Marker stack (shadow only rendered for selected aircraft):
+/* Marker stack:
    1. .aircraft-pointer-glyph (wrapper) — heading rotation + wake-class scale.
-      Doesn't move out of plane, so the inner shadow can sit "on the ground".
-   2. .aircraft-shadow — the projected ground silhouette. Same SVG mask as
-      the real one but black, scaled-down, blurred. Stays planted while the
-      aircraft above it tilts and lifts — that's where the "altitude" cue
-      comes from, not from a filter halo.
-   3. .aircraft-silhouette — the real aircraft, carrying perspective + pitch
-      + bank + a translateY "lift". Sits above the shadow in DOM order.
-   Each layer transitions transform/opacity/filter so successive ADS-B
-   samples settle visually instead of snapping. */
+   2. .aircraft-silhouette — the aircraft shape, carrying perspective + pitch
+      + bank + a translateY lift. Transitions keep successive ADS-B samples
+      visually settled without drawing a ground projection. */
 .aircraft-pointer-glyph {
     position: relative;
     overflow: visible;
@@ -2988,7 +2911,6 @@ body {
     transition: transform 520ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
-.aircraft-shadow,
 .aircraft-silhouette {
     transition:
         transform 520ms cubic-bezier(0.22, 0.61, 0.36, 1),
@@ -2999,7 +2921,6 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
     .aircraft-pointer-glyph,
-    .aircraft-shadow,
     .aircraft-silhouette {
         transition: none;
     }
@@ -3141,6 +3062,35 @@ body {
     left: 8px;
     position: absolute;
     top: 6px;
+}
+
+.nearby-airport-marker-badge {
+    align-items: center;
+    background: color-mix(in oklab, var(--atc-bg) 88%, transparent);
+    border-radius: 999px;
+    box-shadow:
+        0 1px 3px color-mix(in oklab, var(--atc-bg) 42%, transparent),
+        inset 0 1px 0 color-mix(in oklab, var(--atc-card) 58%, transparent);
+    color: var(--atc-text);
+    display: inline-flex;
+    font-family: var(--font-display);
+    gap: 4px;
+    line-height: 1;
+    padding: 2px 5px;
+}
+
+.nearby-airport-marker-badge__code {
+    font-size: 7px;
+    font-weight: 850;
+    letter-spacing: 0.02em;
+}
+
+.nearby-airport-marker-badge__meta {
+    color: var(--atc-muted);
+    font-family: var(--font-sans);
+    font-size: 6px;
+    font-weight: 800;
+    letter-spacing: 0;
 }
 
 .aircraft-table-route-cycle {
@@ -3859,14 +3809,22 @@ body {
     gap: 3px;
 }
 
+.airport-overlay-label__code.endf-tab--code {
+    font-size: 7px;
+    letter-spacing: 0.03em;
+    min-width: 32px;
+    padding: 3px 5px;
+}
+
 .airport-overlay-label__detail {
     background: color-mix(in oklab, var(--atc-bg) 72%, transparent);
     color: var(--atc-text);
     font-family: var(--font-display);
-    font-size: 8.5px;
+    font-size: 7px;
     font-weight: 700;
-    letter-spacing: 0.08em;
-    padding: 1px 5px;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    padding: 1px 4px;
     text-transform: uppercase;
 }
 
@@ -3881,12 +3839,12 @@ body {
     color: var(--endf-ink);
     display: inline-flex;
     font-family: var(--font-sans);
-    font-size: 7.5px;
-    gap: 3px;
+    font-size: 6.5px;
+    gap: 2px;
     letter-spacing: 0;
     line-height: 1;
-    min-height: 14px;
-    padding: 1px 7px 1px 6px;
+    min-height: 10px;
+    padding: 1px 5px 1px 4px;
 }
 
 .airport-overlay-label__detail-label {
@@ -3957,8 +3915,6 @@ body {
     .adsb-loading-overlay.is-exiting,
     .adsb-loading-overlay.is-exiting .adsb-loading-grid,
     .adsb-loading-grid::after,
-    .adsb-loading-grid__matrix::after,
-    .adsb-loading-grid__scan,
     .orb-container canvas {
         animation: none;
     }

--- a/src/utils/aircraftIcon.test.ts
+++ b/src/utils/aircraftIcon.test.ts
@@ -136,13 +136,14 @@ assert.equal(isKnownAircraftIconName("b77w"), true);
 assert.equal(isKnownAircraftIconName("crj9"), true);
 assert.equal(isKnownAircraftIconName("md11"), true);
 
-// Wake-class scale resolver: A1–0.90 → A5–1.10, baseline elsewhere.
-assert.equal(resolveAircraftSizeScale({ category: "A1" }), 0.9);
-assert.equal(resolveAircraftSizeScale({ category: "A2" }), 0.95);
+// Wake-class scale resolver: A1 small aircraft stay clearly smaller than
+// A320-class A3 traffic, while A4/A5 heavies read larger on the map.
+assert.equal(resolveAircraftSizeScale({ category: "A1" }), 0.7);
+assert.equal(resolveAircraftSizeScale({ category: "A2" }), 0.8);
 assert.equal(resolveAircraftSizeScale({ category: "A3" }), 1);
-assert.equal(resolveAircraftSizeScale({ category: "A4" }), 1.05);
-assert.equal(resolveAircraftSizeScale({ category: "A5" }), 1.1);
-assert.equal(resolveAircraftSizeScale({ category: " a5 " }), 1.1);
+assert.equal(resolveAircraftSizeScale({ category: "A4" }), 1.25);
+assert.equal(resolveAircraftSizeScale({ category: "A5" }), 1.45);
+assert.equal(resolveAircraftSizeScale({ category: " a5 " }), 1.45);
 assert.equal(
   resolveAircraftSizeScale({ category: "A0" }),
   AIRCRAFT_BASELINE_SCALE,

--- a/src/utils/aircraftIcon.ts
+++ b/src/utils/aircraftIcon.ts
@@ -155,8 +155,8 @@ const normalizeKey = (value: unknown) =>
   typeof value === "string" ? value.trim().toUpperCase() : "";
 
 // Wake-class scale factors keyed off the ADS-B emitter category (A-level).
-// A1 light → 0.90, A2 small → 0.95, A3 large → 1.00 (baseline), A4 high-vortex
-// large → 1.05, A5 heavy → 1.10. Categories outside A1–A5 (A0 unknown,
+// A1 light → 0.70, A2 small → 0.80, A3 large → 1.00 (A320-class baseline),
+// A4 high-vortex large → 1.25, A5 heavy → 1.45. Categories outside A1–A5 (A0 unknown,
 // A6 high-performance, A7 rotorcraft, B*, C*, missing) keep the baseline so
 // shape, not size, carries their signal. Applied to both the silhouette and
 // the vector-arrow fallback so the wake class is visible regardless of
@@ -164,11 +164,11 @@ const normalizeKey = (value: unknown) =>
 const AIRCRAFT_BASELINE_SCALE = 1;
 
 const CATEGORY_SIZE_SCALE = {
-  A1: 0.9,
-  A2: 0.95,
+  A1: 0.7,
+  A2: 0.8,
   A3: 1,
-  A4: 1.05,
-  A5: 1.1,
+  A4: 1.25,
+  A5: 1.45,
 };
 
 /**

--- a/src/utils/airport.test.ts
+++ b/src/utils/airport.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 
 import { AIRPORT_DISCOVERY_TOPICS } from "../config/airportDiscovery";
-import { airportDisplayName, airportSubtitle } from "./airport";
+import { airportDisplayCode, airportDisplayName, airportSubtitle } from "./airport";
 
 const jfk = {
   icao: "KJFK",
@@ -11,6 +11,9 @@ const jfk = {
 };
 
 assert.equal(airportDisplayName(jfk, "en"), "John F. Kennedy International Airport");
+assert.equal(airportDisplayCode({ icao: "KJFK", iata: "JFK" }), "KJFK");
+assert.equal(airportDisplayCode({ code: "EGLL", iata: "LHR" }), "EGLL");
+assert.equal(airportDisplayCode({ iata: "BOS" }), "BOS");
 assert.equal(airportDisplayName(jfk, "zh-CN"), "约翰·F·肯尼迪国际机场");
 assert.equal(airportSubtitle(jfk, "zh-CN"), "🇺🇸 纽约 · 美国");
 assert.equal(

--- a/src/utils/airport.ts
+++ b/src/utils/airport.ts
@@ -55,6 +55,11 @@ export const airportDisplayName = (airport, locale = "en") => {
   return AIRPORT_NAME_ZH[icao] || fallback;
 };
 
+export const airportDisplayCode = (airport: Record<string, any> = {}) =>
+  String(airport?.icao || airport?.code || airport?.iata || "")
+    .trim()
+    .toUpperCase();
+
 export const airportCityName = (city, locale = "en") => {
   const fallback = String(city || "");
   if (locale !== "zh-CN") return fallback;


### PR DESCRIPTION
## Summary
- add low-saturation terrain sources and map style handling for light/dark modes
- remove airspace map labels, add restricted airspace hatching, and remove aircraft ground projections
- adjust aircraft scale, airport marker labels, FlightAware route arcs, full-trace time tags, and loading overlay scan

## Validation
- Not run per instruction; no full validation.