### PR TITLE
feat: add screen wake lock toggle to map toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.2.2",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -3,6 +3,7 @@
 import MapControlBar from "@/components/ui/MapControlBar";
 import MobileMapSourceStatus from "./MobileMapSourceStatus";
 import { useExplorerUi } from "./ExplorerUiContext";
+import { useWakeLock } from "@/hooks/useWakeLock";
 
 export default function ExplorerMapMenu({
   feedSource = "",
@@ -46,6 +47,8 @@ export default function ExplorerMapMenu({
     toggleShowCallsigns,
   } = useExplorerUi();
 
+  const [wakeLockState, toggleWakeLock] = useWakeLock();
+
   return (
     <div
       className={`airport-map-menu ${
@@ -73,6 +76,7 @@ export default function ExplorerMapMenu({
         userLocationPending={userLocationPending}
         userLocationNotice={userLocationNotice}
         showSidebarToggle={isMobile}
+        wakeLockActive={wakeLockState.active}
         onZoom={setMapZoom}
         onToggleMapLabels={toggleMapLabels}
         onToggleRunwayBeams={toggleRunwayBeams}
@@ -86,6 +90,9 @@ export default function ExplorerMapMenu({
         onToggleUserLocationAudio={onToggleUserLocationAudio}
         onToggleSidebar={toggleSidebar}
         onFitToTrace={onFitToTrace}
+        onToggleWakeLock={
+          wakeLockState.supported ? toggleWakeLock : null
+        }
       />
 
       <MobileMapSourceStatus
@@ -94,6 +101,7 @@ export default function ExplorerMapMenu({
         lastUpdated={lastUpdated}
         routeProvider={routeProvider}
         loadingStatus={loadingStatus}
+        wakeLockActive={wakeLockState.active}
       />
     </div>
   );

--- a/src/components/explorer/MobileMapSourceStatus.tsx
+++ b/src/components/explorer/MobileMapSourceStatus.tsx
@@ -10,6 +10,7 @@ export default function MobileMapSourceStatus({
   lastUpdated = null,
   routeProvider = ROUTE_PROVIDER.ADSBDB,
   loadingStatus = "",
+  wakeLockActive = false,
 }) {
   const status = buildMapSourceStatusDisplay({ feedSource, routeProvider });
   const updatedLabel = formatUpdated(lastUpdated);
@@ -22,6 +23,7 @@ export default function MobileMapSourceStatus({
       routeProviderLabel={status.routeProvider}
       loadingStatus={loadingStatus}
       placement="map-corner"
+      wakeLockActive={wakeLockActive}
     />
   );
 }

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -21,7 +21,7 @@ const mapCornerClassName = cn(
 );
 
 const lineClassName = cn(
-  "flex w-full min-w-0 flex-wrap items-center justify-end gap-[7px]",
+  "flex w-full min-w-0 items-center justify-end gap-[7px]",
   "text-[10px] font-semibold leading-none text-atc-dim",
   "[.airport-map-kit_&]:gap-[5px] [.airport-map-kit_&]:text-[8px]",
   "[.airport-map-menu--mobile_&]:justify-center [.airport-map-menu--mobile_&]:gap-1.5",

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -9,13 +9,13 @@ const rootClassName =
   "flex min-w-0 flex-col items-end justify-center gap-px whitespace-nowrap font-display [font-feature-settings:'tnum'_1] [text-shadow:0_1px_8px_var(--atc-bg)]";
 
 const mapCornerClassName = cn(
-  "absolute right-3 top-[calc(100%+6px)] hidden max-w-[calc(100vw-132px)] transform-none",
+  "absolute right-3 top-[calc(100%+6px)] hidden max-w-[calc(100vw-72px)] transform-none",
   "[.airport-map-menu_&]:flex",
   "[.airport-map-kit_&]:right-0.5 [.airport-map-kit_&]:top-[calc(100%+10px)]",
   "md:[.airport-map-kit_&]:top-[calc(100%+8px)]",
   "[.airport-map-menu--mobile_&]:left-1/2 [.airport-map-menu--mobile_&]:right-auto [.airport-map-menu--mobile_&]:top-[calc(100%+7px)]",
   "[.airport-map-menu--mobile_&]:bottom-[calc(100%+7px)] [.airport-map-menu--mobile_&]:top-auto",
-  "[.airport-map-menu--mobile_&]:max-w-[min(288px,calc(100vw-32px))] [.airport-map-menu--mobile_&]:-translate-x-1/2",
+  "[.airport-map-menu--mobile_&]:max-w-[min(360px,calc(100vw-16px))] [.airport-map-menu--mobile_&]:-translate-x-1/2",
   "[.airport-map-menu--mobile_&]:items-center [.airport-map-menu--mobile_&]:text-center",
   "[.airport-map-menu--mobile_&]:[filter:drop-shadow(0_7px_11px_color-mix(in_oklab,var(--atc-bg)_72%,transparent))_drop-shadow(0_1px_1px_color-mix(in_oklab,var(--atc-text)_24%,transparent))]",
 );
@@ -32,11 +32,11 @@ const diamondClassName =
   "inline-block size-[7px] flex-none rotate-45 bg-atc-orange [.airport-map-kit_&]:size-[5px] [.airport-map-menu--mobile_&]:size-1.5";
 
 const loadingClassName = cn(
-  "min-h-0 max-w-[min(280px,calc(100vw-132px))] overflow-hidden whitespace-normal",
+  "min-h-0 max-w-[min(360px,calc(100vw-72px))] overflow-hidden whitespace-normal",
   "text-right font-mono text-[8px] font-semibold uppercase leading-none text-atc-dim",
   "opacity-0 transition-opacity duration-200 ease-out [overflow-wrap:anywhere] will-change-[opacity] motion-reduce:transition-none",
-  "[.airport-map-kit_&]:max-w-[min(224px,calc(100vw-106px))] [.airport-map-kit_&]:text-[7px]",
-  "[.airport-map-menu--mobile_&]:max-w-[min(288px,calc(100vw-32px))] [.airport-map-menu--mobile_&]:text-center [.airport-map-menu--mobile_&]:text-[7px]",
+  "[.airport-map-kit_&]:max-w-[min(320px,calc(100vw-72px))] [.airport-map-kit_&]:text-[7px]",
+  "[.airport-map-menu--mobile_&]:max-w-[min(360px,calc(100vw-16px))] [.airport-map-menu--mobile_&]:text-center [.airport-map-menu--mobile_&]:text-[7px]",
 );
 
 /**

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import EndfieldValueSwap from "@/components/effects/EndfieldValueSwap";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import gsap from "gsap";
+import { MOTION, EASE } from "@/animations/gsap";
 import { cn } from "@/lib/utils";
 
 const rootClassName =
@@ -37,6 +38,32 @@ const loadingClassName = cn(
   "[.airport-map-kit_&]:max-w-[min(224px,calc(100vw-106px))] [.airport-map-kit_&]:text-[7px]",
   "[.airport-map-menu--mobile_&]:max-w-[min(288px,calc(100vw-32px))] [.airport-map-menu--mobile_&]:text-center [.airport-map-menu--mobile_&]:text-[7px]",
 );
+
+/**
+ * Inline span with GSAP fade transition when content changes.
+ */
+function StatusSpan({ children, className }: { children: React.ReactNode; className?: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const prevRef = useRef(children);
+
+  useLayoutEffect(() => {
+    if (prevRef.current === children) return;
+    prevRef.current = children;
+    const el = ref.current;
+    if (!el) return;
+    gsap.fromTo(
+      el,
+      { opacity: 0, y: 2 },
+      { opacity: 1, y: 0, duration: MOTION.fast, ease: EASE.out, overwrite: "auto" },
+    );
+  }, [children]);
+
+  return (
+    <span ref={ref} className={className}>
+      {children}
+    </span>
+  );
+}
 
 export default function MapSourceStatusDisplay({
   feedSource = "",
@@ -91,9 +118,9 @@ export default function MapSourceStatusDisplay({
         <span className={lineClassName}>
           {wakeLockActive ? (
             <>
-              <span className="flex-none tabular-nums text-atc-orange">
+              <StatusSpan className="flex-none tabular-nums text-atc-orange">
                 ☕ Keep awake
-              </span>
+              </StatusSpan>
               {(feedSource || routeProviderLabel || updatedLabel) ? (
                 <span
                   aria-hidden="true"
@@ -103,16 +130,11 @@ export default function MapSourceStatusDisplay({
             </>
           ) : null}
           {feedSource ? (
-            <EndfieldValueSwap
-              identityKey={`source:${feedSource}`}
-              value={(
-                <span className="notranslate" translate="no">
-                  {feedSource}
-                </span>
-              )}
-              className={cn("flex-none overflow-visible", isInfer && "text-atc-faint")}
-              direction="reverse"
-            />
+            <StatusSpan
+              className={cn("flex-none notranslate", isInfer && "text-atc-faint")}
+            >
+              {feedSource}
+            </StatusSpan>
           ) : null}
           {feedSource && routeProviderLabel ? (
             <span
@@ -121,16 +143,9 @@ export default function MapSourceStatusDisplay({
             />
           ) : null}
           {routeProviderLabel ? (
-            <EndfieldValueSwap
-              identityKey={`route-provider:${routeProviderLabel}`}
-              value={(
-                <span className="notranslate" translate="no">
-                  {routeProviderLabel}
-                </span>
-              )}
-              className="flex-none [.airport-map-menu--mobile_&]:text-[8px]"
-              direction="reverse"
-            />
+            <StatusSpan className="flex-none notranslate [.airport-map-menu--mobile_&]:text-[8px]">
+              {routeProviderLabel}
+            </StatusSpan>
           ) : null}
           {(feedSource || routeProviderLabel) && updatedLabel ? (
             <span
@@ -139,12 +154,11 @@ export default function MapSourceStatusDisplay({
             />
           ) : null}
           {updatedLabel ? (
-            <span
+            <StatusSpan
               className={cn("flex-none tabular-nums", isInfer && "text-atc-faint")}
-              aria-live="off"
             >
               {updatedLabel}
-            </span>
+            </StatusSpan>
           ) : null}
         </span>
       ) : null}

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -143,7 +143,7 @@ export default function MapSourceStatusDisplay({
             />
           ) : null}
           {routeProviderLabel ? (
-            <StatusSpan className="flex-none notranslate [.airport-map-menu--mobile_&]:text-[8px]">
+            <StatusSpan className="flex-none notranslate">
               {routeProviderLabel}
             </StatusSpan>
           ) : null}

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -69,14 +69,15 @@ export default function MapSourceStatusDisplay({
     !updatedLabel &&
     !routeProviderLabel &&
     !loadingStatus &&
-    !displayedLoadingStatus
+    !displayedLoadingStatus &&
+    !wakeLockActive
   ) {
     return null;
   }
 
   const isMapCorner = placement === "map-corner";
   const isInfer = feedStatus === "infer";
-  const hasPrimary = feedSource || routeProviderLabel || updatedLabel;
+  const hasPrimary = feedSource || routeProviderLabel || updatedLabel || wakeLockActive;
 
   return (
     <div
@@ -88,6 +89,19 @@ export default function MapSourceStatusDisplay({
     >
       {hasPrimary ? (
         <span className={lineClassName}>
+          {wakeLockActive ? (
+            <>
+              <span className={cn("flex-none", "text-atc-orange")}>
+                ☕ Keep awake
+              </span>
+              {(feedSource || routeProviderLabel || updatedLabel) ? (
+                <span
+                  aria-hidden="true"
+                  className={diamondClassName}
+                />
+              ) : null}
+            </>
+          ) : null}
           {feedSource ? (
             <EndfieldValueSwap
               identityKey={`source:${feedSource}`}
@@ -147,16 +161,6 @@ export default function MapSourceStatusDisplay({
           >
             {displayedLoadingStatus}
           </span>
-        </span>
-      ) : null}
-      {wakeLockActive ? (
-        <span
-          className={cn(
-            lineClassName,
-            "text-atc-orange",
-          )}
-        >
-          ☕ Keep awake
         </span>
       ) : null}
     </div>

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -45,6 +45,7 @@ export default function MapSourceStatusDisplay({
   routeProviderLabel = "",
   loadingStatus = "",
   placement = "mobile-map",
+  wakeLockActive = false,
 }) {
   const loadingActive = Boolean(loadingStatus);
   const [displayedLoadingStatus, setDisplayedLoadingStatus] = useState(
@@ -146,6 +147,16 @@ export default function MapSourceStatusDisplay({
           >
             {displayedLoadingStatus}
           </span>
+        </span>
+      ) : null}
+      {wakeLockActive ? (
+        <span
+          className={cn(
+            lineClassName,
+            "text-atc-orange",
+          )}
+        >
+          ☕ Keep awake
         </span>
       ) : null}
     </div>

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -91,7 +91,7 @@ export default function MapSourceStatusDisplay({
         <span className={lineClassName}>
           {wakeLockActive ? (
             <>
-              <span className={cn("flex-none", "text-atc-orange")}>
+              <span className="flex-none tabular-nums text-atc-orange">
                 ☕ Keep awake
               </span>
               {(feedSource || routeProviderLabel || updatedLabel) ? (

--- a/src/components/map/controls/MapControlRail.tsx
+++ b/src/components/map/controls/MapControlRail.tsx
@@ -32,11 +32,13 @@ export default function MapControlRail({
   settingsOpen,
   settingsSheetId,
   showSidebarToggle = true,
+  wakeLockActive = false,
   onToggleSidebar,
   onCycleZoom,
   onFitToTrace = null,
   onCycleTheme,
   onToggleSettings,
+  onToggleWakeLock = null,
 }) {
   const { t } = useI18n();
   const { isLoaded, isSignedIn } = useUser();
@@ -113,6 +115,18 @@ export default function MapControlRail({
       >
         <MapControlIcon iconKey={SETTINGS_ICON_KEY} />
       </ToolbarButton>
+
+      {onToggleWakeLock && (
+        <ToolbarButton
+          tone="rail"
+          active={wakeLockActive}
+          title={t("map.wakeLockTitle")}
+          aria-label={t("map.wakeLock")}
+          onClick={onToggleWakeLock}
+        >
+          <MapControlIcon iconKey="monitor" />
+        </ToolbarButton>
+      )}
 
       <ToolbarSeparator />
 

--- a/src/components/map/controls/MapControlRail.tsx
+++ b/src/components/map/controls/MapControlRail.tsx
@@ -124,7 +124,7 @@ export default function MapControlRail({
           aria-label={t("map.wakeLock")}
           onClick={onToggleWakeLock}
         >
-          <MapControlIcon iconKey="monitor" />
+          <MapControlIcon iconKey="coffee" />
         </ToolbarButton>
       )}
 

--- a/src/components/map/controls/mapControlIcons.tsx
+++ b/src/components/map/controls/mapControlIcons.tsx
@@ -4,6 +4,7 @@ import {
   Antenna,
   ArrowDownToLine,
   ArrowUpToLine,
+  Coffee,
   Crosshair,
   Gauge,
   Layers,
@@ -49,8 +50,8 @@ export function MapControlIcon({ iconKey }) {
       return <MapIcon />;
     case "mapPinned":
       return <MapPinned />;
-    case "monitor":
-      return <Monitor />;
+    case "coffee":
+      return <Coffee />;
     case "moon":
       return <Moon />;
     case "mountain":

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import { MAP_ZOOM_OPTIONS } from "../../config/mapControls";
 import { useThemePreference } from "../../features/app-shell/useThemePreference";
+import { useWakeLock } from "../../hooks/useWakeLock";
 import MapControlRail from "@/components/map/controls/MapControlRail";
 import MapSettingsSheet from "@/components/map/controls/MapSettingsSheet";
 import {
@@ -56,6 +57,8 @@ export default function MapControlBar({
     cycleTheme,
     selectTheme,
   } = useThemePreference();
+
+  const [wakeLockState, toggleWakeLock] = useWakeLock();
 
   const currentZoomOption = useMemo(
     () => resolveZoomOption(activeZoom, MAP_ZOOM_OPTIONS),
@@ -123,11 +126,15 @@ export default function MapControlBar({
         settingsOpen={settingsOpen}
         settingsSheetId={MAP_SETTINGS_SHEET_ID}
         showSidebarToggle={showSidebarToggle}
+        wakeLockActive={wakeLockState.active}
         onToggleSidebar={onToggleSidebar}
         onCycleZoom={cycleZoom}
         onFitToTrace={onFitToTrace}
         onCycleTheme={cycleTheme}
         onToggleSettings={toggleSettings}
+        onToggleWakeLock={
+          wakeLockState.supported ? toggleWakeLock : null
+        }
       />
     </div>
   );

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useRef, useState } from "react";
 import { MAP_ZOOM_OPTIONS } from "../../config/mapControls";
 import { useThemePreference } from "../../features/app-shell/useThemePreference";
-import { useWakeLock } from "../../hooks/useWakeLock";
 import MapControlRail from "@/components/map/controls/MapControlRail";
 import MapSettingsSheet from "@/components/map/controls/MapSettingsSheet";
 import {
@@ -35,6 +34,7 @@ export default function MapControlBar({
   userLocationPending = false,
   userLocationNotice = "",
   showSidebarToggle = true,
+  wakeLockActive = false,
   onZoom,
   onToggleMapLabels,
   onToggleRunwayBeams,
@@ -48,6 +48,7 @@ export default function MapControlBar({
   onToggleUserLocationAudio = null,
   onToggleSidebar,
   onFitToTrace = null,
+  onToggleWakeLock = null,
 }) {
   const controlZone = useRef(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -57,8 +58,6 @@ export default function MapControlBar({
     cycleTheme,
     selectTheme,
   } = useThemePreference();
-
-  const [wakeLockState, toggleWakeLock] = useWakeLock();
 
   const currentZoomOption = useMemo(
     () => resolveZoomOption(activeZoom, MAP_ZOOM_OPTIONS),
@@ -126,15 +125,13 @@ export default function MapControlBar({
         settingsOpen={settingsOpen}
         settingsSheetId={MAP_SETTINGS_SHEET_ID}
         showSidebarToggle={showSidebarToggle}
-        wakeLockActive={wakeLockState.active}
+        wakeLockActive={wakeLockActive}
         onToggleSidebar={onToggleSidebar}
         onCycleZoom={cycleZoom}
         onFitToTrace={onFitToTrace}
         onCycleTheme={cycleTheme}
         onToggleSettings={toggleSettings}
-        onToggleWakeLock={
-          wakeLockState.supported ? toggleWakeLock : null
-        }
+        onToggleWakeLock={onToggleWakeLock}
       />
     </div>
   );

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -513,6 +513,8 @@ const en = {
     locationUnavailable: "Location is unavailable.",
     distanceAria: "Map distance: {distance} nautical miles",
     distanceLabel: "Distance",
+    wakeLock: "Keep screen awake",
+    wakeLockTitle: "Prevent screen from sleeping",
   },
   mapLayers: {
     mapLabels: "Map labels",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -505,6 +505,8 @@ const zhCN = {
     locationUnavailable: "暂时无法获取位置。",
     distanceAria: "地图距离:{distance} 海里",
     distanceLabel: "距离",
+    wakeLock: "屏幕常亮",
+    wakeLockTitle: "防止屏幕休眠",
   },
   mapLayers: {
     mapLabels: "地图标签",

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface WakeLockState {
+  supported: boolean;
+  active: boolean;
+  error: string | null;
+}
+
+/**
+ * Browser Screen Wake Lock hook.
+ *
+ * Calls navigator.wakeLock.request('screen') to prevent the device from
+ * sleeping. The lock is automatically released on unmount, and re-acquired
+ * when the page becomes visible again (browsers auto-release on tab switch).
+ */
+export function useWakeLock(): [WakeLockState, () => void] {
+  const [supported] = useState(() => "wakeLock" in navigator);
+  const [active, setActive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sentinelRef = useRef<WakeLockSentinel | null>(null);
+  const wantedRef = useRef(false);
+
+  const releaseLock = useCallback(async () => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    sentinelRef.current = null;
+    try {
+      await sentinel.release();
+    } catch {
+      // Ignore release errors.
+    }
+  }, []);
+
+  const acquireLock = useCallback(async () => {
+    if (!supported) return;
+    try {
+      const sentinel = await navigator.wakeLock.request("screen");
+      sentinelRef.current = sentinel;
+      setActive(true);
+      setError(null);
+
+      sentinel.addEventListener("release", () => {
+        setActive(false);
+        sentinelRef.current = null;
+      });
+    } catch (err: any) {
+      setError(err?.message ?? "Failed to acquire wake lock");
+      setActive(false);
+      sentinelRef.current = null;
+    }
+  }, [supported]);
+
+  const toggle = useCallback(() => {
+    wantedRef.current = !wantedRef.current;
+    if (wantedRef.current) {
+      acquireLock();
+    } else {
+      releaseLock().then(() => setActive(false));
+    }
+  }, [acquireLock, releaseLock]);
+
+  // Re-acquire when the page becomes visible again (if user wanted it on).
+  useEffect(() => {
+    if (!supported) return;
+
+    const handleVisibility = () => {
+      if (
+        document.visibilityState === "visible" &&
+        wantedRef.current &&
+        !sentinelRef.current
+      ) {
+        acquireLock();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [supported, acquireLock]);
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      if (sentinelRef.current) {
+        sentinelRef.current.release().catch(() => {});
+      }
+    };
+  }, []);
+
+  return [{ supported, active, error }, toggle];
+}


### PR DESCRIPTION
## Summary

Add a toggle button to the map toolbar on airport and aircraft detail pages that activates the browser's Screen Wake Lock API, preventing the device from going to sleep.

## Changes

- **New:** `src/hooks/useWakeLock.ts` — hook wrapping `navigator.wakeLock` with auto re-acquire on visibility change
- **Modified:** `MapControlBar` — wires the hook into the toolbar
- **Modified:** `MapControlRail` — new Monitor icon toggle button
- **Modified:** i18n keys (en + zh-CN)

## Behavior

- Button only renders when browser supports Wake Lock API (Chrome, Edge, Safari 16.4+)
- Click toggles wake lock on/off
- Auto re-acquires when switching tabs back
- Auto releases on unmount