### PR TITLE
Airport map: free pan within approach bounds + Recenter button

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -35,7 +35,12 @@ import { useCandidateWatchingSpots } from "@/features/airport/watcher/useCandida
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUserLocationAircraftAudio } from "@/hooks/useUserLocationAircraftAudio";
 import { MAP_MODE_IDS } from "@/features/airport/map-settings/mapSettingsModel";
-import { ZOOM_APPROACH, ZOOM_DETAIL } from "@/utils/airportMapDisplay";
+import {
+  ZOOM_AIRPORT,
+  ZOOM_APPROACH,
+  ZOOM_DETAIL,
+} from "@/utils/airportMapDisplay";
+import { APPROACH_PAN_RADIUS_NM } from "@/utils/airportPanBounds";
 
 const AirportMap = dynamic(() => import("@/components/map/AirportMap"), {
   ssr: false,
@@ -87,6 +92,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
     mapFollowsAircraft,
     setMapZoom,
     applyMapMode,
+    suspendMapFollow,
+    recenterToFocus,
     setUserLocationPreferences,
   } = useExplorerUi();
   const [userLocation, setUserLocation] = useState(null);
@@ -523,6 +530,8 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
               userLocationNotice={userLocationNotice}
               onToggleUserLocation={toggleUserLocation}
               onToggleUserLocationAudio={toggleUserLocationAudio}
+              onRecenter={recenterToFocus}
+              recenterDisabled={mapFollowsAircraft}
             />
           )}
 
@@ -543,6 +552,20 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
             showAirspaces={showAirspaces}
             showCandidateWatchingSpots={showCandidateWatchingSpots}
             baseLayer={mapSettings?.baseLayer}
+            // Airport-view-only soft cage: while the user is at airport
+            // zoom we cap pan to a ~30nm box around the airport so they
+            // can wander out past the runway without losing context.
+            // Approach view is already wide enough that maxBounds adds
+            // nothing, so it's lifted there.
+            freePanRadiusNm={
+              mapZoom === ZOOM_AIRPORT ? APPROACH_PAN_RADIUS_NM : null
+            }
+            // ALL zoom levels suspend auto-follow on user drag — without
+            // this every poll's setView would yank the map back and the
+            // user would feel "stuck in place" trying to look around.
+            // The Recenter button in the map control rail brings them
+            // back when they want it.
+            onUserPan={suspendMapFollow}
             trafficFilter={trafficFilter}
             typeFilter={typeFilter}
             altitudeLevel={altitudeLevel}

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -17,6 +17,8 @@ export default function ExplorerMapMenu({
   onToggleUserLocation = null,
   onToggleUserLocationAudio = null,
   onFitToTrace = null,
+  onRecenter = null,
+  recenterDisabled = true,
   zoomDisabled = false,
 }: Record<string, any> = {}) {
   const {
@@ -78,6 +80,8 @@ export default function ExplorerMapMenu({
         onToggleUserLocationAudio={onToggleUserLocationAudio}
         onToggleSidebar={toggleSidebar}
         onFitToTrace={onFitToTrace}
+        onRecenter={onRecenter}
+        recenterDisabled={recenterDisabled}
       />
 
       <MobileMapSourceStatus

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -126,6 +126,13 @@ function airportExplorerUiReducer(state, action) {
         mapZoom: action.mapZoom,
         mapFollowsAircraft: true,
       };
+    case "recenterToFocus":
+      // Recenter button on the map toolbar: re-engage auto-follow so
+      // the followsCenter effect on AirportMap immediately setView's
+      // back to the focal centre. Independent action from setMapZoom
+      // so the user can recentre without changing zoom level.
+      if (state.mapFollowsAircraft) return state;
+      return { ...state, mapFollowsAircraft: true };
     case "toggleMapLabels":
       return applyManualLayerToggle(
         state,
@@ -520,6 +527,10 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "closeSidebar" });
   }, []);
 
+  const recenterToFocus = useCallback(() => {
+    dispatch({ type: "recenterToFocus" });
+  }, []);
+
   const setMapZoom = useCallback((mapZoom) => {
     dispatch({ type: "setMapZoom", mapZoom });
   }, []);
@@ -684,6 +695,7 @@ export function ExplorerUiProvider({ children }) {
       clearAllPreviewSelections,
       fitToTrace,
       suspendMapFollow,
+      recenterToFocus,
     }),
     [
       sidebarMode,
@@ -738,6 +750,7 @@ export function ExplorerUiProvider({ children }) {
       clearAllPreviewSelections,
       fitToTrace,
       suspendMapFollow,
+      recenterToFocus,
     ],
   );
 

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import L from "leaflet";
 import { MapContext } from "./MapContext";
 import MapTileLayers from "./MapTileLayers";
+import { computeApproachPanBounds } from "@/utils/airportPanBounds";
 import AirportMarker from "./AirportMarker";
 import MapRangeLegend from "./MapRangeLegend";
 import AirspaceLayer from "./AirspaceLayer";
