### PR TITLE
[codex] Add GSAP click feedback

### DIFF
--- a/src/animations/gsap.ts
+++ b/src/animations/gsap.ts
@@ -28,5 +28,14 @@ gsap.defaults({
 
 /** Cleanup helper — kill GSAP animations on a target. */
 export function killTweensOf(target: gsap.TweenTarget): void {
+  if (!target) return;
+  if (Array.isArray(target) && target.length === 0) return;
+  if (
+    typeof NodeList !== "undefined" &&
+    target instanceof NodeList &&
+    target.length === 0
+  ) {
+    return;
+  }
   gsap.killTweensOf(target);
 }

--- a/src/animations/useCardInteraction.ts
+++ b/src/animations/useCardInteraction.ts
@@ -6,7 +6,8 @@
  *
  * Returns event handlers to attach to the card element.
  */
-import { useRef, useCallback } from "react";
+import { useRef, useCallback, useEffect } from "react";
+import type { KeyboardEvent } from "react";
 import gsap from "gsap";
 import { MOTION, EASE, killTweensOf } from "./gsap";
 
@@ -33,6 +34,8 @@ interface CardInteractionOptions {
   hoverY?: number;
   /** Scale on press/active. Default: 0.985 */
   pressScale?: number;
+  /** Small rebound scale after release/click acknowledgement. Default: 1.012 */
+  releaseScale?: number;
   /** Duration for transitions (seconds). Default: MOTION.fast */
   duration?: number;
   /** Whether animations are enabled. Default: true */
@@ -44,23 +47,86 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
     hoverScale = 1.01,
     hoverY = -1,
     pressScale = 0.985,
+    releaseScale = 1.012,
     duration = MOTION.fast,
     enabled = true,
   } = options;
 
   const elRef = useRef<HTMLElement | null>(null);
   const isHovering = useRef(false);
+  const isPressing = useRef(false);
 
   const setRef = useCallback((el: HTMLElement | null) => {
+    if (elRef.current && elRef.current !== el) {
+      killTweensOf(elRef.current);
+    }
     elRef.current = el;
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (elRef.current) killTweensOf(elRef.current);
+    };
+  }, []);
+
+  const press = useCallback(() => {
+    if (!enabled || prefersReducedMotion() || !elRef.current) return;
+    const target = elRef.current;
+    isPressing.current = true;
+    killTweensOf(target);
+    gsap.to(target, {
+      scale: pressScale,
+      y: 0,
+      duration: MOTION.fast * 0.45,
+      ease: EASE.out,
+      overwrite: "auto",
+    });
+  }, [enabled, pressScale]);
+
+  const release = useCallback(() => {
+    if (!enabled || prefersReducedMotion() || !elRef.current) return;
+    const target = elRef.current;
+    const wasPressing = isPressing.current;
+    isPressing.current = false;
+    const targetScale = isHovering.current ? hoverScale : 1;
+    const targetY = isHovering.current ? hoverY : 0;
+    const ackScale = Math.max(targetScale, releaseScale);
+
+    killTweensOf(target);
+    if (!wasPressing) {
+      gsap.to(target, {
+        scale: targetScale,
+        y: targetY,
+        duration,
+        ease: EASE.spring,
+        overwrite: "auto",
+      });
+      return;
+    }
+
+    gsap
+      .timeline({ defaults: { overwrite: "auto" } })
+      .to(target, {
+        scale: ackScale,
+        y: targetY,
+        duration: MOTION.fast * 0.55,
+        ease: EASE.out,
+      })
+      .to(target, {
+        scale: targetScale,
+        y: targetY,
+        duration: duration * 1.15,
+        ease: EASE.spring,
+      });
+  }, [enabled, hoverScale, hoverY, releaseScale, duration]);
 
   /** Attach to onMouseEnter. */
   const onMouseEnter = useCallback(() => {
     if (!enabled || prefersReducedMotion() || !elRef.current) return;
+    const target = elRef.current;
     isHovering.current = true;
-    killTweensOf(elRef.current);
-    gsap.to(elRef.current, {
+    killTweensOf(target);
+    gsap.to(target, {
       scale: hoverScale,
       y: hoverY,
       duration,
@@ -72,9 +138,10 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
   /** Attach to onMouseLeave. */
   const onMouseLeave = useCallback(() => {
     if (!enabled || prefersReducedMotion() || !elRef.current) return;
+    const target = elRef.current;
     isHovering.current = false;
-    killTweensOf(elRef.current);
-    gsap.to(elRef.current, {
+    killTweensOf(target);
+    gsap.to(target, {
       scale: 1,
       y: 0,
       duration: duration * 1.2,
@@ -84,46 +151,51 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
   }, [enabled, duration]);
 
   /** Attach to onMouseDown. */
-  const onMouseDown = useCallback(() => {
-    if (!enabled || prefersReducedMotion() || !elRef.current) return;
-    killTweensOf(elRef.current);
-    gsap.to(elRef.current, {
-      scale: pressScale,
-      duration: MOTION.fast * 0.5,
-      ease: EASE.out,
-      overwrite: "auto",
-    });
-  }, [enabled, pressScale]);
+  const onMouseDown = press;
 
   /** Attach to onMouseUp. */
-  const onMouseUp = useCallback(() => {
-    if (!enabled || prefersReducedMotion() || !elRef.current) return;
-    const targetScale = isHovering.current ? hoverScale : 1;
-    const targetY = isHovering.current ? hoverY : 0;
-    killTweensOf(elRef.current);
-    gsap.to(elRef.current, {
-      scale: targetScale,
-      y: targetY,
-      duration: MOTION.fast,
-      ease: EASE.spring,
-      overwrite: "auto",
-    });
-  }, [enabled, hoverScale, hoverY]);
+  const onMouseUp = release;
+
+  /** Attach to onPointerDown for mouse, touch, and stylus press feedback. */
+  const onPointerDown = press;
+
+  /** Attach to onPointerUp / onPointerCancel / onPointerLeave. */
+  const onPointerUp = release;
+  const onPointerCancel = release;
+  const onPointerLeave = release;
+
+  /** Attach to onKeyDown for keyboard-visible press feedback. */
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.repeat) return;
+      if (event.key === "Enter" || event.key === " ") press();
+    },
+    [press],
+  );
+
+  /** Attach to onKeyUp / onBlur for keyboard release feedback. */
+  const onKeyUp = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key === "Enter" || event.key === " ") release();
+    },
+    [release],
+  );
 
   /** Animate to active state (pass `true`) or inactive (`false`). */
   const animateActive = useCallback(
     (active: boolean) => {
       if (!enabled || prefersReducedMotion() || !elRef.current) return;
-      killTweensOf(elRef.current);
+      const target = elRef.current;
+      killTweensOf(target);
       if (active) {
-        gsap.to(elRef.current, {
+        gsap.to(target, {
           scale: 0.985,
           duration: MOTION.fast * 0.6,
           ease: EASE.out,
           overwrite: "auto",
         });
       } else {
-        gsap.to(elRef.current, {
+        gsap.to(target, {
           scale: 1,
           duration: MOTION.fast,
           ease: EASE.spring,
@@ -140,6 +212,13 @@ export function useCardInteraction(options: CardInteractionOptions = {}) {
     onMouseLeave,
     onMouseDown,
     onMouseUp,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onPointerLeave,
+    onKeyDown,
+    onKeyUp,
+    onBlur: release,
     animateActive,
   };
 }

--- a/src/animations/useListReorderMotion.ts
+++ b/src/animations/useListReorderMotion.ts
@@ -49,8 +49,10 @@ export function useListReorderMotion<T extends HTMLElement>(
       prefersReducedMotion ||
       previousRectsRef.current.size === 0
     ) {
-      gsap.killTweensOf(elements);
-      gsap.set(elements, { clearProps: "transform" });
+      if (elements.length > 0) {
+        gsap.killTweensOf(elements);
+        gsap.set(elements, { clearProps: "transform" });
+      }
       previousRectsRef.current = nextRects;
       return undefined;
     }
@@ -83,8 +85,10 @@ export function useListReorderMotion<T extends HTMLElement>(
     previousRectsRef.current = nextRects;
 
     return () => {
-      gsap.killTweensOf(elements);
-      gsap.set(elements, { clearProps: "transform" });
+      if (elements.length > 0) {
+        gsap.killTweensOf(elements);
+        gsap.set(elements, { clearProps: "transform" });
+      }
     };
   }, [containerRef, disabled, itemSelector, resetKey, triggerKey]);
 }

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -24,33 +24,37 @@ export default function AirportDiscoveryPanel({ topics = [], onOpen }) {
     const ctx = gsap.context(() => {
       // 1. Sections stagger in
       const sections = container.querySelectorAll("section");
-      gsap.fromTo(
-        sections,
-        { opacity: 0, y: 10 },
-        {
-          opacity: 1,
-          y: 0,
-          duration: MOTION.med,
-          ease: EASE.out,
-          stagger: { each: 0.08, from: "start" },
-          overwrite: "auto",
-        },
-      );
+      if (sections.length > 0) {
+        gsap.fromTo(
+          sections,
+          { opacity: 0, y: 10 },
+          {
+            opacity: 1,
+            y: 0,
+            duration: MOTION.med,
+            ease: EASE.out,
+            stagger: { each: 0.08, from: "start" },
+            overwrite: "auto",
+          },
+        );
+      }
 
       // 2. List items stagger in after sections
       const rows = container.querySelectorAll("li");
-      gsap.fromTo(
-        rows,
-        { opacity: 0, x: -6 },
-        {
-          opacity: 1,
-          x: 0,
-          duration: MOTION.med,
-          ease: EASE.out,
-          stagger: { each: 0.04, from: "start" },
-          overwrite: "auto",
-        },
-      );
+      if (rows.length > 0) {
+        gsap.fromTo(
+          rows,
+          { opacity: 0, x: -6 },
+          {
+            opacity: 1,
+            x: 0,
+            duration: MOTION.med,
+            ease: EASE.out,
+            stagger: { each: 0.04, from: "start" },
+            overwrite: "auto",
+          },
+        );
+      }
     }, container);
 
     return () => ctx.revert();

--- a/src/components/ui/FilterCard.tsx
+++ b/src/components/ui/FilterCard.tsx
@@ -16,6 +16,18 @@ const forwardRef = React.forwardRef as <
   ) => React.ReactNode,
 ) => React.ForwardRefExoticComponent<Props & React.RefAttributes<Element>>;
 
+function composeEventHandlers<Event>(
+  internal?: (event: Event) => void,
+  external?: (event: Event) => void,
+) {
+  if (!internal) return external;
+  if (!external) return internal;
+  return (event: Event) => {
+    internal(event);
+    external(event);
+  };
+}
+
 // Compact filter "tile" shared by the AircraftTable filter strip and
 // the AircraftTypeFilterCard / AircraftFilterCardSelect dropdowns.
 // Same visual language as MetricCard (border + inset highlight +
@@ -102,11 +114,27 @@ const filterCardVariants = cva(
 );
 
 export const FilterCard = forwardRef(function FilterCard(
-  { className, shape, asChild = false, active, ...props },
+  {
+    className,
+    shape,
+    asChild = false,
+    active,
+    type,
+    onMouseEnter: externalMouseEnter,
+    onMouseLeave: externalMouseLeave,
+    onPointerDown: externalPointerDown,
+    onPointerUp: externalPointerUp,
+    onPointerCancel: externalPointerCancel,
+    onPointerLeave: externalPointerLeave,
+    onKeyDown: externalKeyDown,
+    onKeyUp: externalKeyUp,
+    onBlur: externalBlur,
+    ...props
+  },
   ref,
 ) {
   const Comp = asChild ? Slot : "button";
-  const extraProps = asChild ? {} : { type: props.type || "button" };
+  const extraProps = asChild ? {} : { type: type || "button" };
 
   // GSAP hover-lift + press-spring, matching MetricCard / SelectableCard.
   // CSS owns the glass-capsule background/box-shadow on active/open; GSAP
@@ -117,8 +145,13 @@ export const FilterCard = forwardRef(function FilterCard(
     ref: gsapRef,
     onMouseEnter,
     onMouseLeave,
-    onMouseDown,
-    onMouseUp,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onPointerLeave,
+    onKeyDown,
+    onKeyUp,
+    onBlur,
   } = useCardInteraction();
   const setRefs = React.useCallback(
     (node: HTMLElement | null) => {
@@ -135,12 +168,17 @@ export const FilterCard = forwardRef(function FilterCard(
       data-active={active ? "true" : undefined}
       data-ui="filter-card"
       className={cn(filterCardVariants({ shape }), className)}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      onMouseDown={onMouseDown}
-      onMouseUp={onMouseUp}
       {...extraProps}
       {...props}
+      onMouseEnter={composeEventHandlers(onMouseEnter, externalMouseEnter)}
+      onMouseLeave={composeEventHandlers(onMouseLeave, externalMouseLeave)}
+      onPointerDown={composeEventHandlers(onPointerDown, externalPointerDown)}
+      onPointerUp={composeEventHandlers(onPointerUp, externalPointerUp)}
+      onPointerCancel={composeEventHandlers(onPointerCancel, externalPointerCancel)}
+      onPointerLeave={composeEventHandlers(onPointerLeave, externalPointerLeave)}
+      onKeyDown={composeEventHandlers(onKeyDown, externalKeyDown)}
+      onKeyUp={composeEventHandlers(onKeyUp, externalKeyUp)}
+      onBlur={composeEventHandlers(onBlur, externalBlur)}
     />
   );
 });

--- a/src/components/ui/MetricCard.tsx
+++ b/src/components/ui/MetricCard.tsx
@@ -149,8 +149,18 @@ function InteractiveMetricCard({
   className?: string;
   children: React.ReactNode;
 }) {
-  const { ref, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp } =
-    useCardInteraction();
+  const {
+    ref,
+    onMouseEnter,
+    onMouseLeave,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onPointerLeave,
+    onKeyDown,
+    onKeyUp,
+    onBlur,
+  } = useCardInteraction();
   return (
     <button
       type="button"
@@ -162,8 +172,13 @@ function InteractiveMetricCard({
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      onMouseDown={onMouseDown}
-      onMouseUp={onMouseUp}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onPointerLeave={onPointerLeave}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      onBlur={onBlur}
       className={cn("group", cardVariants({ interactive: true }), className)}
     >
       {children}

--- a/src/components/ui/SelectableCard.tsx
+++ b/src/components/ui/SelectableCard.tsx
@@ -98,8 +98,13 @@ export function SelectableCard({
     ref: cardRef,
     onMouseEnter,
     onMouseLeave,
-    onMouseDown: gsapMouseDown,
-    onMouseUp: gsapMouseUp,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onPointerLeave,
+    onKeyDown,
+    onKeyUp,
+    onBlur,
   } = useCardInteraction({ enabled: interactive });
 
   return (
@@ -113,8 +118,13 @@ export function SelectableCard({
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      onMouseDown={gsapMouseDown}
-      onMouseUp={gsapMouseUp}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onPointerLeave={onPointerLeave}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      onBlur={onBlur}
       className={cn(
         selectableCardVariants({
           size,

--- a/src/components/ui/TextPillListItem.tsx
+++ b/src/components/ui/TextPillListItem.tsx
@@ -38,8 +38,23 @@ export function TextPillListItem({
   ...rest
 }: TextPillListItemProps) {
   const interactive = as === "button" || as === "a";
-  const { ref, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp } =
-    useCardInteraction({ enabled: interactive });
+  const {
+    ref,
+    onMouseEnter,
+    onMouseLeave,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onPointerLeave,
+    onKeyDown,
+    onKeyUp,
+    onBlur,
+  } = useCardInteraction({
+    enabled: interactive,
+    hoverScale: 1.006,
+    pressScale: 0.972,
+    releaseScale: 1.01,
+  });
 
   const body = (
     <>
@@ -111,7 +126,18 @@ export function TextPillListItem({
   );
 
   const interactionProps = interactive
-    ? { ref, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp }
+    ? {
+        ref,
+        onMouseEnter,
+        onMouseLeave,
+        onPointerDown,
+        onPointerUp,
+        onPointerCancel,
+        onPointerLeave,
+        onKeyDown,
+        onKeyUp,
+        onBlur,
+      }
     : {};
 
   if (as === "button") {

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
+import { useCardInteraction } from "@/animations/useCardInteraction";
 import { cn } from "@/lib/utils";
 
 const forwardRef = React.forwardRef as <
@@ -14,6 +15,18 @@ const forwardRef = React.forwardRef as <
     ref: React.ForwardedRef<Element>,
   ) => React.ReactNode,
 ) => React.ForwardRefExoticComponent<Props & React.RefAttributes<Element>>;
+
+function composeEventHandlers<Event>(
+  internal?: (event: Event) => void,
+  external?: (event: Event) => void,
+) {
+  if (!internal) return external;
+  if (!external) return internal;
+  return (event: Event) => {
+    internal(event);
+    external(event);
+  };
+}
 
 // Shared chrome for every floating toolbar in the app — the home page
 // PageNavigationDock, the sidebar mobile-overlay toolbar, and the map
@@ -210,18 +223,71 @@ const toolbarButtonVariants = cva(
 );
 
 export const ToolbarButton = forwardRef(function ToolbarButton(
-  { className, tone, active = false, asChild = false, ...props },
+  {
+    className,
+    tone,
+    active = false,
+    asChild = false,
+    type,
+    disabled,
+    onMouseEnter: externalMouseEnter,
+    onMouseLeave: externalMouseLeave,
+    onPointerDown: externalPointerDown,
+    onPointerUp: externalPointerUp,
+    onPointerCancel: externalPointerCancel,
+    onPointerLeave: externalPointerLeave,
+    onKeyDown: externalKeyDown,
+    onKeyUp: externalKeyUp,
+    onBlur: externalBlur,
+    ...props
+  },
   ref,
 ) {
   const Comp = asChild ? Slot : "button";
-  const extraProps = asChild ? {} : { type: props.type || "button" };
+  const extraProps = asChild ? { disabled } : { type: type || "button", disabled };
+  const {
+    ref: gsapRef,
+    onMouseEnter,
+    onMouseLeave,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onPointerLeave,
+    onKeyDown,
+    onKeyUp,
+    onBlur,
+  } = useCardInteraction({
+    enabled: !disabled,
+    hoverScale: 1.035,
+    hoverY: -1,
+    pressScale: 0.9,
+    releaseScale: 1.055,
+    duration: 0.18,
+  });
+  const setRefs = React.useCallback(
+    (node: HTMLElement | null) => {
+      gsapRef(node);
+      if (typeof ref === "function") ref(node);
+      else if (ref) (ref as React.MutableRefObject<HTMLElement | null>).current = node;
+    },
+    [gsapRef, ref],
+  );
   return (
     <Comp
-      ref={ref}
+      ref={setRefs}
       data-active={active ? "true" : undefined}
       className={cn(toolbarButtonVariants({ tone }), className)}
       {...extraProps}
       {...props}
+      onMouseEnter={composeEventHandlers(onMouseEnter, externalMouseEnter)}
+      onMouseLeave={composeEventHandlers(onMouseLeave, externalMouseLeave)}
+      onPointerDown={composeEventHandlers(onPointerDown, externalPointerDown)}
+      onPointerUp={composeEventHandlers(onPointerUp, externalPointerUp)}
+      onPointerCancel={composeEventHandlers(onPointerCancel, externalPointerCancel)}
+      onPointerLeave={composeEventHandlers(onPointerLeave, externalPointerLeave)}
+      onKeyDown={composeEventHandlers(onKeyDown, externalKeyDown)}
+      onKeyUp={composeEventHandlers(onKeyUp, externalKeyUp)}
+      onBlur={composeEventHandlers(onBlur, externalBlur)}
     />
   );
 });

--- a/src/components/weather/WeatherSlides.tsx
+++ b/src/components/weather/WeatherSlides.tsx
@@ -541,8 +541,18 @@ function hourlyTemp(val, unit) {
 // MetricCard / SelectableCard glass cards. CSS owns the glass-capsule
 // background/box-shadow on [data-active]; GSAP owns transform only.
 function HourlyCell({ hour, active, onToggle, t, units }) {
-  const { ref, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp } =
-    useCardInteraction();
+  const {
+    ref,
+    onMouseEnter,
+    onMouseLeave,
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+    onPointerLeave,
+    onKeyDown,
+    onKeyUp,
+    onBlur,
+  } = useCardInteraction();
   return (
     <button
       type="button"
@@ -552,8 +562,13 @@ function HourlyCell({ hour, active, onToggle, t, units }) {
       onClick={onToggle}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      onMouseDown={onMouseDown}
-      onMouseUp={onMouseUp}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onPointerLeave={onPointerLeave}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      onBlur={onBlur}
     >
       <span className="hourly-card__time">{hour.time}</span>
       <span className="hourly-card__temp notranslate" translate="no">


### PR DESCRIPTION
## Summary
- Add a stronger GSAP press/rebound acknowledgement to shared interactive surfaces so slow network responses no longer make taps feel ignored.
- Wire pointer/touch/keyboard feedback through toolbar buttons, text-pill list rows, filter cards, metric cards, selectable cards, and hourly weather cells.
- Guard empty GSAP targets in shared animation helpers and discovery/reorder motion paths to avoid noisy `GSAP target not found` warnings.

## Validation
- `/opt/homebrew/bin/pnpm lint` passed with 0 errors and the existing 3 warnings.
- `/opt/homebrew/bin/pnpm build` passed; build emitted the existing Next/Sentry Edge Runtime warning.
- `/opt/homebrew/bin/pnpm test` passed: 100 test files.
- Browser QA on `http://localhost:3000/airport/KBOS` desktop: page loaded, toolbar settings button opened the settings dialog, no new warning/error logs.
- Browser QA on `http://localhost:3000/` desktop: KBOS list row navigated to `/airport/KBOS?locale=zh-CN`, no new warning/error logs.
- Browser QA at 390x844 mobile viewport: KBOS page loaded, mobile toolbar settings button opened the settings dialog, no new warning/error logs.
- Vercel preview QA on `https://adsbao-git-codex-gsap-click-feedback-orriduck.vercel.app/airport/KBOS?locale=zh-CN`: page loaded, settings button opened the settings dialog, no new warning/error logs.
- PR checks passed: Vercel and Vercel Preview Comments.

## Notes
- Standalone `/opt/homebrew/bin/pnpm exec tsc --noEmit` is currently blocked by pre-existing test-file type errors; the Next build TypeScript phase passes.
- Browser screenshot capture timed out in the in-app Browser (`Page.captureScreenshot`), and this repo does not have the Playwright CLI installed for screenshot fallback. DOM, URL, title, interaction, and console checks were completed.
