### PR TITLE
[codex] Add WebMCP onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ You are expected to keep one long-running `pnpm dev` process on port 3000 across
    until curl -s -o /dev/null -w '%{http_code}' http://localhost:3000 | grep -q 200; do sleep 2; done
    ```
 
-4. **After the restart**, reload the page in chrome-devtools-mcp with `ignoreCache: true` before re-checking the broken behavior. Verify the source CSS file with `grep` first, then verify the served bundle (`curl /_next/static/chunks/*.css | grep <class>`) before going deeper into a debugging rabbit hole.
+4. **After the restart**, reload the page in the available browser MCP with cache ignored before re-checking the broken behavior. Verify the source CSS file with `grep` first, then verify the served bundle (`curl /_next/static/chunks/*.css | grep <class>`) before going deeper into a debugging rabbit hole.
 5. Subagents working on ADSBao local development should own this lifecycle: start the tmux process when it is missing, restart it when it breaks, and do the `.next` reset themselves when CSS or JSX is stale. Do not wait for the user to explicitly ask for a dev-server restart.
 6. Never `--turbopack`-disable or `next build` mid-session as a workaround — restarting with `.next` removed is the supported escape hatch and is fast enough on this project (< 10s to ready). Don't add `package.json` scripts for this; it's an operational habit, not a permanent build flag.
 
@@ -74,6 +74,7 @@ You are expected to keep one long-running `pnpm dev` process on port 3000 across
 | `src/features/weather/*` | Weather models and METAR mechanisms |
 | `src/features/about/*` | About-page view models |
 | `src/features/app-shell/*` | Theme preference state and helpers |
+| `src/features/webmcp/*` | Browser-native WebMCP tool registration for agents |
 | `src/hooks/*.ts` | React hooks for METAR, ADS-B positions, route lookups, wiki summaries, and scroll parallax |
 | `src/constants/aircraft.ts` | Shared aircraft color and threshold constants |
 | `src/utils/math.ts` | Shared numeric helpers (`toFiniteNumber`) |
@@ -81,6 +82,39 @@ You are expected to keep one long-running `pnpm dev` process on port 3000 across
 | `src/data/airportFallbacks.ts` | Fallback airport metadata and coordinates |
 
 There is no standalone `src/services` or `src/server` layer. TSX belongs under `src/components/**`; mechanisms, models, clients, hooks, and feature-specific utils live inside the owning feature domain as plain `.ts` modules, except for API DAOs and route-handler helpers under `src/app/api`.
+
+## WebMCP for browser agents
+
+ADSBao exposes a small browser-native WebMCP surface from `src/features/webmcp/*`.
+This is a progressive enhancement: browsers without WebMCP simply skip
+registration, and the normal UI remains the source of truth.
+
+Current tools:
+
+- `search_airports` — searches `/api/search` and returns concise airport
+  matches with ICAO identifiers.
+- `open_airport` — navigates the visible tab to `/airport/{ICAO}`.
+- `open_aircraft` — navigates the visible tab to `/aircraft/{CALLSIGN}`.
+- `get_page_context` — reports the current ADSBao route, title, heading, page
+  kind, and active airport/aircraft identifier when present.
+
+When using a browser agent against ADSBao, prefer these WebMCP tools before
+clicking, typing, or screenshot-driven actuation. Re-list tools after
+navigation because WebMCP availability is page/browser state. Fall back to DOM
+interaction when no relevant WebMCP tool exists.
+
+Local Chrome testing:
+
+1. Enable `chrome://flags/#enable-webmcp-testing`.
+2. Relaunch Chrome and open `http://localhost:3000`.
+3. In DevTools, verify discovery with
+   `navigator.modelContextTesting.listTools()`.
+4. Execute tools with
+   `navigator.modelContextTesting.executeTool("search_airports", JSON.stringify({ query: "KBOS" }))`.
+
+WebMCP requires origin-keyed pages and the `tools` permissions policy. Keep
+`Origin-Agent-Cluster: ?1` and `Permissions-Policy: tools=(self)` in
+`src/config/securityHeaders.ts` unless the WebMCP platform requirement changes.
 
 ## Styling — Tailwind first
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import ThemedToaster from "@/components/app-shell/ThemedToaster";
 import { I18nProvider } from "@/features/app-shell/i18n/i18nProvider";
 import QueryProvider from "@/features/app-shell/queryProvider";
 import { UnitPreferencesProvider } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import WebMcpProvider from "@/features/webmcp/WebMcpProvider";
 import { isConcreteTheme } from "@/utils/theme";
 import "leaflet/dist/leaflet.css";
 import "maplibre-gl/dist/maplibre-gl.css";
@@ -125,6 +126,7 @@ export default async function RootLayout({ children }) {
           <I18nProvider initialLocale={locale}>
             <QueryProvider>
               <UnitPreferencesProvider>
+                <WebMcpProvider />
                 <div className="min-h-dvh bg-atc-bg text-atc-text">{children}</div>
               </UnitPreferencesProvider>
             </QueryProvider>

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -17,13 +17,17 @@ const securityHeaders = [
     value: "nosniff",
   },
   {
+    key: "Origin-Agent-Cluster",
+    value: "?1",
+  },
+  {
     key: "Referrer-Policy",
     value: "strict-origin-when-cross-origin",
   },
   {
     key: "Permissions-Policy",
     value:
-      "camera=(), microphone=(), geolocation=(self), payment=(), usb=(), browsing-topics=()",
+      "camera=(), microphone=(), geolocation=(self), payment=(), tools=(self), usb=(), browsing-topics=()",
   },
 ];
 

--- a/src/features/webmcp/WebMcpProvider.tsx
+++ b/src/features/webmcp/WebMcpProvider.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  registerAdsbaoWebMcpTools,
+  type WebMcpModelContext,
+} from "@/features/webmcp/webMcpTools";
+
+declare global {
+  interface Document {
+    modelContext?: WebMcpModelContext;
+  }
+}
+
+const getPageContext = () => ({
+  href: window.location.href,
+  pathname: window.location.pathname,
+  search: window.location.search,
+  hash: window.location.hash,
+  title: document.title,
+  heading: document.querySelector("h1")?.textContent?.trim() || "",
+});
+
+export default function WebMcpProvider() {
+  useEffect(() => {
+    const modelContext = document.modelContext;
+    if (!modelContext) return;
+
+    const controller = new AbortController();
+    registerAdsbaoWebMcpTools(
+      modelContext,
+      {
+        fetch: window.fetch.bind(window),
+        navigate: (path) => window.location.assign(path),
+        getPageContext,
+      },
+      controller.signal,
+    ).catch((error) => {
+      console.warn("[webmcp] failed to register ADSBao tools", error);
+    });
+
+    return () => controller.abort();
+  }, []);
+
+  return null;
+}

--- a/src/features/webmcp/webMcpTools.test.ts
+++ b/src/features/webmcp/webMcpTools.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+
+import {
+  createAdsbaoWebMcpTools,
+  registerAdsbaoWebMcpTools,
+  type WebMcpModelContext,
+} from "./webMcpTools";
+
+const calls: string[] = [];
+
+const runtime = {
+  fetch: async (url: RequestInfo | URL) => {
+    calls.push(String(url));
+    return new Response(
+      JSON.stringify({
+        source: "openaip",
+        airports: [
+          {
+            ident: "KBOS",
+            iata: "BOS",
+            name: "Boston Logan International Airport",
+            municipality: "Boston",
+            isoCountry: "US",
+            type: "large_airport",
+          },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  },
+  navigate: (path: string) => calls.push(`navigate:${path}`),
+  getPageContext: () => ({
+    href: "https://adsbao.dev/airport/kbos",
+    pathname: "/airport/kbos",
+    search: "",
+    hash: "",
+    title: "KBOS - Boston Logan | ADSBao",
+    heading: "Boston Logan",
+  }),
+};
+
+const tools = createAdsbaoWebMcpTools(runtime);
+assert.deepEqual(
+  tools.map((tool) => tool.name),
+  ["search_airports", "open_airport", "open_aircraft", "get_page_context"],
+);
+
+const searchResult = await tools
+  .find((tool) => tool.name === "search_airports")
+  ?.execute({ query: "Boston", limit: 3 });
+assert.equal(calls[0], "/api/search?q=Boston&limit=3");
+assert.deepEqual((searchResult?.result as Record<string, any>).airports[0], {
+  ident: "KBOS",
+  iata: "BOS",
+  name: "Boston Logan International Airport",
+  municipality: "Boston",
+  country: "US",
+  type: "large_airport",
+});
+
+await tools
+  .find((tool) => tool.name === "open_airport")
+  ?.execute({ icao: " kbos " });
+assert.equal(calls.at(-1), "navigate:/airport/KBOS");
+
+await tools
+  .find((tool) => tool.name === "open_aircraft")
+  ?.execute({ callsign: " afr331e " });
+assert.equal(calls.at(-1), "navigate:/aircraft/AFR331E");
+
+const pageContext = await tools
+  .find((tool) => tool.name === "get_page_context")
+  ?.execute();
+assert.deepEqual((pageContext?.result as Record<string, any>).entity, {
+  type: "airport",
+  id: "KBOS",
+});
+assert.equal((pageContext?.result as Record<string, any>).pageKind, "airport");
+
+const registeredTools: string[] = [];
+const modelContext: WebMcpModelContext = {
+  registerTool(tool) {
+    registeredTools.push(tool.name);
+  },
+};
+assert.deepEqual(await registerAdsbaoWebMcpTools(modelContext, runtime), [
+  "search_airports",
+  "open_airport",
+  "open_aircraft",
+  "get_page_context",
+]);
+assert.deepEqual(registeredTools, [
+  "search_airports",
+  "open_airport",
+  "open_aircraft",
+  "get_page_context",
+]);
+
+console.log("webMcpTools.test.ts ok");

--- a/src/features/webmcp/webMcpTools.ts
+++ b/src/features/webmcp/webMcpTools.ts
@@ -1,0 +1,238 @@
+type WebMcpContent = {
+  type: "text";
+  text: string;
+};
+
+type WebMcpToolResult = {
+  content: WebMcpContent[];
+  result?: unknown;
+};
+
+type WebMcpTool = {
+  name: string;
+  description: string;
+  inputSchema?: Record<string, unknown>;
+  execute: (input?: Record<string, unknown>) => Promise<WebMcpToolResult> | WebMcpToolResult;
+};
+
+type WebMcpRegisterOptions = {
+  signal?: AbortSignal;
+};
+
+export type WebMcpModelContext = {
+  registerTool: (
+    tool: WebMcpTool,
+    options?: WebMcpRegisterOptions,
+  ) => Promise<void> | void;
+};
+
+type WebMcpRuntime = {
+  fetch: typeof fetch;
+  navigate: (path: string) => void;
+  getPageContext: () => {
+    href: string;
+    pathname: string;
+    search: string;
+    hash: string;
+    title: string;
+    heading: string;
+  };
+};
+
+const airportSearchSchema = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      description: "Airport name, ICAO, IATA, city, or free-text search query.",
+    },
+    country: {
+      type: "string",
+      description: "Optional 2-letter ISO country code, such as US, CA, or JP.",
+    },
+    type: {
+      type: "string",
+      enum: ["all", "large_airport", "medium_airport", "small_airport", "heliport"],
+      description: "Optional airport type filter.",
+    },
+    limit: {
+      type: "number",
+      minimum: 1,
+      maximum: 20,
+      description: "Maximum number of airport matches to return.",
+    },
+  },
+  required: ["query"],
+};
+
+const airportNavigationSchema = {
+  type: "object",
+  properties: {
+    icao: {
+      type: "string",
+      description: "ICAO airport identifier, such as KBOS, RJTT, or EGLL.",
+    },
+  },
+  required: ["icao"],
+};
+
+const aircraftNavigationSchema = {
+  type: "object",
+  properties: {
+    callsign: {
+      type: "string",
+      description: "Aircraft callsign to open, such as DAL123 or AFR331E.",
+    },
+  },
+  required: ["callsign"],
+};
+
+const normalizeAirportIdent = (value: unknown) =>
+  String(value || "")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+const normalizeCallsign = (value: unknown) =>
+  String(value || "")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+const numberInRange = (value: unknown, fallback: number, min: number, max: number) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(numeric)));
+};
+
+const toolResult = (text: string, result?: unknown): WebMcpToolResult => ({
+  content: [{ type: "text", text }],
+  result,
+});
+
+const summarizeAirports = (payload: Record<string, unknown>) => {
+  const airports = Array.isArray(payload.airports) ? payload.airports : [];
+  return airports.map((airport: Record<string, unknown>) => ({
+    ident: airport.ident ?? airport.icao ?? "",
+    iata: airport.iata ?? "",
+    name: airport.name ?? "",
+    municipality: airport.municipality ?? airport.city ?? "",
+    country: airport.isoCountry ?? airport.country ?? "",
+    type: airport.type ?? "",
+  }));
+};
+
+const pageKindForPathname = (pathname: string) => {
+  if (pathname.startsWith("/airport/")) return "airport";
+  if (pathname.startsWith("/aircraft/")) return "aircraft";
+  if (pathname === "/" || pathname === "/here") return "home";
+  if (pathname.startsWith("/about")) return "about";
+  if (pathname.startsWith("/changelog")) return "changelog";
+  if (pathname.startsWith("/mechanism")) return "mechanism";
+  return "unknown";
+};
+
+const currentEntityForPathname = (pathname: string) => {
+  const [, section, value] = pathname.split("/");
+  if ((section === "airport" || section === "aircraft") && value) {
+    return {
+      type: section,
+      id: decodeURIComponent(value).toUpperCase(),
+    };
+  }
+  return null;
+};
+
+export function createAdsbaoWebMcpTools(runtime: WebMcpRuntime): WebMcpTool[] {
+  return [
+    {
+      name: "search_airports",
+      description:
+        "Search ADSBao's airport directory and return concise airport matches with ICAO identifiers for navigation.",
+      inputSchema: airportSearchSchema,
+      async execute(input = {}) {
+        const query = String(input.query || "").trim();
+        if (!query) return toolResult("Airport search requires a non-empty query.");
+
+        const limit = numberInRange(input.limit, 8, 1, 20);
+        const url = new URL("/api/search", "https://adsbao.local");
+        url.searchParams.set("q", query);
+        url.searchParams.set("limit", String(limit));
+
+        const country = String(input.country || "").trim().toUpperCase();
+        if (country) url.searchParams.set("country", country);
+
+        const type = String(input.type || "").trim();
+        if (type && type !== "all") url.searchParams.set("type", type);
+
+        const response = await runtime.fetch(`${url.pathname}${url.search}`, {
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) {
+          return toolResult(`Airport search failed with HTTP ${response.status}.`);
+        }
+
+        const payload = await response.json();
+        const airports = summarizeAirports(payload);
+        return toolResult(
+          airports.length
+            ? `Found ${airports.length} airport match${airports.length === 1 ? "" : "es"}.`
+            : "No airport matches found.",
+          { airports, source: payload.source || "unknown" },
+        );
+      },
+    },
+    {
+      name: "open_airport",
+      description:
+        "Navigate the visible ADSBao tab to an airport page by ICAO identifier.",
+      inputSchema: airportNavigationSchema,
+      execute(input = {}) {
+        const icao = normalizeAirportIdent(input.icao);
+        if (!icao) return toolResult("Airport navigation requires an ICAO identifier.");
+        const path = `/airport/${encodeURIComponent(icao)}`;
+        runtime.navigate(path);
+        return toolResult(`Opening airport ${icao}.`, { path, icao });
+      },
+    },
+    {
+      name: "open_aircraft",
+      description:
+        "Navigate the visible ADSBao tab to an aircraft tracking page by callsign.",
+      inputSchema: aircraftNavigationSchema,
+      execute(input = {}) {
+        const callsign = normalizeCallsign(input.callsign);
+        if (!callsign) return toolResult("Aircraft navigation requires a callsign.");
+        const path = `/aircraft/${encodeURIComponent(callsign)}`;
+        runtime.navigate(path);
+        return toolResult(`Opening aircraft ${callsign}.`, { path, callsign });
+      },
+    },
+    {
+      name: "get_page_context",
+      description:
+        "Return the current ADSBao page kind, URL, title, heading, and selected airport or aircraft identifier when present.",
+      execute() {
+        const context = runtime.getPageContext();
+        const result = {
+          ...context,
+          pageKind: pageKindForPathname(context.pathname),
+          entity: currentEntityForPathname(context.pathname),
+        };
+        return toolResult("Current ADSBao page context.", result);
+      },
+    },
+  ];
+}
+
+export async function registerAdsbaoWebMcpTools(
+  modelContext: WebMcpModelContext,
+  runtime: WebMcpRuntime,
+  signal?: AbortSignal,
+) {
+  const tools = createAdsbaoWebMcpTools(runtime);
+  await Promise.all(
+    tools.map((tool) => modelContext.registerTool(tool, { signal })),
+  );
+  return tools.map((tool) => tool.name);
+}


### PR DESCRIPTION
## Summary
- add browser-native WebMCP tool registration for airport search, airport navigation, aircraft navigation, and current page context
- wire the WebMCP provider into the root app layout as a progressive enhancement
- add the required origin-agent-cluster and tools permissions-policy headers
- document the WebMCP workflow and local Chrome testing steps in the agent guide

## Validation
- `pnpm exec tsx src/features/webmcp/webMcpTools.test.ts`
- `pnpm test`
- `pnpm lint` (existing warnings only)
- `pnpm build` (existing Next/Sentry Edge Runtime warning only)
- local browser smoke: loaded `http://localhost:3000/` with no console errors; current browser had no `document.modelContext`, so the no-op path was verified
- HTTP header smoke: confirmed `Origin-Agent-Cluster: ?1` and `Permissions-Policy: ... tools=(self) ...`
