### PR TITLE
Liquid glass polish: more glass surfaces, GSAP transitions & UI fixes

### DIFF
--- a/src/animations/useCardInteraction.ts
+++ b/src/animations/useCardInteraction.ts
@@ -10,6 +10,22 @@ import { useRef, useCallback } from "react";
 import gsap from "gsap";
 import { MOTION, EASE, killTweensOf } from "./gsap";
 
+/**
+ * Read prefers-reduced-motion at call time (not render) so the hook
+ * honors the OS setting even if it changes mid-session. When true, the
+ * transform tweens are skipped entirely — the CSS-driven glass capsule
+ * (background / box-shadow / sheen) still transitions, just without the
+ * GSAP hover-lift / press-spring. Per the official GSAP accessibility
+ * guidance for vestibular-sensitive users.
+ */
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
 interface CardInteractionOptions {
   /** Scale on hover. Default: 1.01 */
   hoverScale?: number;
@@ -41,7 +57,7 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
 
   /** Attach to onMouseEnter. */
   const onMouseEnter = useCallback(() => {
-    if (!enabled || !elRef.current) return;
+    if (!enabled || prefersReducedMotion() || !elRef.current) return;
     isHovering.current = true;
     killTweensOf(elRef.current);
     gsap.to(elRef.current, {
@@ -55,7 +71,7 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
 
   /** Attach to onMouseLeave. */
   const onMouseLeave = useCallback(() => {
-    if (!enabled || !elRef.current) return;
+    if (!enabled || prefersReducedMotion() || !elRef.current) return;
     isHovering.current = false;
     killTweensOf(elRef.current);
     gsap.to(elRef.current, {
@@ -69,7 +85,7 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
 
   /** Attach to onMouseDown. */
   const onMouseDown = useCallback(() => {
-    if (!enabled || !elRef.current) return;
+    if (!enabled || prefersReducedMotion() || !elRef.current) return;
     killTweensOf(elRef.current);
     gsap.to(elRef.current, {
       scale: pressScale,
@@ -81,7 +97,7 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
 
   /** Attach to onMouseUp. */
   const onMouseUp = useCallback(() => {
-    if (!enabled || !elRef.current) return;
+    if (!enabled || prefersReducedMotion() || !elRef.current) return;
     const targetScale = isHovering.current ? hoverScale : 1;
     const targetY = isHovering.current ? hoverY : 0;
     killTweensOf(elRef.current);
@@ -97,7 +113,7 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
   /** Animate to active state (pass `true`) or inactive (`false`). */
   const animateActive = useCallback(
     (active: boolean) => {
-      if (!enabled || !elRef.current) return;
+      if (!enabled || prefersReducedMotion() || !elRef.current) return;
       killTweensOf(elRef.current);
       if (active) {
         gsap.to(elRef.current, {

--- a/src/components/ui/FilterCard.tsx
+++ b/src/components/ui/FilterCard.tsx
@@ -53,8 +53,10 @@ const filterCardVariants = cva(
     "data-[state=open]:[-webkit-backdrop-filter:var(--atc-glass-active-frost)]",
     "data-[state=open]:text-[var(--atc-click-fg)]",
     "data-[state=open]:shadow-[var(--atc-glass-rim-shadow)]",
-    // Focus-visible — yellow ring.
-    "focus-visible:shadow-[inset_0_0_0_2px_var(--endf-yellow)]",
+    // Focus-visible — soft luminous frost ring. (--endf-yellow resolves
+    // to near-black ink in light theme, which read as an ugly black
+    // border; the open-state glass capsule is the primary feedback.)
+    "focus-visible:shadow-[inset_0_0_0_1.5px_var(--app-frost-border)]",
     // SelectTrigger ships a ChevronDown as a direct svg child. Pin
     // it to the right edge so the label/value column stays a clean
     // stack and the card's outer shape matches non-select tiles.

--- a/src/components/ui/FilterCard.tsx
+++ b/src/components/ui/FilterCard.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils";
+import { useCardInteraction } from "@/animations/useCardInteraction";
 
 const forwardRef = React.forwardRef as <
   Element = any,
@@ -104,12 +105,38 @@ export const FilterCard = forwardRef(function FilterCard(
 ) {
   const Comp = asChild ? Slot : "button";
   const extraProps = asChild ? {} : { type: props.type || "button" };
+
+  // GSAP hover-lift + press-spring, matching MetricCard / SelectableCard.
+  // CSS owns the glass-capsule background/box-shadow on active/open; GSAP
+  // owns transform only. The hook's callback ref is merged with the
+  // forwarded ref so Radix (SelectTrigger via asChild) still gets the
+  // node, and Radix Slot composes our mouse handlers with the child's.
+  const {
+    ref: gsapRef,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseDown,
+    onMouseUp,
+  } = useCardInteraction();
+  const setRefs = React.useCallback(
+    (node: HTMLElement | null) => {
+      gsapRef(node);
+      if (typeof ref === "function") ref(node);
+      else if (ref) (ref as React.MutableRefObject<HTMLElement | null>).current = node;
+    },
+    [gsapRef, ref],
+  );
+
   return (
     <Comp
-      ref={ref}
+      ref={setRefs}
       data-active={active ? "true" : undefined}
       data-ui="filter-card"
       className={cn(filterCardVariants({ shape }), className)}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
       {...extraProps}
       {...props}
     />

--- a/src/components/ui/MetricCard.tsx
+++ b/src/components/ui/MetricCard.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils";
+import { useCardInteraction } from "@/animations/useCardInteraction";
 
 type MetricGridProps = React.ComponentProps<"div"> & {
   label?: string;
@@ -133,6 +134,43 @@ const unitClass = cn(
   "[.airport-map-kit_&]:h-2.5 [.airport-map-kit_&]:text-[8px] [.airport-map-kit_&]:leading-2.5",
 );
 
+// Interactive tab card — same GSAP hover-lift + press-spring as
+// SelectableCard / AircraftRow, so every interactive glass card shares
+// one motion feel. CSS owns background/box-shadow/color transitions
+// (the glass capsule); GSAP owns transform only, so the two never fight.
+function InteractiveMetricCard({
+  active,
+  onClick,
+  className,
+  children,
+}: {
+  active: boolean;
+  onClick?: () => void;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const { ref, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp } =
+    useCardInteraction();
+  return (
+    <button
+      type="button"
+      role="tab"
+      ref={ref}
+      aria-selected={active}
+      data-active={active ? "true" : undefined}
+      data-ui="metric-card"
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
+      className={cn("group", cardVariants({ interactive: true }), className)}
+    >
+      {children}
+    </button>
+  );
+}
+
 export function MetricCard({
   label,
   value,
@@ -171,17 +209,13 @@ export function MetricCard({
 
   if (isInteractive) {
     return (
-      <button
-        type="button"
-        role="tab"
-        aria-selected={active}
-        data-active={active ? "true" : undefined}
-        data-ui="metric-card"
+      <InteractiveMetricCard
+        active={active}
         onClick={onClick}
-        className={cn("group", cardVariants({ interactive: true }), className)}
+        className={className}
       >
         {body}
-      </button>
+      </InteractiveMetricCard>
     );
   }
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -26,7 +26,11 @@ const SelectTrigger = forwardRef(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      // No focus:ring-ring — in light theme --ring resolves to the
+      // near-black accent and read as an ugly black border on the
+      // altitude filter and other selects. The open-state glass capsule
+      // is the focus/active feedback instead.
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}>
@@ -71,7 +75,8 @@ const SelectContent = forwardRef(({ className, children, position = "popper", vi
       className={cn(
         "relative z-toast max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden",
         "flex flex-col font-[var(--airport-sidebar-sans)] tracking-normal",
-        "rounded-[var(--atc-radius-card)] border border-atc-line bg-atc-card text-atc-text",
+        "rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] bg-[var(--atc-surface-preview-card)] text-atc-text",
+        "[backdrop-filter:var(--app-frost-strong)] [-webkit-backdrop-filter:var(--app-frost-strong)]",
         "shadow-[var(--atc-menu-panel-shadow)]",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -25,7 +25,12 @@ const TooltipContent = forwardRef(({ className, sideOffset = 4, ...props }, ref)
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        // Frosted-glass tooltip — same material as the dropdown menus
+        // (frost-tint surface + blur + hairline + soft drop) instead of
+        // the old solid near-black blob, so it reads as part of the
+        // liquid-glass system. Text uses --atc-text so it stays legible
+        // on the light frost (and flips correctly in dark theme).
+        "z-50 max-w-[260px] overflow-hidden rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] bg-[var(--atc-surface-preview-card)] px-3 py-2 text-xs leading-snug text-atc-text shadow-[var(--atc-menu-panel-shadow)] [backdrop-filter:var(--app-frost-strong)] [-webkit-backdrop-filter:var(--app-frost-strong)] animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
         className
       )}
       {...props} />

--- a/src/components/weather/WeatherSlides.tsx
+++ b/src/components/weather/WeatherSlides.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/utils/units";
 import AsyncStatusLine from "@/components/ui/AsyncStatusLine";
 import Skeleton from "@/components/ui/Skeleton";
+import { useCardInteraction } from "@/animations/useCardInteraction";
 
 function formatTemperatureValue(celsius, unit) {
   if (celsius == null || !Number.isFinite(Number(celsius))) return "-";
@@ -535,6 +536,43 @@ function hourlyTemp(val, unit) {
   return `${Math.round(convertTemperatureFromC(Number(val), unit))}°`;
 }
 
+// One hourly cell. Pulled out of the map() so it can own a
+// useCardInteraction hook — same GSAP hover-lift + press-spring as the
+// MetricCard / SelectableCard glass cards. CSS owns the glass-capsule
+// background/box-shadow on [data-active]; GSAP owns transform only.
+function HourlyCell({ hour, active, onToggle, t, units }) {
+  const { ref, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp } =
+    useCardInteraction();
+  return (
+    <button
+      type="button"
+      ref={ref}
+      data-active={active ? "true" : undefined}
+      className="hourly-card group"
+      onClick={onToggle}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
+    >
+      <span className="hourly-card__time">{hour.time}</span>
+      <span className="hourly-card__temp notranslate" translate="no">
+        {hourlyTemp(hour.temperatureC, units.temperature)}
+      </span>
+      <span className="hourly-card__condition notranslate" translate="no">
+        {shortWeatherLabel(hour.weatherCode, t) || "—"}
+      </span>
+      {hour.precipitationProbability != null &&
+        hour.precipitationProbability > 0 ? (
+        <span className="hourly-card__precip">
+          <Droplets size={10} aria-hidden="true" />
+          {Math.round(hour.precipitationProbability)}%
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
 export function HourlyForecastSlide({ localWeather }) {
   const { t } = useI18n();
   const { preferences: units } = useUnitPreferences();
@@ -547,33 +585,16 @@ export function HourlyForecastSlide({ localWeather }) {
       {/* 6-hour grid — 3 columns × 2 rows, each cell is a card */}
       {hours.length > 0 ? (
         <div className="hourly-grid">
-          {hours.map((h, i) => {
-            const isActive = activeIdx === i;
-            return (
-              <button
-                key={i}
-                type="button"
-                data-active={isActive ? "true" : undefined}
-                className="hourly-card group"
-                onClick={() => setActiveIdx(isActive ? null : i)}
-              >
-                <span className="hourly-card__time">{h.time}</span>
-                <span className="hourly-card__temp notranslate" translate="no">
-                  {hourlyTemp(h.temperatureC, units.temperature)}
-                </span>
-                <span className="hourly-card__condition notranslate" translate="no">
-                  {shortWeatherLabel(h.weatherCode, t) || "—"}
-                </span>
-                {h.precipitationProbability != null &&
-                  h.precipitationProbability > 0 ? (
-                  <span className="hourly-card__precip">
-                    <Droplets size={10} aria-hidden="true" />
-                    {Math.round(h.precipitationProbability)}%
-                  </span>
-                ) : null}
-              </button>
-            );
-          })}
+          {hours.map((h, i) => (
+            <HourlyCell
+              key={i}
+              hour={h}
+              active={activeIdx === i}
+              onToggle={() => setActiveIdx(activeIdx === i ? null : i)}
+              t={t}
+              units={units}
+            />
+          ))}
         </div>
       ) : null}
 

--- a/src/style.css
+++ b/src/style.css
@@ -2879,10 +2879,13 @@ body {
 }
 
 .search-input {
-    background: color-mix(in oklab, var(--atc-card) 86%, transparent);
-    border: 1px solid var(--app-frost-border);
+    /* Milky frosted-glass pill — same material as the toolbar pills and
+       resting tiles: near-opaque frost tint, luminous rim + soft lift
+       (--atc-control-inset-shadow), edge from light not a hard border. */
+    background: var(--atc-toolbar-surface);
+    border: 1px solid transparent;
     border-radius: var(--atc-radius-pill);
-    box-shadow: var(--app-card-shadow);
+    box-shadow: var(--atc-control-inset-shadow);
     -webkit-backdrop-filter: var(--app-frost);
     backdrop-filter: var(--app-frost);
 }
@@ -3349,14 +3352,15 @@ body {
     -webkit-appearance: none;
     appearance: none;
     outline: none;
-    /* MetricCard bottom-glow */
+    /* Liquid-glass top-light sheen — same material as MetricCard's
+       selected state; fades/slides in when the cell becomes active. */
     &::after {
         content: '';
         position: absolute;
         inset: 0;
-        background: var(--sidebar-tile-bottom-glow);
+        background: var(--atc-glass-sheen);
         opacity: 0;
-        transform: translateY(4px);
+        transform: translateY(8px);
         pointer-events: none;
         transition: opacity .3s ease-out, transform .3s ease-out;
         border-radius: inherit;
@@ -3368,13 +3372,17 @@ body {
     &:hover {
         background: var(--atc-control-hover-bg);
     }
+    /* Active = the shared dark/bright liquid-glass capsule (see
+       --atc-glass-active-bg): translucent ink with a corner dissolve,
+       backdrop frost, specular rim. Border goes transparent — the rim
+       comes from the inset shadows. */
+    &[data-active="true"],
     &:active {
-        background: var(--atc-click-bg);
-    }
-    &[data-active="true"] {
-        background: var(--atc-click-bg);
-        border-color: color-mix(in oklab, var(--atc-click-fg) 50%, var(--atc-click-bg));
-        box-shadow: var(--atc-control-active-shadow-strong);
+        background: var(--atc-glass-active-bg);
+        border-color: transparent;
+        box-shadow: var(--atc-glass-rim-shadow);
+        -webkit-backdrop-filter: var(--atc-glass-active-frost);
+        backdrop-filter: var(--atc-glass-active-frost);
         & .hourly-card__time { color: var(--atc-click-muted); }
         & .hourly-card__condition { color: var(--atc-click-fg); }
         & .hourly-card__temp { color: var(--atc-click-fg); }

--- a/src/style.css
+++ b/src/style.css
@@ -2687,13 +2687,13 @@ body:has(.app-detail-shell) {
        greens through the ink and made the glass look murky brown-green
        instead of neutral smoke. */
     --atc-glass-active-frost: saturate(0.85) blur(14px);
-    /* Real soft drop shadow for floating menus. Previously colored with
-       --atc-bg, which in light theme is near-white — that rendered as a
-       glowing halo around dropdowns rather than a shadow. Neutral black
-       at low opacity reads as clean floating glass in both themes. */
+    /* Tight, crisp drop shadow for floating menus. Previously colored
+       with --atc-bg (near-white in light theme), which rendered as a
+       glowing halo; even a wide neutral shadow reads as a diffuse cloud
+       over the pale map, so keep the blur small and contact-y. */
     --atc-menu-panel-shadow:
-        0 16px 40px rgb(0 0 0 / 0.16),
-        0 4px 12px rgb(0 0 0 / 0.10);
+        0 6px 16px rgb(0 0 0 / 0.12),
+        0 1px 4px rgb(0 0 0 / 0.10);
     --atc-icon-button-shadow: 0 8px 24px
         color-mix(in oklab, var(--atc-bg) 62%, transparent);
     --atc-toolbar-cell-size: 2rem;
@@ -2779,11 +2779,12 @@ body:has(.app-detail-shell) {
     --app-toolbar-shadow:
         0 22px 52px rgb(0 0 0 / 0.36), 0 8px 22px rgb(0 0 0 / 0.28),
         0 1px 3px rgb(0 0 0 / 0.24);
-    /* Deeper menu drop on the near-black shell so frosted dropdowns still
-       lift off the dark canvas. */
+    /* Tight menu drop on the near-black shell — deeper than light theme
+       so frosted dropdowns still lift off the dark canvas, but kept
+       contact-y rather than a wide diffuse cloud. */
     --atc-menu-panel-shadow:
-        0 20px 48px rgb(0 0 0 / 0.44),
-        0 6px 16px rgb(0 0 0 / 0.32);
+        0 8px 20px rgb(0 0 0 / 0.42),
+        0 2px 6px rgb(0 0 0 / 0.32);
     /* Resting-tile glass chrome on dark glass — the specular hairline and
        rim ring derive from --atc-text instead of literal white so the
        edge reads as a soft catch-light, and the drop shadows deepen to

--- a/src/style.css
+++ b/src/style.css
@@ -2818,25 +2818,28 @@ body {
 }
 
 .dither-page-shell {
+    /* Warm glow moved to the bottom edge so the top of the page stays a
+       clean solid canvas under the Safari browser chrome. */
     background:
         radial-gradient(
-            circle at 78% 18%,
+            circle at 78% 96%,
             color-mix(in oklab, var(--atc-orange) 12%, transparent),
-            transparent 30%
+            transparent 32%
         ),
         var(--atc-bg);
 }
 
 .dither-page-panel {
-    /* Same warm-corner sweep as the airport / flight sidebar identity
-       blocks (line 4277), so home and about share the design language
-       with the detail pages. Sits over the inherited --atc-bg fill of
-       .sidebar-shell so the panel still reads as the same surface. */
-    background: linear-gradient(
-        135deg,
-        color-mix(in oklab, var(--atc-orange) 10%, transparent),
-        transparent 48%
-    );
+    /* Solid theme color at the TOP (seamless under the Safari clip) with
+       the warm accent moved to a soft wash rising from the BOTTOM —
+       matching the airport / flight detail sidebars. */
+    background:
+        linear-gradient(
+            to top,
+            color-mix(in oklab, var(--atc-orange) 8%, transparent),
+            transparent 38%
+        ),
+        var(--sidebar);
     border-right: 0;
     border-radius: 0 var(--atc-radius-shell) var(--atc-radius-shell) 0;
     box-shadow: var(--app-panel-shadow);
@@ -2846,11 +2849,13 @@ body {
 }
 
 :root[data-theme="dark"] .dither-page-panel {
-    background: linear-gradient(
-        135deg,
-        color-mix(in oklab, var(--atc-orange) 18%, transparent),
-        transparent 48%
-    );
+    background:
+        linear-gradient(
+            to top,
+            color-mix(in oklab, var(--atc-orange) 14%, transparent),
+            transparent 40%
+        ),
+        var(--sidebar);
 }
 
 .dither-page-background {
@@ -2980,11 +2985,17 @@ body {
 .airport-sidebar-panel,
 .flight-sidebar-panel,
 .sidebar-shell {
-    background: linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--sidebar-accent) 72%, transparent),
-        var(--sidebar)
-    );
+    /* Solid theme color at the TOP so the sidebar's top edge blends
+       seamlessly with iPhone Safari's browser-chrome clip (no gradient
+       seam under the status bar / address bar). The warm accent light is
+       moved to a soft wash rising from the BOTTOM. */
+    background:
+        linear-gradient(
+            to top,
+            color-mix(in oklab, var(--atc-orange) 8%, transparent),
+            transparent 38%
+        ),
+        var(--sidebar);
     border-right: 0;
     box-shadow: var(--app-panel-shadow);
 }
@@ -5137,11 +5148,10 @@ body {
 }
 
 .airport-sidebar-identity {
-    background: linear-gradient(
-        135deg,
-        color-mix(in oklab, var(--atc-orange) 10%, transparent),
-        transparent 48%
-    );
+    /* No top warm sweep — the top of the sidebar stays a solid theme
+       color so it aligns seamlessly with the Safari browser-chrome clip.
+       The warm accent now rises from the panel bottom instead. */
+    background: transparent;
     border-bottom: 0;
     padding: 75px var(--airport-sidebar-inset) 22px;
 }
@@ -5155,27 +5165,10 @@ body {
 }
 
 .flight-sidebar-panel .airport-sidebar-identity {
-    /* Match the airport sidebar's identity gradient so the flight detail
-       page gets the same subtle warm-corner lift instead of a paler,
-       slightly-different-angle variant. */
-    background: linear-gradient(
-        135deg,
-        color-mix(in oklab, var(--atc-orange) 10%, transparent),
-        transparent 48%
-    );
+    /* Solid top to match the airport sidebar — warm light lives at the
+       panel bottom now, not the identity hero. */
+    background: transparent;
     padding-bottom: 22px;
-}
-
-/* Dark theme: --atc-orange flips to a light highlight color, but at 10%
-   alpha on the inky sidebar background it nearly disappears. Bump the
-   stop to 18% so the same diagonal sweep stays visible. */
-:root[data-theme="dark"] .airport-sidebar-identity,
-:root[data-theme="dark"] .flight-sidebar-panel .airport-sidebar-identity {
-    background: linear-gradient(
-        135deg,
-        color-mix(in oklab, var(--atc-orange) 18%, transparent),
-        transparent 48%
-    );
 }
 
 .flight-sidebar-panel .airport-sidebar-identity__rule {

--- a/src/style.css
+++ b/src/style.css
@@ -1378,14 +1378,15 @@ body:has(.app-detail-shell) {
 }
 
 :root[data-theme="dark"] .atc-tile-base {
-    filter: saturate(0.4) brightness(0.82) contrast(1.06);
+    filter: saturate(0.28) brightness(0.82) contrast(1.06);
     mix-blend-mode: normal;
 }
 
-/* Light terrain is still mostly monochrome manual ink; a small amount of
-   blue-green saturation survives so water and vegetation remain legible. */
+/* Standard base map (CARTO voyager) runs hot out of the box — pull the
+   saturation well down so greens/blues read as a muted manual-paper
+   wash that the frosted glass sits over, not a candy basemap. */
 :root[data-theme="light"] .atc-tile-base {
-    filter: saturate(0.92) brightness(1.0) contrast(0.98);
+    filter: saturate(0.62) brightness(1.0) contrast(0.98);
     mix-blend-mode: normal;
 }
 
@@ -1896,8 +1897,13 @@ body:has(.app-detail-shell) {
 }
 
 .search-input:focus-within {
-    outline: 2px solid var(--atc-orange);
-    outline-offset: 2px;
+    /* No hard accent outline — in light theme --atc-orange resolves to
+       near-black ink and read as an ugly black border. Focus shows as a
+       soft luminous frost ring consistent with the glass material. */
+    outline: none;
+    box-shadow:
+        var(--atc-control-inset-shadow),
+        inset 0 0 0 1.5px color-mix(in oklab, var(--app-frost-border) 80%, transparent);
 }
 
 .background-rays {
@@ -2681,9 +2687,13 @@ body:has(.app-detail-shell) {
        greens through the ink and made the glass look murky brown-green
        instead of neutral smoke. */
     --atc-glass-active-frost: saturate(0.85) blur(14px);
+    /* Real soft drop shadow for floating menus. Previously colored with
+       --atc-bg, which in light theme is near-white — that rendered as a
+       glowing halo around dropdowns rather than a shadow. Neutral black
+       at low opacity reads as clean floating glass in both themes. */
     --atc-menu-panel-shadow:
-        0 12px 32px color-mix(in oklab, var(--atc-bg) 60%, transparent),
-        0 2px 6px color-mix(in oklab, var(--atc-bg) 40%, transparent);
+        0 16px 40px rgb(0 0 0 / 0.16),
+        0 4px 12px rgb(0 0 0 / 0.10);
     --atc-icon-button-shadow: 0 8px 24px
         color-mix(in oklab, var(--atc-bg) 62%, transparent);
     --atc-toolbar-cell-size: 2rem;
@@ -2769,6 +2779,11 @@ body:has(.app-detail-shell) {
     --app-toolbar-shadow:
         0 22px 52px rgb(0 0 0 / 0.36), 0 8px 22px rgb(0 0 0 / 0.28),
         0 1px 3px rgb(0 0 0 / 0.24);
+    /* Deeper menu drop on the near-black shell so frosted dropdowns still
+       lift off the dark canvas. */
+    --atc-menu-panel-shadow:
+        0 20px 48px rgb(0 0 0 / 0.44),
+        0 6px 16px rgb(0 0 0 / 0.32);
     /* Resting-tile glass chrome on dark glass — the specular hairline and
        rim ring derive from --atc-text instead of literal white so the
        edge reads as a soft catch-light, and the drop shadows deepen to


### PR DESCRIPTION
Polish pass on top of the v2.4.0 liquid-glass redesign.

## Glass surfaces
- **Hourly forecast cells, tomorrow card, home search pill** now adopt the liquid-glass material — selected hourly cells flip to the glass capsule (corner dissolve + backdrop frost + specular rim); the search pill becomes milky toolbar glass.
- **GSAP transitions** on every interactive glass card (MetricCard tabs, FilterCard chips/select triggers, hourly cells) via the shared `useCardInteraction` hook — hover-lift + press-spring, matching SelectableCard/AircraftRow. CSS owns the glass background/sheen; GSAP owns transform only. The hook now respects `prefers-reduced-motion` for all consumers. (Authored against the official `gsap-core` skill.)

## Fixes (the /goal list)
1. **Sidebar top edge** — every sidebar (airport/flight/home, desktop + mobile) keeps a solid theme-color top (white light / near-black dark) so it aligns seamlessly with the iPhone Safari browser-chrome clip; the warm accent wash moved to the panel bottom.
2. **Menus unified to glassmorphism** — `SelectContent` now uses the same frosted tokens as `MenuPanel`; the menu drop shadow was colored with `--atc-bg` (near-white in light) and read as a glowing halo — switched to a tight neutral shadow in both themes (incl. the language switcher).
3. **Black focus borders removed** — focus rings drawn in `--atc-accent`/`--atc-orange`/`--endf-yellow` resolve to near-black ink in light theme; replaced with soft luminous frost rings on the home search box, altitude filter / select triggers, and FilterCard.
4. **Standard basemap desaturated** — lowered CARTO-voyager tile saturation (light .92→.62, dark .4→.28) for a muted manual-paper wash.
5. **Route filter tooltip** — was a solid near-black blob (`bg-primary`); now a frosted-glass card matching the menus.

## Validation
- `pnpm build` green; all 99 test files pass; `tsc` clean on touched files.
- Local browser (chrome-devtools) on `/airport/KBOS`, light + dark themes: verified glass capsules + GSAP hover transforms, solid sidebar tops (desktop + 414px mobile drawer), frosted select/language menus with no halo, no black focus borders, muted map, and the frosted route-filter tooltip.

No version bump — this is polish on the v2.4.0 milestone; happy to cut v2.4.1 with a changelog entry if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)