### PR TITLE
Add interface unit preferences (distance / temperature / altitude)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import ThemedToaster from "@/components/app-shell/ThemedToaster";
 import { I18nProvider } from "@/features/app-shell/i18n/i18nProvider";
 import QueryProvider from "@/features/app-shell/queryProvider";
+import { UnitPreferencesProvider } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { isConcreteTheme } from "@/utils/theme";
 import "leaflet/dist/leaflet.css";
 import "maplibre-gl/dist/maplibre-gl.css";
@@ -121,7 +122,9 @@ export default async function RootLayout({ children }) {
         <ClerkProvider>
           <I18nProvider initialLocale={locale}>
             <QueryProvider>
-              <div className="min-h-dvh bg-atc-bg text-atc-text">{children}</div>
+              <UnitPreferencesProvider>
+                <div className="min-h-dvh bg-atc-bg text-atc-text">{children}</div>
+              </UnitPreferencesProvider>
             </QueryProvider>
           </I18nProvider>
           <ThemedToaster

--- a/src/components/aircraft/preview/AircraftPreviewMetadata.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMetadata.tsx
@@ -3,8 +3,10 @@
 import type { ComponentProps, ReactNode } from "react";
 import NumberFlow from "@number-flow/react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { getAircraftPositionSourceBadge } from "@/features/aviation/sourceDisplayModel";
 import { toFiniteNumber } from "@/utils/math";
+import { convertDistanceFromNm, distanceUnitLabel } from "@/utils/units";
 
 type NumberFlowFormat = ComponentProps<typeof NumberFlow>["format"];
 
@@ -36,9 +38,12 @@ type NumericMetaProps = {
 // readout reads as live as the aircraft moves through the airspace.
 export default function AircraftPreviewMetadata({ aircraft }: AircraftPreviewMetadataProps) {
   const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const hex = aircraft?.icao24 ? aircraft.icao24.toUpperCase() : "—";
   const track = toFiniteNumber(aircraft?.track);
   const distance = toFiniteNumber(aircraft?.distanceNm);
+  const distanceConverted =
+    distance == null ? null : convertDistanceFromNm(distance, units.distance);
   const sourceBadge = getAircraftPositionSourceBadge(aircraft?.positionQuality);
 
   return (
@@ -50,12 +55,12 @@ export default function AircraftPreviewMetadata({ aircraft }: AircraftPreviewMet
         value={track != null ? Math.round(track) : null}
         suffix="°"
       />
-      {distance != null && (
+      {distanceConverted != null && (
         <NumericMeta
           label={t("metrics.distance")}
-          value={distance}
+          value={distanceConverted}
           format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
-          suffix=" NM"
+          suffix={` ${distanceUnitLabel(units.distance)}`}
         />
       )}
     </dl>

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -8,7 +8,9 @@ import { Plane } from "lucide-react";
 import { toFiniteNumber } from "@/utils/math";
 import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { resolveAircraftDisplayModel } from "@/features/aircraft/aircraftTypeDisplayModel";
+import { formatAltitude } from "@/utils/units";
 import {
   MobilePreviewContent,
   MobilePreviewDetailRow,
@@ -68,6 +70,7 @@ function AirlineLogo({ src }: AirlineLogoProps) {
 
 export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewMobileCardProps) {
   const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const callsign =
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
   const typeDisplay = resolveAircraftDisplayModel(aircraft || {});
@@ -101,11 +104,21 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
     );
   }
   if (altitude != null || onGround) {
+    const altDisplay =
+      altitude == null
+        ? null
+        : formatAltitude(altitude, units.altitude, { kind: "cruise" });
     stats.push(
       onGround ? (
         <Stat key="alt" plain={t("aircraft.gnd")} />
+      ) : altDisplay?.text ? (
+        <Stat key="alt" plain={altDisplay.text} />
       ) : (
-        <Stat key="alt" value={Math.round(altitude)} unit="ft" />
+        <Stat
+          key="alt"
+          value={altDisplay?.value ?? 0}
+          unit={altDisplay?.unit ?? "ft"}
+        />
       ),
     );
   }

--- a/src/components/aircraft/preview/AircraftPreviewTelemetry.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewTelemetry.tsx
@@ -2,17 +2,24 @@
 
 import NumberFlow from "@number-flow/react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { toFiniteNumber } from "@/utils/math";
+import { formatAltitude } from "@/utils/units";
 
 // Live flight telemetry — GS / ALT / V/S. Values tween between polls via
 // NumberFlow so the readout reads as continuously instrumented (the
 // aircraft is actually moving), not as a stuttering update.
 export default function AircraftPreviewTelemetry({ aircraft }) {
   const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const speed = toFiniteNumber(aircraft?.velocity);
   const altitude = toFiniteNumber(aircraft?.altitude);
   const vs = toFiniteNumber(aircraft?.baroRate);
   const onGround = Boolean(aircraft?.onGround);
+  const altitudeDisplay =
+    altitude == null
+      ? null
+      : formatAltitude(altitude, units.altitude, { kind: "cruise" });
 
   return (
     <dl className="aircraft-preview-telemetry">
@@ -23,11 +30,16 @@ export default function AircraftPreviewTelemetry({ aircraft }) {
       />
       {onGround ? (
         <TextStat label={t("metrics.altitude")} value={t("aircraft.gnd")} />
+      ) : altitudeDisplay?.text ? (
+        <TextStat
+          label={t("metrics.altitude")}
+          value={altitudeDisplay.text}
+        />
       ) : (
         <NumericStat
           label={t("metrics.altitude")}
-          value={altitude != null ? Math.round(altitude) : null}
-          unit="ft"
+          value={altitudeDisplay?.value ?? null}
+          unit={altitudeDisplay?.unit ?? "ft"}
         />
       )}
       <NumericStat

--- a/src/components/aircraft/preview/AirportPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/AirportPreviewMetadataCard.tsx
@@ -8,12 +8,19 @@ import { countryName, flagEmoji } from "@/utils/flag";
 import { airportCityName, airportDisplayName } from "@/utils/airport";
 import { toFiniteNumber } from "@/utils/math";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import {
+  convertDistanceFromNm,
+  distanceUnitLabel,
+  formatAltitude,
+} from "@/utils/units";
 
 // Airport variant of the bottom-right preview card. Mirrors the aircraft
 // card's chrome (same container class so the slide-in / blur / sizing
 // match) and exposes a Track link that lands on /airport/[icao].
 export default function AirportPreviewMetadataCard({ airport }) {
   const { locale, t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const pathname = usePathname();
   const icao = (airport?.icao || "").trim().toUpperCase();
   const iata = (airport?.iata || "").trim().toUpperCase();
@@ -25,7 +32,13 @@ export default function AirportPreviewMetadataCard({ airport }) {
   const placeText = [city, country].filter(Boolean).join(", ");
   const placeLine = flag && placeText ? `${flag} ${placeText}` : placeText;
   const distance = toFiniteNumber(airport?.distanceNm);
+  const distanceConverted =
+    distance == null ? null : convertDistanceFromNm(distance, units.distance);
   const elevation = toFiniteNumber(airport?.elevationFt);
+  const elevationDisplay =
+    elevation == null
+      ? null
+      : formatAltitude(elevation, units.altitude, { kind: "ground" });
   const detailRows = [
     { label: t("metrics.iata"), value: iata },
     { label: t("metrics.icao"), value: icao },
@@ -84,19 +97,19 @@ export default function AirportPreviewMetadataCard({ airport }) {
           {t("metrics.distance")}
         </dt>
         <dd className="text-right text-atc-text">
-          {distance == null ? (
+          {distanceConverted == null ? (
             "—"
           ) : (
             <>
               <NumberFlow
-                value={distance}
+                value={distanceConverted}
                 format={{
                   maximumFractionDigits: 1,
                   minimumFractionDigits: 1,
                 }}
               />
               <span className="notranslate ml-1 text-atc-dim" translate="no">
-                NM
+                {distanceUnitLabel(units.distance)}
               </span>
             </>
           )}
@@ -105,13 +118,13 @@ export default function AirportPreviewMetadataCard({ airport }) {
           {t("metrics.elevation")}
         </dt>
         <dd className="text-right text-atc-text">
-          {elevation == null ? (
+          {!elevationDisplay ? (
             "—"
           ) : (
             <>
-              <NumberFlow value={Math.round(elevation)} />
+              <NumberFlow value={elevationDisplay.value ?? 0} />
               <span className="notranslate ml-1 text-atc-dim" translate="no">
-                FT
+                {elevationDisplay.unit.toUpperCase()}
               </span>
             </>
           )}

--- a/src/components/aircraft/preview/AirportPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AirportPreviewMobileCard.tsx
@@ -7,6 +7,12 @@ import { airportCityName, airportDisplayName } from "@/utils/airport";
 import { countryName, flagEmoji } from "@/utils/flag";
 import { toFiniteNumber } from "@/utils/math";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import {
+  convertDistanceFromNm,
+  distanceUnitLabel,
+  formatAltitude,
+} from "@/utils/units";
 import {
   MobilePreviewContent,
   MobilePreviewDetailRow,
@@ -41,6 +47,7 @@ type StatProps = {
 // structure used by aircraft and navaids.
 export default function AirportPreviewMobileCard({ airport }: AirportPreviewMobileCardProps) {
   const { locale, t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const icao = (airport?.icao || "").trim().toUpperCase();
   const iata = (airport?.iata || "").trim().toUpperCase();
   const codeLine = iata && iata !== icao ? `${iata} · ${icao}` : icao || "—";
@@ -51,7 +58,13 @@ export default function AirportPreviewMobileCard({ airport }: AirportPreviewMobi
   const placeText = [city, country].filter(Boolean).join(", ");
   const placeLine = flag && placeText ? `${flag} ${placeText}` : placeText;
   const distance = toFiniteNumber(airport?.distanceNm);
+  const distanceConverted =
+    distance == null ? null : convertDistanceFromNm(distance, units.distance);
   const elevation = toFiniteNumber(airport?.elevationFt);
+  const elevationDisplay =
+    elevation == null
+      ? null
+      : formatAltitude(elevation, units.altitude, { kind: "ground" });
   const hasStats = distance != null || elevation != null;
 
   return (
@@ -63,15 +76,18 @@ export default function AirportPreviewMobileCard({ airport }: AirportPreviewMobi
         secondary={
           hasStats ? (
             <span className="flex items-baseline justify-end gap-[10px]">
-              {distance != null ? (
+              {distanceConverted != null ? (
                 <Stat
-                  value={distance}
-                  unit="NM"
+                  value={distanceConverted}
+                  unit={distanceUnitLabel(units.distance)}
                   format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
                 />
               ) : null}
-              {elevation != null ? (
-                <Stat value={Math.round(elevation)} unit="ft" />
+              {elevationDisplay && elevationDisplay.value != null ? (
+                <Stat
+                  value={elevationDisplay.value}
+                  unit={elevationDisplay.unit}
+                />
               ) : null}
             </span>
           ) : null

--- a/src/components/map/MapRangeLegend.tsx
+++ b/src/components/map/MapRangeLegend.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 import { useMapInstance } from "./MapContext";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import { convertDistanceFromNm, distanceUnitLabel } from "@/utils/units";
 
 // Bottom-left adaptive scale bar (比例尺). Snaps to the largest "nice"
 // NM step under TARGET_PX so the label doesn't flicker through
@@ -16,6 +18,7 @@ const NICE_NM_STEPS = [
 
 export default function MapRangeLegend() {
   const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const map = useMapInstance();
   const [scale, setScale] = useState(null);
 
@@ -55,10 +58,13 @@ export default function MapRangeLegend() {
 
   if (!scale) return null;
 
+  const displayDistance =
+    Math.round(convertDistanceFromNm(scale.nm, units.distance) * 10) / 10;
+
   return (
     <div
       role="note"
-      aria-label={t("map.distanceAria", { distance: scale.nm })}
+      aria-label={t("map.distanceAria", { distance: displayDistance })}
       className="pointer-events-none absolute right-3 top-[calc(12px+env(safe-area-inset-top))] z-map-legend flex items-center gap-2 rounded-[8px] border border-[var(--atc-border-default)] bg-[var(--atc-surface-preview-card)] px-2.5 py-1.5 font-mono text-[var(--map-range-text)] shadow-[var(--app-panel-shadow)] backdrop-blur-md md:bottom-3 md:left-3 md:right-auto md:top-auto"
     >
       <span
@@ -84,7 +90,11 @@ export default function MapRangeLegend() {
         />
       </div>
       <span className="text-[10px] font-semibold tracking-[0.12em] tabular-nums">
-        {scale.nm} <span className="notranslate" translate="no">NM</span>
+        {displayDistance}
+        {" "}
+        <span className="notranslate" translate="no">
+          {distanceUnitLabel(units.distance)}
+        </span>
       </span>
     </div>
   );

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -21,8 +21,35 @@ import {
 import { SelectableCard } from "@/components/ui/SelectableCard";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import {
+  ALTITUDE_UNITS,
+  DISTANCE_UNITS,
+  TEMPERATURE_UNITS,
+} from "@/features/app-shell/unitPreferences/unitPreferencesModel";
 import AsyncStatusLine from "@/components/ui/AsyncStatusLine";
 import { MapControlIcon } from "./mapControlIcons";
+
+const UNIT_GROUPS = [
+  {
+    key: "distance",
+    titleKey: "mapSettings.units.distance.title",
+    options: DISTANCE_UNITS,
+    labelKey: (unit: string) => `mapSettings.units.distance.options.${unit}`,
+  },
+  {
+    key: "temperature",
+    titleKey: "mapSettings.units.temperature.title",
+    options: TEMPERATURE_UNITS,
+    labelKey: (unit: string) => `mapSettings.units.temperature.options.${unit}`,
+  },
+  {
+    key: "altitude",
+    titleKey: "mapSettings.units.altitude.title",
+    options: ALTITUDE_UNITS,
+    labelKey: (unit: string) => `mapSettings.units.altitude.options.${unit}`,
+  },
+] as const;
 
 const LAYER_CONTROLS = [
   {
@@ -101,6 +128,8 @@ export default function MapSettingsSheet({
   mapSettingsSaveCycle = 0,
 }) {
   const { t } = useI18n();
+  const { preferences: unitPreferences, setPreferences: setUnitPreferences } =
+    useUnitPreferences();
   const { isLoaded, isSignedIn } = useUser();
   const settings = normalizeMapSettings(mapSettings);
   const modeOptions = [
@@ -381,6 +410,56 @@ export default function MapSettingsSheet({
                   {userLocationNotice}
                 </div>
               ) : null}
+            </section>
+
+            <section className="mt-6" aria-labelledby={`${id}-units`}>
+              <h3
+                id={`${id}-units`}
+                className="mb-3 text-[11px] font-semibold uppercase text-atc-muted"
+              >
+                {t("mapSettings.unitsSection")}
+              </h3>
+              <div className="space-y-3">
+                {UNIT_GROUPS.map((group) => {
+                  const activeUnit = unitPreferences[group.key];
+                  return (
+                    <div key={group.key} className="flex flex-col gap-1.5">
+                      <span className="text-[11px] font-semibold leading-tight text-atc-text">
+                        {t(group.titleKey)}
+                      </span>
+                      <div
+                        role="radiogroup"
+                        aria-label={t(group.titleKey)}
+                        className="grid auto-cols-fr grid-flow-col gap-1.5"
+                      >
+                        {group.options.map((option) => {
+                          const active = activeUnit === option;
+                          return (
+                            <button
+                              key={option}
+                              type="button"
+                              role="radio"
+                              aria-checked={active}
+                              onClick={() =>
+                                setUnitPreferences({ [group.key]: option } as any)
+                              }
+                              className={cn(
+                                "min-h-[36px] rounded-[8px] border px-2 text-[12px] font-semibold leading-none transition",
+                                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-focus-ring)]",
+                                active
+                                  ? "border-[var(--atc-interaction-primary-accent)] bg-[var(--atc-click-bg)] text-[var(--atc-click-fg)]"
+                                  : "border-[var(--atc-border-default)] bg-[var(--atc-surface-row-rest)] text-atc-text hover:border-[var(--atc-line-strong)]",
+                              )}
+                            >
+                              {t(group.labelKey(option))}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
             </section>
           </div>
 

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -9,8 +9,10 @@ import {
   getFlightRouteAirlineIconUrl,
 } from "../../utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { formatFlightTelemetryMetric } from "@/features/aircraft/tracking/flightTelemetryDisplayModel";
 import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplayModel";
+import { formatAltitude } from "@/utils/units";
 
 // Tiny self-contained <img> that hides itself if the URL 404s. Avoids
 // stamped broken-image icons in dense list rows when the logo isn't
@@ -37,6 +39,7 @@ export default function AircraftRow({
   onSelectAircraft,
 }: Record<string, any>) {
   const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const callsign = aircraft.callsign?.trim() || aircraft.icao24 || "-";
   const route = aircraft.flightRouteLabel || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft.flightRoute);
@@ -49,14 +52,17 @@ export default function AircraftRow({
     routeMunicipalities && routeMunicipalities !== route,
   );
   const distValue = toNumber(aircraft.distanceNm);
-  const distanceDisplay = formatNearbyDistanceDisplay(distValue);
-  const altitudeDisplay = formatFlightTelemetryMetric({
+  const distanceDisplay = formatNearbyDistanceDisplay(distValue, units.distance);
+  const rawAltitude = formatFlightTelemetryMetric({
     metric: "altitude",
     value: aircraft.altitude,
     onGround: aircraft.onGround,
     flightPositionSource: aircraft.flight_position_source,
     positionQuality: aircraft.positionQuality,
   });
+  const altitudeDisplay = rawAltitude
+    ? formatAltitude(aircraft.altitude, units.altitude, { kind: "cruise" })
+    : null;
 
   return (
     <button
@@ -97,10 +103,12 @@ export default function AircraftRow({
           <span>{t("aircraft.gnd")}</span>
         ) : !altitudeDisplay ? (
           <span>-</span>
+        ) : altitudeDisplay.text ? (
+          <NumberWithUnit text={altitudeDisplay.text} unit="" />
         ) : (
           <NumberWithUnit
             value={altitudeDisplay.value}
-            unit={altitudeDisplay.suffix.toUpperCase()}
+            unit={altitudeDisplay.unit.toUpperCase()}
           />
         )}
       </div>

--- a/src/components/sidebar/AirportRow.tsx
+++ b/src/components/sidebar/AirportRow.tsx
@@ -3,9 +3,11 @@
 import { TowerControl } from "lucide-react";
 import NumberFlow from "@number-flow/react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplayModel";
 import { airportCityName, airportDisplayName } from "@/utils/airport";
 import { countryName } from "@/utils/flag";
+import { formatAltitude } from "@/utils/units";
 
 // Airport equivalent of AircraftRow — same column rhythm so an
 // "airports & aircraft" mixed list reads as one coherent table.
@@ -18,6 +20,7 @@ export default function AirportRow({
   onSelectAirport,
 }: Record<string, any>) {
   const { locale, t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const icao = airport?.icao || "";
   const iata = airport?.iata || "";
   const code = iata && iata !== icao ? `${iata} · ${icao}` : icao || "—";
@@ -27,8 +30,12 @@ export default function AirportRow({
     [city, country].filter(Boolean).join(", ") ||
     airportDisplayName(airport, locale);
   const dist = toFiniteNumber(airport?.distanceNm);
-  const distanceDisplay = formatNearbyDistanceDisplay(dist);
+  const distanceDisplay = formatNearbyDistanceDisplay(dist, units.distance);
   const elevation = toFiniteNumber(airport?.elevationFt);
+  const elevationDisplay =
+    elevation == null
+      ? null
+      : formatAltitude(elevation, units.altitude, { kind: "ground" });
   const endpointRole = normalizeEndpointRole(airport?.routeEndpointRole);
   const endpointLabel = endpointRole
     ? t(
@@ -75,10 +82,13 @@ export default function AirportRow({
           <span className="text-[9px] uppercase tracking-normal text-atc-dim">
             {endpointLabel}
           </span>
-        ) : elevation == null ? (
+        ) : !elevationDisplay ? (
           <span>—</span>
         ) : (
-          <NumberWithUnit value={Math.round(elevation)} unit="FT" />
+          <NumberWithUnit
+            value={elevationDisplay.value}
+            unit={elevationDisplay.unit.toUpperCase()}
+          />
         )}
       </div>
     </button>

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -4,8 +4,13 @@ import { useMemo } from "react";
 import NumberFlow from "@number-flow/react";
 import { SidebarMetricCard, SidebarMetricGrid } from "./SidebarMetric";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel";
 import { ARRIVAL, DEPARTURE } from "@/utils/aircraftMovement";
+import {
+  convertTemperatureFromC,
+  temperatureUnitLabel,
+} from "@/utils/units";
 
 export default function SidebarViewSwitch({
   activeView = "briefing",
@@ -27,7 +32,8 @@ export default function SidebarViewSwitch({
   nearMe = false,
 }) {
   const { t } = useI18n();
-  const temperature = formatTemperature(metar);
+  const { preferences: units } = useUnitPreferences();
+  const temperature = formatTemperature(metar, units.temperature);
   const rule = metar?.flightCategory?.toUpperCase() || "WX";
   const showMovementCards =
     nearMe || routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
@@ -105,8 +111,9 @@ export default function SidebarViewSwitch({
   );
 }
 
-function formatTemperature(metar) {
+function formatTemperature(metar, unit) {
   const temp = Number(metar?.rawTemp);
-  if (!Number.isFinite(temp)) return { value: "—", unit: "°C" };
-  return { value: Math.round(temp), unit: "°C" };
+  const label = temperatureUnitLabel(unit);
+  if (!Number.isFinite(temp)) return { value: "—", unit: label };
+  return { value: Math.round(convertTemperatureFromC(temp, unit)), unit: label };
 }

--- a/src/components/weather/WeatherSlides.tsx
+++ b/src/components/weather/WeatherSlides.tsx
@@ -15,7 +15,28 @@ import {
   toNumber,
 } from "../../features/weather/weatherModel";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import {
+  altitudeUnitLabel,
+  convertAltitudeFromFt,
+  convertTemperatureFromC,
+  temperatureUnitLabel,
+} from "@/utils/units";
 import AsyncStatusLine from "@/components/ui/AsyncStatusLine";
+
+function formatTemperatureValue(celsius, unit) {
+  if (celsius == null || !Number.isFinite(Number(celsius))) return "-";
+  const converted = convertTemperatureFromC(Number(celsius), unit);
+  return `${round1(converted)}${temperatureUnitLabel(unit)}`;
+}
+
+function formatGroundAltitudeFeet(ft, unit) {
+  if (ft == null || !Number.isFinite(Number(ft))) return null;
+  // Ceilings / elevations don't use FL — fall back to ft if user picked FL.
+  const targetUnit = unit === "fl" ? "ft" : unit;
+  const converted = convertAltitudeFromFt(Number(ft), targetUnit);
+  return `${Math.round(converted).toLocaleString()} ${altitudeUnitLabel(targetUnit)}`;
+}
 
 export function MetarSlide({
   metarRaw,
@@ -99,9 +120,14 @@ export function FlightRulesSlide({ metar }) {
 
 export function CeilingSlide({ metar }) {
   const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const visibility = toNumber(metar?.rawVisib);
   const ceilingFt = getCeilingFeet(metar);
-  const ceilingLabel = metar?.ceiling || (ceilingFt == null ? "CLR" : `${ceilingFt.toLocaleString()} ft`);
+  const ceilingLabel =
+    metar?.ceiling ||
+    (ceilingFt == null
+      ? "CLR"
+      : formatGroundAltitudeFeet(ceilingFt, units.altitude) ?? `${ceilingFt}`);
 
   return (
     <div className="weather-slide-stack">
@@ -161,6 +187,7 @@ export function WindSlide({ metar, localWeather }) {
 
 export function TemperatureSlide({ metar, localWeather }) {
   const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const temp = toNumber(metar?.rawTemp) ?? localWeather?.temperatureC;
   const dew = toNumber(metar?.rawDewp) ?? null;
   const spread = temp != null && dew != null ? Math.max(0, temp - dew) : null;
@@ -179,15 +206,19 @@ export function TemperatureSlide({ metar, localWeather }) {
         <div className="weather-token-strip weather-token-strip--cols-3">
           <WeatherToken
             label={t("weather.temp")}
-            value={temp == null ? "-" : `${round1(temp)}°C`}
+            value={formatTemperatureValue(temp, units.temperature)}
           />
           <WeatherToken
             label={t("weather.dew")}
-            value={dew == null ? "-" : `${round1(dew)}°C`}
+            value={formatTemperatureValue(dew, units.temperature)}
           />
           <WeatherToken
             label={t("weather.spread")}
-            value={spread == null ? "-" : `${round1(spread)}°C`}
+            value={
+              spread == null
+                ? "-"
+                : `${round1(units.temperature === "f" ? spread * 1.8 : spread)}${temperatureUnitLabel(units.temperature)}`
+            }
           />
         </div>
         <div className="temp-card__band-row" aria-hidden="true">
@@ -245,6 +276,7 @@ export function LocalWeatherSlide({
   localWeatherStatusCode = null,
 }) {
   const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
   const condition = localWeather
     ? t(getWeatherConditionKey(localWeather.weatherCode))
     : t("weather.pending");
@@ -258,7 +290,7 @@ export function LocalWeatherSlide({
       ? localWeatherLoading
         ? t("weather.loading")
         : "-"
-      : `${round1(localWeather.temperatureC)}°C`;
+      : formatTemperatureValue(localWeather.temperatureC, units.temperature);
 
   return (
     <div className="weather-visual-layout">
@@ -281,7 +313,7 @@ export function LocalWeatherSlide({
             />
             <WeatherToken
               label={t("weather.feels")}
-              value={feelsLike == null ? "-" : `${round1(feelsLike)}°C`}
+              value={formatTemperatureValue(feelsLike, units.temperature)}
               valueClassName="weather-token__value--secondary"
             />
           </div>

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -541,6 +541,21 @@ const en = {
     modeSection: "Modes",
     baseMapSection: "Base map",
     layersSection: "Display",
+    unitsSection: "Units",
+    units: {
+      distance: {
+        title: "Distance",
+        options: { nm: "NM", mi: "mi", km: "km" },
+      },
+      temperature: {
+        title: "Temperature",
+        options: { c: "°C", f: "°F" },
+      },
+      altitude: {
+        title: "Altitude",
+        options: { ft: "ft", m: "m", fl: "FL" },
+      },
+    },
     guestPrompt: "Map settings are kept on this device.",
     deviceScope: "{device} settings",
     savedSettingsAvailable: "Saved to your account.",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -533,6 +533,21 @@ const zhCN = {
     modeSection: "模式",
     baseMapSection: "底图",
     layersSection: "显示",
+    unitsSection: "单位",
+    units: {
+      distance: {
+        title: "距离",
+        options: { nm: "海里", mi: "英里", km: "公里" },
+      },
+      temperature: {
+        title: "温度",
+        options: { c: "°C", f: "°F" },
+      },
+      altitude: {
+        title: "高度",
+        options: { ft: "英尺", m: "米", fl: "FL" },
+      },
+    },
     guestPrompt: "未登录时,地图设置会保存在这台设备。",
     deviceScope: "{device}设置",
     savedSettingsAvailable: "已保存到你的账户。",

--- a/src/features/app-shell/unitPreferences/UnitPreferencesProvider.tsx
+++ b/src/features/app-shell/unitPreferences/UnitPreferencesProvider.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  DEFAULT_UNIT_PREFERENCES,
+  mergeUnitPreferences,
+  normalizeUnitPreferences,
+  type UnitPreferences,
+} from "./unitPreferencesModel";
+import {
+  readStoredUnitPreferences,
+  writeStoredUnitPreferences,
+} from "./unitPreferencesStorage";
+
+interface UnitPreferencesContextValue {
+  preferences: UnitPreferences;
+  setPreferences: (patch: Partial<UnitPreferences>) => void;
+  hydrated: boolean;
+}
+
+const DEFAULT_CONTEXT: UnitPreferencesContextValue = {
+  preferences: DEFAULT_UNIT_PREFERENCES,
+  setPreferences: () => {},
+  hydrated: false,
+};
+
+const UnitPreferencesContext =
+  createContext<UnitPreferencesContextValue>(DEFAULT_CONTEXT);
+
+export function UnitPreferencesProvider({ children }: { children: ReactNode }) {
+  const [preferences, setPreferencesState] = useState<UnitPreferences>(
+    DEFAULT_UNIT_PREFERENCES,
+  );
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const stored = readStoredUnitPreferences();
+    if (stored) setPreferencesState(stored);
+    setHydrated(true);
+  }, []);
+
+  const setPreferences = useCallback((patch: Partial<UnitPreferences>) => {
+    setPreferencesState((current) => {
+      const next = mergeUnitPreferences(current, patch);
+      writeStoredUnitPreferences(next);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      preferences: normalizeUnitPreferences(preferences),
+      setPreferences,
+      hydrated,
+    }),
+    [preferences, setPreferences, hydrated],
+  );
+
+  return (
+    <UnitPreferencesContext.Provider value={value}>
+      {children}
+    </UnitPreferencesContext.Provider>
+  );
+}
+
+export function useUnitPreferences() {
+  return useContext(UnitPreferencesContext);
+}

--- a/src/features/app-shell/unitPreferences/unitPreferencesModel.ts
+++ b/src/features/app-shell/unitPreferences/unitPreferencesModel.ts
@@ -1,0 +1,64 @@
+// User-pickable interface units. Stored client-side; defaults match the
+// aviation conventions ADSBao started with so a fresh install reads the same
+// way as today (nautical miles, Celsius, feet).
+
+export const DISTANCE_UNITS = ["nm", "mi", "km"] as const;
+export const TEMPERATURE_UNITS = ["c", "f"] as const;
+export const ALTITUDE_UNITS = ["ft", "m", "fl"] as const;
+
+export type DistanceUnit = (typeof DISTANCE_UNITS)[number];
+export type TemperatureUnit = (typeof TEMPERATURE_UNITS)[number];
+export type AltitudeUnit = (typeof ALTITUDE_UNITS)[number];
+
+export interface UnitPreferences {
+  distance: DistanceUnit;
+  temperature: TemperatureUnit;
+  altitude: AltitudeUnit;
+}
+
+export const DEFAULT_UNIT_PREFERENCES: UnitPreferences = Object.freeze({
+  distance: "nm",
+  temperature: "c",
+  altitude: "ft",
+});
+
+function normalizeMember<T extends string>(
+  value: unknown,
+  members: readonly T[],
+  fallback: T,
+): T {
+  if (typeof value !== "string") return fallback;
+  const lowered = value.toLowerCase() as T;
+  return members.includes(lowered) ? lowered : fallback;
+}
+
+export function normalizeUnitPreferences(
+  value: unknown = DEFAULT_UNIT_PREFERENCES,
+): UnitPreferences {
+  const record =
+    value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  return {
+    distance: normalizeMember(
+      record.distance,
+      DISTANCE_UNITS,
+      DEFAULT_UNIT_PREFERENCES.distance,
+    ),
+    temperature: normalizeMember(
+      record.temperature,
+      TEMPERATURE_UNITS,
+      DEFAULT_UNIT_PREFERENCES.temperature,
+    ),
+    altitude: normalizeMember(
+      record.altitude,
+      ALTITUDE_UNITS,
+      DEFAULT_UNIT_PREFERENCES.altitude,
+    ),
+  };
+}
+
+export function mergeUnitPreferences(
+  current: UnitPreferences,
+  patch: Partial<UnitPreferences>,
+): UnitPreferences {
+  return normalizeUnitPreferences({ ...current, ...patch });
+}

--- a/src/features/app-shell/unitPreferences/unitPreferencesStorage.ts
+++ b/src/features/app-shell/unitPreferences/unitPreferencesStorage.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import {
+  DEFAULT_UNIT_PREFERENCES,
+  normalizeUnitPreferences,
+  type UnitPreferences,
+} from "./unitPreferencesModel";
+
+const STORAGE_KEY = "adsbao:unit-preferences:v1";
+
+export function readStoredUnitPreferences(): UnitPreferences | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return normalizeUnitPreferences(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredUnitPreferences(
+  preferences: UnitPreferences = DEFAULT_UNIT_PREFERENCES,
+) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(normalizeUnitPreferences(preferences)),
+    );
+  } catch {
+    // localStorage unavailable (private mode / quota) — in-memory still applies.
+  }
+}

--- a/src/features/aviation/distanceDisplayModel.ts
+++ b/src/features/aviation/distanceDisplayModel.ts
@@ -1,10 +1,12 @@
-export function formatNearbyDistanceDisplay(distanceNm: unknown) {
-  if (distanceNm == null || distanceNm === "") return null;
-  const distance = Number(distanceNm);
-  if (!Number.isFinite(distance)) return null;
-  const rounded = Math.max(0, Math.round(distance));
-  if (rounded < 1) {
-    return { value: null, unit: "NM", text: "<1" };
-  }
-  return { value: rounded, unit: "NM", text: null };
+import { formatDistance } from "@/utils/units";
+import type { DistanceUnit } from "@/features/app-shell/unitPreferences/unitPreferencesModel";
+
+// Shared distance formatter for the nearby-airport / nearby-aircraft list
+// surfaces. Honors the user's distance unit preference (defaults to NM so the
+// existing call sites keep their previous behavior).
+export function formatNearbyDistanceDisplay(
+  distanceNm: unknown,
+  unit: DistanceUnit = "nm",
+) {
+  return formatDistance(distanceNm, unit, { precision: 0 });
 }

--- a/src/utils/units.test.ts
+++ b/src/utils/units.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+
+import {
+  convertDistanceFromNm,
+  convertTemperatureFromC,
+  convertAltitudeFromFt,
+  formatAltitude,
+  formatDistance,
+  formatTemperature,
+} from "./units";
+
+// --- Distance conversions
+
+assert.equal(convertDistanceFromNm(100, "nm"), 100);
+assert.equal(Math.round(convertDistanceFromNm(100, "km") * 10) / 10, 185.2);
+assert.equal(
+  Math.round(convertDistanceFromNm(100, "mi") * 10) / 10,
+  115.1,
+);
+
+// --- Temperature conversions
+
+assert.equal(convertTemperatureFromC(0, "c"), 0);
+assert.equal(convertTemperatureFromC(0, "f"), 32);
+assert.equal(convertTemperatureFromC(100, "f"), 212);
+assert.equal(convertTemperatureFromC(-40, "f"), -40);
+
+// --- Altitude conversions (raw)
+
+assert.equal(convertAltitudeFromFt(1000, "ft"), 1000);
+assert.equal(Math.round(convertAltitudeFromFt(1000, "m")), 305);
+assert.equal(convertAltitudeFromFt(35000, "fl"), 350);
+
+// --- formatDistance honors precision and sub-one fallback
+
+assert.deepEqual(formatDistance(9.3, "nm", { precision: 0 }), {
+  value: 9,
+  unit: "NM",
+  text: null,
+});
+assert.deepEqual(formatDistance(0.4, "nm", { precision: 0 }), {
+  value: null,
+  unit: "NM",
+  text: "<1",
+});
+assert.equal(formatDistance(null, "nm"), null);
+assert.equal(formatDistance("oops", "km"), null);
+
+// --- formatTemperature carries the right label
+
+{
+  const result = formatTemperature(25, "f");
+  assert.ok(result);
+  assert.equal(result.unit, "°F");
+  assert.equal(result.value, 77);
+}
+
+// --- formatAltitude: FL only kicks in above the minimum
+
+{
+  const cruise = formatAltitude(35000, "fl");
+  assert.deepEqual(cruise, { value: null, unit: "FL", text: "FL350" });
+}
+
+{
+  // Below the FL minimum the helper falls back to ft so a 600 ft taxi reads
+  // as "600 ft" instead of the nonsensical "FL6".
+  const low = formatAltitude(600, "fl");
+  assert.deepEqual(low, { value: 600, unit: "ft", text: null });
+}
+
+{
+  // Ground kind always falls back to ft (or m if user picked m).
+  const elevation = formatAltitude(1234, "fl", { kind: "ground" });
+  assert.deepEqual(elevation, { value: 1234, unit: "ft", text: null });
+}
+
+{
+  const meters = formatAltitude(1000, "m");
+  assert.ok(meters);
+  assert.equal(meters.unit, "m");
+  assert.equal(Math.round(meters.value as number), 305);
+}
+
+console.log("units.test.ts ok");

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -1,0 +1,175 @@
+import type {
+  AltitudeUnit,
+  DistanceUnit,
+  TemperatureUnit,
+} from "@/features/app-shell/unitPreferences/unitPreferencesModel";
+
+const NM_TO_KM = 1.852;
+const NM_TO_MI = 1.15077945;
+const FT_TO_M = 0.3048;
+
+const DISTANCE_LABELS: Record<DistanceUnit, string> = {
+  nm: "NM",
+  mi: "mi",
+  km: "km",
+};
+
+const TEMPERATURE_LABELS: Record<TemperatureUnit, string> = {
+  c: "°C",
+  f: "°F",
+};
+
+const ALTITUDE_LABELS: Record<AltitudeUnit, string> = {
+  ft: "ft",
+  m: "m",
+  fl: "FL",
+};
+
+export function distanceUnitLabel(unit: DistanceUnit) {
+  return DISTANCE_LABELS[unit] ?? DISTANCE_LABELS.nm;
+}
+
+export function temperatureUnitLabel(unit: TemperatureUnit) {
+  return TEMPERATURE_LABELS[unit] ?? TEMPERATURE_LABELS.c;
+}
+
+export function altitudeUnitLabel(unit: AltitudeUnit) {
+  return ALTITUDE_LABELS[unit] ?? ALTITUDE_LABELS.ft;
+}
+
+export function convertDistanceFromNm(nm: number, unit: DistanceUnit) {
+  if (!Number.isFinite(nm)) return nm;
+  if (unit === "km") return nm * NM_TO_KM;
+  if (unit === "mi") return nm * NM_TO_MI;
+  return nm;
+}
+
+export function convertTemperatureFromC(celsius: number, unit: TemperatureUnit) {
+  if (!Number.isFinite(celsius)) return celsius;
+  if (unit === "f") return celsius * 1.8 + 32;
+  return celsius;
+}
+
+export function convertAltitudeFromFt(ft: number, unit: AltitudeUnit) {
+  if (!Number.isFinite(ft)) return ft;
+  if (unit === "m") return ft * FT_TO_M;
+  // Flight levels are 100s of feet; converted by the formatter so the
+  // numeric value isn't lossy when callers ask for the raw conversion.
+  if (unit === "fl") return ft / 100;
+  return ft;
+}
+
+interface FormattedValue {
+  value: number | null;
+  unit: string;
+  text: string | null;
+}
+
+interface FormatDistanceOptions {
+  precision?: "auto" | number;
+  // Below this distance (in the displayed unit, after rounding) callers get
+  // back `text: "<1"` so badges read "<1 NM" instead of "0 NM" for hovers.
+  showSubOneAs?: string | null;
+}
+
+// Formats a distance originally measured in nautical miles. Returns a structured
+// object so callers can lay out the number / unit separately (matches existing
+// formatNearbyDistanceDisplay shape).
+export function formatDistance(
+  nm: unknown,
+  unit: DistanceUnit,
+  { precision = "auto", showSubOneAs = "<1" }: FormatDistanceOptions = {},
+): FormattedValue | null {
+  if (nm == null || nm === "") return null;
+  const numeric = Number(nm);
+  if (!Number.isFinite(numeric)) return null;
+  const converted = convertDistanceFromNm(Math.max(0, numeric), unit);
+  const display = round(converted, precision);
+  if (display < 1 && showSubOneAs != null) {
+    return { value: null, unit: distanceUnitLabel(unit), text: showSubOneAs };
+  }
+  return { value: display, unit: distanceUnitLabel(unit), text: null };
+}
+
+interface FormatTemperatureOptions {
+  precision?: "auto" | number;
+}
+
+export function formatTemperature(
+  celsius: unknown,
+  unit: TemperatureUnit,
+  { precision = "auto" }: FormatTemperatureOptions = {},
+): FormattedValue | null {
+  if (celsius == null || celsius === "") return null;
+  const numeric = Number(celsius);
+  if (!Number.isFinite(numeric)) return null;
+  const converted = convertTemperatureFromC(numeric, unit);
+  return {
+    value: round(converted, precision),
+    unit: temperatureUnitLabel(unit),
+    text: null,
+  };
+}
+
+interface FormatAltitudeOptions {
+  precision?: "auto" | number;
+  // FL display can be misleading at low altitudes (e.g. a plane at 200 ft as
+  // "FL2"). Pass kind="ground" for elevations / ceilings so they fall back to
+  // ft (or m if the user picked m). Default "cruise" honors the user pref.
+  kind?: "cruise" | "ground";
+  flMinimumFt?: number;
+}
+
+export function formatAltitude(
+  ft: unknown,
+  unit: AltitudeUnit,
+  {
+    precision = "auto",
+    kind = "cruise",
+    flMinimumFt = 1000,
+  }: FormatAltitudeOptions = {},
+): FormattedValue | null {
+  if (ft == null || ft === "") return null;
+  const numeric = Number(ft);
+  if (!Number.isFinite(numeric)) return null;
+
+  if (unit === "fl") {
+    if (kind === "ground" || numeric < flMinimumFt) {
+      return {
+        value: Math.round(numeric),
+        unit: altitudeUnitLabel("ft"),
+        text: null,
+      };
+    }
+    const fl = Math.round(numeric / 100);
+    return {
+      value: null,
+      unit: altitudeUnitLabel("fl"),
+      text: `FL${String(fl).padStart(3, "0")}`,
+    };
+  }
+
+  if (unit === "m") {
+    return {
+      value: round(convertAltitudeFromFt(numeric, "m"), precision),
+      unit: altitudeUnitLabel("m"),
+      text: null,
+    };
+  }
+
+  return {
+    value: Math.round(numeric),
+    unit: altitudeUnitLabel("ft"),
+    text: null,
+  };
+}
+
+function round(value: number, precision: "auto" | number): number {
+  if (precision === "auto") {
+    if (Math.abs(value) >= 100) return Math.round(value);
+    if (Math.abs(value) >= 10) return Math.round(value * 10) / 10;
+    return Math.round(value * 10) / 10;
+  }
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}


### PR DESCRIPTION
## Summary
- New `UnitPreferencesProvider` (localStorage-backed, defaults to NM / °C / ft) exposes a `useUnitPreferences()` hook to any client component.
- Map-settings sheet picks up a new **Units** section with radio-group rows for distance (`nm | mi | km`), temperature (`°C | °F`), and altitude (`ft | m | FL`).
- Conversion helpers live in `src/utils/units.ts` with focused unit tests. `formatAltitude` keeps FL sensible — falls back to ft for ground elevations and for cruise values below 1000 ft so a taxiing plane doesn't render as "FL2".
- Threaded the preference through the highest-visibility surfaces:
  - Map range legend (5 NM → 9.3 km / 5.8 mi)
  - Airport + aircraft sidebar rows (DIST + ELEV / ALT)
  - Desktop + mobile preview cards (airport, aircraft metadata + telemetry)
  - METAR temperature slide + ceiling slide
  - Local weather card (temp + feels-like)
  - Sidebar "weather" metric tab (the °C / °F badge)

## Test plan
- [x] `npx tsx scripts/run-tests.ts` — 107 test files pass (incl. new `units.test.ts`).
- [x] `npx next build --webpack` — typechecks clean.
- [x] Browser verify: localStorage flip to `{ distance: km, temperature: f, altitude: fl }` on `/airport/KSFO` reflects across the scale bar, weather metric card, and aircraft rows (showing FL159 / 71 km / 49 °F).
- [x] Reset to defaults shows NM / °C / FT as before — back-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)