### PR TITLE
Map settings: Base map selector (Standard / Terrain)

### DIFF
--- a/src/app/api/proxy/map-style/[theme]/route.ts
+++ b/src/app/api/proxy/map-style/[theme]/route.ts
@@ -11,6 +11,7 @@ import {
   buildProxiedMapLibreStyle,
   buildReadableTerrainMapLibreStyle,
   getMapLibreBaseStyleUrl,
+  shouldApplyReadableTerrain,
 } from "@/features/airport/map/mapTileLanguageModel";
 import { isKnownMapTheme } from "@/features/airport/map/airportMapModel";
 
@@ -38,11 +39,15 @@ export async function GET(request, { params }) {
   const baseTheme = isKnownMapTheme(rawTheme) ? rawTheme : "dark";
   const locale = requestUrl.searchParams.get("locale") || "en";
   const showLabels = requestUrl.searchParams.get("labels") !== "0";
+  // Optional `baseLayer` query (standard | terrain | transport) picks
+  // which OFM style to fetch. Unknown / missing → server defaults to
+  // terrain so existing clients keep the previous look.
+  const baseLayer = requestUrl.searchParams.get("baseLayer") || undefined;
 
   let upstreamStyle;
   try {
     upstreamStyle = await fetchJson(
-      getMapLibreBaseStyleUrl(baseTheme),
+      getMapLibreBaseStyleUrl(baseTheme, baseLayer),
       "OpenFreeMap style",
     );
   } catch (error) {
@@ -62,13 +67,17 @@ export async function GET(request, { params }) {
     });
   }
 
