### PR TITLE
Rename Plane Hunter trigger to 开始拍机 (zh-CN)

### DIFF
--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -296,7 +296,7 @@ const zhCN = {
     loadingTrace: "正在加载航迹…",
     openAirport: "追踪机场",
     viewingAirport: "正在查看机场",
-    planeHunter: "飞机探长",
+    planeHunter: "开始拍机",
     creditPrefix: "图源@",
   },
   planeHunter: {


### PR DESCRIPTION
## Summary
- The aircraft preview's call-to-action button reads **开始拍机** in Chinese now, swapping out the brand name 飞机探长 for an action verb.
- English copy and the studio's own title / kicker / error messages keep using "Plane Hunter" / 飞机探长 so the feature still has an identity outside the trigger.

## Test plan
- [ ] Switch the language to 中文 and open any aircraft preview — the trigger button should read **开始拍机**.
- [ ] Open the studio and confirm the desktop sidebar heading still reads **飞机探长** (the brand name is preserved inside the modal).