### PR TITLE
Allow useAircraftPositions to poll without an ICAO

### DIFF
--- a/src/hooks/useAircraftPositions.ts
+++ b/src/hooks/useAircraftPositions.ts
@@ -47,9 +47,14 @@ export function useAircraftPositions(icao, lat, lon, options: Record<string, any
   const distNm = normalizeAircraftRangeNm(options?.distNm);
   const queryLat = normalizeLatitude(lat);
   const queryLon = normalizeLongitude(lon);
-  const hasActiveQuery = Boolean(
-    icao && hasFiniteFlightPosition({ lat: queryLat, lon: queryLon }),
-  );
+  // ICAO is used only for log labelling — the actual fetch is by
+  // lat/lon. The near-me explorer (no airport ICAO) needs aircraft
+  // polling too, so the active-query gate only checks for valid
+  // coordinates.
+  const hasActiveQuery = hasFiniteFlightPosition({
+    lat: queryLat,
+    lon: queryLon,
+  });
   const [aircraft, setAircraft] = useState([]);
   const [loading, setLoading] = useState(false);
   const [initialLoading, setInitialLoading] = useState(false);


### PR DESCRIPTION
## Summary

User flagged that the new `/here` page wasn't really showing nearby aircraft — the list looked airport-heavy and the Flights metric card stayed at 0.

Root cause: `useAircraftPositions`'s `hasActiveQuery` gate required `icao && hasFiniteFlightPosition(lat, lon)`. The actual ADS-B fetch is by lat/lon only (ICAO is just a log label inside the warning message), so blocking the gate on a truthy ICAO meant the near-me explorer — which deliberately passes `icao = ""` — never polled. Drop the ICAO clause from the gate; `poll()` itself already short-circuits when lat/lon are missing.

After the fix, `/here` shows ~25-50 nearby aircraft (depending on time of day) just like `/airport/[icao]` does, with the search box, route/type/altitude filter chips, click-to-preview, and Plane Hunter all working.

## Test plan

- [x] `/here` — Boston grant — Flights card jumps from 0 → 27, list populates with real callsigns (LVL274V, ICE55L, EIN109…), clicking an aircraft opens the preview card (photo, telemetry, Track trace, Plane Hunter).
- [x] `/airport/KBOS` regression — still passes both `icao` + lat/lon, behavior unchanged.
- [x] `pnpm test` — 106 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)