### PR TITLE
perf: cut per-poll re-renders across the live-traffic render path

### DIFF
--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext";
@@ -38,7 +38,7 @@ const getAircraftColor = (ac, showArrow) => {
   return AIRCRAFT_COLORS.unknown;
 };
 
-export default function AircraftPosition({
+function AircraftPosition({
   aircraft,
   theme = "dark",
   matchesFilters = true,
@@ -93,11 +93,19 @@ export default function AircraftPosition({
     }).addTo(map);
     markerRef.current = marker;
 
+    let lastLat = visualPos.lat;
+    let lastLon = visualPos.lon;
     let rafId = requestAnimationFrame(function tick() {
       const motion = motionRef.current;
       if (motion) {
         const pos = calculateAircraftVisualPosition(motion);
-        marker.setLatLng([pos.lat, pos.lon]);
+        // Skip redundant Leaflet DOM writes when the projected position
+        // hasn't moved (settled / stationary traffic).
+        if (pos.lat !== lastLat || pos.lon !== lastLon) {
+          marker.setLatLng([pos.lat, pos.lon]);
+          lastLat = pos.lat;
+          lastLon = pos.lon;
+        }
       }
       rafId = requestAnimationFrame(tick);
     });
@@ -193,6 +201,13 @@ export default function AircraftPosition({
     container,
   );
 }
+
+// Memoized: the trace tracker now shares references for unchanged aircraft
+// and all other props are stable (booleans + a useCallback handler), so a
+// poll that doesn't change a given aircraft skips its React re-render +
+// portal rebuild. Moving aircraft get a fresh `aircraft` ref → re-render →
+// the [aircraft] effect updates motionRef so the marker keeps animating.
+export default memo(AircraftPosition);
 
 function Pointer({
   color,

--- a/src/features/aircraft/trace/aircraftTraceModel.test.ts
+++ b/src/features/aircraft/trace/aircraftTraceModel.test.ts
@@ -90,6 +90,64 @@ import {
 }
 
 {
+  // Structural sharing: an unchanged aircraft keeps the same object
+  // reference across polls, and a fully-unchanged tick returns the same
+  // array reference (so the poller can skip setState).
+  const tracker = createAircraftTraceTracker({
+    maxSamples: 8,
+    maxAgeMs: 60_000,
+    minDistanceNm: 0.01,
+    minSampleGapMs: 1_000,
+  });
+
+  const pass1 = tracker.update(
+    [
+      { icao24: "aaa111", lat: 42.0, lon: -71.0, altitude: 30000 },
+      { icao24: "bbb222", lat: 43.0, lon: -72.0, altitude: 31000 },
+    ],
+    1_000,
+  );
+  // Identical feed on the next tick → same refs, same array.
+  const pass2 = tracker.update(
+    [
+      { icao24: "aaa111", lat: 42.0, lon: -71.0, altitude: 30000 },
+      { icao24: "bbb222", lat: 43.0, lon: -72.0, altitude: 31000 },
+    ],
+    4_000,
+  );
+  assert.equal(pass2, pass1, "unchanged tick returns the same array reference");
+  assert.equal(pass2[0], pass1[0], "unchanged aircraft keeps the same object reference");
+  assert.equal(pass2[1], pass1[1], "unchanged aircraft keeps the same object reference");
+
+  // One aircraft moves enough to append a sample → that object is new,
+  // the unchanged one is still shared, and the array reference changes.
+  const pass3 = tracker.update(
+    [
+      { icao24: "aaa111", lat: 42.05, lon: -70.95, altitude: 30200 },
+      { icao24: "bbb222", lat: 43.0, lon: -72.0, altitude: 31000 },
+    ],
+    7_000,
+  );
+  assert.notEqual(pass3, pass2, "a changed tick returns a new array reference");
+  assert.notEqual(pass3[0], pass2[0], "moved aircraft gets a fresh object");
+  assert.equal(pass3[1], pass2[1], "still-unchanged aircraft keeps its shared object");
+  assert.equal(pass3[0].traceHistory.length, 2, "moving aircraft grows its trace");
+  assert.equal(pass3[1].traceHistory.length, 1, "stationary aircraft trace unchanged");
+
+  // A changed scalar field (altitude only, same position) still busts the
+  // shared reference so consumers see the new value.
+  const pass4 = tracker.update(
+    [
+      { icao24: "aaa111", lat: 42.05, lon: -70.95, altitude: 30200 },
+      { icao24: "bbb222", lat: 43.0, lon: -72.0, altitude: 31500 },
+    ],
+    10_000,
+  );
+  assert.notEqual(pass4[1], pass3[1], "changed altitude busts the shared reference");
+  assert.equal(pass4[1].altitude, 31500);
+}
+
+{
   const curve = buildAircraftTraceCurve([
     { lat: 42.0, lon: -71.0 },
     { lat: 42.02, lon: -70.99 },

--- a/src/features/aircraft/trace/aircraftTraceModel.ts
+++ b/src/features/aircraft/trace/aircraftTraceModel.ts
@@ -56,7 +56,34 @@ function shouldAppendTracePoint(
 
 function trimTraceHistory(history: TraceRecord[], nowMs: number, config: TraceRecord) {
   const freshHistory = history.filter((point) => nowMs - point.time <= config.maxAgeMs);
+  // Preserve the input reference when nothing was trimmed — lets the
+  // per-id structural sharing below skip rebuilding the emitted object
+  // for aircraft whose trace didn't change this tick.
+  if (
+    freshHistory.length === history.length &&
+    history.length <= config.maxSamples
+  ) {
+    return history;
+  }
   return freshHistory.slice(-config.maxSamples);
+}
+
+// True when the previously-emitted object still matches the incoming item
+// (same own fields) and the same trace-history array — so it can be reused
+// by reference instead of spreading a fresh object every poll.
+function emittedMatchesItem(
+  emitted: TraceRecord | undefined,
+  item: TraceRecord,
+  trimmedHistory: TraceRecord[],
+) {
+  if (!emitted || emitted.traceHistory !== trimmedHistory) return false;
+  const itemKeys = Object.keys(item);
+  // emitted = { ...item, traceHistory } → exactly one extra key.
+  if (Object.keys(emitted).length !== itemKeys.length + 1) return false;
+  for (const key of itemKeys) {
+    if (item[key] !== emitted[key]) return false;
+  }
+  return true;
 }
 
 function getAircraftTraceId(aircraft: TraceRecord = {}) {
@@ -82,17 +109,26 @@ export function createAircraftTraceTracker(options = {}) {
     ...options,
   };
   const histories = new Map<string, TraceRecord[]>();
+  // Per-id cache of the last emitted object so unchanged aircraft keep a
+  // stable reference across polls (enables React.memo to bail), plus the
+  // last returned array so a fully-unchanged tick returns the same array
+  // reference (lets the poller skip setState entirely).
+  const lastEmitted = new Map<string, TraceRecord>();
+  let lastResult: TraceRecord[] = [];
 
   return {
     update(aircraft = [], nowMs = Date.now()) {
       const activeIds = new Set();
+      let changedFromLast = aircraft.length !== lastResult.length;
 
-      const nextAircraft = aircraft.map((item) => {
+      const nextAircraft = aircraft.map((item, index) => {
         const id = getAircraftTraceId(item);
         const point = normalizeTracePoint(item, nowMs);
 
         if (!id || !point) {
-          return { ...item, traceHistory: [] };
+          const emitted = { ...item, traceHistory: [] };
+          if (lastResult[index] !== emitted) changedFromLast = true;
+          return emitted;
         }
 
         activeIds.add(id);
@@ -102,19 +138,34 @@ export function createAircraftTraceTracker(options = {}) {
           ? [...previousHistory, point]
           : previousHistory;
         const trimmedHistory = trimTraceHistory(nextHistory, nowMs, config);
-
         histories.set(id, trimmedHistory);
-        return { ...item, traceHistory: trimmedHistory };
+
+        const prevEmitted = lastEmitted.get(id);
+        const emitted = emittedMatchesItem(prevEmitted, item, trimmedHistory)
+          ? (prevEmitted as TraceRecord)
+          : { ...item, traceHistory: trimmedHistory };
+        lastEmitted.set(id, emitted);
+        if (lastResult[index] !== emitted) changedFromLast = true;
+        return emitted;
       });
 
       for (const id of histories.keys()) {
-        if (!activeIds.has(id)) histories.delete(id);
+        if (!activeIds.has(id)) {
+          histories.delete(id);
+          lastEmitted.delete(id);
+        }
       }
 
+      // Nothing changed (same length, every slot reference-identical) →
+      // return the previous array so consumers can skip re-rendering.
+      if (!changedFromLast) return lastResult;
+      lastResult = nextAircraft;
       return nextAircraft;
     },
     clear() {
       histories.clear();
+      lastEmitted.clear();
+      lastResult = [];
     },
   };
 }

--- a/src/hooks/useAircraftPositions.ts
+++ b/src/hooks/useAircraftPositions.ts
@@ -93,9 +93,14 @@ export function useAircraftPositions(icao, lat, lon, options: Record<string, any
       visibilityRefreshCancelRef.current = null;
     };
 
-    const poll = async ({ commitAfter = 0 } = {}) => {
+    const poll = async ({ commitAfter = 0, showLoading = false } = {}) => {
       if (queryLat == null || queryLon == null) return;
-      setLoading(true);
+      // Only flag `loading` for the initial fetch — steady-state interval
+      // polls must not toggle it, or every tick re-renders consumers (and
+      // flickers the traffic loading overlay). The initial/empty state is
+      // covered by `initialLoading` + `!settled`, and visibility refreshes
+      // use `visibilityRefreshLoading`.
+      if (showLoading) setLoading(true);
       try {
         const aircraftJson = await aircraftPositionClient.fetchNearbyAircraft({
           lat: queryLat,
@@ -122,7 +127,14 @@ export function useAircraftPositions(icao, lat, lon, options: Record<string, any
           typeof aircraftJson?.source === "string" ? aircraftJson.source : "",
         );
         const positionDate = resolveLastSuccessfulPositionDate(nextAircraft);
-        if (positionDate) setLastUpdated(positionDate);
+        if (positionDate) {
+          // Keep the previous Date instance when the timestamp is
+          // unchanged so a stale (identical) poll doesn't re-render via a
+          // fresh Date object of the same time.
+          setLastUpdated((prev) =>
+            prev && prev.getTime() === positionDate.getTime() ? prev : positionDate,
+          );
+        }
         setSettled(true);
         setInitialLoading(false);
         setVisibilityRefreshLoading(false);
@@ -160,7 +172,7 @@ export function useAircraftPositions(icao, lat, lon, options: Record<string, any
       setSettled(false);
       setInitialLoading(true);
       setLastUpdated(null);
-      poll({ commitAfter });
+      poll({ commitAfter, showLoading: true });
       timerRef.current = setInterval(poll, AIRCRAFT_TRAFFIC_CONFIG.pollMs);
     };
 

--- a/src/hooks/useAircraftTrace.ts
+++ b/src/hooks/useAircraftTrace.ts
@@ -349,12 +349,27 @@ export function useAircraftTrace(
     return () => window.clearTimeout(timer);
   }, [persistKey, tracePoints]);
 
-  return {
-    tracePoints,
-    loading: composedTrace.loading,
-    traceFetchLoading: Boolean(recentLoading || fullLoading),
-    traceStatusCode,
-    traceError,
-    traceCycle,
-  };
+  // Memoize the returned object so its identity is stable when the fields
+  // are unchanged — the SelectedAircraftTrace context keys a memo on this
+  // whole object, so a fresh literal every render would churn it (and all
+  // its consumers) on every poll-driven re-render.
+  return useMemo(
+    () => ({
+      tracePoints,
+      loading: composedTrace.loading,
+      traceFetchLoading: Boolean(recentLoading || fullLoading),
+      traceStatusCode,
+      traceError,
+      traceCycle,
+    }),
+    [
+      tracePoints,
+      composedTrace.loading,
+      recentLoading,
+      fullLoading,
+      traceStatusCode,
+      traceError,
+      traceCycle,
+    ],
+  );
 }


### PR DESCRIPTION
Follow-ups from the re-render review, implemented one by one. The ADS-B poll (~3s) drove avoidable re-renders across the fleet; this addresses the root cause and the highest-leverage consumers.

### Shipped
1. **Trace-tracker structural sharing** (`aircraftTraceModel.update`) — return the prior per-id object when an aircraft's fields + trace history are unchanged, and the prior top-level array when nothing changed. `trimTraceHistory` preserves its reference when nothing aged out. This is the keystone: unchanged aircraft now keep a stable reference, so `setAircraft` becomes a no-op and `React.memo` can bail. (+ structural-sharing unit tests.)
2. **`AircraftPosition` memoized** + skip redundant `marker.setLatLng` — a poll that doesn't change an aircraft now skips its React re-render + divIcon portal rebuild; moving aircraft still re-render so the motion ref updates and the marker animates.
4. **`useAircraftTrace` return memoized** — the hook returned a fresh object each render, churning the SelectedAircraftTrace context memo every tick.
5. **`useAircraftPositions`** — only flag `loading` on the initial fetch (steady polls no longer re-render consumers or flicker the traffic overlay; `!settled` covers the initial state), and keep the prior `lastUpdated` Date when the timestamp is unchanged.

(Plus the previously-merged row memos in #417 — these unlock them fully.)

### Deferred (with rationale — risky to ship without browser verification, which the dev server can't currently provide reliably)
- **#3 ExplorerUiContext actions/state split** — a wide refactor of a context driving the whole explorer UI; a subtle wiring slip would break selection/map/sidebar app-wide and wouldn't be caught by build/tests. Wants browser verification.
- **#6 SelectedAircraftTrace incremental polyline diff** — `geometry` is already memoized so Effect 1 only rebuilds when the trace genuinely extends (single selected trace, not the fleet). The remaining win (append only the head segment vs. rebuild) is intricate Leaflet/gradient surgery, low relative value, and unverifiable blind.

### Mechanism docs
Checked `/mechanism` (`aircraftTrace`, `mapOverlays`) — both describe observable behavior, which these optimizations preserve exactly. No copy change needed.

**Validation:** `next build` green; 100 test files pass (incl. new trace structural-sharing assertions); `tsc` clean on touched files.