### PR TITLE
Fix airspace taps and source labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ the full validation decision tree there; do not duplicate it in this file.
   preview URL generated for that PR as the verification target.
 - For FlightAware-related features, merge the work and verify with Chrome,
   because the flow depends on Clerk login state.
+- For UI-only changes, do not use test-driven development. If a skill says to
+  write failing tests first for a UI change, ignore that part of the skill:
+  validate small UI changes locally in the browser, and for larger UI changes
+  push a PR first and verify against the Vercel preview URL.
 - When developing new features or patches, do not preserve backward
   compatibility. Prefer the new pattern working correctly, even if it requires
   a breaking change, and do not prioritize tests over that goal.

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -322,8 +322,8 @@ export default function AirportMap({
     });
   }, [airspaces, contextTileOverlays, contextTiles.airspaces]);
   const selectableAirspaceIds = useMemo(
-    () => airspaces.map((item) => String(item?.id || "")).filter(Boolean),
-    [airspaces],
+    () => renderedAirspaces.map((item) => String(item?.id || "")).filter(Boolean),
+    [renderedAirspaces],
   );
   const renderedNavaids = useMemo(() => {
     if (!contextTileOverlays) return nearbyNavaids;

--- a/src/components/map/AirspaceLayer.tsx
+++ b/src/components/map/AirspaceLayer.tsx
@@ -129,10 +129,11 @@ export default function AirspaceLayer({
       onSelectRef.current?.(id);
     };
     const usePointerEvents = typeof window.PointerEvent !== "undefined";
+    const nativeAirspacePointerOptions = { passive: false, capture: true };
     paneElement?.addEventListener(
       usePointerEvents ? "pointerup" : "touchend",
       handleNativeAirspacePointer as EventListener,
-      { passive: false },
+      nativeAirspacePointerOptions,
     );
     const polygonLayer = L.geoJSON(features as any, {
       interactive: Boolean(onSelectRef.current),
@@ -174,6 +175,7 @@ export default function AirspaceLayer({
       paneElement?.removeEventListener(
         usePointerEvents ? "pointerup" : "touchend",
         handleNativeAirspacePointer as EventListener,
+        nativeAirspacePointerOptions,
       );
       return undefined;
     }
@@ -239,6 +241,7 @@ export default function AirspaceLayer({
       paneElement?.removeEventListener(
         usePointerEvents ? "pointerup" : "touchend",
         handleNativeAirspacePointer as EventListener,
+        nativeAirspacePointerOptions,
       );
     };
   }, [map, features, selectableAirspaceIdSet, showBoundaryLabels]);

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -20,7 +20,7 @@ const mapCornerClassName = cn(
 
 const lineClassName = cn(
   "flex w-full min-w-0 flex-wrap items-center justify-end gap-[7px]",
-  "text-[10px] font-semibold leading-none text-atc-dim uppercase",
+  "text-[10px] font-semibold leading-none text-atc-dim",
   "[.airport-map-kit_&]:gap-[5px] [.airport-map-kit_&]:text-[8px]",
   "[.airport-map-menu--mobile_&]:justify-center [.airport-map-menu--mobile_&]:gap-1.5",
   "[.airport-map-menu--mobile_&]:text-center [.airport-map-menu--mobile_&]:text-[9px]",

--- a/src/features/aviation/flight-routes/flightRouteArcModel.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteArcModel.test.ts
@@ -84,7 +84,7 @@ const flightAwareRoute = {
   });
 
   assert.equal(path.length, 9);
-  assert.deepEqual(path.at(-1), [35.5494, 139.7798]);
+  assert.deepEqual(path.at(-1), [25.2532, 55.3657]);
 }
 
 console.log("flightRouteArcModel.test.ts ok");

--- a/src/features/aviation/flight-routes/flightRouteArcModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteArcModel.ts
@@ -69,7 +69,7 @@ export function resolveFocusedFlightAwareRouteArcPath({
   from?: Record<string, any> | null;
   segments?: unknown;
 } = {}) {
-  const route = selectedAircraft?.flightRoute || focalAircraft?.flightRoute || null;
+  const route = focalAircraft?.flightRoute || selectedAircraft?.flightRoute || null;
   return buildFlightAwareRouteArcPath({
     route,
     routeProvider,

--- a/src/features/aviation/sourceDisplayModel.test.ts
+++ b/src/features/aviation/sourceDisplayModel.test.ts
@@ -9,15 +9,15 @@ import {
 
 assert.equal(
   getAircraftPositionSourceBadge({ source: "adsb_lol", kind: "observed" }),
-  "ADS-B",
+  "ads-b",
 );
 assert.equal(
   getAircraftPositionSourceBadge({ source: "airplanes_live", kind: "observed" }),
-  "Airplanes.live",
+  "ads-b",
 );
 assert.equal(
   getAircraftPositionSourceBadge({ source: "adsb_fi", kind: "observed" }),
-  "adsb.fi",
+  "ads-b",
 );
 assert.equal(
   getAircraftPositionSourceBadge({
@@ -29,14 +29,14 @@ assert.equal(
 );
 assert.equal(
   getAircraftPositionSourceBadge({ source: "flightaware", kind: "estimated" }),
-  "FlightAware · estimated",
+  "flightaware",
 );
 assert.equal(
   getAircraftPositionSourceBadge({
     flight_position_source: "flightaware",
     isEstimated: true,
   }),
-  "FlightAware · estimated",
+  "flightaware",
 );
 assert.equal(
   getAircraftPositionSourceBadge({ flight_position_source: "mlat" }),
@@ -66,8 +66,8 @@ assert.deepEqual(
     routeProvider: ROUTE_PROVIDER.FLIGHTAWARE,
   }),
   {
-    feedSource: "AIRPLANES.LIVE",
-    routeProvider: "FLIGHTAWARE",
+    feedSource: "ads-b",
+    routeProvider: "flightaware",
   },
 );
 
@@ -77,8 +77,8 @@ assert.deepEqual(
     routeProvider: ROUTE_PROVIDER.ADSBDB,
   }),
   {
-    feedSource: "CUSTOM-FEED",
-    routeProvider: "ADSBDB",
+    feedSource: "custom-feed",
+    routeProvider: "adsbdb",
   },
 );
 

--- a/src/features/aviation/sourceDisplayModel.ts
+++ b/src/features/aviation/sourceDisplayModel.ts
@@ -17,22 +17,26 @@ const DATA_SOURCE_LABELS = Object.freeze({
   [DATA_SOURCE.AIRPLANES_LIVE]: "airplanes.live",
   [DATA_SOURCE.ADSB_FI]: "adsb.fi",
   [DATA_SOURCE.ADSBDB]: "adsbdb",
-  [DATA_SOURCE.FLIGHTAWARE]: "FlightAware",
+  [DATA_SOURCE.FLIGHTAWARE]: "flightaware",
   [DATA_SOURCE.COMMUNITY_FEEDBACK]: "Community",
 });
 
+const AIRCRAFT_LOCATION_PROVIDER_LABELS = Object.freeze({
+  adsb: "ads-b",
+  adsb_lol: "ads-b",
+  [DATA_SOURCE.ADSB_LOL]: "ads-b",
+  airplanes_live: "ads-b",
+  [DATA_SOURCE.AIRPLANES_LIVE]: "ads-b",
+  adsb_fi: "ads-b",
+  [DATA_SOURCE.ADSB_FI]: "ads-b",
+  flightaware: "flightaware",
+});
+
 const AIRCRAFT_POSITION_SOURCE_LABELS = Object.freeze({
-  adsb: "ADS-B",
+  ...AIRCRAFT_LOCATION_PROVIDER_LABELS,
   adsc: "ADS-C",
   mlat: "MLAT",
   estimated: "Estimated",
-  adsb_lol: "ADS-B",
-  [DATA_SOURCE.ADSB_LOL]: "ADS-B",
-  airplanes_live: "Airplanes.live",
-  [DATA_SOURCE.AIRPLANES_LIVE]: "Airplanes.live",
-  adsb_fi: "adsb.fi",
-  [DATA_SOURCE.ADSB_FI]: "adsb.fi",
-  flightaware: "FlightAware",
   local_projection: "Local projection",
   unknown: "",
 });
@@ -56,6 +60,12 @@ function getRouteProviderDisplayName(provider) {
   const raw = String(provider || "").trim();
   if (!raw) return "";
   return ROUTE_PROVIDER_LABELS[normalizeKey(raw)] || raw;
+}
+
+function getAircraftLocationProviderDisplayName(source) {
+  const raw = String(source || "").trim();
+  if (!raw) return "";
+  return AIRCRAFT_LOCATION_PROVIDER_LABELS[normalizeKey(raw)] || raw;
 }
 
 export function resolveRouteProvider({ flightAwareEnabled = false } = {}) {
@@ -100,21 +110,9 @@ export function getAircraftPositionSourceBadge(quality: Record<string, any> = {}
   const sourceLabel = AIRCRAFT_POSITION_SOURCE_LABELS[source] || "";
   if (source === "adsc" && kind === "oceanic") return "ADS-C · oceanic";
   if (!sourceLabel) return kind === "stale" ? "Stale" : "";
-  if (kind === "stale") return sourceLabel === "FlightAware" ? "FlightAware · stale" : "Stale";
-  if (
-    source === "flightaware" &&
-    (quality?.isEstimated === true ||
-      kind === "estimated" ||
-      kind === "predicted" ||
-      kind === "interpolated")
-  ) {
-    return `${sourceLabel} · ${kind || "estimated"}`;
-  }
+  if (source === "flightaware") return sourceLabel;
+  if (kind === "stale") return "Stale";
   return sourceLabel;
-}
-
-function badgeText(value) {
-  return String(value || "").trim().toUpperCase();
 }
 
 export function buildMapSourceStatusDisplay({
@@ -122,7 +120,7 @@ export function buildMapSourceStatusDisplay({
   routeProvider = "",
 } = {}) {
   return {
-    feedSource: badgeText(getDataSourceDisplayName(feedSource)),
-    routeProvider: badgeText(getRouteProviderDisplayName(routeProvider)),
+    feedSource: getAircraftLocationProviderDisplayName(feedSource),
+    routeProvider: getRouteProviderDisplayName(routeProvider),
   };
 }


### PR DESCRIPTION
## Summary
- Make mobile airspace touch fallback listen in capture phase and allow every rendered airspace to be selectable.
- Prefer the focused/tracked aircraft route when drawing the FlightAware route arc.
- Normalize aircraft location provider labels across top status and aircraft labels: ADS-B feeds show `ads-b`, FlightAware positions show `flightaware`, including predicted positions.
- Update AGENTS.md with the UI-change validation/TDD rule requested in-thread.

## Validation
- `/opt/homebrew/bin/pnpm exec tsx src/features/aviation/sourceDisplayModel.test.ts`
- `/opt/homebrew/bin/pnpm exec tsx src/features/aviation/flight-routes/flightRouteArcModel.test.ts`
- `/opt/homebrew/bin/pnpm exec tsx src/features/aviation/distanceDisplayModel.test.ts`
- `/opt/homebrew/bin/pnpm exec tsx src/features/airport/map/airspaceSelectionModel.test.ts`
- `/opt/homebrew/bin/pnpm lint` (passes with existing TanStack Virtual React Compiler warning)
- `/opt/homebrew/bin/pnpm test`
- `/opt/homebrew/bin/pnpm build`
- Local browser: `http://localhost:3000/airport/KBOS` at 390x844, tapped an airspace and got the airspace preview.
- Local browser: `http://localhost:3000/aircraft/SWA1121`, focused aircraft label showed `ads-b`.
- Local browser: top map source status showed `ads-b` with `text-transform: none`.
