### PR TITLE
Auto-refresh /here as the user moves

### DIFF
--- a/src/components/screens/NearMeScreen.tsx
+++ b/src/components/screens/NearMeScreen.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { LocateFixed } from "lucide-react";
 import AirportExplorer from "@/components/airport/explorer/AirportExplorer";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { setLocaleSearchParam } from "@/features/app-shell/i18n/i18nModel";
+import { getDistanceNm } from "@/utils/aircraftTrafficIntent";
+
+// Minimum movement (in NM) before the explorer is re-centered on the
+// new lat/lon. ~0.15 NM ≈ 280 m is roughly a city block — small
+// enough that the page reacts to a walk across town within a minute
+// or two, large enough that GPS jitter (typically 5–30 m on phones)
+// doesn't trigger a re-fetch on every watchPosition tick.
+const POSITION_REFRESH_THRESHOLD_NM = 0.15;
 
 // `/here` — explorer view centered on the user's current position
 // instead of an airport. Mirrors the `/airport/[icao]` shell but
@@ -22,25 +30,67 @@ export default function NearMeScreen() {
     "idle" | "requesting" | "granted" | "denied" | "unavailable"
   >("idle");
   const [errorMessage, setErrorMessage] = useState("");
+  // Active geolocation watch id (numeric handle returned by
+  // navigator.geolocation.watchPosition). Stored in a ref so re-renders
+  // don't restart the watch — we only want to start once on mount and
+  // tear it down on unmount.
+  const watchIdRef = useRef<number | null>(null);
 
+  // Continuously track the user's position so a real-world move
+  // refreshes the explorer without the user touching anything.
+  // watchPosition fires every time the OS sees a position change;
+  // we apply a movement threshold downstream so we don't thrash
+  // re-fetches on GPS jitter (typically 5–30m on phones).
   const requestLocation = useCallback(() => {
-    if (typeof navigator === "undefined" || !navigator.geolocation?.getCurrentPosition) {
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.geolocation?.watchPosition
+    ) {
       setStatus("unavailable");
       setErrorMessage(t("nearMe.unsupported"));
       return;
     }
+    // Stop any in-flight watch before starting a new one (the user
+    // hit "Try again" after a previous denial, or the component
+    // re-ran the effect because of a hot reload).
+    if (
+      watchIdRef.current != null &&
+      typeof navigator.geolocation.clearWatch === "function"
+    ) {
+      navigator.geolocation.clearWatch(watchIdRef.current);
+      watchIdRef.current = null;
+    }
     setStatus("requesting");
     setErrorMessage("");
-    navigator.geolocation.getCurrentPosition(
+    watchIdRef.current = navigator.geolocation.watchPosition(
       (position) => {
         const { latitude, longitude } = position.coords;
-        if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
-          setCoords({ lat: latitude, lon: longitude });
-          setStatus("granted");
-        } else {
+        if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
           setStatus("unavailable");
           setErrorMessage(t("nearMe.unsupported"));
+          return;
         }
+        // Always mark "granted" on a successful tick — the prompt
+        // closes as soon as we have any fix.
+        setStatus("granted");
+        // Only push a coord update when the user has materially
+        // moved. The downstream lat/lon-keyed fetches (aircraft
+        // polling, reverse geocode, METAR via closest airport,
+        // airspace tiles) all re-issue on coord changes, so we
+        // gate at this layer.
+        setCoords((previous) => {
+          if (!previous) return { lat: latitude, lon: longitude };
+          const distance = getDistanceNm(
+            previous.lat,
+            previous.lon,
+            latitude,
+            longitude,
+          );
+          if (distance != null && distance < POSITION_REFRESH_THRESHOLD_NM) {
+            return previous;
+          }
+          return { lat: latitude, lon: longitude };
+        });
       },
       (error) => {
         if (error?.code === error?.PERMISSION_DENIED) {
@@ -51,14 +101,26 @@ export default function NearMeScreen() {
           setErrorMessage(error?.message || t("nearMe.unsupported"));
         }
       },
-      { enableHighAccuracy: true, timeout: 12_000, maximumAge: 60_000 },
+      { enableHighAccuracy: true, timeout: 12_000, maximumAge: 30_000 },
     );
   }, [t]);
 
-  // Kick off the geolocation prompt on mount. The browser remembers a
-  // prior grant on this origin so the second visit doesn't re-prompt.
+  // Start the watch on mount. The browser remembers prior grants on
+  // this origin so the second visit doesn't re-prompt. Watch is torn
+  // down on unmount so we don't leak listeners or keep the GPS hot
+  // when the user navigates away.
   useEffect(() => {
     requestLocation();
+    return () => {
+      if (
+        watchIdRef.current != null &&
+        typeof navigator !== "undefined" &&
+        typeof navigator.geolocation?.clearWatch === "function"
+      ) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+        watchIdRef.current = null;
+      }
+    };
   }, [requestLocation]);
 
   const airport = useMemo(


### PR DESCRIPTION
## Summary

Previously `/here` called `getCurrentPosition` once on mount, so the explorer stayed pinned to wherever the device was at the first geolocation read. If the user walked / drove / boarded a flight, the page didn't follow.

Switch to `watchPosition` so position updates stream in continuously. Apply a 0.15 NM (~280 m, roughly a city block) movement threshold before committing a new `coords` to React state — that's the gate that keeps the downstream lat/lon-keyed fetches from thrashing on GPS jitter (typically 5–30 m on phones).

What auto-updates once `coords` change:

- **Aircraft list / map markers** — `useAircraftPositions(_, lat, lon)` keyed on coords.
- **Sidebar identity hero** — `useReverseGeocode(lat, lon, locale)` re-fires when coords cross a `0.01°` cache-bucket boundary (~1 km), so Boston → Cambridge shows the new place name.
- **Weather card** — METAR pulls from the nearest airport derived from the recomputed nearby-airports query.
- **Airspace overlays** — `useAviationContextTiles` already re-fetches when the map center pans (its tile-bbox listener handles this).
- **Map center** — `AirportMap` recenters whenever `lat`/`lon` props change.

Watch teardown: on unmount + on "Try again" after a denial, so we don't leak listeners or keep the GPS hot across navigations.

Threshold rationale: 0.15 NM ≈ 280 m. Walking ~5 km/h, that's roughly every 3.4 minutes — reactive but not noisy. Driving 60 mph, every ~10 seconds — refreshes between traffic. GPS jitter is 5–30 m on phones, well below the threshold.

## Test plan

- [x] Open `/here`, wait for grant — same one-shot UX as before.
- [x] Watch handle stored in a ref so re-renders don't restart the watch.
- [x] Watch torn down on unmount (verified by `clearWatch` in the effect cleanup).
- [x] `pnpm test` — 106 files pass.
- [x] `tsc --noEmit` + `eslint` clean on touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)