### PR TITLE
Polish mobile aircraft selection UI

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -221,6 +221,7 @@ export default function AircraftPreviewCard({
         <MobilePreviewCard
           identityKey={`mobile-${identityKey}`}
           ariaLabel={previewAriaLabel}
+          compact={!isAirport && !isNavaid && !isAirspace && !isCandidateWatchingSpot}
           traceStatus={
             cardTrackHref && !isAirport ? (
               <MobilePreviewTraceStatus active={traceStatusVisible}>
@@ -367,4 +368,3 @@ function usePhotoTone(src) {
 
   return tone;
 }
-

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -140,7 +140,7 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
         label={t("preview.aircraftPreview")}
         primary={callsign}
         secondary={secondary}
-        secondaryClassName="max-w-[min(50vw,220px)] text-[15px] font-extrabold text-atc-text"
+        secondaryClassName="max-w-[min(47vw,176px)] text-[13px] font-extrabold text-atc-text"
       />
       {(route || hasStats) ? (
         <MobilePreviewRuleRow

--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -23,11 +23,13 @@ export default function MobilePreviewCard({
   children,
   actions = null,
   traceStatus = null,
+  compact = false,
 }: Record<string, any>) {
   return (
     <aside
       key={identityKey}
       aria-label={ariaLabel}
+      data-density={compact ? "compact" : undefined}
       data-ui="mobile-preview-card"
       className={cn(
         "fixed left-1/2 z-popover",
@@ -49,6 +51,8 @@ export default function MobilePreviewCard({
         // actions row so the gap around the Track button reads as
         // equal on the left, right, and bottom.
         "flex flex-col gap-[3px] pb-[14px]",
+        compact &&
+          "top-[calc(10px+env(safe-area-inset-top))] w-[min(332px,calc(100vw-20px))] max-w-[calc(100vw-20px)] gap-0 pb-[10px]",
       )}
     >
       {children}
@@ -69,8 +73,9 @@ export function MobilePreviewTraceStatus({ active, children }: Record<string, an
         "font-[var(--font-mono)] text-[10px] font-semibold tracking-[0.08em] leading-[1.15] uppercase",
         "pointer-events-none whitespace-normal overflow-hidden",
         "transition-[max-height,margin-top,opacity,transform] duration-[var(--motion-ui-slow)] ease-[var(--motion-ease-out)]",
+        "[[data-density=compact]_&]:mx-[12px] [[data-density=compact]_&]:text-[9px] [[data-density=compact]_&]:tracking-normal",
         active
-          ? "max-h-[44px] mt-1 opacity-100 translate-y-0"
+          ? "max-h-[44px] mt-1 opacity-100 translate-y-0 [[data-density=compact]_&]:max-h-[20px] [[data-density=compact]_&]:mt-0.5"
           : "max-h-0 mt-0 opacity-0 -translate-y-1",
       )}
     >
@@ -83,7 +88,7 @@ export function MobilePreviewTraceStatus({ active, children }: Record<string, an
 // inside become tappable inside the otherwise pass-through card.
 export function MobilePreviewActions({ children }: Record<string, any>) {
   return (
-    <div className="pointer-events-auto mx-[14px] flex flex-col items-stretch gap-1">
+    <div className="pointer-events-auto mx-[14px] flex flex-col items-stretch gap-1 [[data-density=compact]_&]:mx-[12px] [[data-density=compact]_&]:gap-0.5">
       {children}
     </div>
   );
@@ -91,7 +96,7 @@ export function MobilePreviewActions({ children }: Record<string, any>) {
 
 export function MobilePreviewContent({ children }: React.PropsWithChildren) {
   return (
-    <div className="relative z-[2] box-border flex w-full flex-col items-stretch gap-[6px] px-[14px] pb-[7px] pt-[10px]">
+    <div className="relative z-[2] box-border flex w-full flex-col items-stretch gap-[6px] px-[14px] pb-[7px] pt-[10px] [[data-density=compact]_&]:gap-[4px] [[data-density=compact]_&]:px-[12px] [[data-density=compact]_&]:pb-[5px] [[data-density=compact]_&]:pt-[8px]">
       {children}
     </div>
   );
@@ -113,7 +118,7 @@ export function MobilePreviewIdentity({
   secondaryClassName?: string;
 }) {
   return (
-    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-end gap-2">
+    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-end gap-2 [[data-density=compact]_&]:gap-1.5">
       <div className="flex min-w-0 items-end gap-[6px]">
         <span
           aria-label={label}
@@ -126,6 +131,7 @@ export function MobilePreviewIdentity({
           translate="no"
           className={cn(
             "notranslate min-w-0 truncate whitespace-nowrap font-[var(--font-mono)] text-[20px] font-extrabold leading-none tracking-normal text-atc-text",
+            "[[data-density=compact]_&]:text-[18px]",
             primaryClassName,
           )}
         >
@@ -174,11 +180,11 @@ export function MobilePreviewRuleRow({
   right?: React.ReactNode;
 }) {
   return (
-    <div className="flex min-w-0 items-baseline justify-between gap-3 border-t border-atc-line pt-[5px] font-[var(--font-mono)]">
-      <div className="min-w-0 flex-1 overflow-hidden whitespace-nowrap text-left text-[11px] font-semibold leading-none tracking-normal text-atc-text">
+    <div className="flex min-w-0 items-baseline justify-between gap-3 border-t border-atc-line pt-[5px] font-[var(--font-mono)] [[data-density=compact]_&]:gap-2 [[data-density=compact]_&]:pt-[4px]">
+      <div className="min-w-0 flex-1 overflow-hidden whitespace-nowrap text-left text-[11px] font-semibold leading-none tracking-normal text-atc-text [[data-density=compact]_&]:text-[10px]">
         {left}
       </div>
-      <div className="flex min-w-0 shrink-0 items-baseline justify-end gap-[10px] overflow-hidden whitespace-nowrap text-right text-[11px] font-semibold leading-none tracking-normal text-atc-text">
+      <div className="flex min-w-0 shrink-0 items-baseline justify-end gap-[10px] overflow-hidden whitespace-nowrap text-right text-[11px] font-semibold leading-none tracking-normal text-atc-text [[data-density=compact]_&]:gap-[7px] [[data-density=compact]_&]:text-[10px]">
         {right}
       </div>
     </div>
@@ -187,7 +193,7 @@ export function MobilePreviewRuleRow({
 
 export function MobilePreviewMetaChips({ children }: React.PropsWithChildren) {
   return (
-    <dl className="flex min-w-0 items-baseline gap-[10px]">
+    <dl className="flex min-w-0 items-baseline gap-[10px] [[data-density=compact]_&]:gap-[7px]">
       {children}
     </dl>
   );
@@ -221,12 +227,12 @@ export const MobilePreviewTrackButton = React.forwardRef(
         ref={ref}
         type="button"
         className={cn(
-          "min-h-[34px] w-full px-[10px] cursor-pointer",
+          "min-h-[34px] w-full px-[10px] cursor-pointer [[data-density=compact]_&]:min-h-[30px] [[data-density=compact]_&]:px-2",
           "border border-[var(--atc-action-primary-border)]",
           "rounded-[calc(var(--atc-radius-card)-3px)]",
           "bg-[var(--primary-bright)] text-[var(--primary-ink)]",
           "shadow-[var(--atc-action-primary-shadow)]",
-          "font-[var(--font-display)] text-[11px] font-extrabold not-italic tracking-normal leading-[1.15] text-center",
+          "font-[var(--font-display)] text-[11px] font-extrabold not-italic tracking-normal leading-[1.15] text-center [[data-density=compact]_&]:text-[10px]",
           "[-webkit-tap-highlight-color:transparent]",
           "transition-[box-shadow,filter,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
           "hover:brightness-[1.04] active:scale-[0.97] active:brightness-[0.96]",
@@ -252,9 +258,9 @@ export const MobilePreviewFeedbackLink = React.forwardRef(
         ref={ref}
         type="button"
         className={cn(
-          "flex w-full min-h-[20px] items-center justify-center px-0 py-1",
+          "flex w-full min-h-[20px] items-center justify-center px-0 py-1 [[data-density=compact]_&]:min-h-[15px] [[data-density=compact]_&]:py-0.5",
           "border-0 bg-transparent text-atc-dim cursor-pointer",
-          "font-sans text-[10px] font-bold tracking-normal leading-[1.15] text-center",
+          "font-sans text-[10px] font-bold tracking-normal leading-[1.15] text-center [[data-density=compact]_&]:text-[9px]",
           "[-webkit-tap-highlight-color:transparent]",
           "transition-[color,opacity,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
           "hover:text-atc-text hover:opacity-90 active:text-atc-text active:scale-[0.97]",
@@ -277,10 +283,10 @@ export const MobilePreviewSecondaryButton = React.forwardRef(
         ref={ref}
         type="button"
         className={cn(
-          "min-h-[32px] w-full px-[10px] cursor-pointer",
+          "min-h-[32px] w-full px-[10px] cursor-pointer [[data-density=compact]_&]:min-h-[30px] [[data-density=compact]_&]:px-2",
           "rounded-[calc(var(--atc-radius-card)-3px)] border border-atc-line",
           "bg-[color-mix(in_oklab,var(--atc-card)_72%,var(--primary-bright)_10%)] text-atc-text",
-          "font-[var(--font-display)] text-[11px] font-extrabold not-italic tracking-normal leading-[1.15] text-center",
+          "font-[var(--font-display)] text-[11px] font-extrabold not-italic tracking-normal leading-[1.15] text-center [[data-density=compact]_&]:text-[10px]",
           "[-webkit-tap-highlight-color:transparent]",
           "transition-[background-color,border-color,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
           "hover:border-atc-line-strong hover:bg-atc-card-strong active:scale-[0.97]",

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -68,8 +68,9 @@ export default function AircraftRow({
   return (
     <button
       type="button"
-      className={`aircraft-table-card aircraft-table-row-grid endf-industrial-row grid w-full grid-cols-[18px_minmax(0,1fr)_48px_54px] items-center gap-2 px-[var(--airport-sidebar-inset)] text-left transition-[background,color] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] sm:grid-cols-[18px_minmax(0,1fr)_54px_70px] sm:gap-3 ${
-        selected ? "endf-row-active" : ""
+      data-selected={selected ? "true" : undefined}
+      className={`aircraft-table-card aircraft-table-row-grid endf-industrial-row grid w-full grid-cols-[18px_minmax(0,1fr)_48px_54px] items-center gap-2 px-[var(--airport-sidebar-inset)] text-left transition-[background,color,box-shadow,transform] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] data-[selected=true]:[background:var(--atc-glass-active-bg)] data-[selected=true]:text-[var(--atc-click-fg)] data-[selected=true]:shadow-[var(--atc-glass-rim-shadow)] data-[selected=true]:[backdrop-filter:var(--atc-glass-active-frost)] data-[selected=true]:[-webkit-backdrop-filter:var(--atc-glass-active-frost)] data-[selected=true]:hover:[background:var(--atc-glass-active-bg)] data-[selected=true]:[&_.text-atc-text]:text-[var(--atc-click-fg)] data-[selected=true]:[&_.text-atc-dim]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.text-atc-faint]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.aircraft-table-route-cycle]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.endf-row-glyph]:bg-[var(--atc-click-fg)] data-[selected=true]:[&_.endf-row-glyph]:text-[var(--atc-click-bg)] sm:grid-cols-[18px_minmax(0,1fr)_54px_70px] sm:gap-3 ${
+        selected ? "aircraft-table-row--selected endf-row-active" : ""
       }`}
       aria-pressed={selected}
       onClick={() => aircraftId && onSelectAircraft?.(aircraftId)}

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -234,7 +234,10 @@ export default function AircraftTable({
   );
 
   return (
-    <div className={`flex flex-col ${fill ? "h-full" : ""}`}>
+    <div
+      data-has-pinned-aircraft={pinnedAircraft ? "true" : undefined}
+      className={cn("aircraft-table-shell flex flex-col", fill && "h-full")}
+    >
       <div className="flex-none">
         <div className="flex items-baseline justify-between px-[var(--airport-sidebar-inset)] pt-4 pb-2.5">
           <span className="endf-label endf-label--lead">
@@ -358,7 +361,12 @@ export default function AircraftTable({
         ) : null}
       </div>
 
-      <div className={fill ? "flex-1 min-h-0" : "overflow-visible"}>
+      <div
+        className={cn(
+          "aircraft-table-scroll-shell",
+          fill ? "flex-1 min-h-0" : "overflow-visible",
+        )}
+      >
         {listRows.length === 0 &&
         filteredAirports.length === 0 &&
         !pinnedAircraft ? (

--- a/src/style.css
+++ b/src/style.css
@@ -6616,6 +6616,114 @@ body {
     color: color-mix(in oklab, var(--endf-yellow) 72%, transparent);
 }
 
+.aircraft-table-row--selected,
+.aircraft-table-row--selected.endf-row-active,
+.aircraft-table-pin .aircraft-table-row--selected,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active {
+    background: var(--atc-glass-active-bg);
+    border-color: transparent;
+    border-radius: var(--atc-radius-card);
+    box-shadow: var(--atc-glass-rim-shadow);
+    color: var(--atc-click-fg);
+    -webkit-backdrop-filter: var(--atc-glass-active-frost);
+    backdrop-filter: var(--atc-glass-active-frost);
+}
+
+.aircraft-table-row--selected::before,
+.aircraft-table-row--selected.endf-row-active::before,
+.aircraft-table-pin .aircraft-table-row--selected::before,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active::before {
+    display: none;
+}
+
+.aircraft-table-row--selected::after,
+.aircraft-table-row--selected.endf-row-active::after,
+.aircraft-table-pin .aircraft-table-row--selected::after,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active::after {
+    background: var(--atc-glass-sheen);
+    content: "";
+    inset: 0;
+    opacity: 0.88;
+    pointer-events: none;
+    position: absolute;
+    z-index: 0;
+}
+
+.aircraft-table-row--selected > *,
+.aircraft-table-row--selected.endf-row-active > *,
+.aircraft-table-pin .aircraft-table-row--selected > *,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active > * {
+    position: relative;
+    z-index: 1;
+}
+
+.aircraft-table-row--selected .text-atc-text,
+.aircraft-table-row--selected.endf-row-active .text-atc-text,
+.aircraft-table-pin .aircraft-table-row--selected .text-atc-text,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active .text-atc-text {
+    color: var(--atc-click-fg);
+}
+
+.aircraft-table-row--selected .text-atc-dim,
+.aircraft-table-row--selected .text-atc-faint,
+.aircraft-table-row--selected .aircraft-table-route-cycle,
+.aircraft-table-row--selected.endf-row-active .text-atc-dim,
+.aircraft-table-row--selected.endf-row-active .text-atc-faint,
+.aircraft-table-row--selected.endf-row-active .aircraft-table-route-cycle,
+.aircraft-table-pin .aircraft-table-row--selected .text-atc-dim,
+.aircraft-table-pin .aircraft-table-row--selected .text-atc-faint,
+.aircraft-table-pin .aircraft-table-row--selected .aircraft-table-route-cycle,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active .text-atc-dim,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active .text-atc-faint,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active .aircraft-table-route-cycle {
+    color: var(--atc-click-muted);
+}
+
+.aircraft-table-row--selected .endf-row-glyph,
+.aircraft-table-row--selected.endf-row-active .endf-row-glyph,
+.aircraft-table-pin .aircraft-table-row--selected .endf-row-glyph,
+.aircraft-table-pin .aircraft-table-row--selected.endf-row-active .endf-row-glyph {
+    background: var(--atc-click-fg);
+    border-color: color-mix(in oklab, var(--atc-click-fg) 72%, transparent);
+    color: var(--atc-click-bg);
+}
+
+@media (max-width: 767px) {
+    .aircraft-table-shell[data-has-pinned-aircraft="true"] .aircraft-table-pin {
+        background: linear-gradient(
+            180deg,
+            color-mix(in oklab, var(--atc-bg) 66%, transparent) 0%,
+            color-mix(in oklab, var(--atc-bg) 34%, transparent) 100%
+        );
+        border-bottom: 1px solid var(--atc-line);
+        display: flow-root;
+        padding: 8px 0 9px;
+    }
+
+    .aircraft-table-shell[data-has-pinned-aircraft="true"]
+        .aircraft-table-pin
+        .endf-content-swap,
+    .aircraft-table-shell[data-has-pinned-aircraft="true"]
+        .aircraft-table-pin
+        .endf-content-swap__content {
+        overflow: visible;
+    }
+
+    .aircraft-table-pin .aircraft-table-row--selected {
+        border-radius: var(--atc-radius-card);
+        height: 48px;
+        margin: 0 var(--airport-sidebar-inset);
+        min-height: 48px;
+        overflow: hidden;
+        padding: 7px 12px;
+        width: calc(100% - (var(--airport-sidebar-inset) * 2));
+    }
+
+    .aircraft-table-pin .aircraft-table-row--selected::before {
+        display: none;
+    }
+}
+
 /* Featured row — left yellow rhombus marker + warm ink background. */
 .endf-row-featured {
     background: linear-gradient(


### PR DESCRIPTION
## Summary
- restyle selected aircraft rows with the liquid-glass active material across sidebar states
- add a mobile pinned-selection slot so dividers sit outside the selected pill
- compact mobile aircraft preview cards while preserving aircraft identity, stats, trace status, and actions

## Validation
- pnpm lint
- git diff --check
- Browser: mobile KBOS sidebar selected row, mobile aircraft preview card, desktop KBOS selected row