### PR TITLE
Fix issues from recent commits: no-op tokens, mobile preview key, dead code

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -219,7 +219,7 @@ export default function AircraftPreviewCard({
       )}
       {showMobile && (
         <MobilePreviewCard
-          identityKey={`mobile-${identityKey}`}
+          key={`mobile-${identityKey}`}
           ariaLabel={previewAriaLabel}
           compact={!isAirport && !isNavaid && !isAirspace && !isCandidateWatchingSpot}
           actions={

--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -18,16 +18,17 @@ import { cn } from "@/lib/utils";
 // re-enable interaction inside `MobilePreviewActions`.
 
 export default function MobilePreviewCard({
-  identityKey,
   ariaLabel,
   children,
   actions = null,
   traceStatus = null,
   compact = false,
 }: Record<string, any>) {
+  // NOTE: the enter animation replays on entity change via a `key` on the
+  // *call site* (<MobilePreviewCard key=...>), not a prop here — a `key`
+  // on this root <aside> would be a no-op (React reads key at the call site).
   return (
     <aside
-      key={identityKey}
       aria-label={ariaLabel}
       data-density={compact ? "compact" : undefined}
       data-ui="mobile-preview-card"
@@ -289,7 +290,7 @@ export const MobilePreviewSecondaryButton = React.forwardRef(
           "font-[var(--font-display)] text-[11px] font-extrabold not-italic tracking-normal leading-[1.15] text-center [[data-density=compact]_&]:text-[10px]",
           "[-webkit-tap-highlight-color:transparent]",
           "transition-[background-color,border-color,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
-          "hover:border-atc-line-strong hover:bg-atc-card-strong active:scale-[0.97]",
+          "hover:border-atc-line-strong hover:bg-[var(--tone-card-strong)] active:scale-[0.97]",
           "focus-visible:outline-2 focus-visible:outline-[var(--atc-action-focus-ring)] focus-visible:outline-offset-[3px]",
           className,
         )}

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -109,7 +109,7 @@ const LAYER_CONTROLS = [
 ];
 
 const sectionTitleClassName =
-  "mb-3 text-[11px] font-semibold uppercase tracking-normal text-atc-muted";
+  "mb-3 text-[11px] font-semibold tracking-normal text-atc-muted";
 
 const optionGridClassName = "grid grid-cols-2 gap-2.5";
 

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -40,6 +40,14 @@ export default function AircraftRow({
   onSelectAircraft,
 }: Record<string, any>) {
   const { t } = useI18n();
+  // Press feedback only — the row already changes background on hover, so a
+  // hover lift would jitter the dense list; GSAP owns transform (the CSS
+  // transition below intentionally omits it).
+  const { ref, onMouseDown, onMouseUp, onMouseLeave } = useCardInteraction({
+    hoverScale: 1,
+    hoverY: 0,
+    pressScale: 0.985,
+  });
   const { preferences: units } = useUnitPreferences();
   const callsign = aircraft.callsign?.trim() || aircraft.icao24 || "-";
   const route = aircraft.flightRouteLabel || "";
@@ -68,8 +76,12 @@ export default function AircraftRow({
   return (
     <button
       type="button"
+      ref={ref}
       data-selected={selected ? "true" : undefined}
-      className={`aircraft-table-card aircraft-table-row-grid aircraft-table-row-shell grid w-full grid-cols-[18px_minmax(0,1fr)_48px_54px] items-center gap-2 px-[var(--airport-sidebar-inset)] text-left transition-[background,color,box-shadow,transform] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] data-[selected=true]:[background:var(--atc-glass-active-bg)] data-[selected=true]:text-[var(--atc-click-fg)] data-[selected=true]:shadow-[var(--atc-glass-rim-shadow)] data-[selected=true]:[backdrop-filter:var(--atc-glass-active-frost)] data-[selected=true]:[-webkit-backdrop-filter:var(--atc-glass-active-frost)] data-[selected=true]:hover:[background:var(--atc-glass-active-bg)] data-[selected=true]:[&_.text-atc-text]:text-[var(--atc-click-fg)] data-[selected=true]:[&_.text-atc-dim]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.text-atc-faint]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.aircraft-table-route-cycle]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.aircraft-table-row-glyph]:bg-[var(--atc-click-fg)] data-[selected=true]:[&_.aircraft-table-row-glyph]:text-[var(--atc-click-bg)] sm:grid-cols-[18px_minmax(0,1fr)_54px_70px] sm:gap-3 ${
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseLeave}
+      className={`aircraft-table-card aircraft-table-row-grid aircraft-table-row-shell grid w-full grid-cols-[18px_minmax(0,1fr)_48px_54px] items-center gap-2 px-[var(--airport-sidebar-inset)] text-left transition-[background,color,box-shadow] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] data-[selected=true]:[background:var(--atc-glass-active-bg)] data-[selected=true]:text-[var(--atc-click-fg)] data-[selected=true]:shadow-[var(--atc-glass-rim-shadow)] data-[selected=true]:[backdrop-filter:var(--atc-glass-active-frost)] data-[selected=true]:[-webkit-backdrop-filter:var(--atc-glass-active-frost)] data-[selected=true]:hover:[background:var(--atc-glass-active-bg)] data-[selected=true]:[&_.text-atc-text]:text-[var(--atc-click-fg)] data-[selected=true]:[&_.text-atc-dim]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.text-atc-faint]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.aircraft-table-route-cycle]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.aircraft-table-row-glyph]:bg-[var(--atc-click-fg)] data-[selected=true]:[&_.aircraft-table-row-glyph]:text-[var(--atc-click-bg)] sm:grid-cols-[18px_minmax(0,1fr)_54px_70px] sm:gap-3 ${
         selected ? "aircraft-table-row--selected aircraft-table-row--active" : ""
       }`}
       aria-pressed={selected}

--- a/src/components/ui/AsyncStatusLine.tsx
+++ b/src/components/ui/AsyncStatusLine.tsx
@@ -55,7 +55,7 @@ export function AsyncStatusLineDisplay({
   return (
     <div
       className={cn(
-        "async-status-line inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.04em] text-atc-muted",
+        "async-status-line inline-flex items-center gap-1.5 text-[10px] font-semibold tracking-[0.04em] text-atc-muted",
         "transition-opacity duration-300 ease-out motion-reduce:transition-none",
         isVisible ? "opacity-100" : "opacity-0",
         isFading && "opacity-0",

--- a/src/style.css
+++ b/src/style.css
@@ -35,6 +35,7 @@
     --color-atc-text: var(--atc-text);
     --color-atc-dim: var(--atc-dim);
     --color-atc-faint: var(--atc-faint);
+    --color-atc-muted: var(--atc-dim);
     --color-atc-line: var(--atc-line);
     --color-atc-line-strong: var(--atc-line-strong);
 
@@ -1408,8 +1409,8 @@ body:has(.app-detail-shell) {
 }
 
 /* Anything previously tagged as monospace (telemetry, METAR, ICAO) now
-   renders Chakra Petch with tabular numerals + slight tracking so digit
-   columns still align cleanly. */
+   renders Manrope (the global font) with tabular numerals + slight
+   tracking so digit columns still align cleanly. */
 .font-mono,
 [class*="font-mono"] {
     font-feature-settings:
@@ -4786,12 +4787,6 @@ body {
     font-size: clamp(15px, 4.4vw, 17px);
 }
 
-.airport-sidebar-panel--mobile .weather-metar-code {
-    font-size: clamp(12px, 3.25vw, 14px);
-    line-height: 1.35;
-    max-height: none;
-}
-
 .sidebar-shell {
     /* Shared baseline tokens for every sidebar variant: padding inset and
        the typography stack. Defined on the shell so AircraftTable rows
@@ -7203,15 +7198,6 @@ body {
             0 0 6px var(--map-label-glow);
     }
 
-    .airport-map-kit .nearby-airport-marker-dot {
-        height: 5px;
-        width: 5px;
-    }
-
-    .airport-map-kit .nearby-airport-marker-label {
-        left: 6px;
-        top: 5px;
-    }
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
Fixes the bugs/issues surfaced while reviewing the recent commits (#407–#414 + the Endfield rename).

**Bugs**
- `text-atc-muted` was an unregistered Tailwind color → 8 muted-text spots rendered at full strength. Registered `--color-atc-muted` → `--atc-dim` so they dim as intended (verified in built CSS: `text-atc-muted{color:var(--atc-dim)}`).
- `MobilePreviewCard` set `key` on its own root `<aside>` (a no-op) and took it as the `identityKey` prop, so the mobile preview enter-animation never replayed on entity change. Moved `key` to the call site, dropped the prop.
- `hover:bg-atc-card-strong` (mobile secondary button) was an unregistered color (no-op) → `var(--tone-card-strong)`.

**Cleanup**
- `AircraftRow`: #414 imported `useCardInteraction` but never attached it (dead import; no press feedback). Wired it (press-only, to avoid hover jitter in the virtualized list) and dropped `transform` from the CSS transition so GSAP owns it.
- Removed dead `uppercase` classes (globally neutralized) on the map-settings section title and `AsyncStatusLine`.
- Removed dead CSS (`.weather-metar-code`, `.nearby-airport-marker-dot/-label`) and fixed the stale "Chakra Petch" comment (now Manrope).

**Validation:** `pnpm build` green; 100 test files pass; `tsc` clean on touched files.