### PR TITLE
v1.13.0 — bottom-floating mobile toolbar and device-aware settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@ the full validation decision tree there; do not duplicate it in this file.
 
 - Before changing code or docs, read `CLAUDE.md` and choose the validation mode
   from its `Validation modes` section.
+- For ADSBao local development, follow `CLAUDE.md`'s dev-server lifecycle:
+  subagents should start and maintain the tmux-backed port 3000 process, and
+  should restart it with `.next` cleared when it breaks or serves stale CSS/JS.
 - For Vercel preview validation, push the work to a PR first, then use the
   preview URL generated for that PR as the verification target.
 - For FlightAware-related features, merge the work and verify with Chrome,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,11 @@ Frontend runs on `http://localhost:3000` by default.
 
 You are expected to keep one long-running `pnpm dev` process on port 3000 across the session. Pattern:
 
-1. **Before touching code**, check whether port 3000 is already serving by hitting `http://localhost:3000` (any 2xx/3xx counts). If it isn't, start the server in the background with the Bash tool's `run_in_background: true` and wait until it's ready (`curl -s -o /dev/null -w '%{http_code}' http://localhost:3000` returns `200`).
+1. **Before touching code**, check whether port 3000 is already serving by hitting `http://localhost:3000` (any 2xx/3xx counts). If it isn't, start and maintain the server yourself. In Codex, prefer a detached tmux session so subagents can keep the process alive without asking the user:
+   ```bash
+   tmux new-session -d -s adsbao-dev -c /Users/ruyyi/Devs/ADSBao '/opt/homebrew/bin/pnpm run dev'
+   ```
+   Then wait until ready (`curl -s -o /dev/null -w '%{http_code}' http://localhost:3000` returns `200`).
 2. **Adopt, don't fight, an existing dev server.** If port 3000 is already taken by a `pnpm dev` you started in a prior turn, just use it — don't kill it. Next.js + Turbopack HMR will pick up most edits.
 3. **Restart with cache clear when you spot stale-bundle symptoms**, even if you never see an error in the terminal. Symptoms that mean "Turbopack is serving old code":
    - DevTools shows both old + new class names in the same stylesheet after you renamed something.
@@ -28,13 +32,15 @@ You are expected to keep one long-running `pnpm dev` process on port 3000 across
    lsof -nP -iTCP:3000 -sTCP:LISTEN | awk 'NR>1 {print $2}' | xargs -r kill
    sleep 2
    rm -rf .next
