### PR TITLE
Unit preferences polish: tween, card reuse, default basemap, header alignment

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -48,6 +48,7 @@ type StatProps = {
   value?: number;
   unit?: string;
   plain?: string;
+  prefix?: string;
   format?: NumberFlowFormat;
 };
 
@@ -111,13 +112,12 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
     stats.push(
       onGround ? (
         <Stat key="alt" plain={t("aircraft.gnd")} />
-      ) : altDisplay?.text ? (
-        <Stat key="alt" plain={altDisplay.text} />
       ) : (
         <Stat
           key="alt"
           value={altDisplay?.value ?? 0}
           unit={altDisplay?.unit ?? "ft"}
+          prefix={altDisplay?.prefix}
         />
       ),
     );
@@ -169,17 +169,24 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
   );
 }
 
-function Stat({ value = 0, unit, plain, format }: StatProps) {
+function Stat({ value = 0, unit, plain, prefix, format }: StatProps) {
   return (
     <>
       {plain != null ? (
         <span className="tabular-nums">{plain}</span>
       ) : (
-        <NumberFlow
-          value={value}
-          format={format}
-          className="tabular-nums"
-        />
+        <>
+          {prefix ? (
+            <span className="notranslate text-atc-dim" translate="no">
+              {prefix}
+            </span>
+          ) : null}
+          <NumberFlow
+            value={value}
+            format={format}
+            className="tabular-nums"
+          />
+        </>
       )}
       {unit && (
         <span

--- a/src/components/aircraft/preview/AircraftPreviewTelemetry.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewTelemetry.tsx
@@ -30,16 +30,12 @@ export default function AircraftPreviewTelemetry({ aircraft }) {
       />
       {onGround ? (
         <TextStat label={t("metrics.altitude")} value={t("aircraft.gnd")} />
-      ) : altitudeDisplay?.text ? (
-        <TextStat
-          label={t("metrics.altitude")}
-          value={altitudeDisplay.text}
-        />
       ) : (
         <NumericStat
           label={t("metrics.altitude")}
           value={altitudeDisplay?.value ?? null}
           unit={altitudeDisplay?.unit ?? "ft"}
+          prefix={altitudeDisplay?.prefix}
         />
       )}
       <NumericStat
@@ -52,7 +48,7 @@ export default function AircraftPreviewTelemetry({ aircraft }) {
   );
 }
 
-function NumericStat({ label, value, unit, signed = false }) {
+function NumericStat({ label, value, unit, prefix = "", signed = false }) {
   return (
     <div className="aircraft-preview-stat">
       <dt className="aircraft-preview-stat__label">{label}</dt>
@@ -62,11 +58,21 @@ function NumericStat({ label, value, unit, signed = false }) {
             —
           </span>
         ) : (
-          <NumberFlow
-            value={value}
-            format={signed ? { signDisplay: "exceptZero" } : undefined}
-            className="aircraft-preview-stat__number"
-          />
+          <>
+            {prefix ? (
+              <span
+                className="aircraft-preview-stat__prefix notranslate"
+                translate="no"
+              >
+                {prefix}
+              </span>
+            ) : null}
+            <NumberFlow
+              value={value}
+              format={signed ? { signDisplay: "exceptZero" } : undefined}
+              className="aircraft-preview-stat__number"
+            />
+          </>
         )}
         {value != null && unit && (
           <span

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -432,29 +432,17 @@ export default function MapSettingsSheet({
                         aria-label={t(group.titleKey)}
                         className="grid auto-cols-fr grid-flow-col gap-1.5"
                       >
-                        {group.options.map((option) => {
-                          const active = activeUnit === option;
-                          return (
-                            <button
-                              key={option}
-                              type="button"
-                              role="radio"
-                              aria-checked={active}
-                              onClick={() =>
-                                setUnitPreferences({ [group.key]: option } as any)
-                              }
-                              className={cn(
-                                "min-h-[36px] rounded-[8px] border px-2 text-[12px] font-semibold leading-none transition",
-                                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-focus-ring)]",
-                                active
-                                  ? "border-[var(--atc-interaction-primary-accent)] bg-[var(--atc-click-bg)] text-[var(--atc-click-fg)]"
-                                  : "border-[var(--atc-border-default)] bg-[var(--atc-surface-row-rest)] text-atc-text hover:border-[var(--atc-line-strong)]",
-                              )}
-                            >
-                              {t(group.labelKey(option))}
-                            </button>
-                          );
-                        })}
+                        {group.options.map((option) => (
+                          <SelectableCard
+                            key={option}
+                            size="compact"
+                            active={activeUnit === option}
+                            title={t(group.labelKey(option))}
+                            onClick={() =>
+                              setUnitPreferences({ [group.key]: option } as any)
+                            }
+                          />
+                        ))}
                       </div>
                     </div>
                   );

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -103,12 +103,11 @@ export default function AircraftRow({
           <span>{t("aircraft.gnd")}</span>
         ) : !altitudeDisplay ? (
           <span>-</span>
-        ) : altitudeDisplay.text ? (
-          <NumberWithUnit text={altitudeDisplay.text} unit="" />
         ) : (
           <NumberWithUnit
             value={altitudeDisplay.value}
             unit={altitudeDisplay.unit.toUpperCase()}
+            prefix={altitudeDisplay.prefix}
           />
         )}
       </div>
@@ -197,18 +196,25 @@ function AircraftIdentityCell({
 // replacing the older static-text + EndfieldValueSwap cross-fade. Cost is
 // bounded by virtualization: only the rows in the visible window mount, so
 // the previous ~290-instance worst case becomes ~24 (12 rows × 2 cells).
-function NumberWithUnit({ value, unit, format, text }: Record<string, any>) {
+function NumberWithUnit({ value, unit, format, text, prefix }: Record<string, any>) {
   return (
     <span className="grid w-full grid-cols-[minmax(0,1fr)_var(--aircraft-table-unit-width,14px)] items-baseline gap-x-0.5 tabular-nums">
-      {text != null ? (
-        <span className="block min-w-0 text-right">{text}</span>
-      ) : (
-        <NumberFlow
-          value={value}
-          format={format}
-          className="block min-w-0 text-right"
-        />
-      )}
+      <span className="flex min-w-0 items-baseline justify-end">
+        {prefix ? (
+          <span className="notranslate flex-none text-atc-dim" translate="no">
+            {prefix}
+          </span>
+        ) : null}
+        {text != null ? (
+          <span className="block min-w-0 text-right">{text}</span>
+        ) : (
+          <NumberFlow
+            value={value}
+            format={format}
+            className="block min-w-0 text-right"
+          />
+        )}
+      </span>
       <sub
         className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] font-semibold leading-none text-atc-dim"
         translate="no"

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -321,10 +321,10 @@ export default function AircraftTable({
         <div className="aircraft-table-header aircraft-table-row-grid grid grid-cols-[18px_minmax(0,1fr)_48px_54px] items-center gap-2 border-b border-[var(--atc-line)] px-[var(--airport-sidebar-inset)] py-1.5 font-mono text-[9px] uppercase text-atc-faint sm:grid-cols-[18px_minmax(0,1fr)_54px_70px] sm:gap-3">
           <span aria-hidden="true" />
           <span>{t("sidebar.callsignOrRoute")}</span>
-          <span className="text-right">{t("sidebar.distance")}</span>
-          <span className="text-right">
+          <NumericHeader>{t("sidebar.distance")}</NumericHeader>
+          <NumericHeader>
             {hasRouteEndpointAirports ? t("sidebar.endpoint") : t("sidebar.altitude")}
-          </span>
+          </NumericHeader>
         </div>
 
         {pinnedAircraft && (
@@ -666,6 +666,19 @@ function AircraftFilterCardSelect({
 function toNumber(value) {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
+}
+
+// Header cell that mirrors the row's NumberWithUnit 2-column sub-grid (number
+// column + small unit-suffix column). Without this, the header text right-
+// aligns to the cell's edge but row values right-align inside the inner grid,
+// so the header sits ~14px to the right of every value.
+function NumericHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="grid w-full grid-cols-[minmax(0,1fr)_var(--aircraft-table-unit-width,14px)] items-baseline gap-x-0.5">
+      <span className="block min-w-0 text-right">{children}</span>
+      <span aria-hidden="true" />
+    </span>
+  );
 }
 
 function filterAndSortAircraft({

--- a/src/components/ui/SelectableCard.tsx
+++ b/src/components/ui/SelectableCard.tsx
@@ -12,14 +12,15 @@ type SelectableCardProps = {
   disabled?: boolean;
   onClick?: () => void;
   className?: string;
+  size?: "default" | "compact";
 };
 
 const selectableCardVariants = cva(
   cn(
     "group relative isolate overflow-hidden",
-    "flex min-h-[118px] flex-col items-start rounded-[var(--atc-radius-card)]",
+    "flex flex-col items-start rounded-[var(--atc-radius-card)]",
     "border border-[var(--sidebar-tile-rest-border)] bg-[var(--atc-control-surface)] bg-clip-padding",
-    "p-3 text-left text-atc-text shadow-[var(--atc-control-inset-shadow)]",
+    "text-left text-atc-text shadow-[var(--atc-control-inset-shadow)]",
     "transition-[background,border-color,box-shadow,color,opacity] duration-150",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-accent)]",
     "data-[active=true]:bg-[var(--atc-click-bg)]",
@@ -34,6 +35,10 @@ const selectableCardVariants = cva(
   ),
   {
     variants: {
+      size: {
+        default: "min-h-[118px] p-3",
+        compact: "min-h-[44px] items-center px-2 py-2 justify-center",
+      },
       interactive: {
         true: cn(
           "cursor-pointer hover:bg-[var(--atc-control-hover-bg)]",
@@ -47,6 +52,7 @@ const selectableCardVariants = cva(
       },
     },
     defaultVariants: {
+      size: "default",
       interactive: true,
       disabled: false,
     },
@@ -79,7 +85,9 @@ export function SelectableCard({
   disabled = false,
   onClick,
   className,
+  size = "default",
 }: SelectableCardProps) {
+  const isCompact = size === "compact";
   return (
     <button
       type="button"
@@ -90,6 +98,7 @@ export function SelectableCard({
       onClick={onClick}
       className={cn(
         selectableCardVariants({
+          size,
           interactive: Boolean(onClick) && !disabled,
           disabled,
         }),
@@ -97,7 +106,14 @@ export function SelectableCard({
       )}
     >
       {icon ? <span className={iconClass}>{icon}</span> : null}
-      <span className={titleClass}>{title}</span>
+      <span
+        className={cn(
+          titleClass,
+          isCompact && "text-[12px] font-semibold leading-none",
+        )}
+      >
+        {title}
+      </span>
       {description ? <span className={descriptionClass}>{description}</span> : null}
     </button>
   );

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -99,7 +99,7 @@ const MAP_BASE_LAYER_IDS = Object.freeze({
   TERRAIN: "terrain",
 });
 
-export const DEFAULT_MAP_BASE_LAYER = MAP_BASE_LAYER_IDS.TERRAIN;
+export const DEFAULT_MAP_BASE_LAYER = MAP_BASE_LAYER_IDS.STANDARD;
 
 const MAP_BASE_LAYER_OPTIONS = [
   {

--- a/src/utils/units.test.ts
+++ b/src/utils/units.test.ts
@@ -59,7 +59,12 @@ assert.equal(formatDistance("oops", "km"), null);
 
 {
   const cruise = formatAltitude(35000, "fl");
-  assert.deepEqual(cruise, { value: null, unit: "FL", text: "FL350" });
+  assert.deepEqual(cruise, {
+    value: 350,
+    unit: "",
+    text: null,
+    prefix: "FL ",
+  });
 }
 
 {

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -63,6 +63,10 @@ interface FormattedValue {
   value: number | null;
   unit: string;
   text: string | null;
+  // Optional prefix string rendered before the animated number (e.g. "FL "
+  // for flight levels). Callers can keep the number on NumberFlow and the
+  // prefix static so unit-switch transitions tween cleanly.
+  prefix?: string;
 }
 
 interface FormatDistanceOptions {
@@ -143,9 +147,10 @@ export function formatAltitude(
     }
     const fl = Math.round(numeric / 100);
     return {
-      value: null,
-      unit: altitudeUnitLabel("fl"),
-      text: `FL${String(fl).padStart(3, "0")}`,
+      value: fl,
+      unit: "",
+      text: null,
+      prefix: "FL ",
     };
   }
 


### PR DESCRIPTION
Follow-up to #396 hitting four feedback items:

1. **Animated transitions.** `formatAltitude` returns `{ value, unit:"", prefix:"FL " }` for flight levels so the digits flow through `NumberFlow` (and the label reads "FL 350" with a real space) instead of being a static "FL350" string.
2. **Card style.** Adds a `size: "compact"` variant to `SelectableCard` and uses it for the Units section, so the rows match the modes / base-layer card language instead of bespoke pills.
3. **Default base map.** New `DEFAULT_MAP_BASE_LAYER = STANDARD` so signed-out visitors land on standard, not terrain.
4. **Header alignment.** New `NumericHeader` in the nearby table wraps DIST / ALT labels in the same 2-column sub-grid the row's `NumberWithUnit` uses, so the headers right-align to the *number* column edge (not the cell edge, which sat ~14px past every value).

## Test plan
- [x] `npx tsx scripts/run-tests.ts` — 107 test files pass.
- [x] `npx next build --webpack` — typechecks clean.
- [x] Browser verify on `/airport/KSFO`: FL prefix renders + digits tween; settings sheet's Units section shows three rows of compact SelectableCards; standard map renders by default; DIST / ALT headers now align with row values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)