### PR TITLE
Release v2.0.0 — Plane Hunter GA + iOS detail-page scroll fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "1.13.1",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -469,7 +469,7 @@ function AirportExplorerContent({ icao = "", airport = null, onBack }) {
       <div
         className={`font-sans text-atc-text ${
           isMobile
-            ? "fixed inset-0 z-0 flex overflow-hidden overscroll-y-auto"
+            ? "app-detail-shell fixed inset-0 z-0 flex overflow-hidden overscroll-y-none"
             : `airport-map-kit ${
                 sidebarOpen ? "airport-map-kit--sidebar-open" : ""
               } flex h-dvh overflow-hidden`

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -754,7 +754,7 @@ function FlightExplorerContent({ callsign }) {
       <div
         className={`font-sans text-atc-text ${
           isMobile
-            ? "fixed inset-0 z-0 flex overflow-hidden overscroll-y-auto"
+            ? "app-detail-shell fixed inset-0 z-0 flex overflow-hidden overscroll-y-none"
             : `airport-map-kit ${
                 sidebarOpen ? "airport-map-kit--sidebar-open" : ""
               } flex h-dvh overflow-hidden`

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -6,6 +6,21 @@
 
 export const CHANGELOG = [
   {
+    version: "v2.0.0",
+    kind: "breaking",
+    title: "Plane Hunter mode goes GA",
+    summary:
+      "Plane Hunter ships to every signed-in user as a two-step capture studio: full-bleed shooting (native OS camera or library upload), then a compose pane that bakes the chosen template into a shareable PNG. A new Maps template centers an OpenStreetMap tile on the photographer's location and overlays the aircraft when it falls inside the visible tile.",
+    highlights: [
+      "Two-step flow — capture step is a full-bleed viewfinder with shutter, library upload, opt-in rule-of-thirds grid, and a back arrow; compose step holds tabbed Templates / Settings and share / retake / copy actions",
+      "Touch devices hand off to the OS camera via `<input capture>` instead of an in-page getUserMedia viewfinder, so iOS Safari and Android Chrome get the system camera UI",
+      "New Maps template centers an OSM tile on your location with a diamond \"I'm here\" marker; the aircraft renders as a heading-rotated plane glyph when it sits inside the tile, with picker-selectable corner placement",
+      "Compose pane matches Map Settings — control-surface chips with ink-fill + bottom-glow active state, arranged in grids so all four templates fit on one row",
+      "Plane Hunter is GA — feature flag removed, Chinese trigger label renamed to 开始拍机",
+      "Fixed: iOS Safari rubber-band scroll on airport / flight detail pages — the full-viewport map shell no longer drags up off the screen",
+    ],
+  },
+  {
     version: "v1.13.1",
     kind: "patch",
     title: "Toolbar opacity polish and louder map-settings error logging",

--- a/src/style.css
+++ b/src/style.css
@@ -1270,6 +1270,19 @@ body {
     font-family: var(--font-sans);
 }
 
+/* iOS Safari rubber-bands the document body even when no element is
+   scrollable, so dragging up on an airport / flight detail page slides
+   the whole map UI and exposes the page background. Lock document
+   overscroll only while a `.app-detail-shell` (full-viewport map
+   layout) is mounted — static pages keep their normal scroll, and
+   in-component gestures (preview-card swipe-to-dismiss, map drag)
+   stay live because we don't touch `touch-action`. */
+html:has(.app-detail-shell),
+body:has(.app-detail-shell) {
+    overflow: hidden;
+    overscroll-behavior: none;
+}
+
 .sidebar-shell,
 .dither-page-panel {
     --atc-bg: var(--sidebar);


### PR DESCRIPTION
## Summary
- **Plane Hunter mode goes GA.** Two-step capture studio (full-bleed shooting + tabbed compose), new Maps template centered on the photographer's location with a diamond \"I'm here\" marker and a heading-rotated plane glyph when the aircraft is nearby, native OS camera + library upload paths, light-theme polish to match Map Settings.
- **Bump to v2.0.0** — \`package.json\` + new \`CHANGELOG[0]\` entry. About panel and site metadata read from \`CHANGELOG[0]\` so no other version strings need updating.
- **Bug fix (iOS):** the airport and flight detail pages no longer rubber-band the document body. Added \`.app-detail-shell\` marker class on the mobile detail wrappers + a \`:has()\` rule that clamps \`overflow\` / \`overscroll-behavior\` on \`html\` and \`body\` while a detail shell is mounted. Static pages and in-component gestures (preview-card swipe-to-dismiss) are unaffected.

## Test plan
- [ ] iPhone Safari: open an airport detail page and try to drag the map UI upward — the page should no longer slide and expose the background.
- [ ] Same check on a flight (\`/aircraft/...\`) detail page.
- [ ] Confirm the preview-card swipe-to-dismiss and map drag/pinch still work on mobile.
- [ ] Static pages (Home, About, Mechanism, Changelog) scroll as before.
- [ ] \`/about\` shows \`2.0.0\` in the version badge; \`/changelog\` top entry is the new v2.0.0 release.