### PR TITLE
Reverse-geocode the near-me identity hero

### DIFF
--- a/src/app/api/proxy/reverse-geocode/route.ts
+++ b/src/app/api/proxy/reverse-geocode/route.ts
@@ -1,0 +1,100 @@
+import {
+  createCorsPreflightResponse,
+  enforceProxyRequest,
+  jsonProxyResponse,
+  normalizeLatitude,
+  normalizeLongitude,
+} from "@/app/api/_shared/apiProxySecurity";
+
+// Same-origin proxy in front of Nominatim's `/reverse` endpoint so
+// the near-me explorer can resolve "what city am I in" without
+// adding nominatim.openstreetmap.org to the global CSP `connect-src`
+// list. We also identify ourselves with a proper User-Agent (Nominatim
+// rejects requests without one for sustained use) and apply a tight
+// rate limit on the proxy so a single tab can't hammer the upstream.
+
+const rateLimit = {
+  key: "proxy:reverse-geocode",
+  maxRequests: 30,
+  windowMs: 60_000,
+};
+
+// Nominatim's usage policy asks every client to identify itself.
+// Vercel functions don't expose the deployment URL synchronously here,
+// so we fall back to a stable label. Override via NEXT_PUBLIC_SITE_URL
+// when present.
+const USER_AGENT = `ADSBao/1.0 (${process.env.NEXT_PUBLIC_SITE_URL || "https://adsbao.dev"})`;
+
+// 30 minutes shared cache + 30 minutes stale-while-revalidate. Cities
+// don't move; Nominatim asks clients to cache aggressively.
+const CACHE_HEADERS = {
+  "Cache-Control":
+    "public, max-age=1800, s-maxage=1800, stale-while-revalidate=1800",
+};
+
+export const runtime = "nodejs";
+
+export function OPTIONS(request) {
+  return createCorsPreflightResponse(request);
+}
+
+export async function GET(request) {
+  const securityResponse = enforceProxyRequest(request, { rateLimit });
+  if (securityResponse) return securityResponse;
+
+  const url = new URL(request.url);
+  const lat = normalizeLatitude(url.searchParams.get("lat"));
+  const lon = normalizeLongitude(url.searchParams.get("lon"));
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return jsonProxyResponse(
+      request,
+      { error: "lat and lon query parameters are required" },
+      { status: 400 },
+    );
+  }
+
+  const language = sanitizeAcceptLanguage(
+    url.searchParams.get("language") || "en",
+  );
+  const upstream = new URL("https://nominatim.openstreetmap.org/reverse");
+  upstream.searchParams.set("lat", String(lat));
+  upstream.searchParams.set("lon", String(lon));
+  upstream.searchParams.set("format", "json");
+  // zoom=10 returns city / town granularity — the right altitude for
+  // a hero copy: "Boston" / "Massachusetts" / "United States".
+  upstream.searchParams.set("zoom", "10");
+  upstream.searchParams.set("accept-language", language);
+
+  try {
+    const response = await fetch(upstream, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+    });
+    if (!response.ok) {
+      return jsonProxyResponse(
+        request,
+        { error: `Upstream HTTP ${response.status}` },
+        { status: 502 },
+      );
+    }
+    const json = await response.json();
+    return jsonProxyResponse(request, json, { headers: CACHE_HEADERS });
+  } catch (error) {
+    console.error("[reverse-geocode] Nominatim request failed", error);
+    return jsonProxyResponse(
+      request,
+      { error: "Failed to reverse-geocode" },
+      { status: 502 },
+    );
+  }
+}
+
+// `accept-language` should look like `zh-CN,en` or `en` — strip anything
+// outside the standard locale tag character set so we don't pass user
+// input straight through to the upstream.
+function sanitizeAcceptLanguage(raw: string) {
+  return String(raw || "")
+    .trim()
+    .slice(0, 60)
+    .replace(/[^A-Za-z0-9,\-_]/g, "")
+    .toLowerCase() || "en";
+}

