### PR TITLE
Refine nearby badge distance spacing

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -4219,8 +4219,11 @@ body {
 
 .airport-overlay-label__code-suffix {
     align-self: flex-end;
-    font-size: 0.82em;
-    margin-left: 2px;
+    font-size: 0.72em;
+    letter-spacing: 0.02em;
+    margin-left: 4px;
+    opacity: 0.78;
+    transform: translateY(-0.04em);
 }
 
 .airport-overlay-label--map-badge .airport-overlay-label__detail {


### PR DESCRIPTION
## Summary
- Make nearby airport badge distance suffix smaller and visually separated from the airport code.
- Verified the stale local CSS bundle was the reason navaid dots/leaders did not appear in the user screenshot; after `.next` reset, navaid dots and dashed leaders render correctly.

## Validation
- `/opt/homebrew/bin/pnpm lint` (passes with existing TanStack Virtual React Compiler warning)
- Local browser: `http://localhost:3000/airport/KBOS?locale=en`, checked navaid dot/leader DOM after `.next` reset.
- Local browser: nearby airport badge suffix now renders at 5.4px with 4px gap and 0.78 opacity.