-   pnpm dev   # use run_in_background: true
+   tmux kill-session -t adsbao-dev 2>/dev/null || true
+   tmux new-session -d -s adsbao-dev -c /Users/ruyyi/Devs/ADSBao '/opt/homebrew/bin/pnpm run dev'
    # then poll until ready:
    until curl -s -o /dev/null -w '%{http_code}' http://localhost:3000 | grep -q 200; do sleep 2; done
    ```
 
 4. **After the restart**, reload the page in chrome-devtools-mcp with `ignoreCache: true` before re-checking the broken behavior. Verify the source CSS file with `grep` first, then verify the served bundle (`curl /_next/static/chunks/*.css | grep <class>`) before going deeper into a debugging rabbit hole.
-5. Never `--turbopack`-disable or `next build` mid-session as a workaround — restarting with `.next` removed is the supported escape hatch and is fast enough on this project (< 10s to ready). Don't add `package.json` scripts for this; it's an operational habit, not a permanent build flag.
+5. Subagents working on ADSBao local development should own this lifecycle: start the tmux process when it is missing, restart it when it breaks, and do the `.next` reset themselves when CSS or JSX is stale. Do not wait for the user to explicitly ask for a dev-server restart.
+6. Never `--turbopack`-disable or `next build` mid-session as a workaround — restarting with `.next` removed is the supported escape hatch and is fast enough on this project (< 10s to ready). Don't add `package.json` scripts for this; it's an operational habit, not a permanent build flag.
 
 ## Stack
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/dao/userMapSettings.dao.test.ts
+++ b/src/app/api/dao/userMapSettings.dao.test.ts
@@ -93,7 +93,8 @@ function createFakeSupabaseClient({
   assert.ok(upsertCall, "repository should write a settings row");
   assert.equal(upsertCall.row.email, "owner@example.com");
   assert.equal(upsertCall.row.environment, "preview");
-  assert.deepEqual(upsertCall.options, { onConflict: "email,environment" });
+  assert.equal(upsertCall.row.device, "desktop");
+  assert.deepEqual(upsertCall.options, { onConflict: "email,environment,device" });
   assert.equal(upsertCall.row.has_selected_mode, true);
   assert.deepEqual(upsertCall.row.settings.layerOverrides, {
     [MAP_LAYER_KEYS.AIRSPACES]: true,
@@ -130,9 +131,10 @@ function createFakeSupabaseClient({
 
   assert.deepEqual(calls.slice(1), [
     { type: "from", table: USER_MAP_SETTINGS_TABLE },
-    { type: "select", columns: "email,environment,settings,has_selected_mode,updated_at" },
+    { type: "select", columns: "email,environment,device,settings,has_selected_mode,updated_at" },
     { type: "eq", column: "email", value: "owner@example.com" },
     { type: "eq", column: "environment", value: "production" },
+    { type: "eq", column: "device", value: "desktop" },
     { type: "maybeSingle" },
   ]);
   assert.equal(row.settings.selectedMode, MAP_MODE_IDS.CONTROLLER);
@@ -292,6 +294,48 @@ function createFakeSupabaseClient({
   assert.ok(upsertCall, "repository should migrate legacy immersive account settings");
   assert.equal(upsertCall.row.settings.selectedMode, MAP_MODE_IDS.CONTROLLER);
   assert.equal(upsertCall.row.settings.baseMode, MAP_MODE_IDS.CONTROLLER);
+}
+
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    writeData: {
+      email: "owner@example.com",
+      environment: "preview",
+      device: "mobile",
+      settings: {
+        selectedMode: MAP_MODE_IDS.RADIO,
+        baseMode: MAP_MODE_IDS.RADIO,
+        hasSelectedMode: true,
+      },
+      has_selected_mode: true,
+    },
+  });
+  const repository = createUserMapSettingsRepositoryFromEnv({
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SERVICE_ROLE_KEY: "sb_secret_test",
+      VERCEL_ENV: "preview",
+    },
+    createClientImpl,
+  });
+
+  const row = await repository.upsertSettingsByEmail({
+    email: "owner@example.com",
+    device: "mobile",
+    settings: {
+      selectedMode: MAP_MODE_IDS.RADIO,
+      baseMode: MAP_MODE_IDS.RADIO,
+      hasSelectedMode: true,
+    },
+  });
+
+  const deviceFilters = calls.filter(
+    (call) => call.type === "eq" && call.column === "device",
+  );
+  assert.deepEqual(deviceFilters.map((call) => call.value), ["mobile"]);
+  const upsertCall = calls.find((call) => call.type === "upsert");
+  assert.equal(upsertCall.row.device, "mobile");
+  assert.equal(row.device, "mobile");
 }
 
 console.log("userMapSettings.dao.test.ts ok");

--- a/src/app/api/dao/userMapSettings.dao.ts
+++ b/src/app/api/dao/userMapSettings.dao.ts
@@ -8,10 +8,11 @@ import {
   DEFAULT_MAP_SETTINGS,
   mergeMapSettings,
   normalizeMapSettings,
+  normalizeMapSettingsDevice,
 } from "../../../features/airport/map-settings/mapSettingsModel";
 
 const USER_MAP_SETTINGS_TABLE = "user_map_settings";
-const SELECT_COLUMNS = "email,environment,settings,has_selected_mode,updated_at";
+const SELECT_COLUMNS = "email,environment,device,settings,has_selected_mode,updated_at";
 
 type UserMapSettingsRecord = Record<string, any>;
 
@@ -36,12 +37,14 @@ function createUserMapSettingsRepository({
       const normalizedEnvironment = normalizeFeatureFlagEnvironment(
         options.environment || defaultEnvironment,
       );
+      const normalizedDevice = normalizeMapSettingsDevice(options.device);
 
       const { data, error } = await client
         .from(USER_MAP_SETTINGS_TABLE)
         .select(SELECT_COLUMNS)
         .eq("email", normalizedEmail)
         .eq("environment", normalizedEnvironment)
+        .eq("device", normalizedDevice)
         .maybeSingle();
 
       if (error && error.code !== "PGRST116") {
@@ -52,6 +55,7 @@ function createUserMapSettingsRepository({
       return {
         email: normalizeUserEmail(data.email),
         environment: normalizeFeatureFlagEnvironment(data.environment),
+        device: normalizeMapSettingsDevice(data.device),
         settings: normalizeMapSettings({
           ...data.settings,
           hasSelectedMode: data.has_selected_mode,
@@ -63,6 +67,7 @@ function createUserMapSettingsRepository({
     async upsertSettingsByEmail({
       email,
       environment,
+      device,
       settings,
     }: UserMapSettingsRecord = {}) {
       const normalizedEmail = normalizeUserEmail(email);
@@ -70,8 +75,10 @@ function createUserMapSettingsRepository({
       const normalizedEnvironment = normalizeFeatureFlagEnvironment(
         environment || defaultEnvironment,
       );
+      const normalizedDevice = normalizeMapSettingsDevice(device);
       const existingRow = await this.readSettingsByEmail(normalizedEmail, {
         environment: normalizedEnvironment,
+        device: normalizedDevice,
       });
       const normalizedSettings = mergeMapSettings({
         settings: existingRow?.settings || DEFAULT_MAP_SETTINGS,
@@ -85,6 +92,7 @@ function createUserMapSettingsRepository({
           {
             email: normalizedEmail,
             environment: normalizedEnvironment,
+            device: normalizedDevice,
             settings: {
               ...normalizedSettings,
               updatedAt,
@@ -92,7 +100,7 @@ function createUserMapSettingsRepository({
             has_selected_mode: normalizedSettings.hasSelectedMode === true,
             updated_at: updatedAt,
           },
-          { onConflict: "email,environment" },
+          { onConflict: "email,environment,device" },
         )
         .select(SELECT_COLUMNS)
         .single();
@@ -104,6 +112,7 @@ function createUserMapSettingsRepository({
       return {
         email: normalizeUserEmail(data.email),
         environment: normalizeFeatureFlagEnvironment(data.environment),
+        device: normalizeMapSettingsDevice(data.device),
         settings: normalizeMapSettings({
           ...data.settings,
           hasSelectedMode: data.has_selected_mode,

--- a/src/app/api/map-settings/route.ts
+++ b/src/app/api/map-settings/route.ts
@@ -4,15 +4,19 @@ import {
   persistMapSettingsForUser,
   resolveMapSettingsForUser,
 } from "@/features/airport/map-settings/userMapSettings.server";
+import { normalizeMapSettingsDevice } from "@/features/airport/map-settings/mapSettingsModel";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: Request) {
   const user = await currentUser();
-  const settings = await resolveMapSettingsForUser({ user });
+  const url = new URL(request.url);
+  const device = normalizeMapSettingsDevice(url.searchParams.get("device"));
+  const settings = await resolveMapSettingsForUser({ user, device });
 
   return Response.json(
     {
       signedIn: Boolean(user),
+      device,
       settings,
     },
     {
@@ -33,14 +37,17 @@ export async function PUT(request: Request) {
   }
 
   const body = await request.json().catch(() => ({}));
+  const device = normalizeMapSettingsDevice(body?.device);
   const settings = await persistMapSettingsForUser({
     user,
+    device,
     settings: body?.settings,
   });
 
   return Response.json(
     {
       signedIn: true,
+      device,
       settings,
     },
     {

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -441,6 +441,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     country: airportProfile.country,
     lat: airportProfile.lat,
     lon: airportProfile.lon,
+    elevationFt: airportProfile.elevationFt,
     metar: weather.metar,
     metarRaw: weather.metarRaw,
     metarLoading: weather.metarLoading,
@@ -526,6 +527,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             icao={airportProfile.icao}
             lat={airportProfile.lat}
             lon={airportProfile.lon}
+            airportElevationFt={airportProfile.elevationFt}
             zoom={mapZoom}
             aircraft={traffic.aircraft}
             nearbyAirports={nearbyAirports.airports}

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect } from "react";
 import BrandingVideoBackground from "@/components/effects/BrandingVideoBackground";
 import PageNavigationDock from "@/components/navigation/PageNavigationDock";
 import SidebarBrandMark from "@/components/sidebar/SidebarBrandMark";
@@ -21,42 +20,6 @@ export default function DitherPageShell({
     typeof resolvedDescription === "string"
       ? resolvedDescription.trim().length > 0
       : Boolean(resolvedDescription);
-
-  useEffect(() => {
-    const media = window.matchMedia("(max-width: 720px)");
-    let restore: (() => void) | null = null;
-
-    const applyDocumentScrollLock = () => {
-      restore?.();
-      restore = null;
-      if (!media.matches) return;
-
-      const originalBodyOverflow = document.body.style.overflow;
-      const originalHtmlOverflow = document.documentElement.style.overflow;
-      const originalBodyOverscroll = document.body.style.overscrollBehavior;
-      const originalHtmlOverscroll =
-        document.documentElement.style.overscrollBehavior;
-
-      document.body.style.overflow = "hidden";
-      document.documentElement.style.overflow = "hidden";
-      document.body.style.overscrollBehavior = "none";
-      document.documentElement.style.overscrollBehavior = "none";
-
-      restore = () => {
-        document.body.style.overflow = originalBodyOverflow;
-        document.documentElement.style.overflow = originalHtmlOverflow;
-        document.body.style.overscrollBehavior = originalBodyOverscroll;
-        document.documentElement.style.overscrollBehavior = originalHtmlOverscroll;
-      };
-    };
-
-    applyDocumentScrollLock();
-    media.addEventListener("change", applyDocumentScrollLock);
-    return () => {
-      media.removeEventListener("change", applyDocumentScrollLock);
-      restore?.();
-    };
-  }, []);
 
   return (
     <div

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -29,6 +29,7 @@ export default function ExplorerMapMenu({
     showAirspaces,
     showCandidateWatchingSpots,
     mapSettings,
+    mapSettingsDevice,
     mapSettingsSaveStatus,
     setMapZoom,
     applyMapMode,
@@ -57,6 +58,7 @@ export default function ExplorerMapMenu({
         showAirspaces={showAirspaces}
         showCandidateWatchingSpots={showCandidateWatchingSpots}
         mapSettings={mapSettings}
+        mapSettingsDevice={mapSettingsDevice}
         mapSettingsSaveStatus={mapSettingsSaveStatus}
         userLocationActive={userLocationActive}
         userLocationAudioActive={userLocationAudioActive}

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -15,6 +15,7 @@ import { AIRPORT_EXPLORER_UI_CONFIG } from "@/config/aviation";
 import { DEFAULT_AIRPORT_EXPLORER_UI_STATE } from "@/features/airport/explorer/airportExplorerUiModel";
 import {
   DEFAULT_MAP_SETTINGS,
+  MAP_SETTINGS_DEVICE_TYPES,
   MAP_LAYER_KEYS,
   buildCustomMapSettings,
   buildPresetMapSettings,
@@ -37,6 +38,11 @@ const ExplorerUiContext = createContext(null);
 const DEFAULT_MAP_LAYERS = mapSettingsToExplorerLayers(DEFAULT_MAP_SETTINGS);
 const DEFAULT_USER_LOCATION_PREFERENCES =
   mapSettingsToUserLocationPreferences(DEFAULT_MAP_SETTINGS);
+
+const mapSettingsDeviceForSidebarMode = (sidebarMode) =>
+  sidebarMode === "mobile"
+    ? MAP_SETTINGS_DEVICE_TYPES.MOBILE
+    : MAP_SETTINGS_DEVICE_TYPES.DESKTOP;
 
 const initialUiState = {
   ...DEFAULT_AIRPORT_EXPLORER_UI_STATE,
@@ -328,6 +334,7 @@ export function ExplorerUiProvider({ children }) {
     selectedCandidateWatchingSpotId,
   } = state;
   const isMobile = sidebarMode === "mobile";
+  const mapSettingsDevice = mapSettingsDeviceForSidebarMode(sidebarMode);
 
   useEffect(() => {
     const syncSidebarMode = () => {
@@ -350,12 +357,12 @@ export function ExplorerUiProvider({ children }) {
     const hydrateMapSettings = async () => {
       hasHydratedMapSettingsRef.current = false;
       setMapSettingsSaveStatus("idle");
-      const cachedSettings = readStoredMapSettings();
+      const cachedSettings = readStoredMapSettings(mapSettingsDevice);
       let userSettings = null;
 
       if (isSignedIn) {
         try {
-          const response = await fetch("/api/map-settings", {
+          const response = await fetch(`/api/map-settings?device=${mapSettingsDevice}`, {
             cache: "no-store",
           });
           if (response.ok) {
@@ -401,6 +408,7 @@ export function ExplorerUiProvider({ children }) {
   }, [
     isLoaded,
     isSignedIn,
+    mapSettingsDevice,
   ]);
 
   useEffect(() => {
@@ -415,7 +423,7 @@ export function ExplorerUiProvider({ children }) {
     if (serialized === persistedMapSettingsRef.current) return undefined;
 
     if (!isSignedIn) {
-      writeStoredMapSettings(nextSettings);
+      writeStoredMapSettings(nextSettings, mapSettingsDevice);
       persistedMapSettingsRef.current = serialized;
       return undefined;
     }
@@ -430,7 +438,7 @@ export function ExplorerUiProvider({ children }) {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ settings: nextSettings }),
+          body: JSON.stringify({ settings: nextSettings, device: mapSettingsDevice }),
           signal: controller.signal,
         });
         if (!response.ok) throw new Error("save failed");
@@ -463,6 +471,7 @@ export function ExplorerUiProvider({ children }) {
     isLoaded,
     isSignedIn,
     mapSettings,
+    mapSettingsDevice,
   ]);
 
   const toggleSidebar = useCallback(() => {
@@ -590,6 +599,7 @@ export function ExplorerUiProvider({ children }) {
       userLocationEnabled,
       userLocationAudioEnabled,
       mapSettings,
+      mapSettingsDevice,
       mapSettingsSaveStatus,
       trafficFilter,
       typeFilter,
@@ -641,6 +651,7 @@ export function ExplorerUiProvider({ children }) {
       userLocationEnabled,
       userLocationAudioEnabled,
       mapSettings,
+      mapSettingsDevice,
       mapSettingsSaveStatus,
       trafficFilter,
       typeFilter,

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -58,6 +58,7 @@ export default function AirportMap({
   icao = "",
   lat = null,
   lon = null,
+  airportElevationFt = null,
   zoom = 13,
   aircraft = [],
   nearbyAirports = [],
@@ -259,6 +260,7 @@ export default function AirportMap({
       // would silently hide the focal because it's "at the airport".
       airportLat: icao ? lat : null,
       airportLon: icao ? lon : null,
+      airportElevationFt: icao ? airportElevationFt : null,
       nearbyAirports,
       zoom,
     });
@@ -267,6 +269,7 @@ export default function AirportMap({
     icao,
     lat,
     lon,
+    airportElevationFt,
     nearbyAirports,
     zoom,
   ]);

--- a/src/components/map/MapRangeLegend.tsx
+++ b/src/components/map/MapRangeLegend.tsx
@@ -59,7 +59,7 @@ export default function MapRangeLegend() {
     <div
       role="note"
       aria-label={t("map.distanceAria", { distance: scale.nm })}
-      className="pointer-events-none absolute bottom-3 left-3 z-map-legend flex items-center gap-2 bg-[var(--map-range-background)] px-2 py-1 font-mono text-[var(--map-range-text)] backdrop-blur-sm"
+      className="pointer-events-none absolute right-3 top-[calc(12px+env(safe-area-inset-top))] z-map-legend flex items-center gap-2 rounded-[8px] border border-[var(--atc-border-default)] bg-[var(--atc-surface-preview-card)] px-2.5 py-1.5 font-mono text-[var(--map-range-text)] shadow-[var(--app-panel-shadow)] backdrop-blur-md md:bottom-3 md:left-3 md:right-auto md:top-auto"
     >
       <span
         className="text-[9px] font-semibold uppercase tracking-[0.22em] text-[var(--map-range-label)]"

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -79,6 +79,7 @@ export default function MapSettingsSheet({
   showNavaidMarkers,
   showAirspaces = true,
   showCandidateWatchingSpots = false,
+  mapSettingsDevice = "desktop",
   userLocationActive = false,
   userLocationAudioActive = false,
   userLocationPending = false,
@@ -122,6 +123,10 @@ export default function MapSettingsSheet({
     : t("mapLayers.disableUserLocationAudio");
   const showGuestPrompt = isLoaded && !isSignedIn;
   const showSignedInPersistence = isLoaded && isSignedIn;
+  const deviceLabelKey =
+    mapSettingsDevice === "mobile"
+      ? "mapSettings.devices.mobile"
+      : "mapSettings.devices.desktop";
   const signedInPersistenceKey =
     mapSettingsSaveStatus === "saving"
       ? "mapSettings.savingSettings"
@@ -370,7 +375,12 @@ export default function MapSettingsSheet({
               role="status"
               aria-live="polite"
             >
-              {t(signedInPersistenceKey)}
+              <span className="block text-[11px] font-semibold leading-tight text-atc-text">
+                {t("mapSettings.deviceScope", { device: t(deviceLabelKey) })}
+              </span>
+              <span className="mt-1 block">
+                {t(signedInPersistenceKey)}
+              </span>
             </div>
           ) : null}
         </div>

--- a/src/components/navigation/PageNavigationDock.tsx
+++ b/src/components/navigation/PageNavigationDock.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import Link from "next/link";
 import { SignInButton, UserButton, useUser } from "@clerk/nextjs";
 import { usePathname } from "next/navigation";
@@ -47,8 +49,31 @@ export default function PageNavigationDock() {
   } = useThemePreference();
   const { isLoaded, isSignedIn } = useUser();
   const showSignedIn = isLoaded && isSignedIn;
+  // Mobile pins the dock to the bottom of the viewport, so the language
+  // and theme menus need to flip upward to stay on-screen. Desktop keeps
+  // the dock at the top and opens menus downward as before.
+  const [isMobileDock, setIsMobileDock] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+    const media = window.matchMedia("(max-width: 720px)");
+    const apply = () => setIsMobileDock(media.matches);
+    apply();
+    media.addEventListener("change", apply);
+    return () => media.removeEventListener("change", apply);
+  }, []);
+  const menuPlacement = isMobileDock ? "top" : "bottom";
+  // Mount to <body> so the dock's position:fixed is anchored to the
+  // viewport. Some route wrappers (e.g. HomeScreen's app-route-transition)
+  // set `will-change: transform`, which would otherwise become the
+  // containing block and pin the dock to the bottom of the document
+  // instead of the visible viewport on long mobile pages.
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    setPortalTarget(document.body);
+  }, []);
 
-  return (
+  const dock = (
     <nav className="page-nav-dock" aria-label={t("nav.homePage")}>
       <Toolbar>
         {PAGE_ITEMS.map((item) => {
@@ -75,7 +100,7 @@ export default function PageNavigationDock() {
 
         <LanguageSwitch
           className={buttonClass}
-          menuPlacement="bottom"
+          menuPlacement={menuPlacement}
           menuAlign="right"
         />
 
@@ -86,7 +111,7 @@ export default function PageNavigationDock() {
           title={themeTitle}
           onClick={cycleTheme}
           onSelectTheme={selectTheme}
-          menuPlacement="bottom"
+          menuPlacement={menuPlacement}
           menuAlign="right"
         />
 
@@ -114,4 +139,6 @@ export default function PageNavigationDock() {
       </Toolbar>
     </nav>
   );
+
+  return portalTarget ? createPortal(dock, portalTarget) : dock;
 }

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -24,6 +24,7 @@ export default function MapControlBar({
   showAirspaces = true,
   showCandidateWatchingSpots = false,
   mapSettings = null,
+  mapSettingsDevice = "desktop",
   mapSettingsSaveStatus = "idle",
   userLocationActive = false,
   userLocationAudioActive = false,
@@ -85,6 +86,7 @@ export default function MapControlBar({
         showNavaidMarkers={showNavaidMarkers}
         showAirspaces={showAirspaces}
         showCandidateWatchingSpots={showCandidateWatchingSpots}
+        mapSettingsDevice={mapSettingsDevice}
         mapSettingsSaveStatus={mapSettingsSaveStatus}
         userLocationActive={userLocationActive}
         userLocationAudioActive={userLocationAudioActive}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -6,6 +6,21 @@
 
 export const CHANGELOG = [
   {
+    version: "v1.13.0",
+    kind: "feat",
+    title: "Bottom-floating mobile toolbar and device-aware settings",
+    summary:
+      "Mobile now exposes a single bottom-pinned toolbar pill across every page, static pages scroll as one document, and signed-in users get separate desktop and mobile map preferences. The approach-altitude masking rule also stops hiding high-altitude overflights.",
+    highlights: [
+      "Mobile toolbar floats at the bottom center across home, about, mechanism, changelog, and the airport/flight sidebar overlays",
+      "Desktop static pages move the navigation dock to the top-right corner so it lines up with the detail-page map toolbar",
+      "Static pages (home, about, mechanism, changelog) scroll as a single document on mobile, with bottom clearance for the floating toolbar",
+      "Approach-level traffic hiding now also gates on the altitude delta against the airport, so high-altitude overflights remain visible",
+      "Signed-in users save independent desktop and mobile map settings, picked up automatically by the device they're on",
+      "About page version now reads from the changelog so future releases only need a single changelog edit",
+    ],
+  },
+  {
     version: "v1.12.0",
     kind: "feat",
     title: "Map readability and badge polish",

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -454,9 +454,14 @@ const en = {
     modeSection: "Modes",
     layersSection: "Display",
     guestPrompt: "Map settings are kept on this device.",
+    deviceScope: "{device} settings",
     savedSettingsAvailable: "Saved to your account.",
     savingSettings: "Saving...",
     saveError: "Could not save changes.",
+    devices: {
+      desktop: "Desktop",
+      mobile: "Mobile",
+    },
     modes: {
       spotting: "Watcher Mode",
       radio: "Radio Mode",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -449,9 +449,14 @@ const zhCN = {
     modeSection: "模式",
     layersSection: "显示",
     guestPrompt: "未登录时,地图设置会保存在这台设备。",
+    deviceScope: "{device}设置",
     savedSettingsAvailable: "已保存到你的账户。",
     savingSettings: "保存中...",
     saveError: "保存失败,请重试。",
+    devices: {
+      desktop: "桌面端",
+      mobile: "移动端",
+    },
     modes: {
       spotting: "看客模式",
       radio: "无线电模式",

--- a/src/config/siteMeta.test.ts
+++ b/src/config/siteMeta.test.ts
@@ -1,18 +1,21 @@
 import assert from "node:assert/strict";
 
+import { CHANGELOG } from "./changelog";
 import {
   ADSBAO_SITE_VERSION,
   buildAdsbaoUserAgent,
 } from "./siteMeta";
 
-assert.equal(ADSBAO_SITE_VERSION, "1.11.1");
+const expectedVersion = String(CHANGELOG[0]?.version || "").replace(/^v/i, "");
+assert.ok(expectedVersion, "changelog must expose a leading entry version");
+assert.equal(ADSBAO_SITE_VERSION, expectedVersion);
 assert.equal(
   buildAdsbaoUserAgent("adsbdb/v0"),
-  "ADSBao/1.11.1 (+https://github.com/orriduck/ADSBao) adsbdb/v0",
+  `ADSBao/${expectedVersion} (+https://github.com/orriduck/ADSBao) adsbdb/v0`,
 );
 assert.equal(
   buildAdsbaoUserAgent(),
-  "ADSBao/1.11.1 (+https://github.com/orriduck/ADSBao)",
+  `ADSBao/${expectedVersion} (+https://github.com/orriduck/ADSBao)`,
 );
 
 console.log("siteMeta.test.ts ok");

--- a/src/config/siteMeta.ts
+++ b/src/config/siteMeta.ts
@@ -1,5 +1,12 @@
+import { CHANGELOG } from "./changelog";
+
 const ADSBAO_PRODUCT_NAME = "ADSBao";
-export const ADSBAO_SITE_VERSION = "1.11.1";
+// Derive the product version from the most recent changelog entry so a
+// release only has to be recorded in one place. The changelog stores
+// `v1.13.0` style strings; strip the leading "v" for the user-agent and
+// about-page display.
+export const ADSBAO_SITE_VERSION = String(CHANGELOG[0]?.version || "0.0.0")
+  .replace(/^v/i, "");
 const ADSBAO_REPOSITORY_URL = "https://github.com/orriduck/ADSBao";
 
 export function buildAdsbaoUserAgent(suffix = "") {

--- a/src/features/airport/explorer/airportExplorerModel.ts
+++ b/src/features/airport/explorer/airportExplorerModel.ts
@@ -22,6 +22,7 @@ export function resolveAirportProfile({ icao = "", airport = null }: AirportExpl
     country: airport?.country || airportFallback?.country || "",
     lat: COORDS[normalizedIcao]?.[0] || airport?.lat || 0,
     lon: COORDS[normalizedIcao]?.[1] || airport?.lon || 0,
+    elevationFt: airport?.elevationFt ?? null,
   };
 }
 

--- a/src/features/airport/map-settings/mapSettingsModel.test.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.test.ts
@@ -7,11 +7,21 @@ import {
   buildMapSettingsFromLayerState,
   buildPresetMapSettings,
   getSelectableMapModeOptions,
+  getAlternateMapSettingsDevice,
   mapSettingsToExplorerLayers,
   mergeMapSettings,
   normalizeMapSettings,
+  normalizeMapSettingsDevice,
   resolveMapSettingsHydration,
 } from "./mapSettingsModel";
+
+{
+  assert.equal(normalizeMapSettingsDevice("mobile"), "mobile");
+  assert.equal(normalizeMapSettingsDevice("desktop"), "desktop");
+  assert.equal(normalizeMapSettingsDevice("tablet"), "desktop");
+  assert.equal(getAlternateMapSettingsDevice("mobile"), "desktop");
+  assert.equal(getAlternateMapSettingsDevice("desktop"), "mobile");
+}
 
 {
   const spotting = buildPresetMapSettings({ modeId: MAP_MODE_IDS.SPOTTING });

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -101,10 +101,20 @@ export const DEFAULT_MAP_SETTINGS: MapSettingsRecord = Object.freeze({
   updatedAt: "",
 });
 
+export const MAP_SETTINGS_DEVICE_TYPES = Object.freeze({
+  DESKTOP: "desktop",
+  MOBILE: "mobile",
+});
+
+export const DEFAULT_MAP_SETTINGS_DEVICE = MAP_SETTINGS_DEVICE_TYPES.DESKTOP;
+
 const MAP_MODE_ID_SET: Set<string> = new Set(Object.values(MAP_MODE_IDS));
 const PRESET_MODE_ID_SET: Set<string> = new Set(MAP_MODE_OPTIONS.map((mode) => mode.id));
 const LAYER_KEY_SET: Set<string> = new Set(PERSISTED_MAP_LAYER_KEYS);
 const DISABLED_MAP_MODE_ID_SET: Set<string> = new Set(DISABLED_MAP_MODE_IDS);
+const MAP_SETTINGS_DEVICE_SET: Set<string> = new Set(
+  Object.values(MAP_SETTINGS_DEVICE_TYPES),
+);
 
 function getMapModePreset(modeId) {
   return MAP_MODE_PRESETS[modeId] || MAP_MODE_PRESETS[DEFAULT_MAP_SETTINGS.baseMode];
@@ -127,6 +137,19 @@ export function isSelectableMapModeId(value) {
 
 export function getSelectableMapModeOptions() {
   return MAP_MODE_OPTIONS.filter((mode) => isSelectableMapModeId(mode.id));
+}
+
+export function normalizeMapSettingsDevice(value: unknown) {
+  const device = String(value || "").trim().toLowerCase();
+  return MAP_SETTINGS_DEVICE_SET.has(device)
+    ? device
+    : DEFAULT_MAP_SETTINGS_DEVICE;
+}
+
+export function getAlternateMapSettingsDevice(value: unknown) {
+  return normalizeMapSettingsDevice(value) === MAP_SETTINGS_DEVICE_TYPES.MOBILE
+    ? MAP_SETTINGS_DEVICE_TYPES.DESKTOP
+    : MAP_SETTINGS_DEVICE_TYPES.MOBILE;
 }
 
 function getMapSettingsBaseMode(

--- a/src/features/airport/map-settings/mapSettingsStorage.test.ts
+++ b/src/features/airport/map-settings/mapSettingsStorage.test.ts
@@ -37,6 +37,26 @@ try {
     MAP_MODE_IDS.CONTROLLER,
     "cache should migrate legacy immersive settings to the default mode",
   );
+
+  writeStoredMapSettings(
+    {
+      selectedMode: MAP_MODE_IDS.RADIO,
+      baseMode: MAP_MODE_IDS.RADIO,
+      hasSelectedMode: true,
+    },
+    "mobile",
+  );
+
+  assert.equal(
+    normalizeMapSettings(readStoredMapSettings("mobile") || {}).selectedMode,
+    MAP_MODE_IDS.RADIO,
+    "mobile settings should be stored separately from desktop settings",
+  );
+  assert.equal(
+    normalizeMapSettings(readStoredMapSettings("desktop") || {}).selectedMode,
+    MAP_MODE_IDS.CONTROLLER,
+    "desktop settings should keep the legacy storage key",
+  );
 } finally {
   if (typeof originalWindow === "undefined") {
     delete (globalThis as any).window;

--- a/src/features/airport/map-settings/mapSettingsStorage.ts
+++ b/src/features/airport/map-settings/mapSettingsStorage.ts
@@ -2,15 +2,24 @@
 
 import {
   DEFAULT_MAP_SETTINGS,
+  DEFAULT_MAP_SETTINGS_DEVICE,
   normalizeMapSettings,
+  normalizeMapSettingsDevice,
 } from "./mapSettingsModel";
 
 const MAP_SETTINGS_STORAGE_KEY = "adsbao:airport-map-settings:v1";
 
-export function readStoredMapSettings() {
+function mapSettingsStorageKeyForDevice(device: unknown) {
+  const normalizedDevice = normalizeMapSettingsDevice(device);
+  return normalizedDevice === DEFAULT_MAP_SETTINGS_DEVICE
+    ? MAP_SETTINGS_STORAGE_KEY
+    : `${MAP_SETTINGS_STORAGE_KEY}:${normalizedDevice}`;
+}
+
+export function readStoredMapSettings(device: unknown = DEFAULT_MAP_SETTINGS_DEVICE) {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.localStorage.getItem(MAP_SETTINGS_STORAGE_KEY);
+    const raw = window.localStorage.getItem(mapSettingsStorageKeyForDevice(device));
     if (!raw) return null;
     return normalizeMapSettings(JSON.parse(raw));
   } catch {
@@ -18,11 +27,14 @@ export function readStoredMapSettings() {
   }
 }
 
-export function writeStoredMapSettings(settings = DEFAULT_MAP_SETTINGS) {
+export function writeStoredMapSettings(
+  settings = DEFAULT_MAP_SETTINGS,
+  device: unknown = DEFAULT_MAP_SETTINGS_DEVICE,
+) {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(
-      MAP_SETTINGS_STORAGE_KEY,
+      mapSettingsStorageKeyForDevice(device),
       JSON.stringify(normalizeMapSettings(settings)),
     );
   } catch {

--- a/src/features/airport/map-settings/userMapSettings.server.test.ts
+++ b/src/features/airport/map-settings/userMapSettings.server.test.ts
@@ -42,7 +42,7 @@ const user = {
     {
       type: "settings",
       email: "owner@example.com",
-      options: undefined,
+      options: { device: undefined },
     },
   ]);
 }
@@ -68,9 +68,11 @@ const user = {
       baseMode: "immersive",
       hasSelectedMode: true,
     },
+    device: "mobile",
   });
 
   assert.equal(calls[0].email, "owner@example.com");
+  assert.equal(calls[0].device, "mobile");
   assert.equal(calls[0].settings.selectedMode, MAP_MODE_IDS.CONTROLLER);
 }
 

--- a/src/features/airport/map-settings/userMapSettings.server.ts
+++ b/src/features/airport/map-settings/userMapSettings.server.ts
@@ -9,13 +9,14 @@ type UserMapSettingsServerRecord = Record<string, any>;
 
 export async function resolveMapSettingsForUser({
   user,
+  device,
   repository = createUserMapSettingsRepositoryFromEnv(),
 }: UserMapSettingsServerRecord = {}) {
   const email = getClerkUserPrimaryEmail(user);
   if (!email || !repository) return null;
 
   try {
-    const row = await repository.readSettingsByEmail(email);
+    const row = await repository.readSettingsByEmail(email, { device });
     return row?.settings ? normalizeMapSettings(row.settings) : null;
   } catch (error: any) {
     console.warn(`[map-settings] Supabase read failed for ${email}:`, error.message);
@@ -25,6 +26,7 @@ export async function resolveMapSettingsForUser({
 
 export async function persistMapSettingsForUser({
   user,
+  device,
   settings,
   repository = createUserMapSettingsRepositoryFromEnv(),
 }: UserMapSettingsServerRecord = {}) {
@@ -33,6 +35,7 @@ export async function persistMapSettingsForUser({
 
   const row = await repository.upsertSettingsByEmail({
     email,
+    device,
     settings: normalizeMapSettings(settings),
   });
   return row?.settings ? normalizeMapSettings(row.settings) : null;

--- a/src/features/airport/map/airportMapModel.test.ts
+++ b/src/features/airport/map/airportMapModel.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import { ZOOM_AIRPORT, ZOOM_APPROACH } from "../../../utils/airportMapDisplay";
 import {
+  airportGroundTrafficAltitudeThresholdFtForRadiusNm,
   getMapOverlayTheme,
   getVisibleAircraft,
   isKnownMapTheme,
@@ -14,10 +15,13 @@ import {
 } from "./airportMapModel";
 
 const aircraft = [
-  { icao24: "near", lat: 42.3657, lon: -71.0097 },
-  { icao24: "airport-ring", lat: 42.3816, lon: -71.0096 },
-  { icao24: "near-secondary", lat: 42.58, lon: -70.92 },
-  { icao24: "far", lat: 42.55, lon: -71.22 },
+  { icao24: "near", lat: 42.3657, lon: -71.0097, altitude: 240 },
+  { icao24: "unknown-altitude-near", lat: 42.366, lon: -71.01 },
+  { icao24: "overflight", lat: 42.3657, lon: -71.0097, altitude: 35_000 },
+  { icao24: "airport-ring", lat: 42.3816, lon: -71.0096, altitude: 700 },
+  { icao24: "near-secondary", lat: 42.58, lon: -70.92, altitude: 180 },
+  { icao24: "high-secondary", lat: 42.58, lon: -70.92, altitude: 22_000 },
+  { icao24: "far", lat: 42.55, lon: -71.22, altitude: 100 },
   { icao24: "missing", lat: null, lon: -71.22 },
 ];
 
@@ -63,15 +67,15 @@ assert.deepEqual(
 );
 
 assert.deepEqual(
-  getVisibleAircraft({ aircraft, airportLat: 42.3656, airportLon: -71.0096, zoom: ZOOM_AIRPORT })
+  getVisibleAircraft({
+    aircraft,
+    airportLat: 42.3656,
+    airportLon: -71.0096,
+    airportElevationFt: 19,
+    zoom: ZOOM_AIRPORT,
+  })
     .map((item) => item.icao24),
-  ["airport-ring", "near-secondary", "far"],
-);
-
-assert.deepEqual(
-  getVisibleAircraft({ aircraft, airportLat: 42.3656, airportLon: -71.0096, zoom: ZOOM_APPROACH })
-    .map((item) => item.icao24),
-  ["near-secondary", "far"],
+  ["overflight", "airport-ring", "near-secondary", "high-secondary", "far"],
 );
 
 assert.deepEqual(
@@ -79,11 +83,27 @@ assert.deepEqual(
     aircraft,
     airportLat: 42.3656,
     airportLon: -71.0096,
-    nearbyAirports: [{ icao: "KBVY", lat: 42.5842, lon: -70.9165 }],
+    airportElevationFt: 19,
+    zoom: ZOOM_APPROACH,
+  })
+    .map((item) => item.icao24),
+  ["overflight", "near-secondary", "high-secondary", "far"],
+);
+
+assert.deepEqual(
+  getVisibleAircraft({
+    aircraft,
+    airportLat: 42.3656,
+    airportLon: -71.0096,
+    airportElevationFt: 19,
+    nearbyAirports: [{ icao: "KBVY", lat: 42.5842, lon: -70.9165, elevationFt: 107 }],
     zoom: ZOOM_APPROACH,
   }).map((item) => item.icao24),
-  ["far"],
+  ["overflight", "high-secondary", "far"],
 );
+
+assert.equal(airportGroundTrafficAltitudeThresholdFtForRadiusNm(3), 1050);
+assert.equal(airportGroundTrafficAltitudeThresholdFtForRadiusNm(0.5), 300);
 
 assert.equal(
   getMapOverlayTheme("light").labelShadowColor,

--- a/src/features/airport/map/airportMapModel.ts
+++ b/src/features/airport/map/airportMapModel.ts
@@ -6,6 +6,7 @@ type AirportMapCoordinate = {
   icao24?: string;
   lat?: unknown;
   lon?: unknown;
+  elevationFt?: unknown;
   [key: string]: unknown;
 };
 
@@ -22,6 +23,7 @@ type AirportMapInitialCenterOptions = {
 type AirportGroundFilterOptions = {
   airportLat?: unknown;
   airportLon?: unknown;
+  airportElevationFt?: unknown;
   nearbyAirports?: AirportMapCoordinate[];
 };
 
@@ -81,6 +83,12 @@ const toFiniteCoordinate = (value: unknown) => {
   return Number.isFinite(numeric) ? numeric : null;
 };
 
+const toFiniteNumber = (value: unknown) => {
+  if (value == null || value === "") return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
 export const resolveAirportMapFocalCenter = ({ lat, lon }: AirportMapFocalCenterOptions = {}) => {
   const focalLat = toFiniteCoordinate(lat);
   const focalLon = toFiniteCoordinate(lon);
@@ -101,24 +109,60 @@ export const resolveAirportMapInitialCenter = ({
   });
 };
 
-const airportGroundFilters = ({ airportLat, airportLon, nearbyAirports = [] }: AirportGroundFilterOptions) =>
+const airportGroundFilters = ({
+  airportLat,
+  airportLon,
+  airportElevationFt,
+  nearbyAirports = [],
+}: AirportGroundFilterOptions) =>
   [
-    { lat: airportLat, lon: airportLon },
+    { lat: airportLat, lon: airportLon, elevationFt: airportElevationFt },
     ...nearbyAirports.map((airport) => ({
       lat: airport?.lat,
       lon: airport?.lon,
+      elevationFt: airport?.elevationFt,
     })),
   ].filter((airport) => airport.lat != null && airport.lon != null);
 
-const isInsideAirportGroundArea = (aircraft: AirportMapAircraft, airport: AirportMapCoordinate, radiusNm: number) => {
+export const airportGroundTrafficAltitudeThresholdFtForRadiusNm = (radiusNm: unknown) => {
+  const radius = toFiniteNumber(radiusNm);
+  if (radius == null || radius <= 0) return null;
+  return Math.max(300, Math.round(radius * 350));
+};
+
+const isNearAirportElevation = (
+  aircraft: AirportMapAircraft,
+  airport: AirportMapCoordinate,
+  radiusNm: number,
+) => {
+  if (aircraft.onGround === true) return true;
+  const aircraftAltitudeFt = toFiniteNumber(aircraft.altitude);
+  const airportElevationFt = toFiniteNumber(airport.elevationFt);
+  const thresholdFt = airportGroundTrafficAltitudeThresholdFtForRadiusNm(radiusNm);
+  if (aircraftAltitudeFt == null) return true;
+  if (thresholdFt == null) return false;
+  if (airportElevationFt == null) return aircraftAltitudeFt <= thresholdFt;
+  return Math.abs(aircraftAltitudeFt - airportElevationFt) <= thresholdFt;
+};
+
+const isInsideAirportGroundArea = (
+  aircraft: AirportMapAircraft,
+  airport: AirportMapCoordinate,
+  radiusNm: number,
+) => {
   const distNm = getDistanceNm(airport.lat, airport.lon, aircraft.lat, aircraft.lon);
-  return distNm != null && distNm <= radiusNm;
+  return (
+    distNm != null &&
+    distNm <= radiusNm &&
+    isNearAirportElevation(aircraft, airport, radiusNm)
+  );
 };
 
 export const getVisibleAircraft = ({
   aircraft,
   airportLat,
   airportLon,
+  airportElevationFt,
   nearbyAirports = [],
   zoom,
 }: VisibleAircraftOptions) => {
@@ -127,6 +171,7 @@ export const getVisibleAircraft = ({
   const groundFilters = airportGroundFilters({
     airportLat,
     airportLon,
+    airportElevationFt,
     nearbyAirports,
   });
 

--- a/src/style.css
+++ b/src/style.css
@@ -79,11 +79,18 @@
     --z-index-map-legend: 100;
     --z-index-map-ui: 200;
     --z-index-map-panel: 300;
+    --z-index-map-ui-floating: 350;
     --z-index-popover: 400;
     --z-index-dropdown: 500;
     --z-index-modal: 600;
     --z-index-modal-content: 610;
     --z-index-toast: 700;
+
+    /* Vertical breathing room the always-on bottom mobile toolbar pill
+       needs at the foot of the viewport so it does not cover the last
+       row of a page's content. Toolbar shell min-height + bottom inset
+       + small gap. */
+    --map-toolbar-mobile-clearance: calc(42px + max(24px, env(safe-area-inset-bottom) + 12px));
 }
 
 :root {
@@ -1664,22 +1671,17 @@ body {
 
 .page-nav-dock {
     display: flex;
-    justify-content: center;
-    /* Center over the right-hand content area, not the whole viewport.
-       The dither shell renders a sidebar on the left (`.dither-page-panel`
-       with `width: var(--app-sidebar-width)` and a 12px margin), so a true
-       viewport-center would visually skew the dock toward the sidebar
-       side. Shifting right by half the sidebar+inset reproduces the same
-       formula used by `.airport-map-kit--sidebar-open .airport-map-menu`,
-       so the toolbar lines up consistently across the home and detail
-       pages. On narrow screens (mobile, where the sidebar collapses) the
-       media query below resets this to a true viewport center. */
-    left: calc(50% + (var(--app-sidebar-width) + 12px) / 2);
+    justify-content: flex-end;
+    /* Desktop: pin the dock to the top-right corner so the static pages
+       share the same toolbar placement as the airport/flight detail
+       desktop map kit (`.airport-map-kit .airport-map-menu` uses an
+       inset-top/right of `--map-kit-inset`). The media query below
+       repins this to bottom-center on mobile. */
     max-width: calc(100vw - 24px);
     pointer-events: none;
     position: fixed;
+    right: max(12px, env(safe-area-inset-right));
     top: max(12px, env(safe-area-inset-top));
-    transform: translateX(-50%);
     width: max-content;
     z-index: var(--z-index-toast);
 }
@@ -1697,19 +1699,44 @@ body {
         display: none;
     }
 
+    /* Mobile static pages scroll as a single document — release the
+       desktop `h-screen` flex layout so the shell grows with content
+       and the browser's own scroller handles overflow. */
+    .dither-page-shell {
+        height: auto !important;
+        min-height: 100dvh;
+    }
+
     .dither-page-panel {
         background: var(--atc-bg);
         box-shadow: none;
-        padding-top: 58px;
         width: 100vw !important;
+        /* Leaves room for the floating bottom toolbar so the last row
+           of content remains visible when scrolled to the end. */
+        padding-bottom: var(--map-toolbar-mobile-clearance);
+    }
+
+    /* Inner panels normally use `flex-1 overflow-y-auto` so the desktop
+       sidebar panel scrolls internally. On mobile we want the whole
+       page to scroll instead, so reset those containers to natural
+       flow. */
+    .dither-page-panel > .flex-1.overflow-y-auto,
+    .dither-page-panel main.flex-1.overflow-y-auto,
+    .dither-page-panel .dither-list.flex-1.overflow-y-auto {
+        flex: 0 0 auto;
+        overflow: visible;
     }
 
     .page-nav-dock {
-        /* On narrow screens the dither sidebar collapses to full-width,
-           so the desktop content-center offset would skew the dock off
-           screen. Reset to a true viewport center. */
+        /* Mobile: pin the toolbar pill to the bottom center, matching
+           the explorer map toolbar so navigation stays in one place
+           across the app. */
+        justify-content: center;
         left: 50%;
-        top: max(12px, env(safe-area-inset-top));
+        right: auto;
+        top: auto;
+        bottom: max(12px, env(safe-area-inset-bottom));
+        transform: translateX(-50%);
     }
 }
 
@@ -2684,9 +2711,17 @@ body {
 
 .airport-sidebar-panel--mobile .sidebar-top-dock,
 .flight-sidebar-panel--mobile .sidebar-top-dock {
-    height: calc(52px + env(safe-area-inset-top));
-    padding-top: max(12px, env(safe-area-inset-top));
+    /* The sidebar dock floats at the bottom of the viewport on mobile
+       so the app always exposes a single bottom-pinned toolbar. The
+       dock's pill stays clickable via the Toolbar primitive's own
+       pointer-events: auto. */
+    align-items: flex-end;
+    height: auto;
+    inset: auto 0 max(12px, env(safe-area-inset-bottom));
+    padding: 0 16px;
+    z-index: var(--z-index-map-ui-floating);
 }
+
 
 /* Sidebar's top toolbar dock — transparent slot that absolutely
    positions the floating Toolbar pill (sidebar mobile overlay) at the
@@ -4607,7 +4642,11 @@ body {
 @media (max-width: 767px) {
     .airport-sidebar-panel--mobile .airport-sidebar-identity,
     .flight-sidebar-panel .airport-sidebar-identity {
-        padding-top: calc(75px + env(safe-area-inset-top));
+        /* Match the home page's dither-page-header top padding so the
+           "拍机宝" brand mark lands at the same vertical position
+           across the app on mobile. The dock no longer pins at the top
+           on mobile, so we no longer need to reserve 75px for it. */
+        padding-top: calc(28px + env(safe-area-inset-top));
         padding-bottom: 20px;
     }
 
@@ -6741,5 +6780,9 @@ body {
         inset: auto 0 max(12px, env(safe-area-inset-bottom));
         padding: 0 16px;
         pointer-events: none;
+        /* Stays above the mobile sidebar overlay so the toolbar pill (with
+           the sidebar-close button) is always reachable from the list. */
+        z-index: var(--z-index-map-ui-floating);
     }
+
 }

