### PR TITLE
perf: memoize sidebar aircraft & airport rows to cut per-poll re-renders

### DIFF
--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Plane } from "lucide-react";
 import NumberFlow from "@number-flow/react";
 import {
@@ -33,7 +33,7 @@ function AirlineLogo({ src, className }: Record<string, any>) {
   );
 }
 
-export default function AircraftRow({
+function AircraftRow({
   aircraft,
   aircraftId,
   selected,
@@ -128,6 +128,39 @@ export default function AircraftRow({
     </button>
   );
 }
+
+// Memoized so a poll tick only re-renders rows whose displayed fields
+// actually changed. The upstream pipeline (trace tracker + per-poll
+// distance re-map) hands down a fresh object identity for every aircraft
+// each tick, so the comparator is field-based, not referential.
+function aircraftRowPropsEqual(
+  prev: Record<string, any>,
+  next: Record<string, any>,
+) {
+  if (
+    prev.selected !== next.selected ||
+    prev.aircraftId !== next.aircraftId ||
+    prev.onSelectAircraft !== next.onSelectAircraft
+  ) {
+    return false;
+  }
+  const a = prev.aircraft || {};
+  const b = next.aircraft || {};
+  if (a === b) return true;
+  return (
+    a.callsign === b.callsign &&
+    a.icao24 === b.icao24 &&
+    a.flightRouteLabel === b.flightRouteLabel &&
+    a.flightRoute === b.flightRoute &&
+    a.distanceNm === b.distanceNm &&
+    a.altitude === b.altitude &&
+    a.onGround === b.onGround &&
+    a.flight_position_source === b.flight_position_source &&
+    a.positionQuality === b.positionQuality
+  );
+}
+
+export default memo(AircraftRow, aircraftRowPropsEqual);
 
 function AircraftIdentityCell({
   callsign,

--- a/src/components/sidebar/AirportRow.tsx
+++ b/src/components/sidebar/AirportRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { TowerControl } from "lucide-react";
 import NumberFlow from "@number-flow/react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
@@ -13,7 +14,7 @@ import { formatAltitude } from "@/utils/units";
 // "airports & aircraft" mixed list reads as one coherent table.
 // Left: ICAO · IATA / city + country. Right: DIST and ELEV (in place of
 // the aircraft row's GS / ALT).
-export default function AirportRow({
+function AirportRow({
   airport,
   airportId,
   selected,
@@ -94,6 +95,35 @@ export default function AirportRow({
     </button>
   );
 }
+
+// Memoized (field-based, like AircraftRow) so poll-driven re-renders of the
+// list don't re-render every airport row when its displayed data is unchanged.
+function airportRowPropsEqual(
+  prev: Record<string, any>,
+  next: Record<string, any>,
+) {
+  if (
+    prev.selected !== next.selected ||
+    prev.airportId !== next.airportId ||
+    prev.onSelectAirport !== next.onSelectAirport
+  ) {
+    return false;
+  }
+  const a = prev.airport || {};
+  const b = next.airport || {};
+  if (a === b) return true;
+  return (
+    a.icao === b.icao &&
+    a.iata === b.iata &&
+    a.city === b.city &&
+    a.country === b.country &&
+    a.distanceNm === b.distanceNm &&
+    a.elevationFt === b.elevationFt &&
+    a.routeEndpointRole === b.routeEndpointRole
+  );
+}
+
+export default memo(AirportRow, airportRowPropsEqual);
 
 // Mirrors AircraftRow.NumberWithUnit — virtualization bounds the instance
 // count, so NumberFlow's digit-level animation is affordable here too.


### PR DESCRIPTION
Performance pass from a re-render-focused review. The ADS-B poll (~3s) hands down a brand-new object for every aircraft each tick, so every visible sidebar row was re-rendering every poll (re-running `useCardInteraction` + all distance/altitude/route formatting) even when its data was unchanged.

**Change:** wrap `AircraftRow` and `AirportRow` in `React.memo` with field-based comparators (referential memo is useless here because identities churn upstream). Rows now re-render only when a displayed field actually changes — distance, altitude, onGround, route, or selection. The comparators cover every field each row renders, so live ticks and selection still propagate.

**Validation:** `next build` green; 100 test files pass; `tsc` clean on touched files.

### Recommended follow-ups (higher-leverage, higher-risk — separate PRs)
1. **Keystone — structural sharing in `aircraftTraceModel.update()`**: it spreads a fresh object per aircraft each poll, defeating referential memo everywhere. Return the prior per-id object + history array when unchanged → unlocks default memo on rows *and* markers and lets the poll skip `setState` when nothing changed.
2. **Map markers**: `AircraftPosition` isn't memoized (full DOM/portal rebuild per aircraft per poll) and each marker runs its own 60fps `requestAnimationFrame`. Memoize (excluding lat/lon/heading, which drive the marker via refs) and consolidate into one shared RAF loop; skip ticking static/ground traffic.
3. **`ExplorerUiContext`** is one monolithic context; any change re-renders every consumer. Split stable actions from state.
4. **`useAircraftTrace`** returns a fresh object each render, churning the trace context memo every tick.
5. **`useAircraftPositions`** toggles `loading` + calls `setAircraft` every poll even when data is identical → extra full-tree renders; gate them.
6. **`SelectedAircraftTrace`** rebuilds all polylines every poll; diff and update only the growing head segment.