-  const style = buildLocalizedMapLibreStyle(
-    buildReadableTerrainMapLibreStyle(
-      buildProxiedMapLibreStyle(upstreamStyle),
-      { theme: baseTheme },
-    ),
-    { locale, showLabels },
-  );
+  // Only the terrain base layer gets the readable-hillshade pass.
+  // Standard / transport pass through clean so the user can actually
+  // see the difference when they switch.
+  const proxiedStyle = buildProxiedMapLibreStyle(upstreamStyle);
+  const styleWithTerrain = shouldApplyReadableTerrain(baseLayer)
+    ? buildReadableTerrainMapLibreStyle(proxiedStyle, { theme: baseTheme })
+    : proxiedStyle;
+  const style = buildLocalizedMapLibreStyle(styleWithTerrain, {
+    locale,
+    showLabels,
+  });
 
   return logProxyRouteResponse({
     request,

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -62,6 +62,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     showNavaidMarkers,
     showAirspaces,
     showCandidateWatchingSpots,
+    mapSettings,
     userLocationEnabled,
     userLocationAudioEnabled,
     trafficFilter,
@@ -541,6 +542,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             showNavaidMarkers={showNavaidMarkers}
             showAirspaces={showAirspaces}
             showCandidateWatchingSpots={showCandidateWatchingSpots}
+            baseLayer={mapSettings?.baseLayer}
             trafficFilter={trafficFilter}
             typeFilter={typeFilter}
             altitudeLevel={altitudeLevel}

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -33,6 +33,7 @@ export default function ExplorerMapMenu({
     mapSettingsSaveStatus,
     setMapZoom,
     applyMapMode,
+    setMapBaseLayer,
     toggleSidebar,
     toggleMapLabels,
     toggleRunwayBeams,
@@ -72,6 +73,7 @@ export default function ExplorerMapMenu({
         onToggleAirspaces={toggleAirspaces}
         onToggleCandidateWatchingSpots={toggleCandidateWatchingSpots}
         onSelectMapMode={applyMapMode}
+        onSelectBaseLayer={setMapBaseLayer}
         onToggleUserLocation={onToggleUserLocation}
         onToggleUserLocationAudio={onToggleUserLocationAudio}
         onToggleSidebar={toggleSidebar}

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -18,7 +18,9 @@ import {
   MAP_SETTINGS_DEVICE_TYPES,
   MAP_LAYER_KEYS,
   buildCustomMapSettings,
+  buildMapSettingsWithBaseLayer,
   buildPresetMapSettings,
+  isKnownMapBaseLayer,
   isSelectableMapModeId,
   mapSettingsToExplorerLayers,
   mapSettingsToUserLocationPreferences,
@@ -163,6 +165,20 @@ function airportExplorerUiReducer(state, action) {
         buildPresetMapSettings({
           modeId: action.modeId,
           audioEnabled: state.mapSettings?.audioEnabled,
+          // Carry the user's current base map choice across mode
+          // switches — they picked it deliberately, no need to reset
+          // it just because they cycled the mode preset.
+          baseLayer: state.mapSettings?.baseLayer,
+        }),
+      );
+    case "setMapBaseLayer":
+      if (!isKnownMapBaseLayer(action.baseLayer)) return state;
+      if (state.mapSettings?.baseLayer === action.baseLayer) return state;
+      return applyMapSettingsToUiState(
+        state,
+        buildMapSettingsWithBaseLayer({
+          settings: state.mapSettings,
+          baseLayer: action.baseLayer,
         }),
       );
     case "hydrateMapSettings":
@@ -532,6 +548,10 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "applyMapMode", modeId });
   }, []);
 
+  const setMapBaseLayer = useCallback((baseLayer) => {
+    dispatch({ type: "setMapBaseLayer", baseLayer });
+  }, []);
+
   const setUserLocationPreferences = useCallback(
     ({ userLocationEnabled, userLocationAudioEnabled = false }) => {
       dispatch({
@@ -650,6 +670,7 @@ export function ExplorerUiProvider({ children }) {
       toggleAirspaces,
       toggleCandidateWatchingSpots,
       applyMapMode,
+      setMapBaseLayer,
       setUserLocationPreferences,
       selectAircraft,
       setSelectedAircraftId,
@@ -703,6 +724,7 @@ export function ExplorerUiProvider({ children }) {
       toggleAirspaces,
       toggleCandidateWatchingSpots,
       applyMapMode,
+      setMapBaseLayer,
       setUserLocationPreferences,
       selectAircraft,
       setSelectedAircraftId,

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -98,6 +98,7 @@ function FlightExplorerContent({ callsign }) {
     showMapLabels,
     showNavaidMarkers,
     showAirspaces,
+    mapSettings,
     trafficFilter,
     typeFilter,
     altitudeLevel,
@@ -809,6 +810,7 @@ function FlightExplorerContent({ callsign }) {
             showRunwayBeams={false}
             showNavaidMarkers={showNavaidMarkers}
             showAirspaces={showAirspaces}
+            baseLayer={mapSettings?.baseLayer}
             trafficFilter={trafficFilter}
             typeFilter={typeFilter}
             altitudeLevel={altitudeLevel}

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -74,6 +74,7 @@ export default function AirportMap({
   showNavaidMarkers = false,
   showAirspaces = true,
   showCandidateWatchingSpots = false,
+  baseLayer = "terrain",
   trafficFilter = "all",
   typeFilter = "all",
   altitudeLevel = "all",
@@ -424,6 +425,7 @@ export default function AirportMap({
             theme={currentTheme}
             locale={locale}
             showLabels={showMapLabels}
+            baseLayer={baseLayer}
             selectionActive={selectionActive}
           />
           <AirspaceLayer

--- a/src/components/map/MapTileLayers.tsx
+++ b/src/components/map/MapTileLayers.tsx
@@ -17,6 +17,7 @@ export default function MapTileLayers({
   theme = "dark",
   locale = "en",
   showLabels = true,
+  baseLayer = "terrain",
   selectionActive = false,
 }: Record<string, any>) {
   const map = useMapInstance();
@@ -44,6 +45,7 @@ export default function MapTileLayers({
       theme,
       locale,
       showLabels,
+      baseLayer,
       signal: abort.signal,
     })
       .then((style) => {
@@ -81,7 +83,7 @@ export default function MapTileLayers({
       removeLayer(layerRef.current, map);
       layerRef.current = null;
     };
-  }, [map, theme, locale, showLabels]);
+  }, [map, theme, locale, showLabels, baseLayer]);
 
   useEffect(() => {
     setSelectionOpacity(layerRef.current, theme, selectionActive);
@@ -94,6 +96,7 @@ async function loadLocalizedMapStyle({
   theme,
   locale,
   showLabels,
+  baseLayer,
   signal,
 }: Record<string, any>) {
   const params = new URLSearchParams({
@@ -101,6 +104,7 @@ async function loadLocalizedMapStyle({
     labels: showLabels ? "1" : "0",
     v: MAP_STYLE_THEME_REVISION,
   });
+  if (baseLayer) params.set("baseLayer", baseLayer);
   return requestJson(`/api/proxy/map-style/${theme}?${params}`, { signal });
 }
 

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -2,10 +2,12 @@
 
 import { useUser } from "@clerk/nextjs";
 import {
+  DEFAULT_MAP_BASE_LAYER,
   MAP_LAYER_KEYS,
   MAP_MODE_IDS,
   CUSTOM_MAP_MODE_OPTION,
   DISABLED_MAP_MODE_IDS,
+  getMapBaseLayerOptions,
   getSelectableMapModeOptions,
   normalizeMapSettings,
 } from "@/features/airport/map-settings/mapSettingsModel";
@@ -85,6 +87,7 @@ export default function MapSettingsSheet({
   userLocationPending = false,
   userLocationNotice = "",
   onSelectMapMode,
+  onSelectBaseLayer,
   onToggleMapLabels,
   onToggleBeams,
   onToggleNavaidMarkers,
@@ -101,6 +104,8 @@ export default function MapSettingsSheet({
     ...getSelectableMapModeOptions(),
     CUSTOM_MAP_MODE_OPTION,
   ];
+  const baseLayerOptions = getMapBaseLayerOptions();
+  const activeBaseLayerId = settings.baseLayer || DEFAULT_MAP_BASE_LAYER;
   const state = {
     showMapLabels,
     showBeams,
@@ -185,6 +190,30 @@ export default function MapSettingsSheet({
                       title={t(mode.labelKey)}
                       description={t(mode.descriptionKey)}
                       onClick={() => onSelectMapMode?.(mode.id)}
+                    />
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="mt-6" aria-labelledby={`${id}-base-map`}>
+              <h3
+                id={`${id}-base-map`}
+                className="mb-3 text-xs font-semibold uppercase text-atc-muted"
+              >
+                {t("mapSettings.baseMapSection")}
+              </h3>
+              <div className="grid grid-cols-2 gap-2">
+                {baseLayerOptions.map((option) => {
+                  const active = activeBaseLayerId === option.id;
+                  return (
+                    <SelectableCard
+                      key={option.id}
+                      active={active}
+                      icon={<MapControlIcon iconKey={option.iconKey} />}
+                      title={t(option.labelKey)}
+                      description={t(option.descriptionKey)}
+                      onClick={() => onSelectBaseLayer?.(option.id)}
                     />
                   );
                 })}

--- a/src/components/map/controls/mapControlIcons.tsx
+++ b/src/components/map/controls/mapControlIcons.tsx
@@ -9,9 +9,11 @@ import {
   Layers,
   ListFilter,
   LocateFixed,
+  Map as MapIcon,
   MapPinned,
   Monitor,
   Moon,
+  Mountain,
   Plane,
   PlaneLanding,
   Radar,
@@ -43,12 +45,16 @@ export function MapControlIcon({ iconKey }) {
       return <ListFilter />;
     case "locateFixed":
       return <LocateFixed />;
+    case "map":
+      return <MapIcon />;
     case "mapPinned":
       return <MapPinned />;
     case "monitor":
       return <Monitor />;
     case "moon":
       return <Moon />;
+    case "mountain":
+      return <Mountain />;
     case "plane":
       return <Plane />;
     case "planeLanding":

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -38,6 +38,7 @@ export default function MapControlBar({
   onToggleAirspaces,
   onToggleCandidateWatchingSpots,
   onSelectMapMode,
+  onSelectBaseLayer,
   onToggleUserLocation = null,
   onToggleUserLocationAudio = null,
   onToggleSidebar,
@@ -93,6 +94,7 @@ export default function MapControlBar({
         userLocationPending={userLocationPending}
         userLocationNotice={userLocationNotice}
         onSelectMapMode={onSelectMapMode}
+        onSelectBaseLayer={onSelectBaseLayer}
         onToggleMapLabels={onToggleMapLabels}
         onToggleBeams={onToggleRunwayBeams}
         onToggleNavaidMarkers={onToggleNavaidMarkers}

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -452,6 +452,7 @@ const en = {
     title: "Map settings",
     description: "Choose a map mode, then fine-tune the layers shown on this airport map.",
     modeSection: "Modes",
+    baseMapSection: "Base map",
     layersSection: "Display",
     guestPrompt: "Map settings are kept on this device.",
     deviceScope: "{device} settings",
@@ -473,6 +474,14 @@ const en = {
       radio: "Navigation aids and labels for listening context.",
       controller: "Airspace, navaids, and route context.",
       custom: "Your manual overrides on top of a preset.",
+    },
+    baseLayers: {
+      standard: "Standard",
+      terrain: "Terrain",
+    },
+    baseLayerDescriptions: {
+      standard: "Clean street map with no terrain shading.",
+      terrain: "Hillshade and topographic relief under the base map.",
     },
   },
   watcherMode: {

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -447,6 +447,7 @@ const zhCN = {
     title: "地图设置",
     description: "选择地图模式,再微调这个机场地图显示的图层。",
     modeSection: "模式",
+    baseMapSection: "底图",
     layersSection: "显示",
     guestPrompt: "未登录时,地图设置会保存在这台设备。",
     deviceScope: "{device}设置",
@@ -468,6 +469,14 @@ const zhCN = {
       radio: "显示导航台和标签,适合配合无线电收听。",
       controller: "显示空域、导航台和航路语境。",
       custom: "基于某个预设叠加你的手动调整。",
+    },
+    baseLayers: {
+      standard: "标准地图",
+      terrain: "地形地貌",
+    },
+    baseLayerDescriptions: {
+      standard: "干净的街道底图,无地形渲染。",
+      terrain: "在底图下方叠加山体阴影和地势起伏。",
     },
   },
   watcherMode: {

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -86,10 +86,59 @@ export const CUSTOM_MAP_MODE_OPTION = Object.freeze({
 
 export const DISABLED_MAP_MODE_IDS = Object.freeze([]);
 
+// Base map vector style the map renders underneath every other layer.
+// `terrain` keeps the current readable-topo treatment (hillshade +
+// muted palette) so existing users see no change unless they switch.
+// A `transport`-themed style was considered but every free option
+// either drops multilingual label support (raster tiles like
+// ÖPNVKarte bake local-language labels) or requires an API key
+// (Thunderforest, MapTiler) — left for a follow-up once we decide
+// which provider to take on.
+const MAP_BASE_LAYER_IDS = Object.freeze({
+  STANDARD: "standard",
+  TERRAIN: "terrain",
+});
+
+export const DEFAULT_MAP_BASE_LAYER = MAP_BASE_LAYER_IDS.TERRAIN;
+
+const MAP_BASE_LAYER_OPTIONS = [
+  {
+    id: MAP_BASE_LAYER_IDS.STANDARD,
+    labelKey: "mapSettings.baseLayers.standard",
+    descriptionKey: "mapSettings.baseLayerDescriptions.standard",
+    iconKey: "map",
+  },
+  {
+    id: MAP_BASE_LAYER_IDS.TERRAIN,
+    labelKey: "mapSettings.baseLayers.terrain",
+    descriptionKey: "mapSettings.baseLayerDescriptions.terrain",
+    iconKey: "mountain",
+  },
+] as const;
+
+const MAP_BASE_LAYER_ID_SET: Set<string> = new Set(
+  Object.values(MAP_BASE_LAYER_IDS),
+);
+
+export function isKnownMapBaseLayer(value: unknown) {
+  return typeof value === "string" && MAP_BASE_LAYER_ID_SET.has(value);
+}
+
+export function normalizeMapBaseLayer(value: unknown) {
+  return isKnownMapBaseLayer(value)
+    ? (value as string)
+    : DEFAULT_MAP_BASE_LAYER;
+}
+
+export function getMapBaseLayerOptions() {
+  return MAP_BASE_LAYER_OPTIONS;
+}
+
 export const DEFAULT_MAP_SETTINGS: MapSettingsRecord = Object.freeze({
   selectedMode: MAP_MODE_IDS.CONTROLLER,
   baseMode: MAP_MODE_IDS.CONTROLLER,
   layerOverrides: Object.freeze({}),
+  baseLayer: DEFAULT_MAP_BASE_LAYER,
   audioEnabled: false,
   hasSelectedMode: false,
   updatedAt: "",
@@ -196,6 +245,7 @@ export function normalizeMapSettings(
     selectedMode,
     baseMode,
     layerOverrides: normalizeMapLayerOverrides(settings?.layerOverrides),
+    baseLayer: normalizeMapBaseLayer(settings?.baseLayer ?? settings?.base_layer),
     audioEnabled: settings?.audioEnabled === true,
     hasSelectedMode:
       settings?.hasSelectedMode === true || settings?.has_selected_mode === true,
@@ -263,6 +313,13 @@ export function mergeMapSettings({
     selectedMode,
     baseMode,
     layerOverrides: nextLayerOverrides,
+    baseLayer:
+      hasOwnSetting(updateRecord, "baseLayer") ||
+      hasOwnSetting(updateRecord, "base_layer")
+        ? normalizeMapBaseLayer(
+            updateRecord.baseLayer ?? updateRecord.base_layer,
+          )
+        : normalized.baseLayer,
     audioEnabled: hasOwnSetting(updateRecord, "audioEnabled")
       ? updateRecord.audioEnabled === true
       : normalized.audioEnabled,
@@ -280,6 +337,20 @@ export function mergeMapSettings({
   });
 }
 
+// Build a settings record with a swapped base layer, preserving the
+// rest of the user's selections. Used by the Base map switcher in the
+// settings sheet.
+export function buildMapSettingsWithBaseLayer({
+  settings = DEFAULT_MAP_SETTINGS,
+  baseLayer = DEFAULT_MAP_BASE_LAYER,
+  now = new Date().toISOString(),
+}: MapSettingsOptions = {}) {
+  return mergeMapSettings({
+    settings,
+    updates: { baseLayer: normalizeMapBaseLayer(baseLayer), updatedAt: now },
+  });
+}
+
 function resolveMapSettingsLayers(
   settings: MapSettingsRecord = DEFAULT_MAP_SETTINGS,
 ) {
@@ -294,6 +365,7 @@ function resolveMapSettingsLayers(
 export function buildPresetMapSettings({
   modeId,
   audioEnabled = false,
+  baseLayer = DEFAULT_MAP_BASE_LAYER,
   now = new Date().toISOString(),
 }: MapSettingsOptions = {}) {
   if (!isSelectableMapModeId(modeId)) {
@@ -304,6 +376,7 @@ export function buildPresetMapSettings({
     selectedMode: preset.id,
     baseMode: preset.id,
     layerOverrides: {},
+    baseLayer: normalizeMapBaseLayer(baseLayer),
     audioEnabled: audioEnabled === true,
     hasSelectedMode: true,
     updatedAt: now,

--- a/src/features/airport/map/mapTileLanguageModel.ts
+++ b/src/features/airport/map/mapTileLanguageModel.ts
@@ -1,7 +1,24 @@
-const OPENFREEMAP_STYLES = Object.freeze({
-  dark: "https://tiles.openfreemap.org/styles/dark",
-  light: "https://tiles.openfreemap.org/styles/positron",
+// OpenFreeMap publishes positron / bright / liberty for light and a
+// dedicated dark style. We map the user's `baseLayer` setting onto the
+// closest OFM upstream:
+//   standard  → positron (clean light) / dark — no terrain shading
+//   terrain   → positron / dark + readable-hillshade processing
+const OPENFREEMAP_STYLE_TABLE: Record<
+  string,
+  Partial<Record<"light" | "dark", string>>
+> = Object.freeze({
+  standard: {
+    light: "https://tiles.openfreemap.org/styles/positron",
+    dark: "https://tiles.openfreemap.org/styles/dark",
+  },
+  terrain: {
+    light: "https://tiles.openfreemap.org/styles/positron",
+    dark: "https://tiles.openfreemap.org/styles/dark",
+  },
 });
+
+const DEFAULT_BASE_LAYER = "terrain";
+const OPENFREEMAP_FALLBACK_DARK = "https://tiles.openfreemap.org/styles/dark";
 
 const MAP_LABEL_LOCALES = Object.freeze({
   en: "en",
@@ -169,8 +186,21 @@ function normalizeMapLabelLocale(locale: string) {
   return MAP_LABEL_LOCALES[locale] || MAP_LABEL_LOCALES.en;
 }
 
-export function getMapLibreBaseStyleUrl(theme: string) {
-  return OPENFREEMAP_STYLES[theme] || OPENFREEMAP_STYLES.dark;
+export function getMapLibreBaseStyleUrl(theme: string, baseLayer?: string) {
+  const themeKey = theme === "light" ? "light" : "dark";
+  const layerKey = baseLayer && OPENFREEMAP_STYLE_TABLE[baseLayer]
+    ? baseLayer
+    : DEFAULT_BASE_LAYER;
+  return (
+    OPENFREEMAP_STYLE_TABLE[layerKey]?.[themeKey] || OPENFREEMAP_FALLBACK_DARK
+  );
+}
+
+// Whether the proxy should apply the readable-hillshade processing on
+// top of the upstream OFM style. The "terrain" base layer is the only
+// option that wants this; standard/transport stay clean.
+export function shouldApplyReadableTerrain(baseLayer?: string) {
+  return (baseLayer || DEFAULT_BASE_LAYER) === "terrain";
 }
 
 function getMapLibreLabelTextField(locale: string) {


### PR DESCRIPTION
## Summary

Adds a Base map section to the Map settings sheet with two options:

- **Standard** — clean street map, no terrain shading
- **Terrain** — same OpenFreeMap base + the existing readable-hillshade pass (default; preserves current look)

Choice is persisted per-device via the existing `mapSettings` flow (signed-in users → Supabase, otherwise localStorage). Mode switches now carry the user's `baseLayer` across — switching from Watcher → Airspace no longer resets the map choice.

## Why no Transport option

Every free transit-themed tile provider has a deal-breaker:
- **ÖPNVKarte / CyclOSM** — raster tiles, labels are baked in local script → breaks the app's en/zh toggle for international users
- **Thunderforest Transport** — best fit, but requires an API key (150k/mo free tier) — left for a follow-up

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 106 test files pass
- [x] `pnpm knip` — exit 0
- [x] `pnpm build` — green
- [ ] Open map settings sheet → Base map section shows 2 cards
- [ ] Click Standard → map re-renders without hillshade (clean positron / dark)
- [ ] Click Terrain → hillshade returns
- [ ] Cycle mode (Watcher/Radio/Airspace) → baseLayer stays as user chose
- [ ] Signed-in: refresh page → choice persists; sign out + back in on a fresh device → desktop and mobile settings remain independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)