### PR TITLE
[codex] Polish mobile flight actions and pinned row

### DIFF
--- a/src/animations/useListReorderMotion.ts
+++ b/src/animations/useListReorderMotion.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+import type { RefObject } from "react";
+import gsap from "gsap";
+import { EASE, MOTION } from "./gsap";
+
+const DEFAULT_ITEM_SELECTOR = "[data-gsap-reorder-key]";
+
+type ListReorderMotionOptions = {
+  disabled?: boolean;
+  itemSelector?: string;
+  resetKey?: unknown;
+};
+
+export function useListReorderMotion<T extends HTMLElement>(
+  containerRef: RefObject<T | null>,
+  triggerKey: unknown,
+  {
+    disabled = false,
+    itemSelector = DEFAULT_ITEM_SELECTOR,
+    resetKey,
+  }: ListReorderMotionOptions = {},
+) {
+  const previousRectsRef = useRef<Map<string, DOMRect>>(new Map());
+  const previousResetKeyRef = useRef(resetKey);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    const elements = Array.from(
+      container.querySelectorAll<HTMLElement>(itemSelector),
+    );
+    const nextRects = new Map<string, DOMRect>();
+    for (const element of elements) {
+      const key = element.dataset.gsapReorderKey;
+      if (key) nextRects.set(key, element.getBoundingClientRect());
+    }
+
+    const resetChanged = previousResetKeyRef.current !== resetKey;
+    previousResetKeyRef.current = resetKey;
+    const prefersReducedMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+
+    if (
+      disabled ||
+      resetChanged ||
+      prefersReducedMotion ||
+      previousRectsRef.current.size === 0
+    ) {
+      gsap.killTweensOf(elements);
+      gsap.set(elements, { clearProps: "transform" });
+      previousRectsRef.current = nextRects;
+      return undefined;
+    }
+
+    for (const element of elements) {
+      const key = element.dataset.gsapReorderKey;
+      if (!key) continue;
+      const previousRect = previousRectsRef.current.get(key);
+      const nextRect = nextRects.get(key);
+      if (!previousRect || !nextRect) continue;
+
+      const deltaX = previousRect.left - nextRect.left;
+      const deltaY = previousRect.top - nextRect.top;
+      if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) continue;
+
+      gsap.fromTo(
+        element,
+        { x: deltaX, y: deltaY },
+        {
+          x: 0,
+          y: 0,
+          clearProps: "transform",
+          duration: MOTION.slow,
+          ease: EASE.snap,
+          overwrite: "auto",
+        },
+      );
+    }
+
+    previousRectsRef.current = nextRects;
+
+    return () => {
+      gsap.killTweensOf(elements);
+      gsap.set(elements, { clearProps: "transform" });
+    };
+  }, [containerRef, disabled, itemSelector, resetKey, triggerKey]);
+}

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -18,12 +18,10 @@ import MobilePreviewCard, {
   MobilePreviewFeedbackLink,
   MobilePreviewSecondaryButton,
   MobilePreviewTrackButton,
-  MobilePreviewTraceStatus,
 } from "./MobilePreviewCard";
 import PlaneHunterStudio from "./PlaneHunterStudio";
 import RouteFeedbackModal from "./RouteFeedbackModal";
 import { useSelectedAircraftTrace } from "@/components/aircraft/trace/SelectedAircraftTraceContext";
-import { AsyncStatusLineDisplay } from "@/components/ui/AsyncStatusLine";
 import { useAircraftPhoto } from "@/features/aircraft/preview/useAircraftPhoto";
 import { useAircraftTraceAsyncStatus } from "@/features/aircraft/trace/useAircraftTraceAsyncStatus";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
