### PR TITLE
Unify sidebar browse lists & page toolbars on the liquid-glass system (v2.4.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.4.1",
+  "version": "2.4.2",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/about/AboutPanel.tsx
+++ b/src/components/about/AboutPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrowUpRight, Github } from "lucide-react";
+import { TextPillListItem } from "@/components/ui/TextPillListItem";
 import {
   ABOUT_BUILD_META,
   ABOUT_DATA_SOURCES,
@@ -97,28 +98,22 @@ export default function AboutPanel() {
           </div>
         </div>
 
-        <ol className="dither-list px-6 divide-y divide-[var(--atc-line)]">
+        <ol className="dither-list flex flex-col gap-1 px-6">
           {ABOUT_DATA_SOURCES.map((source) => (
             <li key={source.host || source.title || source.glyph}>
-              <a
+              <TextPillListItem
+                as="a"
                 {...getExternalLinkOpenTarget(source.href)}
                 onClick={(event) => openExternalLink(event, source.href)}
-                className="about-data-source-row group endf-underline -mx-6 grid grid-cols-[max-content_minmax(0,1fr)] items-center gap-3 px-6 py-3 transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)]"
-              >
-                <span className="endf-tab endf-tab--code whitespace-nowrap">
-                  <span>{source.glyph}</span>
-                </span>
-                <span className="min-w-0">
-                  <strong className="block whitespace-normal break-words text-[13px] font-semibold leading-snug text-atc-text">
-                    {source.titleKey ? t(source.titleKey) : source.title}
-                  </strong>
-                  <small className="mt-0.5 block whitespace-normal break-words text-[11.5px] leading-snug text-atc-dim">
-                    {source.descriptionKey
-                      ? t(source.descriptionKey)
-                      : source.description}
-                  </small>
-                </span>
-              </a>
+                pill={source.glyph}
+                title={source.titleKey ? t(source.titleKey) : source.title}
+                subtitle={
+                  source.descriptionKey
+                    ? t(source.descriptionKey)
+                    : source.description
+                }
+                trailing={<ArrowUpRight className="h-4 w-4" aria-hidden="true" />}
+              />
             </li>
           ))}
         </ol>

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { TextPillListItem } from "@/components/ui/TextPillListItem";
 import {
   airportDisplayCode,
   airportDisplayName,
@@ -90,7 +91,7 @@ function NearMeDiscoverySection() {
         id="airport-discovery-nearby"
         title={t("search.discovery.nearby.title")}
       />
-      <ul className="mt-3 divide-y divide-[var(--atc-line)] border-y border-[var(--atc-line)]">
+      <ul className="mt-3 flex flex-col gap-1">
         <NearbyPromptRow onRequest={handleOpenNearMe} />
       </ul>
     </section>
@@ -108,7 +109,7 @@ function AirportDiscoveryTopicSection({ topic, onOpen }) {
         description={t(topic.descriptionKey)}
       />
 
-      <ul className="mt-3 divide-y divide-[var(--atc-line)] border-y border-[var(--atc-line)]">
+      <ul className="mt-3 flex flex-col gap-1">
         {topic.airports.map((airport) => (
           <AirportDiscoveryAirportRow
             key={airport.icao || airport.code || airport.name}
@@ -150,27 +151,14 @@ function NearbyPromptRow({ onRequest }: { onRequest: () => void }) {
 
   return (
     <li>
-      <button
-        type="button"
-        className="group endf-underline -mx-3 grid w-[calc(100%+1.5rem)] grid-cols-[62px_minmax(0,1fr)_16px] items-center gap-3 px-3 py-3.5 text-left transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)]"
+      <TextPillListItem
+        as="button"
         onClick={onRequest}
-      >
-        <span className="endf-tab endf-tab--code whitespace-nowrap">
-          <span>HERE</span>
-        </span>
-        <span className="min-w-0">
-          <strong className="block truncate text-[13px] font-semibold text-atc-text">
-            {title}
-          </strong>
-          <small className="mt-0.5 block text-[11.5px] leading-snug text-atc-dim">
-            {hint}
-          </small>
-        </span>
-        <ChevronRight
-          className="h-4 w-4 text-atc-faint transition-transform group-hover:translate-x-0.5 group-hover:text-atc-text"
-          aria-hidden="true"
-        />
-      </button>
+        pill="HERE"
+        title={title}
+        subtitle={hint}
+        trailing={<ChevronRight className="h-4 w-4" aria-hidden="true" />}
+      />
     </li>
   );
 }
@@ -182,27 +170,14 @@ function AirportDiscoveryAirportRow({ airport, onOpen }) {
 
   return (
     <li>
-      <button
-        type="button"
-        className="group endf-underline -mx-3 grid w-[calc(100%+1.5rem)] grid-cols-[62px_minmax(0,1fr)_16px] items-center gap-3 px-3 py-3 text-left transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-atc-accent/60"
+      <TextPillListItem
+        as="button"
         onClick={() => onOpen(airport)}
-      >
-        <span className="endf-tab endf-tab--code">
-          <span>{code}</span>
-        </span>
-        <span className="min-w-0">
-          <strong className="block min-w-0 truncate text-[13px] font-semibold text-atc-text">
-            {airportDisplayName(airport, locale)}
-          </strong>
-          <small className="mt-0.5 block truncate text-[11.5px] text-atc-dim">
-            {label || airportSubtitle(airport, locale)}
-          </small>
-        </span>
-        <ChevronRight
-          className="h-4 w-4 text-atc-faint transition-transform group-hover:translate-x-0.5 group-hover:text-atc-text"
-          aria-hidden="true"
-        />
-      </button>
+        pill={code}
+        title={airportDisplayName(airport, locale)}
+        subtitle={label || airportSubtitle(airport, locale)}
+        trailing={<ChevronRight className="h-4 w-4" aria-hidden="true" />}
+      />
     </li>
   );
 }

--- a/src/components/airport/search/AirportRow.tsx
+++ b/src/components/airport/search/AirportRow.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from "react";
 import { airportDisplayCode, airportDisplayName, airportSubtitle } from "@/utils/airport";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
-import { useCardInteraction } from "@/animations/useCardInteraction";
+import { TextPillListItem } from "@/components/ui/TextPillListItem";
 
 export default function AirportRow({
   airport,
@@ -13,40 +13,20 @@ export default function AirportRow({
 }) {
   const { locale } = useI18n();
   const motionStyle = { "--motion-order": motionOrder } as CSSProperties;
-  const {
-    ref: rowRef,
-    onMouseEnter,
-    onMouseLeave,
-    onMouseDown,
-    onMouseUp,
-  } = useCardInteraction({ hoverScale: 1.01, hoverY: -1, pressScale: 0.99 });
 
+  // Search results render as the shared liquid-glass list tile (GSAP
+  // hover/press lives inside the primitive). The featured best-match row
+  // flips to the active glass capsule so it reads as the obvious pick.
   return (
     <li style={motionStyle}>
-      <button
-        type="button"
-        ref={rowRef}
-        className={`search-airport-row group endf-underline -mx-6 grid w-[calc(100%+3rem)] grid-cols-[72px_minmax(0,1fr)] items-center gap-3 px-6 py-3 text-left transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] ${
-          featured ? "endf-row-featured" : ""
-        }`}
+      <TextPillListItem
+        as="button"
+        active={featured}
         onClick={() => onOpen(airport)}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
-      >
-        <span className="endf-tab endf-tab--code">
-          <span>{airportDisplayCode(airport)}</span>
-        </span>
-        <span className="min-w-0">
-          <strong className="block truncate text-[13px] font-semibold text-atc-text">
-            {airportDisplayName(airport, locale)}
-          </strong>
-          <small className="mt-0.5 block truncate text-[11.5px] text-atc-dim">
-            {airportSubtitle(airport, locale)}
-          </small>
-        </span>
-      </button>
+        pill={airportDisplayCode(airport)}
+        title={airportDisplayName(airport, locale)}
+        subtitle={airportSubtitle(airport, locale)}
+      />
     </li>
   );
 }

--- a/src/components/airport/search/AirportSearchResults.tsx
+++ b/src/components/airport/search/AirportSearchResults.tsx
@@ -50,7 +50,7 @@ export function AirportSearchResults({
           {t("search.noAirportMatched", { query: query.trim() })}
         </div>
       ) : (
-        <ul className="app-list-motion dither-list px-6 divide-y divide-[var(--atc-line)]">
+        <ul className="app-list-motion dither-list flex flex-col gap-1 px-6">
           {rows.map((airport, index) => (
             <AirportRow
               key={airport.icao || airport.code || airport.name}

--- a/src/components/changelog/ChangelogPanel.tsx
+++ b/src/components/changelog/ChangelogPanel.tsx
@@ -10,6 +10,17 @@ import { CHANGELOG } from "@/config/changelog";
 // optional current marker, summary, then short highlights.
 
 const CHINESE_RELEASE_COPY = {
+  "v2.4.2": {
+    title: "统一的浏览列表与工具栏",
+    summary:
+      "首页、关于、机制、更新日志的浏览列表统一为一种整齐的列表风格 —— 对齐的代码药丸、单行行高、圆角磨砂 hover,选中/展开行采用液态玻璃胶囊。页面工具栏复用机场详情页工具栏的按钮样式。",
+    highlights: [
+      "所有侧栏浏览列表统一走 TextPillListItem 一个组件:扁平对齐行、圆角磨砂 hover、玻璃胶囊选中态",
+      "选中的搜索结果、展开的机制条目升起为共享的液态玻璃胶囊",
+      "首页/关于/机制/更新日志工具栏复用机场详情的 rail 按钮风格(磨砂 hover,不再深色墨水填充)",
+      "更新日志条目变为干净的阅读块,版本药丸去掉斜切",
+    ],
+  },
   "v2.4.1": {
     title: "液态玻璃打磨",
     summary:
@@ -373,7 +384,7 @@ export default function ChangelogPanel() {
         </div>
       </div>
 
-      <ol className="dither-list flex-1 overflow-y-auto px-6 pb-6">
+      <ol className="dither-list flex flex-1 flex-col gap-2 overflow-y-auto px-6 pb-6">
         {CHANGELOG.map((release, index) => (
           <ChangelogEntry
             key={release.version}
@@ -395,7 +406,7 @@ function ChangelogEntry({ release, isLatest, locale }) {
   const summary = localizedRelease?.summary || release.summary;
   const highlights = localizedRelease?.highlights || release.highlights;
   return (
-    <li className="changelog-entry endf-underline last:border-b-0">
+    <li className="changelog-entry">
       <div className="changelog-entry__header">
         {isLatest ? (
           <span className="endf-tab">

--- a/src/components/mechanism/MechanismPanel.tsx
+++ b/src/components/mechanism/MechanismPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import DitherPageShell from "@/components/app-shell/DitherPageShell";
+import { TextPillListItem } from "@/components/ui/TextPillListItem";
 import { MECHANISM_ITEMS } from "@/config/mechanism";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { cn } from "@/lib/utils";
@@ -26,36 +27,23 @@ export default function MechanismPanel() {
           </div>
         </div>
 
-        <ol className="dither-list px-6 divide-y divide-[var(--atc-line)]">
+        <ol className="dither-list flex flex-col gap-1 px-6">
           {MECHANISM_ITEMS.map((item, index) => {
             const expanded = item.id === expandedId;
             const panelId = `mechanism-${item.id}`;
 
             return (
               <li key={item.id}>
-                <button
-                  type="button"
+                <TextPillListItem
+                  as="button"
+                  active={expanded}
                   aria-expanded={expanded}
                   aria-controls={panelId}
                   onClick={() => setExpandedId(expanded ? null : item.id)}
-                  className={cn(
-                    "about-data-source-row group endf-underline -mx-6 grid w-[calc(100%+3rem)] grid-cols-[max-content_minmax(0,1fr)] items-center gap-3 px-6 py-3 text-left transition-colors hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] md:w-[calc(100%+38px)]",
-                    expanded &&
-                      "bg-[color-mix(in_oklab,var(--atc-elev)_72%,transparent)]",
-                  )}
-                >
-                  <span className="endf-tab endf-tab--code whitespace-nowrap">
-                    <span>{String(index + 1).padStart(2, "0")}</span>
-                  </span>
-                  <span className="min-w-0">
-                    <strong className="block whitespace-normal break-words text-[13px] font-semibold leading-snug text-atc-text">
-                      {t(item.titleKey)}
-                    </strong>
-                    <small className="mt-0.5 block whitespace-normal break-words text-[11.5px] leading-snug text-atc-dim">
-                      {t(item.signalKey)}
-                    </small>
-                  </span>
-                </button>
+                  pill={String(index + 1).padStart(2, "0")}
+                  title={t(item.titleKey)}
+                  subtitle={t(item.signalKey)}
+                />
 
                 <div
                   id={panelId}
@@ -67,7 +55,7 @@ export default function MechanismPanel() {
                   )}
                 >
                   <div className="min-h-0 overflow-hidden">
-                    <div className="px-6 pb-4 pt-1">
+                    <div className="px-3.5 pb-3 pt-3">
                       <p className="text-[11.5px] leading-relaxed text-atc-dim">
                         {t(item.bodyKey)}
                       </p>

--- a/src/components/navigation/PageNavigationDock.tsx
+++ b/src/components/navigation/PageNavigationDock.tsx
@@ -34,7 +34,10 @@ function resolveActiveHref(pathname) {
   return "/";
 }
 
-const buttonClass = toolbarButtonVariants({ tone: "soft" });
+// Reuse the airport detail map-rail button tone so every page's toolbar
+// shares one interaction style: hover reveals a soft frosted tint (not a
+// dark-ink fill), active flips to the glass capsule.
+const buttonClass = toolbarButtonVariants({ tone: "rail" });
 
 export default function PageNavigationDock() {
   const { locale, t } = useI18n();
@@ -83,6 +86,7 @@ export default function PageNavigationDock() {
           return (
             <ToolbarButton
               key={item.href}
+              tone="rail"
               asChild
               active={active}
               aria-current={active ? "page" : undefined}
@@ -131,7 +135,7 @@ export default function PageNavigationDock() {
           </ToolbarAccountSlot>
         ) : (
           <SignInButton mode="modal">
-            <ToolbarButton title={t("auth.signIn")} aria-label={t("auth.signIn")}>
+            <ToolbarButton tone="rail" title={t("auth.signIn")} aria-label={t("auth.signIn")}>
               <LogIn aria-hidden="true" />
             </ToolbarButton>
           </SignInButton>

--- a/src/components/ui/TextPillListItem.tsx
+++ b/src/components/ui/TextPillListItem.tsx
@@ -2,45 +2,62 @@
 
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { useCardInteraction } from "@/animations/useCardInteraction";
 
 type TextPillListItemProps = {
   pill: ReactNode;
   title: ReactNode;
   subtitle?: ReactNode;
   meta?: ReactNode;
+  /** Optional trailing slot — e.g. a chevron on tappable rows. */
+  trailing?: ReactNode;
   active?: boolean;
-  as?: "div" | "button";
-  onClick?: () => void;
+  as?: "div" | "button" | "a";
+  onClick?: (event?: any) => void;
   className?: string;
-};
+} & Record<string, any>;
+
+// Shared liquid-glass list tile: a horizontal "code pill + title + subtitle"
+// row rendered as a piece of frosted glass, matching the airport detail
+// page's metric / selectable cards. Resting = milky frosted surface with a
+// luminous rim + soft lift; interactive rows get a GSAP hover-lift /
+// press-spring and flip to the dark/bright glass capsule when active.
+// One primitive drives the ATC frequency list, the home/about/mechanism
+// browse lists, and search results so they all share the same material.
 
 export function TextPillListItem({
   pill,
   title,
   subtitle,
   meta,
+  trailing,
   active = false,
   as = "div",
   onClick,
   className,
+  ...rest
 }: TextPillListItemProps) {
+  const interactive = as === "button" || as === "a";
+  const { ref, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp } =
+    useCardInteraction({ enabled: interactive });
+
   const body = (
     <>
       <span
         className={cn(
-          "inline-flex min-w-18 items-center justify-center rounded-full px-3 py-1.5",
+          "inline-flex min-w-14 items-center justify-center rounded-full px-2.5 py-1",
           "bg-atc-text text-center text-[10px] font-black uppercase leading-none text-atc-bg",
           "group-data-[active=true]:bg-[var(--atc-click-fg)] group-data-[active=true]:text-[var(--atc-click-bg)]",
         )}
       >
         {pill}
       </span>
-      <span className="min-w-0 flex flex-col items-start">
-        <span className="block min-w-0 whitespace-normal break-words text-[13px] font-extrabold leading-tight text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
+      <span className="flex min-w-0 flex-col items-start">
+        <span className="block w-full min-w-0 truncate text-[13px] font-bold leading-tight text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
           {title}
         </span>
         {subtitle ? (
-          <span className="mt-0.5 block min-w-0 whitespace-normal break-words text-[11px] font-medium leading-snug text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
+          <span className="mt-0.5 block w-full min-w-0 truncate text-[11px] font-medium leading-snug text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
             {subtitle}
           </span>
         ) : null}
@@ -50,15 +67,52 @@ export function TextPillListItem({
           </span>
         ) : null}
       </span>
+      {trailing ? (
+        <span className="flex items-center self-center text-atc-faint transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-atc-text group-data-[active=true]:text-[var(--atc-click-muted)]">
+          {trailing}
+        </span>
+      ) : null}
     </>
   );
+
   const classes = cn(
-    "group grid w-full grid-cols-[max-content_minmax(0,1fr)] items-start gap-x-4 rounded-[var(--atc-radius-card)] px-0 py-2.5 text-left",
-    "transition-colors duration-150",
+    "group relative isolate overflow-hidden text-left",
+    "grid w-full items-start gap-x-3.5",
+    trailing
+      ? "grid-cols-[max-content_minmax(0,1fr)_max-content]"
+      : "grid-cols-[max-content_minmax(0,1fr)]",
+    // Flat at rest (no border/shadow) so the divided list stays tidy and
+    // aligned like the original — but always rounded, so the hover tint and
+    // active capsule read as rounded glass (a square highlight clashes with
+    // the rounded design language).
+    "rounded-[var(--atc-radius-card)] px-3.5 py-2.5",
+    "transition-[background,border-color,box-shadow,color] duration-150",
+    // Active = the shared liquid-glass capsule (dark in light theme, bright
+    // in dark theme) — same material as MetricCard / SelectableCard.
+    "data-[active=true]:[background:var(--atc-glass-active-bg)]",
+    "data-[active=true]:[backdrop-filter:var(--atc-glass-active-frost)] data-[active=true]:[-webkit-backdrop-filter:var(--atc-glass-active-frost)]",
     "data-[active=true]:text-[var(--atc-click-fg)]",
-    as === "button" && "cursor-pointer focus:outline-none",
+    "data-[active=true]:shadow-[var(--atc-glass-rim-shadow)]",
+    // Top-light sheen sweeps in on active.
+    "after:content-[''] after:absolute after:inset-0 after:[background:var(--atc-glass-sheen)]",
+    "after:pointer-events-none after:opacity-0 after:translate-y-2",
+    "after:transition-[opacity,transform] after:duration-300 after:ease-out",
+    "data-[active=true]:after:opacity-100 data-[active=true]:after:translate-y-0",
+    // Keep content above the sheen layer.
+    "[&>*]:relative [&>*]:z-[1]",
+    interactive &&
+      cn(
+        // Hover reveals a soft frosted highlight (not a permanent card).
+        "cursor-pointer hover:bg-[var(--atc-control-hover-bg)]",
+        "data-[active=true]:hover:[background:var(--atc-glass-active-bg)]",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-accent)]",
+      ),
     className,
   );
+
+  const interactionProps = interactive
+    ? { ref, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp }
+    : {};
 
   if (as === "button") {
     return (
@@ -68,9 +122,26 @@ export function TextPillListItem({
         data-active={active ? "true" : undefined}
         onClick={onClick}
         className={classes}
+        {...interactionProps}
+        {...rest}
       >
         {body}
       </button>
+    );
+  }
+
+  if (as === "a") {
+    return (
+      <a
+        data-ui="text-pill-list-item"
+        data-active={active ? "true" : undefined}
+        onClick={onClick}
+        className={classes}
+        {...interactionProps}
+        {...rest}
+      >
+        {body}
+      </a>
     );
   }
 
@@ -79,6 +150,7 @@ export function TextPillListItem({
       data-ui="text-pill-list-item"
       data-active={active ? "true" : undefined}
       className={classes}
+      {...rest}
     >
       {body}
     </div>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -7,6 +7,19 @@
 
 export const CHANGELOG = [
   {
+    version: "v2.4.2",
+    kind: "patch",
+    title: "Unified browse lists & toolbars",
+    summary:
+      "The home, about, mechanism, and changelog browse lists now share one tidy list style — aligned code pills, single-line rows, a rounded frosted hover, and the liquid-glass capsule for the selected/expanded row. Page toolbars reuse the airport detail toolbar's button style.",
+    highlights: [
+      "All sidebar browse lists route through one TextPillListItem primitive: flat aligned rows, rounded frosted hover, glass-capsule active state",
+      "Selected search result and expanded mechanism row lift into the shared liquid-glass capsule",
+      "Home/about/mechanism/changelog toolbars reuse the airport detail rail button tone (frosted hover, not a dark-ink fill)",
+      "Changelog entries become clean reading blocks with de-skewed version pills",
+    ],
+  },
+  {
     version: "v2.4.1",
     kind: "patch",
     title: "Liquid glass polish",

--- a/src/style.css
+++ b/src/style.css
@@ -6699,23 +6699,31 @@ body {
     background: var(--atc-surface-preview-card) !important;
 }
 
+/* Flat reading block — no per-entry border/shadow (that read as nested
+   glass on the already-frosted panel). Entries are separated by the
+   list gap; the de-skewed version pill heads each one. */
 .changelog-entry {
-    border-bottom: 1px solid var(--atc-line);
-    padding: 13px 0;
-    margin-inline: -24px;
-    padding-inline: 24px;
-    border-radius: 4px;
-    transition: background-color 150ms;
-}
-.changelog-entry:hover {
-    background: color-mix(in oklab, var(--atc-elev) 55%, transparent);
+    padding: 6px 4px;
+    border-radius: var(--atc-radius-card);
 }
 
 .changelog-entry__header {
     align-items: center;
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
+    gap: 6px;
+}
+
+/* Drop the Endfield parallelogram skew on the version badge + current
+   chip inside the changelog so they read as clean glass-system pills. */
+.changelog-entry .endf-tab,
+.changelog-entry .endf-chip {
+    transform: none;
+    border-radius: var(--atc-radius-pill);
+}
+.changelog-entry .endf-tab > *,
+.changelog-entry .endf-chip > * {
+    transform: none;
 }
 
 .changelog-entry .endf-tab--outline {
@@ -6915,9 +6923,7 @@ body {
     }
 
     .changelog-screen li.changelog-entry {
-        padding: 10px 0;
-        margin-inline: -19px;
-        padding-inline: 19px;
+        padding: 12px 14px;
     }
 
     .changelog-entry__header {


### PR DESCRIPTION
Aligns the home / about / mechanism / changelog browse lists and the page toolbars with the airport detail page's liquid-glass system.

## Browse lists — one primitive, tidy & glassy
All sidebar browse lists now route through a single upgraded `TextPillListItem`:
- Flat, aligned **code-pill rows** with single-line truncated titles (compact — no more 3-line wraps).
- **Rounded frosted hover** highlight (the glass material appears on interaction, not as a permanent card).
- The shared **liquid-glass capsule** for the active row — selected search result, expanded mechanism item.
- Iterated away from two dead-ends surfaced in review: per-row glass tiles (read as *nested* glass on the frosted panel) and full-width dividers (clashed with the rounded hover). Final = gapped rounded rows.
- Changelog entries become clean reading blocks with de-skewed version pills.

Migrated: `AirportDiscoveryPanel`, `AirportRow`/`AirportSearchResults`, `AboutPanel`, `MechanismPanel`, `ChangelogPanel`.

## Toolbars
`PageNavigationDock` (home/about/mechanism/changelog) now reuses the airport detail map-rail button tone, so every toolbar shares one interaction: frosted hover instead of a dark-ink fill. Same `Toolbar` shell as before.

## Release
Bump `2.4.1 → 2.4.2` + changelog (EN in `changelog.ts`, ZH in `ChangelogPanel.tsx`).

## Validation
- `pnpm build` green; all 99 test files pass; `tsc` clean on touched files.
- Local browser (chrome-devtools): home/about/mechanism/changelog lists (rest + hover + active), page toolbar hover vs airport detail toolbar — matched. Dev server restarted clean (`.next` cleared) to rule out stale styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)