### PR TITLE
Force simplified Chinese in here-mode + recenter map after resume

### DIFF
--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -194,6 +194,7 @@ export default function AirportMap({
       const targetCenter = floatingSidebarAware
         ? getOffsetMapCenter(map, focalCenter, zoom)
         : ([focalCenter.lat, focalCenter.lon] as any);
+      map.invalidateSize();
       map.setView(targetCenter, zoom, {
         animate: false,
       });
@@ -202,8 +203,29 @@ export default function AirportMap({
     setOffsetAwareView();
     const transitionSettleTimer = window.setTimeout(setOffsetAwareView, 320);
 
+    // Mobile browsers can suspend / freeze the page when the user
+    // switches apps or locks the screen. When the tab becomes visible
+    // again the map's internal size and center can drift (especially
+    // after a viewport resize triggered by the OS keyboard dismissing
+    // or a virtual keyboard appearing). Re-applying the offset-aware
+    // view on visibility resume + on bfcache restore keeps the focal
+    // point pinned to the user's coords without waiting for the next
+    // geolocation tick.
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        setOffsetAwareView();
+      }
+    };
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) setOffsetAwareView();
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("pageshow", handlePageShow);
+
     return () => {
       window.clearTimeout(transitionSettleTimer);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("pageshow", handlePageShow);
     };
   }, [floatingSidebarAware, focalCenter, followsCenter, zoom]);
 

--- a/src/features/location/reverseGeocodeClient.ts
+++ b/src/features/location/reverseGeocodeClient.ts
@@ -70,9 +70,26 @@ function cacheKey(lat: number, lon: number, language: string) {
 // the user's UI locale first so localizable fields (city / state /
 // country) come back in their language when Nominatim has translated
 // names, with English as the fallback.
+//
+// Chinese is special: OSM stores multiple Chinese variants (`name:zh-Hans`,
+// `name:zh-Hant`, plain `name:zh`, sometimes `name:zh-CN` / `name:zh-TW`).
+// Plain `zh-CN` in accept-language tends to fall through to whichever
+// `name:zh` happens to be tagged — which on the mainland is a mix of
+// simplified and traditional. Explicitly preferring `zh-Hans` (for
+// zh-CN) or `zh-Hant` (for zh-TW) before the regional tag keeps the
+// rendered place names consistent with the user's chosen locale.
 function buildAcceptLanguage(language: string) {
   const primary = normalizeString(language).toLowerCase();
   if (!primary || primary === "en") return "en";
+  if (primary === "zh-cn" || primary === "zh-hans") {
+    return "zh-Hans,zh-CN,zh,en";
+  }
+  if (primary === "zh-tw" || primary === "zh-hant") {
+    return "zh-Hant,zh-TW,zh,en";
+  }
+  if (primary === "zh-hk") {
+    return "zh-Hant,zh-HK,zh,en";
+  }
   return `${primary},en`;
 }
 


### PR DESCRIPTION
## Summary
- **Locale mix on /here.** Nominatim was returning a mix of simplified and traditional Chinese place names because the proxy was sending the raw locale (`zh-CN`) as accept-language — OSM's `name:zh` tag is contributor-managed and inconsistent. The client now sends `zh-Hans,zh-CN,zh,en` for zh-CN users (and the matching `zh-Hant` chain for zh-TW / zh-HK) so Nominatim picks the simplified or traditional variant explicitly.
- **Map drifting off-center after resume.** Mobile browsers suspend the tab when the user switches apps or locks the screen. On resume the Leaflet map's internal size could be stale and the user's focal point would sit off-center until the next geolocation tick. `AirportMap` now re-applies the offset-aware setView (with an `invalidateSize` first) on `visibilitychange → visible` and on `pageshow.persisted` (bfcache restore).

## Test plan
- [x] `npx tsx scripts/run-tests.ts` — 107 test files pass.
- [x] `npx next build --webpack` — typechecks clean.
- [ ] Verify on mobile: open `/here` in zh-CN, background the tab, return → marker stays in the viewport center.
- [ ] Verify Chinese place name appears in simplified form regardless of which OSM tag the underlying city happens to expose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)