### PR TITLE
[codex] Use Manrope as global font

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.4.2",
+  "version": "2.4.3",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -116,7 +116,7 @@ export default async function RootLayout({ children }) {
           crossOrigin=""
         />
         <link
-          href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;600;700;800&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;600;700;800&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/src/app/opengraph-image/route.tsx
+++ b/src/app/opengraph-image/route.tsx
@@ -3,19 +3,19 @@ import { SITE_NAME, SITE_SOCIAL_IMAGE } from "@/config/site";
 
 const FONT_URLS = [
   {
-    name: "Plus Jakarta Sans",
+    name: "Manrope",
     weight: 500,
-    url: "https://fonts.gstatic.com/s/plusjakartasans/v12/LDIbaomQNQcsA88c7O9yZ4KMCoOg4IA6-91aHEjcWuA_m07NSg.ttf",
+    url: "https://fonts.gstatic.com/s/manrope/v20/xn7_YHE41ni1AdIRqAuZuw1Bx9mbZk7PFO_F.ttf",
   },
   {
-    name: "Plus Jakarta Sans",
+    name: "Manrope",
     weight: 700,
-    url: "https://fonts.gstatic.com/s/plusjakartasans/v12/LDIbaomQNQcsA88c7O9yZ4KMCoOg4IA6-91aHEjcWuA_TknNSg.ttf",
+    url: "https://fonts.gstatic.com/s/manrope/v20/xn7_YHE41ni1AdIRqAuZuw1Bx9mbZk4aE-_F.ttf",
   },
   {
-    name: "Plus Jakarta Sans",
+    name: "Manrope",
     weight: 800,
-    url: "https://fonts.gstatic.com/s/plusjakartasans/v12/LDIbaomQNQcsA88c7O9yZ4KMCoOg4IA6-91aHEjcWuA_KUnNSg.ttf",
+    url: "https://fonts.gstatic.com/s/manrope/v20/xn7_YHE41ni1AdIRqAuZuw1Bx9mbZk59E-_F.ttf",
   },
   {
     name: "Noto Sans SC",
@@ -29,7 +29,7 @@ const imageSize = {
   height: SITE_SOCIAL_IMAGE.height,
 };
 
-const fontFamily = '"Plus Jakarta Sans", "Noto Sans SC", sans-serif';
+const fontFamily = '"Manrope", "Noto Sans SC", sans-serif';
 
 const colors = {
   paper: "#f1f1ef",
@@ -193,7 +193,7 @@ export async function GET() {
                 color: colors.ink,
                 fontSize: 126,
                 fontWeight: 800,
-                letterSpacing: -3,
+                letterSpacing: "normal",
                 lineHeight: 0.92,
               }}
             >
@@ -215,7 +215,7 @@ export async function GET() {
                 color: colors.ink,
                 fontSize: 50,
                 fontWeight: 800,
-                letterSpacing: -0.8,
+                letterSpacing: "normal",
                 lineHeight: 1,
               }}
             >

--- a/src/components/aircraft/preview/PlaneHunterStudio.tsx
+++ b/src/components/aircraft/preview/PlaneHunterStudio.tsx
@@ -1676,7 +1676,7 @@ export default function PlaneHunterStudio({
               </div>
               <h2
                 className="mt-5 text-[26px] font-extrabold leading-[1.08] text-atc-text"
-                style={{ fontFamily: "var(--font-display)", letterSpacing: "0" }}
+                style={{ fontFamily: "var(--font-display)", letterSpacing: "normal" }}
               >
                 {t("planeHunter.title")}
               </h2>

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -43,7 +43,7 @@ export default function DitherPageShell({
           </div>
           <h1
             className="endf-page-title mt-5 text-[30px] font-extrabold leading-[1.16] text-atc-text"
-            style={{ fontFamily: "var(--font-display)", letterSpacing: "0" }}
+            style={{ fontFamily: "var(--font-display)", letterSpacing: "normal" }}
           >
             <span className="block break-words">{resolvedTitle}</span>
           </h1>

--- a/src/components/brand/BrandLogo.tsx
+++ b/src/components/brand/BrandLogo.tsx
@@ -69,10 +69,10 @@ export default function BrandLogo({
         x="52"
         y="34.5"
         fill="currentColor"
-        fontFamily='"Plus Jakarta Sans", "Noto Sans SC", system-ui, sans-serif'
+        fontFamily='"Manrope", "Noto Sans SC", system-ui, sans-serif'
         fontWeight="800"
         fontSize={isCjkWordmark ? "27" : "29"}
-        letterSpacing="0"
+        letterSpacing="normal"
       >
         {normalizedWordmark}
       </text>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -7,16 +7,25 @@
 
 export const CHANGELOG = [
   {
+    version: "v2.4.3",
+    kind: "patch",
+    title: "Manrope typography",
+    summary:
+      "ADSBao now uses Manrope across the app for a cleaner, more confident transport-product voice.",
+    highlights: [
+      "Global font stack switches to Manrope with Noto Sans SC retained for Chinese text",
+      "Logo, Open Graph image, and display titles use preset normal tracking instead of custom spacing",
+    ],
+  },
+  {
     version: "v2.4.2",
     kind: "patch",
-    title: "Unified browse lists & toolbars",
+    title: "Browse lists & toolbar polish",
     summary:
-      "The home, about, mechanism, and changelog browse lists now share one tidy list style — aligned code pills, single-line rows, a rounded frosted hover, and the liquid-glass capsule for the selected/expanded row. Page toolbars reuse the airport detail toolbar's button style.",
+      "Static-page browse lists and page toolbars now share the same tidy liquid-glass patterns.",
     highlights: [
-      "All sidebar browse lists route through one TextPillListItem primitive: flat aligned rows, rounded frosted hover, glass-capsule active state",
-      "Selected search result and expanded mechanism row lift into the shared liquid-glass capsule",
-      "Home/about/mechanism/changelog toolbars reuse the airport detail rail button tone (frosted hover, not a dark-ink fill)",
-      "Changelog entries become clean reading blocks with de-skewed version pills",
+      "Home, about, mechanism, and changelog lists use aligned rows with frosted hover and glass active states",
+      "Static-page toolbars reuse the airport detail toolbar tone and sizing",
     ],
   },
   {
@@ -24,14 +33,11 @@ export const CHANGELOG = [
     kind: "patch",
     title: "Liquid glass polish",
     summary:
-      "Polish pass on the liquid-glass redesign: more surfaces adopt the material, GSAP hover/press motion on every interactive glass card, and a batch of UI fixes — solid sidebar tops, unified menu glassmorphism, no black focus borders, a muted standard basemap, and a frosted route tooltip.",
+      "More controls, cards, and menus now match the liquid-glass system with cleaner motion and focus states.",
     highlights: [
-      "Hourly forecast, tomorrow card, and home search bar adopt the liquid-glass material; selected hourly cells flip to the glass capsule",
-      "GSAP hover-lift + press-spring on metric tabs, filter chips, and hourly cells, with prefers-reduced-motion respected",
-      "Every sidebar keeps a solid theme-color top edge so it aligns seamlessly with the iPhone Safari browser-chrome clip; warm light moved to the bottom",
-      "Dropdowns and tooltips unified to frosted glassmorphism; menu drop shadows no longer read as a glowing halo",
-      "Removed the near-black focus borders on the search box, altitude filter, and select triggers",
-      "Standard basemap desaturated to a muted manual-paper wash",
+      "Hourly forecast, tomorrow card, and home search adopt the shared glass material",
+      "Interactive glass cards get smoother hover and press motion with reduced-motion support",
+      "Menus, tooltips, focus rings, and standard basemap tone were cleaned up",
     ],
   },
   {
@@ -39,14 +45,11 @@ export const CHANGELOG = [
     kind: "feat",
     title: "Liquid glass redesign",
     summary:
-      "Every floating surface is rebuilt as Apple-style liquid glass over a colored basemap: milky frosted tiles and toolbars at rest, and a polished glass capsule for selected states — dark smoke in light theme, luminous white in dark theme — with a signature corner dissolve.",
+      "ADSBao's floating surfaces were rebuilt around a two-material liquid-glass system.",
     highlights: [
-      "Selected cards, filter chips, settings options, and toolbar buttons share one glass-capsule material: smoky translucent ink, backdrop frost, specular top rim, and a bottom-right corner that dissolves to reveal the surface behind",
-      "Dark theme selected state inverts to a bright white-glass capsule with dark ink text on the near-black shell",
-      "Resting tiles and toolbar pills become bright milky frosted glass with luminous rims, soft lift shadows, and crisp dark icons",
-      "Colored CARTO voyager basemap replaces the washed vector style so the frost has real geography to diffuse",
-      "Sidebar and panels rebuilt as a token-driven frosted material system (--app-frost, --atc-glass-*, --atc-control-*) shared across every surface",
-      "DESIGN.md rewritten as the liquid-glass source of truth for future UI work",
+      "Selected states use one shared glass capsule across cards, filters, settings, and toolbars",
+      "Resting tiles and toolbar pills use a bright frosted material with luminous rims",
+      "DESIGN.md and shared tokens now define the material system for future UI work",
     ],
   },
   {
@@ -54,15 +57,11 @@ export const CHANGELOG = [
     kind: "patch",
     title: "Hydration stability, list row polish & flight tracking resilience",
     summary:
-      "Eliminated SSR hydration mismatches and intermediate-state flicker across the app. Unified list row hover with background + underline. Flight tracking now uses nearby-favored positions and per-provider timeouts.",
+      "Hydration, list-row feedback, and flight tracking fallbacks are more stable.",
     highlights: [
-      "New Skeleton component replaces text placeholders during weather/settings loading — no more flash of unstyled content",
-      "Map settings and feature flags gate rendering on hydration to prevent layout jumps",
-      "Unified list row hover (background tint + underline) on home, about, mechanism, and changelog pages",
-      "HERE badge replaces near-me icon with aligned ICAO code row width",
-      "Flight map center falls back to nearby-favored position when merged data is fresher than callsign result",
-      "Per-provider 4s timeout in callsign fetch — one slow source no longer blocks the entire poll",
-      "useWakeLock detects browser support in useEffect to fix SSR hydration error",
+      "Skeleton loading and hydration gates reduce layout flicker",
+      "Static-page list rows get unified hover feedback",
+      "Flight tracking falls back to fresher nearby data and per-provider timeouts",
     ],
   },
   {
@@ -70,12 +69,11 @@ export const CHANGELOG = [
     kind: "feat",
     title: "Screen wake lock & status bar polish",
     summary:
-      "Map toolbar gets a screen wake lock toggle to keep the device awake during long spotting sessions. The map status bar gets wider, single-line rendering, and GSAP transitions.",
+      "The map toolbar can keep the screen awake, and the source status bar is easier to scan.",
     highlights: [
-      "Wake lock toggle in map toolbar — Coffee icon, click to prevent screen sleep",
-      "Status bar shows '☕ Keep awake' indicator when active, inline with source badges",
-      "Replaced EndfieldValueSwap with GSAP StatusSpan for smoother text transitions",
-      "Status bar width increased and flex-wrap removed — always single-line",
+      "Wake lock toggle prevents screen sleep during spotting sessions",
+      "Status bar shows keep-awake state inline with source badges",
+      "Source text transitions are smoother and stay single-line",
     ],
   },
   {

--- a/src/style.css
+++ b/src/style.css
@@ -38,9 +38,9 @@
     --color-atc-line: var(--atc-line);
     --color-atc-line-strong: var(--atc-line-strong);
 
-    /* Consumer flight-tracking typography. Plus Jakarta Sans gives ADSBao
-       the geometric mobility-product feel requested from Uber's type
-       system, while Noto Sans SC carries CJK glyphs. */
+    /* Consumer flight-tracking typography. Manrope gives ADSBao the
+       geometric mobility-product feel requested from Uber's type system,
+       while Noto Sans SC carries CJK glyphs. */
     --font-sans: var(--theme-font-sans);
     --font-mono: var(--theme-font-mono);
     --font-nav: var(--theme-font-nav);
@@ -458,15 +458,15 @@
    near-black in light mode and near-white in dark mode. */
 :root {
     --theme-font-harmony-medium:
-        "Plus Jakarta Sans", "Noto Sans SC", system-ui, sans-serif;
+        "Manrope", "Noto Sans SC", system-ui, sans-serif;
     --theme-font-sans:
-        "Plus Jakarta Sans", "Noto Sans SC", system-ui, sans-serif;
+        "Manrope", "Noto Sans SC", system-ui, sans-serif;
     --theme-font-mono:
-        "Plus Jakarta Sans", "Noto Sans SC", system-ui, sans-serif;
+        "Manrope", "Noto Sans SC", system-ui, sans-serif;
     --theme-font-nav:
-        "Plus Jakarta Sans", "Noto Sans SC", system-ui, sans-serif;
+        "Manrope", "Noto Sans SC", system-ui, sans-serif;
     --theme-font-display:
-        "Plus Jakarta Sans", "Noto Sans SC", system-ui, sans-serif;
+        "Manrope", "Noto Sans SC", system-ui, sans-serif;
     --theme-primary-bright: oklch(0.18 0.006 100);
     --theme-primary-deep: oklch(0.18 0.006 100);
     --theme-primary-ink: oklch(0.985 0.003 100);
@@ -1410,7 +1410,7 @@ body:has(.app-detail-shell) {
     font-weight: 700;
     height: 18px;
     justify-content: center;
-    letter-spacing: 0;
+    letter-spacing: normal;
     line-height: 1;
     text-shadow: 0 1px 2px rgb(0 0 0 / 0.45);
     width: 34px;
@@ -1494,7 +1494,7 @@ body:has(.app-detail-shell) {
     font-family: var(--font-mono);
     font-size: 10px;
     font-weight: 700;
-    letter-spacing: 0;
+    letter-spacing: normal;
     paint-order: stroke;
     opacity: 0.5;
     pointer-events: none;
@@ -1650,7 +1650,7 @@ body:has(.app-detail-shell) {
 .navaid-count-marker strong {
     font-size: 11px;
     font-weight: 900;
-    letter-spacing: 0;
+    letter-spacing: normal;
     line-height: 1;
 }
 
@@ -1658,7 +1658,7 @@ body:has(.app-detail-shell) {
     color: var(--navaid-label-muted);
     font-size: 7px;
     font-weight: 800;
-    letter-spacing: 0;
+    letter-spacing: normal;
     line-height: 1;
 }
 
@@ -2818,7 +2818,7 @@ body:has(.app-detail-shell) {
 }
 
 body {
-    letter-spacing: 0;
+    letter-spacing: normal;
 }
 
 .font-mono,
@@ -2828,7 +2828,7 @@ body {
     font-feature-settings:
         "tnum" 1,
         "ss01" 1;
-    letter-spacing: 0;
+    letter-spacing: normal;
 }
 
 .dither-page-shell {
@@ -2909,7 +2909,7 @@ body {
 }
 
 .dither-page-panel p {
-    letter-spacing: 0;
+    letter-spacing: normal;
 }
 
 .search-input {
@@ -2937,7 +2937,7 @@ body {
 .endf-label,
 .endf-section-head__count {
     font-family: var(--font-sans);
-    letter-spacing: 0;
+    letter-spacing: normal;
     text-transform: none;
 }
 
@@ -2950,7 +2950,7 @@ body {
 .endf-chip {
     border-radius: var(--atc-radius-pill);
     font-family: var(--font-sans);
-    letter-spacing: 0;
+    letter-spacing: normal;
     text-transform: none;
     transform: none;
 }
@@ -3121,13 +3121,13 @@ body {
 .airport-sidebar-display-mono {
     font-style: normal;
     font-weight: 800;
-    letter-spacing: 0;
+    letter-spacing: normal;
 }
 
 .aircraft-preview-stat__label,
 .aircraft-preview-meta-row__label,
 .route-feedback-form__label {
-    letter-spacing: 0;
+    letter-spacing: normal;
     text-transform: none;
 }
 
@@ -3175,7 +3175,7 @@ body {
 .route-feedback-form__open {
     border-radius: var(--atc-radius-pill);
     font-family: var(--font-sans);
-    letter-spacing: 0;
+    letter-spacing: normal;
     text-transform: none;
 }
 
@@ -3198,7 +3198,7 @@ body {
 
 .route-feedback-form__input {
     border-radius: 12px;
-    letter-spacing: 0;
+    letter-spacing: normal;
 }
 
 .route-feedback-modal__overlay {
@@ -4616,7 +4616,7 @@ body {
 .aircraft-table-header {
     background: color-mix(in oklab, var(--atc-bg) 42%, transparent);
     border-top: 1px solid color-mix(in oklab, var(--atc-line) 54%, transparent);
-    letter-spacing: 0;
+    letter-spacing: normal;
     min-height: 38px;
 }
 
@@ -4865,7 +4865,7 @@ body {
     font-family: var(--font-sans);
     font-size: 6.5px;
     gap: 2px;
-    letter-spacing: 0;
+    letter-spacing: normal;
     line-height: 1;
     min-height: 10px;
     padding: 1px 5px 1px 4px;
@@ -4986,7 +4986,7 @@ body {
 
 .airport-sidebar-panel .metar-token-strip strong {
     font-size: 17px;
-    letter-spacing: 0;
+    letter-spacing: normal;
 }
 
 .airport-sidebar-panel--mobile .metar-token-strip strong {
@@ -5237,7 +5237,7 @@ body {
     display: inline-block;
     font-size: 0.32em;
     font-weight: 700;
-    letter-spacing: 0;
+    letter-spacing: normal;
     margin-left: 0.18em;
     text-transform: uppercase;
     transform: translateY(0.52em);
@@ -5284,7 +5284,7 @@ body {
     font-family: var(--airport-sidebar-sans);
     font-size: 10px;
     font-weight: 700;
-    letter-spacing: 0;
+    letter-spacing: normal;
     text-transform: uppercase;
 }
 
@@ -5292,7 +5292,7 @@ body {
     color: var(--atc-dim);
     font-family: var(--airport-sidebar-sans);
     font-size: 12px;
-    letter-spacing: 0;
+    letter-spacing: normal;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -6675,7 +6675,7 @@ body {
 /* Modernization override must stay last. */
 [class*="uppercase"],
 [class*="tracking-"] {
-    letter-spacing: 0 !important;
+    letter-spacing: normal !important;
 }
 
 [class*="uppercase"] {
@@ -6693,7 +6693,7 @@ body {
 .route-feedback-form__submit,
 .route-feedback-form__cancel {
     font-family: var(--font-sans) !important;
-    letter-spacing: 0 !important;
+    letter-spacing: normal !important;
     text-transform: none !important;
 }
 


### PR DESCRIPTION
## Summary
- Switches the global Google Fonts request from Plus Jakarta Sans to Manrope while keeping Noto Sans SC as the CJK fallback.
- Updates ADSBao font tokens, logo text, and Open Graph image font data to Manrope.
- Replaces zero/negative tracking overrides touched by the font system with the preset `normal` value.
- Bumps the app to v2.4.3 and shortens the recent changelog entries.

## Validation
- /opt/homebrew/bin/pnpm lint (passes; existing 3 warnings)
- git diff --check -- scoped font/version/changelog files
- curl http://localhost:3000/airport/KBOS confirms the Manrope stylesheet is rendered
- Chrome computed-style check: desktop airport, mobile airport, and home shell resolve body/logo/title to Manrope with letter-spacing normal