--- a/supabase/migrations/20260605175000_add_device_to_user_map_settings.sql
+++ b/supabase/migrations/20260605175000_add_device_to_user_map_settings.sql
@@ -1,0 +1,19 @@
+alter table public.user_map_settings
+  add column if not exists device text not null default 'desktop';
+
+alter table public.user_map_settings
+  drop constraint if exists user_map_settings_pkey;
+
+alter table public.user_map_settings
+  add constraint user_map_settings_device_check
+    check (device in ('desktop', 'mobile'));
+
+alter table public.user_map_settings
+  add constraint user_map_settings_pkey
+    primary key (email, environment, device);
+
+comment on column public.user_map_settings.device is
+  'Settings target device type. Signed-in users can keep separate desktop and mobile map settings.';
+
+comment on table public.user_map_settings is
+  'Server-managed map mode and layer settings keyed by Clerk primary email, environment, and device.';


### PR DESCRIPTION
## Summary
- **Mobile toolbar**: every page now exposes one floating pill at the bottom center (home, about, mechanism, changelog, airport/flight sidebar overlays). `PageNavigationDock` portals to `<body>` to escape the `app-route-transition` `will-change: transform` ancestor that otherwise breaks `position: fixed`. On desktop the dock moves to the top-right corner to match `.airport-map-kit .airport-map-menu` placement.
- **Static page scrolling**: home/about/mechanism/changelog scroll as one document on mobile (no more nested `flex-1 overflow-y-auto` panels), with bottom clearance reserved for the floating toolbar pill.
- **Approach-altitude masking**: traffic hidden inside the approach ring now also requires the altitude delta to the airport to be within a distance-derived threshold, so high-altitude overflights stay visible (`airportMapModel.ts`).
- **Device-aware map settings**: signed-in users persist independent desktop and mobile preferences. Supabase migration adds a `device` column, DAO + REST route honor it, and the explorer picks up the right row per viewport.
- **Version source of truth**: `ADSBAO_SITE_VERSION` derives from `CHANGELOG[0].version`; the about page picks up the latest entry automatically.

## Test plan
- [x] `pnpm test` (107 test files passed)
- [x] `pnpm build`
- [x] Local mobile (390×844): home / about toolbar floats at bottom center, list scrolls as one document; airport sidebar overlay shows the dock at the bottom and hides the map menu.
- [x] Local desktop (1440×900): home dock pinned to the top-right corner.
- [ ] Vercel preview spot-check after CI builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)