### PR TITLE
Mobile: pull-to-refresh + swipe-up to dismiss preview card

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -24,6 +24,7 @@ import { useSelectedAircraftTrace } from "@/components/aircraft/trace/SelectedAi
 import { useAircraftPhoto } from "@/features/aircraft/preview/useAircraftPhoto";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel";
+import { useSwipeUpToDismiss } from "@/hooks/useSwipeUpToDismiss";
 
 const PHOTO_TONE_DARK = "dark";
 const PHOTO_TONE_LIGHT = "light";
@@ -40,6 +41,7 @@ export default function AircraftPreviewCard({
   sidebarOpen = false,
   airportProfile = null,
   onApplyTemporaryRoute,
+  onDismiss,
   suppressMobileWhenAlreadyTracking = false,
 }) {
   const { t } = useI18n();
@@ -116,6 +118,15 @@ export default function AircraftPreviewCard({
     if (!cardTrackHref || alreadyTracking) return;
     router.push(cardTrackHref);
   };
+
+  // Swipe up anywhere on screen while the mobile preview is showing →
+  // clear the selection so the card hides. Threshold is conservative
+  // enough that a normal Leaflet pan doesn't trigger; the user has to
+  // flick up >100px in <600ms. Only registered when `onDismiss` is
+  // wired AND the mobile card is currently visible.
+  useSwipeUpToDismiss(showMobile && typeof onDismiss === "function", () => {
+    onDismiss?.();
+  });
 
   // Mobile route-feedback affordance: small text link → centered modal.
   // The desktop inline form (in AircraftPreviewMetadataCard) is more

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -82,6 +82,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     setSelectedAirspaceId,
     selectCandidateWatchingSpot,
     setSelectedCandidateWatchingSpotId,
+    clearAllPreviewSelections,
     mapFollowsAircraft,
     setMapZoom,
     applyMapMode,
@@ -484,11 +485,12 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
         sidebarOpen={sidebarOpen}
         airportProfile={airportProfile}
         onApplyTemporaryRoute={traffic.applyTemporaryRoute}
+        onDismiss={clearAllPreviewSelections}
       />
       <div
         className={`font-sans text-atc-text ${
           isMobile
-            ? "fixed inset-0 z-0 flex overflow-hidden overscroll-none"
+            ? "fixed inset-0 z-0 flex overflow-hidden"
             : `airport-map-kit ${
                 sidebarOpen ? "airport-map-kit--sidebar-open" : ""
               } flex h-dvh overflow-hidden`
@@ -571,7 +573,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
           />
 
           {isMobile && sidebarOpen && (
-            <div className="absolute inset-0 z-map-panel">
+            <div className="absolute inset-0 z-map-panel overscroll-contain">
               <AirportSidebar {...sidebarProps} onClose={closeSidebar} />
             </div>
           )}

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -285,6 +285,28 @@ function airportExplorerUiReducer(state, action) {
         selectedNavaidKey: "",
         selectedAirspaceId: "",
       };
+    case "clearAllPreviewSelections":
+      // Used by the swipe-up-to-dismiss gesture: clears whatever entity
+      // is currently selected (aircraft / airport / navaid / airspace /
+      // watching spot) so the mobile preview card hides. No-op when
+      // nothing is selected so React can bail on the dispatch.
+      if (
+        !state.selectedAircraftId &&
+        !state.selectedAirportIcao &&
+        !state.selectedNavaidKey &&
+        !state.selectedAirspaceId &&
+        !state.selectedCandidateWatchingSpotId
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        selectedAircraftId: "",
+        selectedAirportIcao: "",
+        selectedNavaidKey: "",
+        selectedAirspaceId: "",
+        selectedCandidateWatchingSpotId: "",
+      };
     case "fitToTrace":
       return {
         ...state,
@@ -573,6 +595,10 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "setSelectedCandidateWatchingSpotId", spotId });
   }, []);
 
+  const clearAllPreviewSelections = useCallback(() => {
+    dispatch({ type: "clearAllPreviewSelections" });
+  }, []);
+
   const fitToTrace = useCallback(() => {
     dispatch({ type: "fitToTrace" });
   }, []);
@@ -634,6 +660,7 @@ export function ExplorerUiProvider({ children }) {
       setSelectedAirspaceId,
       selectCandidateWatchingSpot,
       setSelectedCandidateWatchingSpotId,
+      clearAllPreviewSelections,
       fitToTrace,
       suspendMapFollow,
     }),
@@ -686,6 +713,7 @@ export function ExplorerUiProvider({ children }) {
       setSelectedAirspaceId,
       selectCandidateWatchingSpot,
       setSelectedCandidateWatchingSpotId,
+      clearAllPreviewSelections,
       fitToTrace,
       suspendMapFollow,
     ],

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -111,6 +111,7 @@ function FlightExplorerContent({ callsign }) {
     selectAirport,
     selectNavaid,
     selectAirspace,
+    clearAllPreviewSelections,
     toggleMapLabels,
     fitToTrace,
     suspendMapFollow,
@@ -759,11 +760,12 @@ function FlightExplorerContent({ callsign }) {
         isMobile={isMobile}
         sidebarOpen={sidebarOpen}
         onApplyTemporaryRoute={applyTemporaryRoute}
+        onDismiss={clearAllPreviewSelections}
       />
       <div
         className={`font-sans text-atc-text ${
           isMobile
-            ? "fixed inset-0 z-0 flex overflow-hidden overscroll-none"
+            ? "fixed inset-0 z-0 flex overflow-hidden"
             : `airport-map-kit ${
                 sidebarOpen ? "airport-map-kit--sidebar-open" : ""
               } flex h-dvh overflow-hidden`
@@ -853,7 +855,7 @@ function FlightExplorerContent({ callsign }) {
           </AirportMap>
 
           {isMobile && sidebarOpen && (
-            <div className="absolute inset-0 z-map-panel">
+            <div className="absolute inset-0 z-map-panel overscroll-contain">
               <FlightSidebar {...sidebarProps} onClose={closeSidebar} />
             </div>
           )}

--- a/src/hooks/useSwipeUpToDismiss.ts
+++ b/src/hooks/useSwipeUpToDismiss.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type SwipeOptions = {
+  // Minimum vertical distance (in px) the finger has to cover upward
+  // before the gesture counts as a dismiss. Defaulted high enough that
+  // a casual map pan / pinch won't accidentally trigger.
+  thresholdPx?: number;
+  // Maximum time (ms) between touchstart and touchend. A slow scroll
+  // shouldn't dismiss; only a quick flick does.
+  maxDurationMs?: number;
+  // Allowed |Δx| / |Δy| ratio. Lower = more strictly vertical.
+  maxHorizontalRatio?: number;
+};
+
+// Listens on the whole document (passive) for a single-finger upward
+// swipe and invokes `onDismiss` when the gesture clears the threshold.
+// Does NOT preventDefault, so Leaflet pan / pinch / native scroll keep
+// working — the dismiss fires on touchend after the gesture completes.
+//
+// Use case: mobile preview card. A user can flick up anywhere on the
+// screen — over the map, the card, or the toolbar — to clear the
+// current selection and hide the preview, without aiming for a close
+// button. The map may pan a bit as a side effect; if that's a problem,
+// the caller can raise `thresholdPx` to ignore short pans.
+export function useSwipeUpToDismiss(
+  active: boolean,
+  onDismiss: () => void,
+  options: SwipeOptions = {},
+) {
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  const thresholdPx = options.thresholdPx ?? 100;
+  const maxDurationMs = options.maxDurationMs ?? 600;
+  const maxHorizontalRatio = options.maxHorizontalRatio ?? 0.6;
+
+  useEffect(() => {
+    if (!active) return undefined;
+    if (typeof document === "undefined") return undefined;
+
+    let startX = 0;
+    let startY = 0;
+    let startTime = 0;
+    let tracking = false;
+
+    const handleStart = (event: TouchEvent) => {
+      // Multi-touch (pinch) is never a dismiss — bail.
+      if (event.touches.length !== 1) {
+        tracking = false;
+        return;
+      }
+      const touch = event.touches[0];
+      startX = touch.clientX;
+      startY = touch.clientY;
+      startTime = event.timeStamp;
+      tracking = true;
+    };
+
+    const handleEnd = (event: TouchEvent) => {
+      if (!tracking) return;
+      tracking = false;
+      const touch = event.changedTouches[0];
+      if (!touch) return;
+      const dx = touch.clientX - startX;
+      const dy = touch.clientY - startY; // negative = upward
+      const dt = event.timeStamp - startTime;
+
+      if (dt > maxDurationMs) return;
+      if (-dy < thresholdPx) return;
+      if (Math.abs(dx) > Math.abs(dy) * maxHorizontalRatio) return;
+
+      onDismissRef.current();
+    };
+
+    const handleCancel = () => {
+      tracking = false;
+    };
+
+    document.addEventListener("touchstart", handleStart, { passive: true });
+    document.addEventListener("touchend", handleEnd, { passive: true });
+    document.addEventListener("touchcancel", handleCancel, { passive: true });
+
+    return () => {
+      document.removeEventListener("touchstart", handleStart);
+      document.removeEventListener("touchend", handleEnd);
+      document.removeEventListener("touchcancel", handleCancel);
+    };
+  }, [active, thresholdPx, maxDurationMs, maxHorizontalRatio]);
+}


### PR DESCRIPTION
## Summary

Three small coupled changes for mobile detail pages:

1. Drop `overscroll-none` on the AirportExplorer / FlightExplorer mobile wrapper so Chrome's pull-to-refresh works again. Leaflet's own passive:false touch handlers preventDefault inside the map container, so map pan/pinch are unaffected — only chrome (toolbar, preview card, blank edges) can fall through to body, which is exactly where pull-to-refresh should fire.
2. Add `overscroll-contain` to the mobile sidebar overlay wrapper so the list's internal scroll stays scoped (reinstates the original intent of the deleted rule).
3. New `useSwipeUpToDismiss` hook + `clearAllPreviewSelections` reducer action. While the mobile preview card is visible, a single-finger flick up anywhere (>=100px in <=600ms, vertical-dominant) clears whatever entity is selected. Uses passive document listeners so Leaflet pan/pinch keep working.

## Why three things together

They all interact with the same mobile gesture surface. Splitting them risks shipping `overscroll-none` back in by accident, or shipping the dismiss hook with the wrong overscroll behaviour.

## Test plan

- [x] `pnpm lint` → 0 errors
- [x] `pnpm test` → 106 test files pass
- [x] `pnpm knip` → exit 0
- [x] `pnpm build` → green
- [ ] Mobile / KBOS: pull down from toolbar area → Chrome pull-to-refresh fires
- [ ] Mobile / KBOS: pan the map → no refresh, map pans normally regardless of zoom
- [ ] Mobile / KBOS: tap an aircraft → preview card shows → flick up anywhere → card hides
- [ ] Mobile / KBOS: tap an aircraft → preview card shows → slow pan up the map → card stays (under threshold)
- [ ] Mobile / aircraft detail page: same flick-up dismiss behaviour
- [ ] Mobile / sidebar open: scroll inside sidebar → no body refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)