@@ -75,6 +76,12 @@ export default function AirportMap({
   showAirspaces = true,
   showCandidateWatchingSpots = false,
   baseLayer = "terrain",
+  // Free-pan zone. When `freePanRadiusNm` is a positive number AND
+  // followsCenter is true the map snaps a `maxBounds` around the focal
+  // centre so the user can drag freely inside that box. Pass null /
+  // undefined to leave the map unbounded (default).
+  freePanRadiusNm = null,
+  onUserPan = null,
   trafficFilter = "all",
   typeFilter = "all",
   altitudeLevel = "all",
@@ -206,6 +213,47 @@ export default function AirportMap({
       window.clearTimeout(transitionSettleTimer);
     };
   }, [floatingSidebarAware, focalCenter, followsCenter, zoom]);
+
+  // Free-pan box around the airport. When a `freePanRadiusNm` value is
+  // provided the map gets `maxBounds` set so the user can drag freely
+  // inside that envelope but can't lose the focal airport off-screen.
+  // Passing `null` (default) clears the bounds and restores full-globe
+  // panning. Tied to `focalCenter` so the bounds re-anchor if the
+  // airport changes.
+  useEffect(() => {
+    if (!mapInstance || !focalCenter) return undefined;
+    const map: any = mapInstance;
+    if (!freePanRadiusNm || typeof map.setMaxBounds !== "function") {
+      try { map.setMaxBounds?.(null); } catch { /* noop */ }
+      return undefined;
+    }
+    const bounds = computeApproachPanBounds(
+      focalCenter.lat,
+      focalCenter.lon,
+      freePanRadiusNm,
+    );
+    if (!bounds) {
+      try { map.setMaxBounds(null); } catch { /* noop */ }
+      return undefined;
+    }
+    try { map.setMaxBounds(bounds); } catch { /* noop */ }
+    return () => {
+      try { map.setMaxBounds?.(null); } catch { /* noop */ }
+    };
+  }, [mapInstance, focalCenter, freePanRadiusNm]);
+
+  // User-initiated drag → suspend the polling auto-recenter so the
+  // map stays where they dragged it. The toolbar's "Recenter" button
+  // is what brings them back. Only wires up when the parent actually
+  // hands us an `onUserPan` callback.
+  useEffect(() => {
+    if (!mapInstance || !onUserPan) return undefined;
+    const handleDragStart = () => onUserPan();
+    mapInstance.on?.("dragstart", handleDragStart);
+    return () => {
+      mapInstance.off?.("dragstart", handleDragStart);
+    };
+  }, [mapInstance, onUserPan]);
 
   // Clicks on the map background (not on an aircraft marker) clear the
   // selection so the user can drop "trace mode" without targeting an

--- a/src/components/map/controls/MapControlRail.tsx
+++ b/src/components/map/controls/MapControlRail.tsx
@@ -35,6 +35,8 @@ export default function MapControlRail({
   onToggleSidebar,
   onCycleZoom,
   onFitToTrace = null,
+  onRecenter = null,
+  recenterDisabled = true,
   onCycleTheme,
   onToggleSettings,
 }) {
@@ -69,6 +71,19 @@ export default function MapControlRail({
           aria-pressed={!zoomActive && !zoomDisabled}
         >
           <MapControlIcon iconKey="route" />
+        </ToolbarButton>
+      )}
+
+      {onRecenter && (
+        <ToolbarButton
+          tone="rail"
+          title={t("map.recenter")}
+          aria-label={t("map.recenter")}
+          onClick={onRecenter}
+          disabled={recenterDisabled}
+          aria-disabled={recenterDisabled}
+        >
+          <MapControlIcon iconKey="crosshair" />
         </ToolbarButton>
       )}
 

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -43,6 +43,8 @@ export default function MapControlBar({
   onToggleUserLocationAudio = null,
   onToggleSidebar,
   onFitToTrace = null,
+  onRecenter = null,
+  recenterDisabled = true,
 }) {
   const controlZone = useRef(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -118,6 +120,8 @@ export default function MapControlBar({
         onToggleSidebar={onToggleSidebar}
         onCycleZoom={cycleZoom}
         onFitToTrace={onFitToTrace}
+        onRecenter={onRecenter}
+        recenterDisabled={recenterDisabled}
         onCycleTheme={cycleTheme}
         onToggleSettings={toggleSettings}
       />

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -407,6 +407,7 @@ const en = {
     layerOverlaysAria: "Map layer overlays",
     toggleSidebar: "Toggle sidebar",
     fitTrace: "Fit map to trace",
+    recenter: "Recenter on airport",
     zoomLockedFlightAware: "Zoom is locked while using FlightAware fallback",
     approachingView: "Approaching view (click to cycle)",
     themeButtonAria: "Theme: {label} (click to switch)",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -402,6 +402,7 @@ const zhCN = {
     layerOverlaysAria: "地图图层叠加",
     toggleSidebar: "切换侧栏",
     fitTrace: "适配航迹",
+    recenter: "回到机场中心",
     zoomLockedFlightAware: "FlightAware 兜底时锁定缩放",
     approachingView: "进近视图(点击循环)",
     themeButtonAria: "主题:{label}(点击切换)",

--- a/src/utils/airportPanBounds.test.ts
+++ b/src/utils/airportPanBounds.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+
+import {
+  APPROACH_PAN_RADIUS_NM,
+  computeApproachPanBounds,
+} from "./airportPanBounds";
+
+const NM_PER_DEGREE_LAT = 60;
+
+// KBOS — 42.36°N, 71.01°W
+const bos = computeApproachPanBounds(42.36, -71.01);
+assert.ok(bos, "expected bounds for KBOS");
+const [[south, west], [north, east]] = bos!;
+const expectedLatDelta = APPROACH_PAN_RADIUS_NM / NM_PER_DEGREE_LAT;
+assert.ok(Math.abs((north - south) / 2 - expectedLatDelta) < 1e-9, "lat half-span matches radius");
+assert.ok(west < -71.01 && east > -71.01, "longitude box brackets the airport");
+const lonHalfSpan = (east - west) / 2;
+// at 42°N, cos(42) ≈ 0.743, so lon delta should be ~ latDelta / 0.743
+const expectedLonHalfSpan = expectedLatDelta / Math.cos((42.36 * Math.PI) / 180);
+assert.ok(Math.abs(lonHalfSpan - expectedLonHalfSpan) < 1e-9, "lon half-span widens by cos(lat)");
+
+// Invalid inputs return null instead of throwing.
+assert.equal(computeApproachPanBounds(Number.NaN, 0), null);
+assert.equal(computeApproachPanBounds(0, Number.POSITIVE_INFINITY), null);
+assert.equal(computeApproachPanBounds(0, 0, 0), null);
+assert.equal(computeApproachPanBounds(0, 0, -5), null);
+
+// Polar-ish airport still produces a wide-but-finite box.
+const polar = computeApproachPanBounds(89.5, 0);
+assert.ok(polar, "expected bounds near pole");
+const [, [polarN]] = polar!;
+assert.ok(Number.isFinite(polarN), "polar latitude box is finite");
+
+console.log("airportPanBounds.test.ts ok");

--- a/src/utils/airportPanBounds.ts
+++ b/src/utils/airportPanBounds.ts
@@ -1,0 +1,35 @@
+// Bounding box for the "free pan" zone the user is allowed to roam in
+// while at airport zoom. Picked to roughly match approach-airspace
+// scale (~30nm radius from the airport) so the user can wander out
+// past the runway threshold but not lose the airport entirely.
+//
+// Returns a Leaflet-shaped `[[s,w],[n,e]]` tuple. Pure / framework-
+// free so tests don't need to touch Leaflet.
+
+const NM_PER_DEGREE_LAT = 60;
+
+export const APPROACH_PAN_RADIUS_NM = 30;
+
+export type LatLngBounds = [[number, number], [number, number]];
+
+export function computeApproachPanBounds(
+  lat: number,
+  lon: number,
+  radiusNm: number = APPROACH_PAN_RADIUS_NM,
+): LatLngBounds | null {
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (!Number.isFinite(radiusNm) || radiusNm <= 0) return null;
+
+  const latDelta = radiusNm / NM_PER_DEGREE_LAT;
+  const cosLat = Math.cos((lat * Math.PI) / 180);
+  // Near the poles cos(lat) approaches 0 — fall back to a very wide
+  // longitudinal box so the user can still pan. Sub-equatorial airports
+  // are nowhere near this case in practice but the guard is cheap.
+  const safeCosLat = Math.max(Math.abs(cosLat), 0.05);
+  const lonDelta = latDelta / safeCosLat;
+
+  return [
+    [lat - latDelta, lon - lonDelta],
+    [lat + latDelta, lon + lonDelta],
+  ];
+}


### PR DESCRIPTION
## Summary

Airport detail page only — gives the user real drag freedom on the map without losing the airport:

- **Drag at any zoom suspends auto-follow** (`dragstart` → `suspendMapFollow`) so the map stays where the user dragged it instead of being yanked back every poll tick.
- **Soft 30nm cage at airport zoom**. When `mapZoom === ZOOM_AIRPORT` (zoom 11), Leaflet `maxBounds` is set to a ~30nm box around the airport — wander past the runway, can't lose the airport off-screen.
- **New Recenter button** on the map control rail (Crosshair icon, rail tone). Enabled only while `mapFollowsAircraft = false`. Click → re-engage auto-follow → existing `followsCenter` effect snaps back to focal centre.

Flight detail page unchanged (`FlightExplorer` doesn't pass the new props).

## Test plan

- [x] `pnpm lint` → 0 errors
- [x] `pnpm test` → 107 test files pass (new `airportPanBounds.test.ts`)
- [x] `pnpm knip` → exit 0
- [x] `pnpm build` → green
- [x] Browser verified at `/airport/KBOS`:
  - Airport zoom: drag holds new centre across 5s of polling; 4000px panBy clamps inside the box
  - Recenter button snaps view back to KBOS
  - Approach + Detail zoom: no maxBounds set
  - Recenter button disabled while already following
- [ ] Pinch-zoom across the breakpoints on touch — should be smooth
- [ ] Drag from inside the box outward → leaflet elastic-snap-back at edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)