### PR TITLE
v1.13.1 — toolbar opacity polish + louder map-settings error log

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -6,6 +6,17 @@
 
 export const CHANGELOG = [
   {
+    version: "v1.13.1",
+    kind: "patch",
+    title: "Toolbar opacity polish and louder map-settings error logging",
+    summary:
+      "Every floating toolbar pill (home dock, sidebar overlay, map control rail) now sits on a more opaque surface so it stays legible against busy map and dither backdrops on both light and dark themes. Server-side map-settings reads also escalate failures from warn to error, so schema drift surfaces immediately instead of silently looking like \"never saved\".",
+    highlights: [
+      "Toolbar surface token bumped from 88% to 96% card opacity — affects every Toolbar caller (home page dock, sidebar mobile overlay, map control rail) on light and dark themes",
+      "Map-settings DAO read errors are now logged as `console.error` instead of `console.warn`, so a missing `device` column (or any future schema drift) is visible immediately in server logs",
+    ],
+  },
+  {
     version: "v1.13.0",
     kind: "feat",
     title: "Bottom-floating mobile toolbar and device-aware settings",

--- a/src/features/airport/map-settings/userMapSettings.server.ts
+++ b/src/features/airport/map-settings/userMapSettings.server.ts
@@ -19,7 +19,13 @@ export async function resolveMapSettingsForUser({
     const row = await repository.readSettingsByEmail(email, { device });
     return row?.settings ? normalizeMapSettings(row.settings) : null;
   } catch (error: any) {
-    console.warn(`[map-settings] Supabase read failed for ${email}:`, error.message);
+    // Promoted from warn → error. A `null` here makes the UI fall back
+    // to defaults, which looks identical to "user has never saved
+    // anything" — schema drift would stay invisible until the user
+    // tries to PUT and sees a 500. Surface it loudly here so the
+    // mismatch is caught immediately, while still letting the UI render
+    // with the default settings.
+    console.error(`[map-settings] Supabase read failed for ${email}:`, error.message);
     return null;
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -2419,7 +2419,7 @@ body {
     );
     --atc-toolbar-surface: color-mix(
         in oklab,
-        var(--atc-card) 88%,
+        var(--atc-card) 96%,
         transparent
     );
     --atc-control-hover-bg: color-mix(


### PR DESCRIPTION
## Summary

- Bumps `--atc-toolbar-surface` from 88% → 96% card opacity. Every Toolbar caller (home / about / changelog page dock, sidebar mobile overlay, map control rail) gets the more opaque pill on both light and dark themes — single-token edit, no per-caller changes.
- Promotes the map-settings DAO read-failure log from `console.warn` to `console.error`. The function still returns `null` (UI falls back to defaults), but schema drift no longer silently looks like "user has never saved" — the next mismatch will surface in server logs immediately.
- Version: 1.13.0 → 1.13.1 + changelog entry.

## Context

While debugging "mobile settings don't save", root cause turned out to be the v1.13 `device` column on `user_map_settings` being missing on one deployed Supabase. PUT 500'd; GET silently returned `null` so the UI looked like "nothing saved yet". The warn→error promotion makes the next occurrence visible without changing behavior.

## Test plan

- [x] `pnpm lint` → 0 errors
- [x] `pnpm test` → 106 test files pass
- [x] `pnpm knip` → exit 0
- [ ] Open `/airport/KBOS` on mobile + desktop → toolbar pill looks noticeably more solid against the map
- [ ] (Manual) Once deployed, confirm next map-settings read error shows up in `console.error` not `console.warn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)