### PR TITLE
Show airspaces on /here via the aviation context tile fetch

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -539,6 +539,12 @@ function AirportExplorerContent({
             nearbyNavaids={airport?.nearbyNavaids || []}
             airspaces={airport?.airspaces || []}
             airport={airport}
+            // In near-me mode the airport profile has no ICAO and so
+            // no server-side airspaces / navaids attached. Flip the
+            // lat/lon-keyed aviation context tile fetch on so the
+            // map still shows Class B/C/D etc. polygons around the
+            // user — same hook the flight explorer already uses.
+            contextTileOverlays={nearMe}
             showMapLabels={showMapLabels}
             showRunwayBeams={showRunwayBeams}
             showNavaidMarkers={showNavaidMarkers}


### PR DESCRIPTION
## Summary

The new `/here` explorer was rendering aircraft + nearby airport pins + base map but no airspace polygons. User in Boston flagged this — Boston has Class B + surrounding Class C/D and none of it was showing.

Root cause: airspaces on the airport detail flow come from `airport.airspaces`, which is server-side fetched and ICAO-keyed. The near-me profile has no ICAO, so that array is empty. AirportMap also has a lat/lon-keyed alternative — `useAviationContextTiles` — that the flight explorer already enables via the `contextTileOverlays` prop. Just flip it on when `nearMe` is set.

One-line change in `AirportExplorer.tsx`: pass `contextTileOverlays={nearMe}` to `AirportMap`. The merge logic that combines server-side `airspaces` with tile-fetched `contextTiles.airspaces` already exists — for the near-me profile, the server array is empty so we just get the tile-fetched layer.

## Test plan

- [x] Reload `/here` from a Boston geolocation grant — Class B + surrounding Class C/D polygons render around BOS, MHT, BED, BVY, OWD.
- [x] `/airport/KBOS` regression check — `nearMe` is false there, `contextTileOverlays` stays false, the existing server-side `airport.airspaces` flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)