--- a/src/components/sidebar/AirportIdentity.tsx
+++ b/src/components/sidebar/AirportIdentity.tsx
@@ -7,6 +7,7 @@ import { countryName, flagEmoji } from "../../utils/flag";
 import { airportCityName, airportDisplayName } from "../../utils/airport";
 import { resolveTimezone } from "../../utils/timezone";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useReverseGeocode } from "@/hooks/useReverseGeocode";
 
 export default function AirportIdentity({
   icao = "",
@@ -24,8 +25,35 @@ export default function AirportIdentity({
   nearMe = false,
 }) {
   const { locale, t } = useI18n();
+  // Reverse-geocode the user's lat/lon when in near-me mode so the
+  // identity hero reads as the actual place (Boston / Massachusetts /
+  // 🇺🇸 United States) rather than the static "HERE / Your location"
+  // labels. While the geocode is in-flight the UI falls back to the
+  // static copy so the hero never appears empty.
+  const { data: place } = useReverseGeocode(
+    nearMe ? lat : null,
+    nearMe ? lon : null,
+    locale,
+  );
+  const nearMeBadge =
+    nearMe && (place?.city || place?.county)
+      ? place.city || place.county
+      : t("sidebar.nearMeBadge");
+  const nearMeTitle =
+    nearMe && place?.state ? place.state : t("sidebar.nearMeTitle");
+  const nearMeCountryCode = place?.countryCode || "";
+  const nearMeCountryLabel =
+    place?.countryName ||
+    (nearMeCountryCode ? countryName(nearMeCountryCode, locale) : "") ||
+    "";
+  const nearMeFlag = nearMeCountryCode ? flagEmoji(nearMeCountryCode) : "";
+  const nearMeSubtitle =
+    nearMe && (nearMeFlag || nearMeCountryLabel)
+      ? [nearMeFlag, nearMeCountryLabel].filter(Boolean).join(" ").trim()
+      : t("sidebar.nearMeSubtitle");
+
   const codeLine = nearMe
-    ? t("sidebar.nearMeBadge")
+    ? nearMeBadge
     : iata && iata !== icao
       ? `${iata} · ${icao}`
       : icao || "—";
@@ -33,10 +61,10 @@ export default function AirportIdentity({
   const countryLabel = nearMe ? "" : countryName(country, locale) || country;
   const cityLabel = nearMe ? "" : airportCityName(city, locale);
   const displayName = nearMe
-    ? t("sidebar.nearMeTitle")
+    ? nearMeTitle
     : airportDisplayName({ icao, iata, name, localizedName }, locale);
   const placeText = nearMe
-    ? t("sidebar.nearMeSubtitle")
+    ? nearMeSubtitle
     : [cityLabel, countryLabel].filter(Boolean).join(", ");
   const placeLine =
     !nearMe && flag && placeText

--- a/src/features/location/reverseGeocodeClient.ts
+++ b/src/features/location/reverseGeocodeClient.ts
@@ -1,0 +1,120 @@
+// Reverse-geocodes a lat/lon to city / state / country labels using
+// OpenStreetMap's Nominatim service. Nominatim is free, CORS-friendly
+// (it ships `access-control-allow-origin: *`), and respects the
+// browser's Origin header for usage attribution.
+//
+// Results are cached in-memory keyed by rounded lat/lon so a single
+// session never re-hits the API for the same coords (Nominatim's
+// usage policy caps clients at 1 req/sec; the cache plus the
+// geolocation jitter floor keep us well under that).
+
+type NominatimAddress = {
+  city?: unknown;
+  town?: unknown;
+  village?: unknown;
+  hamlet?: unknown;
+  municipality?: unknown;
+  borough?: unknown;
+  county?: unknown;
+  district?: unknown;
+  state_district?: unknown;
+  state?: unknown;
+  region?: unknown;
+  country?: unknown;
+  country_code?: unknown;
+};
+
+type NominatimResponse = {
+  address?: NominatimAddress;
+};
+
+export type ReverseGeocodeResult = {
+  // Most specific human-friendly place name available — city, then a
+  // town/village/borough fallback for non-urban locations.
+  city: string;
+  // County / district level above the city (US: "Suffolk County",
+  // UK: a district, etc.). Empty when the response doesn't list one.
+  county: string;
+  // First-level subdivision: US state, Chinese province, etc.
+  state: string;
+  // Localized country name + ISO-3166 alpha-2 country code (uppercase).
+  countryName: string;
+  countryCode: string;
+};
+
+const CACHE = new Map<string, ReverseGeocodeResult>();
+// Same-origin proxy in front of Nominatim so we don't have to relax
+// the app's CSP `connect-src` and the upstream sees our application
+// User-Agent (set inside the proxy route).
+const ENDPOINT = "/api/proxy/reverse-geocode";
+
+function normalizeString(value: unknown) {
+  return String(value || "").trim();
+}
+
+function firstNonEmpty(...values: Array<unknown>) {
+  for (const value of values) {
+    const text = normalizeString(value);
+    if (text) return text;
+  }
+  return "";
+}
+
+function cacheKey(lat: number, lon: number, language: string) {
+  // ~1km resolution is plenty for "what city am I in" — and the GPS
+  // jitter floor would otherwise re-issue this request constantly.
+  return `${lat.toFixed(2)}:${lon.toFixed(2)}:${language}`;
+}
+
+// `accept-language` can be a comma-delimited preference list; we pass
+// the user's UI locale first so localizable fields (city / state /
+// country) come back in their language when Nominatim has translated
+// names, with English as the fallback.
+function buildAcceptLanguage(language: string) {
+  const primary = normalizeString(language).toLowerCase();
+  if (!primary || primary === "en") return "en";
+  return `${primary},en`;
+}
+
+export async function fetchReverseGeocode(
+  lat: number,
+  lon: number,
+  language = "en",
+): Promise<ReverseGeocodeResult | null> {
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  const key = cacheKey(lat, lon, language);
+  if (CACHE.has(key)) return CACHE.get(key) || null;
+
+  const url =
+    `${ENDPOINT}?lat=${lat}&lon=${lon}` +
+    `&language=${encodeURIComponent(buildAcceptLanguage(language))}`;
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) throw new Error(`reverse-geocode HTTP ${response.status}`);
+  const json = (await response.json()) as NominatimResponse;
+  const address = json?.address || {};
+
+  const result: ReverseGeocodeResult = {
+    // City fallback chain — Nominatim populates the most specific
+    // bucket the OSM relation provided. Urban points usually fill
+    // `city`; rural points fill `town` / `village` / `hamlet`.
+    city: firstNonEmpty(
+      address.city,
+      address.town,
+      address.village,
+      address.borough,
+      address.hamlet,
+      address.municipality,
+    ),
+    county: firstNonEmpty(
+      address.county,
+      address.district,
+      address.state_district,
+    ),
+    state: firstNonEmpty(address.state, address.region),
+    countryName: normalizeString(address.country),
+    countryCode: normalizeString(address.country_code).toUpperCase(),
+  };
+
+  CACHE.set(key, result);
+  return result;
+}

--- a/src/hooks/useReverseGeocode.ts
+++ b/src/hooks/useReverseGeocode.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  fetchReverseGeocode,
+  type ReverseGeocodeResult,
+} from "@/features/location/reverseGeocodeClient";
+
+// Resolve a lat/lon to a localized place (city / county / state /
+// country). Cancels out when the coords change so a stale response
+// can't clobber the active one. Falls back to `null` on network /
+// parse errors — the consumer is expected to show its own fallback
+// copy in that case.
+export function useReverseGeocode(
+  lat: number | null | undefined,
+  lon: number | null | undefined,
+  language = "en",
+) {
+  const [data, setData] = useState<ReverseGeocodeResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+      setData(null);
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    fetchReverseGeocode(lat as number, lon as number, language)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch(() => {
+        if (!cancelled) setData(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [lat, lon, language]);
+
+  return { data, loading };
+}


### PR DESCRIPTION
## Summary

Static "HERE / Your location / Live aircraft around you" in the near-me sidebar replaced with the user's actual place — city in the badge, state as the title, flag + country as the subtitle.

In Boston this reads as **Position · Quincy** / **Massachusetts** / **🇺🇸 United States** (Quincy is the nearest city at the geolocated lat/lon, with Boston a few NM north).

### How it works

- **`src/app/api/proxy/reverse-geocode/route.ts`** — Next.js route handler in front of Nominatim's `/reverse` endpoint. Same-origin so we don't have to add `https://nominatim.openstreetmap.org` to the global CSP `connect-src`. Sends the User-Agent Nominatim requires for sustained use, applies a tight rate limit (30 req/min/IP), and caches responses 30 min + another 30 min stale-while-revalidate. `zoom=10` returns city granularity (zoom 18 = building, zoom 5 = country).
- **`src/features/location/reverseGeocodeClient.ts`** — Thin client with in-memory caching keyed by `lat.toFixed(2) / lon.toFixed(2)` (~1km buckets so geolocation jitter doesn't re-issue). Fallback chain for the city extracts `city → town → village → borough → hamlet → municipality`; county chain is `county → district → state_district`.
- **`src/hooks/useReverseGeocode.ts`** — Small hook with cancel-on-coord-change.
- **`AirportIdentity` near-me branch** — Badge = city (fallback county), title = state (fallback "Your location"), subtitle = flag + country (fallback "Live aircraft around you"). While the geocode is in-flight or on error the existing static labels still render so the hero is never blank.

`accept-language` honors the user's UI locale (zh-CN first, English fallback) so localized place names come back when Nominatim has translations.

### Why I didn't relax CSP

The original first attempt hit Nominatim directly from the client. CSP `connect-src` blocked it (`Failed to fetch`). Same-origin proxy keeps the CSP tight, lets us set the User-Agent the upstream's usage policy requires, and gives a single chokepoint for caching + rate-limiting in front of a third-party we don't control.

## Test plan

- [x] `/here` from a Boston grant — hero renders as `Quincy` / `Massachusetts` / `🇺🇸 United States`, lat/lon and device-local time still visible below.
- [x] `/airport/KBOS` — unchanged (hook only fires when `nearMe` is true, and AirportIdentity falls back to the airport identity when no reverse-geocode data).
- [x] Proxy returns localized state/city when `language=zh-CN` (verified with `curl /api/proxy/reverse-geocode?lat=42.28&lon=-71.03&language=zh-CN` against Nominatim — Quincy stays Quincy in many cases since OSM tags aren't always translated, but country/state come back as 美国 / 马萨诸塞州 where available).
- [x] `pnpm test` — 106 files pass.
- [x] `tsc --noEmit` clean for touched files.
- [x] `eslint` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)