### PR TITLE
Refine map toolbar placement

### DIFF
--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -31,7 +31,7 @@ export default function MobilePreviewCard({
       data-ui="mobile-preview-card"
       className={cn(
         "fixed left-1/2 z-popover",
-        "bottom-[calc(64px+env(safe-area-inset-bottom))]",
+        "top-[calc(12px+env(safe-area-inset-top))]",
         "w-[min(342px,calc(100vw-24px))] max-w-[calc(100vw-24px)]",
         "isolate overflow-hidden select-none pointer-events-none",
         "app-preview-transition mobile-preview-card-enter",

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -47,6 +47,7 @@ export default function ExplorerMapMenu({
       }`}
     >
       <MapControlBar
+        menuPlacement={isMobile ? "top" : "bottom"}
         activeZoom={mapZoom}
         zoomActive={mapFollowsAircraft}
         zoomDisabled={zoomDisabled}

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -13,6 +13,7 @@ const mapCornerClassName = cn(
   "[.airport-map-kit_&]:right-0.5 [.airport-map-kit_&]:top-[calc(100%+10px)]",
   "md:[.airport-map-kit_&]:top-[calc(100%+8px)]",
   "[.airport-map-menu--mobile_&]:left-1/2 [.airport-map-menu--mobile_&]:right-auto [.airport-map-menu--mobile_&]:top-[calc(100%+7px)]",
+  "[.airport-map-menu--mobile_&]:bottom-[calc(100%+7px)] [.airport-map-menu--mobile_&]:top-auto",
   "[.airport-map-menu--mobile_&]:max-w-[min(288px,calc(100vw-32px))] [.airport-map-menu--mobile_&]:-translate-x-1/2",
   "[.airport-map-menu--mobile_&]:items-center [.airport-map-menu--mobile_&]:text-center",
   "[.airport-map-menu--mobile_&]:[filter:drop-shadow(0_7px_11px_color-mix(in_oklab,var(--atc-bg)_72%,transparent))_drop-shadow(0_1px_1px_color-mix(in_oklab,var(--atc-text)_24%,transparent))]",

--- a/src/components/map/controls/MapControlRail.tsx
+++ b/src/components/map/controls/MapControlRail.tsx
@@ -22,6 +22,7 @@ const RAIL_BUTTON_CLASS = toolbarButtonVariants({ tone: "rail" });
 
 
 export default function MapControlRail({
+  menuPlacement = "bottom",
   currentZoomOption,
   zoomActive = true,
   zoomDisabled = false,
@@ -86,7 +87,7 @@ export default function MapControlRail({
 
       <LanguageSwitch
         className={RAIL_BUTTON_CLASS}
-        menuPlacement="bottom"
+        menuPlacement={menuPlacement}
         menuAlign="center"
       />
 
@@ -97,7 +98,7 @@ export default function MapControlRail({
         title={themeTitle}
         onClick={onCycleTheme}
         onSelectTheme={onSelectTheme}
-        menuPlacement="bottom"
+        menuPlacement={menuPlacement}
         menuAlign="center"
       />
 

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -58,7 +58,7 @@ export default function SidebarViewSwitch({
         <SidebarMetricCard
           label={t("sidebar.atc")}
           value={<NumberFlow value={atcCount} />}
-          unit="FREQ"
+          unit={t("sidebar.metricUnits.frequency")}
           active={activeView === "atc"}
           onClick={() => onViewChange?.("atc")}
         />
@@ -66,7 +66,7 @@ export default function SidebarViewSwitch({
       <SidebarMetricCard
         label={t("sidebar.spotting")}
         value={<NumberFlow value={spottingCount} />}
-        unit="PHOTO"
+        unit={t("sidebar.metricUnits.spots")}
         active={activeView === "spotting"}
         onClick={onOpenSpotting}
       />
@@ -75,14 +75,14 @@ export default function SidebarViewSwitch({
           <SidebarMetricCard
             label={t("sidebar.departures")}
             value={<NumberFlow value={departureCount} />}
-            unit="OUT"
+            unit={t("sidebar.metricUnits.flights")}
             active={activeView === "departures"}
             onClick={() => onViewChange?.("departures")}
           />
           <SidebarMetricCard
             label={t("sidebar.arrivals")}
             value={<NumberFlow value={arrivalCount} />}
-            unit="IN"
+            unit={t("sidebar.metricUnits.flights")}
             active={activeView === "arrivals"}
             onClick={() => onViewChange?.("arrivals")}
           />

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -14,6 +14,7 @@ import { ZOOM_AIRPORT } from "../../utils/airportMapDisplay";
 const MAP_SETTINGS_SHEET_ID = "map-settings-sheet";
 
 export default function MapControlBar({
+  menuPlacement = "bottom",
   activeZoom = ZOOM_AIRPORT,
   zoomActive = true,
   zoomDisabled = false,
@@ -100,6 +101,7 @@ export default function MapControlBar({
       />
 
       <MapControlRail
+        menuPlacement={menuPlacement}
         currentZoomOption={currentZoomOption}
         zoomActive={zoomActive}
         zoomDisabled={zoomDisabled}

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -230,6 +230,11 @@ const en = {
     arrivals: "Arrivals",
     atc: "ATC",
     spotting: "Spotting",
+    metricUnits: {
+      flights: "flights",
+      frequency: "freq",
+      spots: "spots",
+    },
   },
   metrics: {
     speed: "Speed",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -225,6 +225,11 @@ const zhCN = {
     arrivals: "到达",
     atc: "ATC",
     spotting: "拍机点",
+    metricUnits: {
+      flights: "架次",
+      frequency: "频率",
+      spots: "位置",
+    },
   },
   metrics: {
     speed: "速度",

--- a/src/features/app-shell/i18n/i18nProvider.tsx
+++ b/src/features/app-shell/i18n/i18nProvider.tsx
@@ -87,7 +87,7 @@ export function I18nProvider({
   );
 
   return (
-    <NextIntlClientProvider key={locale} locale={locale} messages={messages}>
+    <NextIntlClientProvider locale={locale} messages={messages}>
       <I18nRuntimeContext.Provider value={runtime}>
         {children}
       </I18nRuntimeContext.Provider>

--- a/src/style.css
+++ b/src/style.css
@@ -212,7 +212,7 @@
 @keyframes mobile-preview-card-enter {
     from {
         opacity: 0;
-        transform: translate(-50%, 10px);
+        transform: translate(-50%, -10px);
     }
     to {
         opacity: 1;
@@ -335,8 +335,23 @@
     .map-settings-sheet,
     .map-settings-sheet-overlay {
         animation: none;
-        transform: none;
         transition: none;
+    }
+
+    .mobile-preview-card-enter {
+        transform: translateX(-50%);
+    }
+
+    .app-preview-transition:not(.mobile-preview-card-enter),
+    .nearby-row-enter,
+    .app-route-transition,
+    .app-panel-transition,
+    .app-list-motion > *,
+    .candidate-watching-spot-preview-motion,
+    .candidate-watching-spot-marker__shell,
+    .map-settings-sheet,
+    .map-settings-sheet-overlay {
+        transform: none;
     }
 }
 
@@ -6524,13 +6539,9 @@ body {
     background: transparent;
     border: 0;
     height: auto;
-    inset: var(--map-kit-inset) auto auto 50%;
+    inset: var(--map-kit-inset) var(--map-kit-inset) auto auto;
     padding: 0;
-    transform: translateX(-50%);
-}
-
-.airport-map-kit--sidebar-open .airport-map-menu {
-    left: calc(50% + ((var(--app-sidebar-width) + var(--map-kit-inset)) / 2));
+    transform: none;
 }
 
 .airport-map-kit .map-ctrl-zone {
@@ -6727,7 +6738,7 @@ body {
         display: flex;
         justify-content: center;
         height: auto;
-        inset: max(12px, env(safe-area-inset-top)) 0 auto;
+        inset: auto 0 max(12px, env(safe-area-inset-bottom));
         padding: 0 16px;
         pointer-events: none;
     }


### PR DESCRIPTION
## Summary
- Move the airport map toolbar to the desktop top-right and mobile bottom-center positions.
- Move mobile preview cards to the top-center and keep source status above the bottom toolbar.
- Preserve map mode state across locale switches by avoiding a full app remount when locale changes.
- Open map toolbar language/theme menus upward on mobile.

## Validation
- Local browser: `/airport/KBOS?locale=en` desktop toolbar right gap is 13px.
- Local browser mobile 390x844: toolbar bottom-centered, preview card top-centered, source status above toolbar.
- Local browser mobile: language and theme menus render above the bottom toolbar.
- Local browser: Radio mode stays selected and airspace remains off after switching locale from zh-CN to en.
- `pnpm lint` passes with the existing TanStack Virtual React Compiler warning in `VirtualNearbyList.tsx`.
- `pnpm build` passes.