@@ -159,6 +157,8 @@ export default function AircraftPreviewCard({
     : alreadyTracking
       ? t("preview.trackingTrace")
       : t("preview.trackTrace");
+  const showMobileTrackButton =
+    Boolean(cardTrackHref) && !(alreadyTracking && isAircraftPreview);
   const previewAriaLabel = isAirport
     ? t("preview.airportPreview")
     : isNavaid
@@ -222,23 +222,10 @@ export default function AircraftPreviewCard({
           identityKey={`mobile-${identityKey}`}
           ariaLabel={previewAriaLabel}
           compact={!isAirport && !isNavaid && !isAirspace && !isCandidateWatchingSpot}
-          traceStatus={
-            cardTrackHref && !isAirport ? (
-              <MobilePreviewTraceStatus active={traceStatusVisible}>
-                <AsyncStatusLineDisplay
-                  state={traceAsyncState}
-                  pendingLabel={traceStatusLabels.pendingLabel}
-                  successLabel={traceStatusLabels.successLabel}
-                  errorLabel={traceStatusLabels.errorLabel}
-                  className="justify-center w-full"
-                />
-              </MobilePreviewTraceStatus>
-            ) : null
-          }
           actions={
-            (cardTrackHref || showMobilePlaneHunterTrigger || showMobileFeedbackTrigger) ? (
+            (showMobileTrackButton || showMobilePlaneHunterTrigger || showMobileFeedbackTrigger) ? (
               <MobilePreviewActions>
-                {showMobilePlaneHunterTrigger && cardTrackHref ? (
+                {showMobilePlaneHunterTrigger && showMobileTrackButton ? (
                   <div className="grid grid-cols-2 gap-1">
                     <MobilePreviewSecondaryButton
                       onClick={() => setPlaneHunterOpen(true)}
@@ -252,6 +239,14 @@ export default function AircraftPreviewCard({
                     >
                       {mobileTrackLabel}
                     </MobilePreviewTrackButton>
+                    {showMobileFeedbackTrigger && (
+                      <MobilePreviewFeedbackLink
+                        onClick={() => setFeedbackModalOpen(true)}
+                        className="col-start-2"
+                      >
+                        {mobileFeedbackLabel}
+                      </MobilePreviewFeedbackLink>
+                    )}
                   </div>
                 ) : (
                   <>
@@ -263,7 +258,7 @@ export default function AircraftPreviewCard({
                         {t("preview.planeHunter")}
                       </MobilePreviewSecondaryButton>
                     )}
-                    {cardTrackHref && (
+                    {showMobileTrackButton && (
                       <MobilePreviewTrackButton
                         onClick={handleMobileTap}
                         disabled={alreadyTracking}
@@ -273,7 +268,7 @@ export default function AircraftPreviewCard({
                     )}
                   </>
                 )}
-                {showMobileFeedbackTrigger && (
+                {showMobileFeedbackTrigger && !(showMobilePlaneHunterTrigger && showMobileTrackButton) && (
                   <MobilePreviewFeedbackLink
                     onClick={() => setFeedbackModalOpen(true)}
                   >
@@ -296,7 +291,10 @@ export default function AircraftPreviewCard({
               sourceAttribution={candidateWatchingSpotAttribution}
             />
           ) : (
-            <AircraftPreviewMobileCard aircraft={aircraft} />
+            <AircraftPreviewMobileCard
+              aircraft={aircraft}
+              traceStatusState={traceStatusVisible ? traceAsyncState : null}
+            />
           )}
         </MobilePreviewCard>
       )}

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -147,7 +147,7 @@ export default function AircraftPreviewMobileCard({
         primary={
           <span className="inline-flex min-w-0 max-w-full items-center gap-1.5">
             <span className="min-w-0 truncate">{callsign}</span>
-            <TraceStatusPulse
+            <TraceStatusDot
               state={traceStatusState}
               labels={{
                 pending: t("preview.loadingTrace"),
@@ -187,7 +187,7 @@ export default function AircraftPreviewMobileCard({
   );
 }
 
-function TraceStatusPulse({
+function TraceStatusDot({
   state,
   labels,
 }: {
@@ -196,13 +196,15 @@ function TraceStatusPulse({
 }) {
   if (!state || state.phase === "idle") return null;
 
-  const tone = state.hasError
+  const isErrorStatus =
+    state.statusCode != null && state.statusCode >= 400;
+  const tone = state.hasError || isErrorStatus
     ? "error"
     : state.phase === "pending"
-      ? "pending"
+      ? "loading"
       : "success";
   const label =
-    tone === "pending"
+    tone === "loading"
       ? labels.pending
       : tone === "error"
         ? labels.error
@@ -211,16 +213,13 @@ function TraceStatusPulse({
   return (
     <span
       className={cn(
-        "relative inline-flex size-[9px] flex-none rounded-full",
-        "before:absolute before:inset-[-4px] before:rounded-full before:opacity-45",
-        "before:animate-ping motion-reduce:before:animate-none",
-        tone === "pending" &&
-          "bg-[var(--primary-bright)] before:bg-[var(--primary-bright)]",
-        tone === "success" &&
-          "bg-[var(--atc-mint)] before:bg-[var(--atc-mint)]",
-        tone === "error" &&
-          "bg-[var(--atc-red)] before:bg-[var(--atc-red)]",
+        "mobile-trace-status-dot",
+        tone === "loading" && "mobile-trace-status-dot--loading",
+        tone === "success" && "mobile-trace-status-dot--success",
+        tone === "error" && "mobile-trace-status-dot--error",
+        state.phase === "fading" && "mobile-trace-status-dot--fading",
       )}
+      data-status={tone}
       aria-label={label}
       role="status"
       title={label}

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import type { ComponentProps, ReactElement } from "react";
 import NumberFlow from "@number-flow/react";
 import { Plane } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { toFiniteNumber } from "@/utils/math";
 import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
@@ -19,6 +20,7 @@ import {
   MobilePreviewMetaChips,
   MobilePreviewRuleRow,
 } from "./MobilePreviewCard";
+import type { AsyncStatusState } from "@/hooks/useAsyncStatus";
 
 type NumberFlowFormat = ComponentProps<typeof NumberFlow>["format"];
 
@@ -38,6 +40,7 @@ type AircraftPreviewMobileCardAircraft = {
 
 type AircraftPreviewMobileCardProps = {
   aircraft?: AircraftPreviewMobileCardAircraft | null;
+  traceStatusState?: AsyncStatusState | null;
 };
 
 type AirlineLogoProps = {
@@ -69,7 +72,10 @@ function AirlineLogo({ src }: AirlineLogoProps) {
   );
 }
 
-export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewMobileCardProps) {
+export default function AircraftPreviewMobileCard({
+  aircraft,
+  traceStatusState = null,
+}: AircraftPreviewMobileCardProps) {
   const { t } = useI18n();
   const { preferences: units } = useUnitPreferences();
   const callsign =
@@ -138,7 +144,19 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
       <MobilePreviewIdentity
         icon={Plane}
         label={t("preview.aircraftPreview")}
-        primary={callsign}
+        primary={
+          <span className="inline-flex min-w-0 max-w-full items-center gap-1.5">
+            <span className="min-w-0 truncate">{callsign}</span>
+            <TraceStatusPulse
+              state={traceStatusState}
+              labels={{
+                pending: t("preview.loadingTrace"),
+                success: t("preview.loadedTrace"),
+                error: t("preview.traceLoadError"),
+              }}
+            />
+          </span>
+        }
         secondary={secondary}
         secondaryClassName="max-w-[min(47vw,176px)] text-[13px] font-extrabold text-atc-text"
       />
@@ -166,6 +184,47 @@ export default function AircraftPreviewMobileCard({ aircraft }: AircraftPreviewM
         />
       ) : null}
     </MobilePreviewContent>
+  );
+}
+
+function TraceStatusPulse({
+  state,
+  labels,
+}: {
+  state: AsyncStatusState | null;
+  labels: { pending: string; success: string; error: string };
+}) {
+  if (!state || state.phase === "idle") return null;
+
+  const tone = state.hasError
+    ? "error"
+    : state.phase === "pending"
+      ? "pending"
+      : "success";
+  const label =
+    tone === "pending"
+      ? labels.pending
+      : tone === "error"
+        ? labels.error
+        : labels.success;
+
+  return (
+    <span
+      className={cn(
+        "relative inline-flex size-[9px] flex-none rounded-full",
+        "before:absolute before:inset-[-4px] before:rounded-full before:opacity-45",
+        "before:animate-ping motion-reduce:before:animate-none",
+        tone === "pending" &&
+          "bg-[var(--primary-bright)] before:bg-[var(--primary-bright)]",
+        tone === "success" &&
+          "bg-[var(--atc-mint)] before:bg-[var(--atc-mint)]",
+        tone === "error" &&
+          "bg-[var(--atc-red)] before:bg-[var(--atc-red)]",
+      )}
+      aria-label={label}
+      role="status"
+      title={label}
+    />
   );
 }
 

--- a/src/components/sidebar/AircraftList.tsx
+++ b/src/components/sidebar/AircraftList.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type { CSSProperties } from "react";
+import { useMemo, useRef } from "react";
+import { useListReorderMotion } from "@/animations/useListReorderMotion";
 import { getAircraftIdentity } from "../../features/airport/context/airportContextUiModel";
 import AircraftRow from "./AircraftRow";
 
@@ -10,8 +12,22 @@ export default function AircraftList({
   selectedAircraftId = "",
   onSelectAircraft,
 }) {
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const motionKey = useMemo(
+    () =>
+      aircraft
+        .map((item, index) => getAircraftIdentity(item) || `aircraft:${index}`)
+        .join("|"),
+    [aircraft],
+  );
+  useListReorderMotion(listRef, motionKey, { resetKey });
+
   return (
-    <ul key={resetKey} className="app-list-motion divide-y divide-atc-line">
+    <ul
+      key={resetKey}
+      ref={listRef}
+      className="app-list-motion divide-y divide-atc-line"
+    >
       {aircraft.map((item, index) => {
         const aircraftId = getAircraftIdentity(item);
         const motionStyle = {
@@ -20,6 +36,7 @@ export default function AircraftList({
         return (
           <li
             key={aircraftId || index}
+            data-gsap-reorder-key={aircraftId || `aircraft:${index}`}
             className="relative list-none [perspective:800px]"
             style={motionStyle}
           >

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -36,6 +36,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useExplorerUi } from "@/components/explorer/ExplorerUiContext";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useListReorderMotion } from "@/animations/useListReorderMotion";
 import {
   aircraftTypeSearchText,
   resolveAircraftDisplayModel,
@@ -220,18 +221,27 @@ export default function AircraftTable({
         altitudeLevel,
         entityFilter,
         movementFilter,
-        selectedAircraftId,
       ].join("::"),
     [
       altitudeLevel,
       entityFilter,
       movementFilter,
       query,
-      selectedAircraftId,
       trafficFilter,
       typeFilter,
     ],
   );
+  const airportListMotionRef = useRef<HTMLUListElement | null>(null);
+  const airportListMotionKey = useMemo(
+    () =>
+      filteredAirports
+        .map((airport, index) => `airport:${airport.icao || index}`)
+        .join("|"),
+    [filteredAirports],
+  );
+  useListReorderMotion(airportListMotionRef, airportListMotionKey, {
+    resetKey: aircraftListResetKey,
+  });
 
   return (
     <div
@@ -395,7 +405,10 @@ export default function AircraftTable({
               />
             )}
             {filteredAirports.length > 0 && (
-              <ul className="app-list-motion divide-y divide-atc-line">
+              <ul
+                ref={airportListMotionRef}
+                className="app-list-motion divide-y divide-atc-line"
+              >
                 {filteredAirports.map((airport, index) => {
                   const motionStyle = {
                     "--motion-order": Math.min(index, 5),
@@ -403,6 +416,7 @@ export default function AircraftTable({
                   return (
                     <li
                       key={`airport:${airport.icao}`}
+                      data-gsap-reorder-key={`airport:${airport.icao || index}`}
                       className="relative list-none [perspective:800px]"
                       style={motionStyle}
                     >

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
+import { useListReorderMotion } from "@/animations/useListReorderMotion";
 import AircraftRow from "./AircraftRow";
 import AirportRow from "./AirportRow";
 
@@ -70,6 +71,11 @@ export default function VirtualNearbyList({
 
   const virtualRows = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
+  const motionKey = useMemo(
+    () => items.map((item) => item.id).join("|"),
+    [items],
+  );
+  useListReorderMotion(parentRef, motionKey, { resetKey: resetSignal });
 
   return (
     <div ref={parentRef} className="app-virtual-list-motion h-full overflow-y-auto">
@@ -149,22 +155,24 @@ function NearbyVirtualRow({
         transform: `translateY(${start}px)`,
       }}
     >
-      <div className={entering ? "nearby-row-enter" : ""}>
-        {item.type === "aircraft" ? (
-          <AircraftRow
-            aircraft={item.data}
-            aircraftId={item.id}
-            selected={item.id === selectedAircraftId}
-            onSelectAircraft={onSelectAircraft}
-          />
-        ) : (
-          <AirportRow
-            airport={item.data}
-            airportId={item.data?.icao}
-            selected={item.data?.icao === selectedAirportIcao}
-            onSelectAirport={onSelectAirport}
-          />
-        )}
+      <div data-gsap-reorder-key={item.id}>
+        <div className={entering ? "nearby-row-enter" : ""}>
+          {item.type === "aircraft" ? (
+            <AircraftRow
+              aircraft={item.data}
+              aircraftId={item.id}
+              selected={item.id === selectedAircraftId}
+              onSelectAircraft={onSelectAircraft}
+            />
+          ) : (
+            <AirportRow
+              airport={item.data}
+              airportId={item.data?.icao}
+              selected={item.data?.icao === selectedAirportIcao}
+              onSelectAirport={onSelectAirport}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/style.css
+++ b/src/style.css
@@ -300,6 +300,82 @@
         var(--motion-ease-out) both;
 }
 
+.mobile-trace-status-dot {
+    --mobile-trace-status-loading: oklch(0.72 0.15 70);
+    background: color-mix(in oklab, var(--atc-mint) 88%, var(--atc-text) 12%);
+    border-radius: 999px;
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--atc-bg) 72%, transparent),
+        0 0 8px color-mix(in oklab, var(--atc-mint) 24%, transparent);
+    display: inline-block;
+    flex: 0 0 auto;
+    height: 9px;
+    opacity: 1;
+    transform: scale(1);
+    transition: background-color 220ms var(--motion-ease-out),
+        box-shadow 220ms var(--motion-ease-out),
+        opacity 360ms var(--motion-ease-out),
+        transform 360ms var(--motion-ease-out);
+    vertical-align: middle;
+    width: 9px;
+}
+
+.mobile-trace-status-dot--loading {
+    background: color-mix(
+        in oklab,
+        var(--mobile-trace-status-loading) 92%,
+        var(--atc-text) 8%
+    );
+    animation: mobile-trace-status-dot-loading 1.35s ease-in-out infinite;
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--atc-bg) 72%, transparent),
+        0 0 7px
+            color-mix(in oklab, var(--mobile-trace-status-loading) 22%, transparent);
+}
+
+.mobile-trace-status-dot--success {
+    background: color-mix(in oklab, var(--atc-mint) 88%, var(--atc-text) 12%);
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--atc-bg) 72%, transparent),
+        0 0 8px color-mix(in oklab, var(--atc-mint) 24%, transparent);
+}
+
+.mobile-trace-status-dot--error {
+    background: var(--atc-red);
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--atc-bg) 72%, transparent),
+        0 0 8px color-mix(in oklab, var(--atc-red) 24%, transparent);
+}
+
+.mobile-trace-status-dot--fading {
+    opacity: 0;
+    transform: scale(0.86);
+}
+
+@keyframes mobile-trace-status-dot-loading {
+    0%,
+    100% {
+        opacity: 0.68;
+        transform: scale(0.92);
+        box-shadow: 0 0 0 1px
+                color-mix(in oklab, var(--atc-bg) 72%, transparent),
+            0 0 4px
+                color-mix(
+                    in oklab,
+                    var(--mobile-trace-status-loading) 14%,
+                    transparent
+                );
+    }
+    50% {
+        opacity: 1;
+        transform: scale(1.08);
+        box-shadow: 0 0 0 1px
+                color-mix(in oklab, var(--atc-bg) 72%, transparent),
+            0 0 10px
+                color-mix(
+                    in oklab,
+                    var(--mobile-trace-status-loading) 28%,
+                    transparent
+                );
+    }
+}
+
 @keyframes map-settings-sheet-enter {
     from {
         opacity: 0;
@@ -370,6 +446,7 @@
     .mobile-preview-card-enter,
     .candidate-watching-spot-preview-motion,
     .candidate-watching-spot-marker__shell,
+    .mobile-trace-status-dot,
     .map-settings-sheet,
     .map-settings-sheet-overlay {
         animation: none;
@@ -387,6 +464,7 @@
     .app-list-motion > *,
     .candidate-watching-spot-preview-motion,
     .candidate-watching-spot-marker__shell,
+    .mobile-trace-status-dot,
     .map-settings-sheet,
     .map-settings-sheet-overlay {
         transform: none;

--- a/src/style.css
+++ b/src/style.css
@@ -4103,6 +4103,7 @@ body {
     margin: 0;
     overflow: visible;
     position: relative;
+    z-index: 3;
 }
 
 .aircraft-table-pin .endf-row-active {
@@ -6690,14 +6691,13 @@ body {
 
 @media (max-width: 767px) {
     .aircraft-table-shell[data-has-pinned-aircraft="true"] .aircraft-table-pin {
-        background: linear-gradient(
-            180deg,
-            color-mix(in oklab, var(--atc-bg) 66%, transparent) 0%,
-            color-mix(in oklab, var(--atc-bg) 34%, transparent) 100%
-        );
-        border-bottom: 1px solid var(--atc-line);
+        background: transparent;
+        border-bottom: 0;
         display: flow-root;
-        padding: 8px 0 9px;
+        margin-bottom: -1px;
+        margin-top: -1px;
+        padding: 0;
+        z-index: 4;
     }
 
     .aircraft-table-shell[data-has-pinned-aircraft="true"]
@@ -6709,14 +6709,15 @@ body {
         overflow: visible;
     }
 
-    .aircraft-table-pin .aircraft-table-row--selected {
-        border-radius: var(--atc-radius-card);
-        height: 48px;
-        margin: 0 var(--airport-sidebar-inset);
-        min-height: 48px;
+    .aircraft-table-pin .aircraft-table-row--selected,
+    .aircraft-table-pin .aircraft-table-row--selected.endf-row-active {
+        border-radius: 0;
+        height: 56px;
+        margin: 0;
+        min-height: 56px;
         overflow: hidden;
-        padding: 7px 12px;
-        width: calc(100% - (var(--airport-sidebar-inset) * 2));
+        padding: 8px var(--airport-sidebar-inset);
+        width: 100%;
     }
 
     .aircraft-table-pin .aircraft-table-row--selected::before {


### PR DESCRIPTION
## Summary
- Make the mobile selected-aircraft pinned row full-width, taller, square-edged, and layered above the table/list dividers while preserving column alignment.
- Replace mobile trace-status copy with a callsign-adjacent status pulse.
- Move the route-correction affordance directly under the trace action in the mobile preview action column.

## Validation
- /opt/homebrew/bin/pnpm lint (passes; existing warnings in PlaneHunterStudio, VirtualNearbyList, and useWeatherSlides remain)
- git diff --check
- Local mobile CDP visual checks on http://localhost:3000/airport/KBOS?locale=zh-CN and /aircraft/RPA4486?locale=zh-CN
- /opt/homebrew/bin/pnpm exec tsc --noEmit was run and still fails on pre-existing unrelated test typing issues in airportFacilities, airportFacilityModel, mapSettingsModel, runwayAnnotationModel, and openAipDirectory test files

Not merged per request.