### PR TITLE
Fix mobile airspace taps and tracking route display

### DIFF
--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -29,7 +29,7 @@ import {
   resolveTrackedAircraftSelectionSync,
   resolveFlightTrackingDisplayContext,
 } from "@/features/aircraft/tracking/flightTrackingDisplayModel";
-import { buildFlightAwareRouteArcPath } from "@/features/aviation/flight-routes/flightRouteArcModel";
+import { resolveFocusedFlightAwareRouteArcPath } from "@/features/aviation/flight-routes/flightRouteArcModel";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled";
 import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel";
 import { mergeTrackedAircraftIntoNearby } from "@/features/airport/explorer/airportExplorerModel";
@@ -660,18 +660,20 @@ function FlightExplorerContent({ callsign }) {
   }, [focalKey, selectedAircraftId, setSelectedAircraftId, showNearbyContext]);
 
   const focalRoutePath = useMemo(() => {
-    return buildFlightAwareRouteArcPath({
-      route: enrichedTrackedAircraft?.flightRoute,
+    return resolveFocusedFlightAwareRouteArcPath({
+      selectedAircraft,
+      focalAircraft: enrichedTrackedAircraft,
       routeProvider,
       routeEndpointAirportsOnly,
       from: { lat: focalLat, lon: focalLon },
     });
   }, [
-    enrichedTrackedAircraft?.flightRoute,
+    enrichedTrackedAircraft,
     focalLat,
     focalLon,
     routeProvider,
     routeEndpointAirportsOnly,
+    selectedAircraft,
   ]);
 
   useEffect(() => {

--- a/src/components/map/AirspaceLayer.tsx
+++ b/src/components/map/AirspaceLayer.tsx
@@ -11,6 +11,11 @@ import {
   resolveAirspaceOverlayFocusStyle,
   resolveAirspaceOverlayStyle,
 } from "@/features/airport/map/airspaceOverlayModel";
+import {
+  airspaceFeatureIdsAtClientPoint,
+  resolveAirspaceClientPoint,
+  resolveClickedAirspaceId,
+} from "@/features/airport/map/airspaceSelectionModel";
 import { ensureAirportMapPane } from "@/features/airport/map/mapPane";
 import {
   safeAddToMap,
@@ -96,6 +101,39 @@ export default function AirspaceLayer({
     const airspacePane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.airspace);
     const paneElement = map.getPane(airspacePane);
     if (paneElement) paneElement.style.pointerEvents = visibleRef.current ? "auto" : "none";
+    const handleNativeAirspacePointer = (event: PointerEvent | TouchEvent) => {
+      if (
+        typeof PointerEvent !== "undefined" &&
+        event instanceof PointerEvent &&
+        event.pointerType === "mouse"
+      ) {
+        return;
+      }
+      if (!visibleRef.current || !onSelectRef.current) return;
+      const clientPoint = resolveAirspaceClientPoint(event);
+      const hitIds = airspaceFeatureIdsAtClientPoint(clientPoint);
+      const clickedId = hitIds[0] || "";
+      if (!clickedId && hitIds.length === 0) return;
+      const latlng = resolveAirspaceLatLngFromClientPoint(map, clientPoint);
+      const id = resolveClickedAirspaceId({
+        hitIds,
+        features,
+        latlng,
+        clickedId,
+        selectableAirspaceIds: selectableAirspaceIdSet,
+        selectedAirspaceId: selectedAirspaceIdRef.current,
+      });
+      if (!id) return;
+      L.DomEvent.stop(event as any);
+      event.preventDefault?.();
+      onSelectRef.current?.(id);
+    };
+    const usePointerEvents = typeof window.PointerEvent !== "undefined";
+    paneElement?.addEventListener(
+      usePointerEvents ? "pointerup" : "touchend",
+      handleNativeAirspacePointer as EventListener,
+      { passive: false },
+    );
     const polygonLayer = L.geoJSON(features as any, {
       interactive: Boolean(onSelectRef.current),
       pane: airspacePane,
@@ -116,8 +154,10 @@ export default function AirspaceLayer({
             L.DomEvent.stop(event.originalEvent);
             event.originalEvent.stopPropagation?.();
           }
+          const clientPoint = resolveAirspaceClientPoint(event?.originalEvent);
+          const hitIds = airspaceFeatureIdsAtClientPoint(clientPoint);
           const id = resolveClickedAirspaceId({
-            clientPoint: resolveAirspaceClickClientPoint(event?.originalEvent),
+            hitIds,
             features,
             latlng: event?.latlng,
             clickedId: featureId,
@@ -130,7 +170,13 @@ export default function AirspaceLayer({
     });
 
     const added = safeAddToMap(polygonLayer, map, { label: "AirspaceLayer" });
-    if (!added) return undefined;
+    if (!added) {
+      paneElement?.removeEventListener(
+        usePointerEvents ? "pointerup" : "touchend",
+        handleNativeAirspacePointer as EventListener,
+      );
+      return undefined;
+    }
     layerRef.current = polygonLayer;
     applyAirspaceGroupOpacity(
       polygonLayer,
@@ -190,6 +236,10 @@ export default function AirspaceLayer({
       interiorHatchesRef.current = [];
       safeRemoveFromMap(polygonLayer, map);
       layerRef.current = null;
+      paneElement?.removeEventListener(
+        usePointerEvents ? "pointerup" : "touchend",
+        handleNativeAirspacePointer as EventListener,
+      );
     };
   }, [map, features, selectableAirspaceIdSet, showBoundaryLabels]);
 
@@ -381,134 +431,23 @@ function getAirspaceFeatureLayers(layerGroup: L.GeoJSON) {
   return layers;
 }
 
+function resolveAirspaceLatLngFromClientPoint(
+  map: L.Map,
+  point?: { x: number; y: number } | null,
+) {
+  if (!point || typeof map.containerPointToLatLng !== "function") return null;
+  const container = map.getContainer?.();
+  const rect = container?.getBoundingClientRect?.();
+  if (!rect) return null;
+  return map.containerPointToLatLng(L.point(point.x - rect.left, point.y - rect.top));
+}
+
 function setAirspaceLayerDomMetadata(layer: any, airspaceId: string) {
   const path = typeof layer?.getElement === "function"
     ? layer.getElement()
     : null;
   if (!path || !airspaceId) return;
   path.dataset.airspaceFeatureId = airspaceId;
-}
-
-function resolveClickedAirspaceId({
-  clientPoint,
-  features,
-  latlng,
-  clickedId,
-  selectableAirspaceIds,
-  selectedAirspaceId,
-}: {
-  clientPoint?: { x: number; y: number } | null;
-  features: Record<string, any>[];
-  latlng?: L.LatLng | null;
-  clickedId: string;
-  selectableAirspaceIds: Set<string>;
-  selectedAirspaceId: string;
-}) {
-  const allAirspacesSelectable = selectableAirspaceIds.size === 0;
-  const isSelectable = (id: string) =>
-    Boolean(id) && (allAirspacesSelectable || selectableAirspaceIds.has(id));
-  const overlappingIds = uniqueStrings([
-    ...airspaceFeatureIdsAtClientPoint(clientPoint),
-    ...airspaceFeatureIdsAtLatLng(features, latlng),
-  ]);
-
-  if (!isSelectable(clickedId)) {
-    return overlappingIds.find(isSelectable) || "";
-  }
-
-  if (!selectedAirspaceId || clickedId !== selectedAirspaceId) {
-    return clickedId;
-  }
-  const nextId = overlappingIds.find((id) => id !== selectedAirspaceId && isSelectable(id));
-  if (nextId) return nextId;
-  const hasOverlappingAirspace = overlappingIds.some((id) => id !== selectedAirspaceId);
-  return hasOverlappingAirspace ? "" : selectedAirspaceId;
-}
-
-function resolveAirspaceClickClientPoint(event?: Event | null) {
-  const pointer = event as MouseEvent | undefined;
-  const x = Number(pointer?.clientX);
-  const y = Number(pointer?.clientY);
-  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
-  return { x, y };
-}
-
-function airspaceFeatureIdsAtClientPoint(point?: { x: number; y: number } | null) {
-  const x = Number(point?.x);
-  const y = Number(point?.y);
-  if (!Number.isFinite(x) || !Number.isFinite(y)) return [];
-  return uniqueStrings(
-    airspaceClientPointSamples(x, y).flatMap((sample) =>
-      document
-        .elementsFromPoint(sample.x, sample.y)
-        .map((element) => element.getAttribute?.("data-airspace-feature-id") || "")
-        .filter(Boolean),
-    ),
-  );
-}
-
-function uniqueStrings(values: string[]) {
-  return Array.from(new Set(values));
-}
-
-function airspaceClientPointSamples(x: number, y: number) {
-  const radius = 12;
-  return [
-    { x, y },
-    { x: x - radius, y },
-    { x: x + radius, y },
-    { x, y: y - radius },
-    { x, y: y + radius },
-    { x: x - radius, y: y - radius },
-    { x: x + radius, y: y - radius },
-    { x: x - radius, y: y + radius },
-    { x: x + radius, y: y + radius },
-  ];
-}
-
-function airspaceFeatureIdsAtLatLng(
-  features: Record<string, any>[],
-  latlng?: L.LatLng | null,
-) {
-  const lat = Number(latlng?.lat);
-  const lng = Number(latlng?.lng);
-  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return [];
-  const point = [lng, lat];
-  return features
-    .filter((feature) => pointInGeoJsonGeometry(point, feature?.geometry))
-    .map((feature) => String(feature?.properties?.id || ""))
-    .filter(Boolean)
-    .reverse();
-}
-
-function pointInGeoJsonGeometry(point: number[], geometry: Record<string, any> = {}) {
-  if (geometry.type === "Polygon") {
-    return pointInPolygon(point, geometry.coordinates);
-  }
-  if (geometry.type === "MultiPolygon") {
-    return Array.isArray(geometry.coordinates) &&
-      geometry.coordinates.some((polygon: number[][][]) =>
-        pointInPolygon(point, polygon),
-      );
-  }
-  return false;
-}
-
-function pointInPolygon(point: number[], rings: number[][][] = []) {
-  if (!rings.length || !pointInRing(point, rings[0])) return false;
-  return !rings.slice(1).some((ring) => pointInRing(point, ring));
-}
-
-function pointInRing([x, y]: number[], ring: number[][] = []) {
-  let inside = false;
-  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
-    const [xi, yi] = ring[i];
-    const [xj, yj] = ring[j];
-    const intersects =
-      yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
-    if (intersects) inside = !inside;
-  }
-  return inside;
 }
 
 function groupLabelsByLayerIndex<T extends SVGElement>(elements: T[]) {

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { formatFlightTelemetryMetric } from "@/features/aircraft/tracking/flightTelemetryDisplayModel";
+import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplayModel";
 
 // Tiny self-contained <img> that hides itself if the URL 404s. Avoids
 // stamped broken-image icons in dense list rows when the logo isn't
@@ -48,6 +49,7 @@ export default function AircraftRow({
     routeMunicipalities && routeMunicipalities !== route,
   );
   const distValue = toNumber(aircraft.distanceNm);
+  const distanceDisplay = formatNearbyDistanceDisplay(distValue);
   const altitudeDisplay = formatFlightTelemetryMetric({
     metric: "altitude",
     value: aircraft.altitude,
@@ -76,13 +78,12 @@ export default function AircraftRow({
         hasRouteMunicipalities={hasRouteMunicipalities}
       />
       <div className="aircraft-table-cell aircraft-table-cell--distance text-right font-mono text-[12px] font-semibold text-atc-text">
-        {distValue == null ? (
+        {!distanceDisplay ? (
           <span>-</span>
         ) : (
           <NumberWithUnit
-            value={distValue}
-            unit="NM"
-            format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
+            value={distanceDisplay.value}
+            unit={distanceDisplay.unit}
           />
         )}
       </div>

--- a/src/components/sidebar/AirportRow.tsx
+++ b/src/components/sidebar/AirportRow.tsx
@@ -3,6 +3,7 @@
 import { TowerControl } from "lucide-react";
 import NumberFlow from "@number-flow/react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplayModel";
 import { airportCityName, airportDisplayName } from "@/utils/airport";
 import { countryName } from "@/utils/flag";
 
@@ -26,6 +27,7 @@ export default function AirportRow({
     [city, country].filter(Boolean).join(", ") ||
     airportDisplayName(airport, locale);
   const dist = toFiniteNumber(airport?.distanceNm);
+  const distanceDisplay = formatNearbyDistanceDisplay(dist);
   const elevation = toFiniteNumber(airport?.elevationFt);
   const endpointRole = normalizeEndpointRole(airport?.routeEndpointRole);
   const endpointLabel = endpointRole
@@ -60,16 +62,10 @@ export default function AirportRow({
         ) : null}
       </div>
       <div className="aircraft-table-cell aircraft-table-cell--distance text-right font-mono text-[12px] font-semibold text-atc-text">
-        {dist == null ? (
+        {!distanceDisplay ? (
           <span>—</span>
-        ) : endpointRole ? (
-          <StaticNumberWithUnit value={Math.round(dist)} unit="NM" />
         ) : (
-          <NumberWithUnit
-            value={dist}
-            unit="NM"
-            format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
-          />
+          <NumberWithUnit value={distanceDisplay.value} unit={distanceDisplay.unit} />
         )}
       </div>
       <div className="aircraft-table-cell aircraft-table-cell--altitude text-right font-mono text-[12px] font-semibold text-atc-text">
@@ -97,22 +93,6 @@ function NumberWithUnit({ value, unit, format }: Record<string, any>) {
         format={format}
         className="block min-w-0 text-right"
       />
-      <sub
-        className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] font-semibold leading-none text-atc-dim"
-        translate="no"
-      >
-        {unit}
-      </sub>
-    </span>
-  );
-}
-
-function StaticNumberWithUnit({ value, unit }: Record<string, any>) {
-  return (
-    <span className="grid w-full grid-cols-[minmax(0,1fr)_var(--aircraft-table-unit-width,14px)] items-baseline gap-x-0.5 tabular-nums">
-      <span className="block min-w-0 text-right">
-        {value}
-      </span>
       <sub
         className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] font-semibold leading-none text-atc-dim"
         translate="no"

--- a/src/features/airport/map/airspaceSelectionModel.test.ts
+++ b/src/features/airport/map/airspaceSelectionModel.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+
+import {
+  resolveAirspaceClientPoint,
+  resolveClickedAirspaceId,
+} from "./airspaceSelectionModel";
+
+const baseFeature = {
+  type: "Feature",
+  properties: { id: "base" },
+  geometry: {
+    type: "Polygon",
+    coordinates: [[
+      [-72, 42],
+      [-70, 42],
+      [-70, 44],
+      [-72, 44],
+      [-72, 42],
+    ]],
+  },
+};
+
+const innerFeature = {
+  type: "Feature",
+  properties: { id: "inner" },
+  geometry: {
+    type: "Polygon",
+    coordinates: [[
+      [-71.5, 42.5],
+      [-70.5, 42.5],
+      [-70.5, 43.5],
+      [-71.5, 43.5],
+      [-71.5, 42.5],
+    ]],
+  },
+};
+
+{
+  const point = resolveAirspaceClientPoint({
+    changedTouches: [{ clientX: 41, clientY: 72 }],
+  });
+
+  assert.deepEqual(point, { x: 41, y: 72 });
+}
+
+{
+  const point = resolveAirspaceClientPoint({
+    clientX: 120,
+    clientY: 240,
+  });
+
+  assert.deepEqual(point, { x: 120, y: 240 });
+}
+
+{
+  const id = resolveClickedAirspaceId({
+    hitIds: [],
+    features: [baseFeature, innerFeature],
+    latlng: { lat: 43, lng: -71 },
+    clickedId: "",
+    selectableAirspaceIds: new Set(["base", "inner"]),
+    selectedAirspaceId: "",
+  });
+
+  assert.equal(id, "inner");
+}
+
+console.log("airspaceSelectionModel.test.ts ok");

--- a/src/features/airport/map/airspaceSelectionModel.ts
+++ b/src/features/airport/map/airspaceSelectionModel.ts
@@ -1,0 +1,155 @@
+type ClientPoint = {
+  x: number;
+  y: number;
+};
+
+type LatLngLike = {
+  lat?: unknown;
+  lng?: unknown;
+};
+
+type TouchLike = {
+  clientX?: unknown;
+  clientY?: unknown;
+};
+
+type PointerLike = TouchLike & {
+  changedTouches?: ArrayLike<TouchLike>;
+  touches?: ArrayLike<TouchLike>;
+};
+
+export function resolveAirspaceClientPoint(event?: PointerLike | null): ClientPoint | null {
+  const directPoint = toClientPoint(event);
+  if (directPoint) return directPoint;
+
+  const changedTouch = event?.changedTouches?.[0];
+  const changedPoint = toClientPoint(changedTouch);
+  if (changedPoint) return changedPoint;
+
+  return toClientPoint(event?.touches?.[0]);
+}
+
+export function resolveClickedAirspaceId({
+  hitIds = [],
+  features = [],
+  latlng = null,
+  clickedId = "",
+  selectableAirspaceIds = new Set<string>(),
+  selectedAirspaceId = "",
+}: {
+  hitIds?: string[];
+  features?: Record<string, any>[];
+  latlng?: LatLngLike | null;
+  clickedId?: string;
+  selectableAirspaceIds?: Set<string>;
+  selectedAirspaceId?: string;
+}) {
+  const allAirspacesSelectable = selectableAirspaceIds.size === 0;
+  const isSelectable = (id: string) =>
+    Boolean(id) && (allAirspacesSelectable || selectableAirspaceIds.has(id));
+  const overlappingIds = uniqueStrings([
+    ...hitIds,
+    ...airspaceFeatureIdsAtLatLng(features, latlng),
+  ]);
+  const normalizedClickedId = String(clickedId || "");
+
+  if (!isSelectable(normalizedClickedId)) {
+    return overlappingIds.find(isSelectable) || "";
+  }
+
+  if (!selectedAirspaceId || normalizedClickedId !== selectedAirspaceId) {
+    return normalizedClickedId;
+  }
+  const nextId = overlappingIds.find((id) => id !== selectedAirspaceId && isSelectable(id));
+  if (nextId) return nextId;
+  const hasOverlappingAirspace = overlappingIds.some((id) => id !== selectedAirspaceId);
+  return hasOverlappingAirspace ? "" : selectedAirspaceId;
+}
+
+export function airspaceFeatureIdsAtClientPoint(
+  point?: ClientPoint | null,
+  root: Document = document,
+) {
+  const x = Number(point?.x);
+  const y = Number(point?.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return [];
+  return uniqueStrings(
+    airspaceClientPointSamples(x, y).flatMap((sample) =>
+      root
+        .elementsFromPoint(sample.x, sample.y)
+        .map((element) => element.getAttribute?.("data-airspace-feature-id") || "")
+        .filter(Boolean),
+    ),
+  );
+}
+
+function toClientPoint(value?: TouchLike | null): ClientPoint | null {
+  const x = Number(value?.clientX);
+  const y = Number(value?.clientY);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return { x, y };
+}
+
+function uniqueStrings(values: string[]) {
+  return Array.from(new Set(values));
+}
+
+function airspaceClientPointSamples(x: number, y: number) {
+  const radius = 12;
+  return [
+    { x, y },
+    { x: x - radius, y },
+    { x: x + radius, y },
+    { x, y: y - radius },
+    { x, y: y + radius },
+    { x: x - radius, y: y - radius },
+    { x: x + radius, y: y - radius },
+    { x: x - radius, y: y + radius },
+    { x: x + radius, y: y + radius },
+  ];
+}
+
+function airspaceFeatureIdsAtLatLng(
+  features: Record<string, any>[],
+  latlng?: LatLngLike | null,
+) {
+  const lat = Number(latlng?.lat);
+  const lng = Number(latlng?.lng);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return [];
+  const point = [lng, lat];
+  return features
+    .filter((feature) => pointInGeoJsonGeometry(point, feature?.geometry))
+    .map((feature) => String(feature?.properties?.id || ""))
+    .filter(Boolean)
+    .reverse();
+}
+
+function pointInGeoJsonGeometry(point: number[], geometry: Record<string, any> = {}) {
+  if (geometry.type === "Polygon") {
+    return pointInPolygon(point, geometry.coordinates);
+  }
+  if (geometry.type === "MultiPolygon") {
+    return Array.isArray(geometry.coordinates) &&
+      geometry.coordinates.some((polygon: number[][][]) =>
+        pointInPolygon(point, polygon),
+      );
+  }
+  return false;
+}
+
+function pointInPolygon(point: number[], rings: number[][][] = []) {
+  if (!rings.length || !pointInRing(point, rings[0])) return false;
+  return !rings.slice(1).some((ring) => pointInRing(point, ring));
+}
+
+function pointInRing([x, y]: number[], ring: number[][] = []) {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    const intersects =
+      yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}

--- a/src/features/aviation/distanceDisplayModel.test.ts
+++ b/src/features/aviation/distanceDisplayModel.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+
+import { formatNearbyDistanceDisplay } from "./distanceDisplayModel";
+
+{
+  const display = formatNearbyDistanceDisplay(9.3);
+
+  assert.deepEqual(display, {
+    value: 9,
+    unit: "NM",
+  });
+}
+
+{
+  assert.equal(formatNearbyDistanceDisplay(null), null);
+  assert.equal(formatNearbyDistanceDisplay("not-a-number"), null);
+}
+
+console.log("distanceDisplayModel.test.ts ok");

--- a/src/features/aviation/distanceDisplayModel.ts
+++ b/src/features/aviation/distanceDisplayModel.ts
@@ -1,0 +1,9 @@
+export function formatNearbyDistanceDisplay(distanceNm: unknown) {
+  if (distanceNm == null || distanceNm === "") return null;
+  const distance = Number(distanceNm);
+  if (!Number.isFinite(distance)) return null;
+  return {
+    value: Math.max(0, Math.round(distance)),
+    unit: "NM",
+  };
+}

--- a/src/features/aviation/flight-routes/flightRouteArcModel.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteArcModel.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { ROUTE_PROVIDER } from "../sourceDisplayModel";
 import {
   buildFlightAwareRouteArcPath,
+  resolveFocusedFlightAwareRouteArcPath,
   shouldShowFlightAwareRouteArc,
 } from "./flightRouteArcModel";
 
@@ -65,6 +66,25 @@ const flightAwareRoute = {
     }),
     true,
   );
+}
+
+{
+  const selectedRoute = {
+    source: "flightaware",
+    origin: { icao: "KJFK", lat: 40.6413, lon: -73.7781 },
+    destination: { icao: "RJTT", lat: 35.5494, lon: 139.7798 },
+  };
+  const path = resolveFocusedFlightAwareRouteArcPath({
+    selectedAircraft: { callsign: "JAL5", flightRoute: selectedRoute },
+    focalAircraft: { callsign: "AAL100", flightRoute: flightAwareRoute },
+    routeProvider: ROUTE_PROVIDER.FLIGHTAWARE,
+    routeEndpointAirportsOnly: true,
+    from: { lat: 40.71, lon: -73.9 },
+    segments: 8,
+  });
+
+  assert.equal(path.length, 9);
+  assert.deepEqual(path.at(-1), [35.5494, 139.7798]);
 }
 
 console.log("flightRouteArcModel.test.ts ok");

--- a/src/features/aviation/flight-routes/flightRouteArcModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteArcModel.ts
@@ -53,3 +53,28 @@ export function buildFlightAwareRouteArcPath({
     segments,
   });
 }
+
+export function resolveFocusedFlightAwareRouteArcPath({
+  selectedAircraft = null,
+  focalAircraft = null,
+  routeProvider = "",
+  routeEndpointAirportsOnly = false,
+  from = null,
+  segments = 32,
+}: {
+  selectedAircraft?: Record<string, any> | null;
+  focalAircraft?: Record<string, any> | null;
+  routeProvider?: unknown;
+  routeEndpointAirportsOnly?: unknown;
+  from?: Record<string, any> | null;
+  segments?: unknown;
+} = {}) {
+  const route = selectedAircraft?.flightRoute || focalAircraft?.flightRoute || null;
+  return buildFlightAwareRouteArcPath({
+    route,
+    routeProvider,
+    routeEndpointAirportsOnly,
+    from,
+    segments,
+  });
+}


### PR DESCRIPTION
## Summary
- restore mobile airspace selection by adding native pointer/touch hit testing around the Leaflet airspace layer
- show nearby list distances as rounded integer NM values across aircraft and airport rows
- prefer the focused/selected aircraft route when deciding whether to render the FlightAware route arc

## Validation
- /opt/homebrew/bin/pnpm test
- /opt/homebrew/bin/pnpm lint (0 errors; existing VirtualNearbyList TanStack Virtual React Compiler warning remains)
- /opt/homebrew/bin/pnpm build
- Browser local: http://localhost:3000/airport/KBOS at 390x844, tapped an airspace and saw BOSTON CLASS B AREA A preview
- Browser local: http://localhost:3000/airport/KBOS at 1280x820, nearby list showed integer NM distances and no decimal NM values