### PR TITLE
cleanup: dedupe sidebar row memo comparators + tidy trace no-id branch

### DIFF
--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -14,6 +14,7 @@ import { formatFlightTelemetryMetric } from "@/features/aircraft/tracking/flight
 import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplayModel";
 import { formatAltitude } from "@/utils/units";
 import { useCardInteraction } from "@/animations/useCardInteraction";
+import { rowPropsEqual } from "./rowPropsEqual";
 
 // Tiny self-contained <img> that hides itself if the URL 404s. Avoids
 // stamped broken-image icons in dense list rows when the logo isn't
@@ -130,37 +131,25 @@ function AircraftRow({
 }
 
 // Memoized so a poll tick only re-renders rows whose displayed fields
-// actually changed. The upstream pipeline (trace tracker + per-poll
-// distance re-map) hands down a fresh object identity for every aircraft
-// each tick, so the comparator is field-based, not referential.
-function aircraftRowPropsEqual(
-  prev: Record<string, any>,
-  next: Record<string, any>,
-) {
-  if (
-    prev.selected !== next.selected ||
-    prev.aircraftId !== next.aircraftId ||
-    prev.onSelectAircraft !== next.onSelectAircraft
-  ) {
-    return false;
-  }
-  const a = prev.aircraft || {};
-  const b = next.aircraft || {};
-  if (a === b) return true;
-  return (
-    a.callsign === b.callsign &&
-    a.icao24 === b.icao24 &&
-    a.flightRouteLabel === b.flightRouteLabel &&
-    a.flightRoute === b.flightRoute &&
-    a.distanceNm === b.distanceNm &&
-    a.altitude === b.altitude &&
-    a.onGround === b.onGround &&
-    a.flight_position_source === b.flight_position_source &&
-    a.positionQuality === b.positionQuality
-  );
-}
-
-export default memo(AircraftRow, aircraftRowPropsEqual);
+// actually changed (the pipeline hands down fresh object identities every
+// tick, so the compare is field-based — see rowPropsEqual).
+export default memo(AircraftRow, (prev, next) =>
+  rowPropsEqual(prev, next, {
+    scalarKeys: ["selected", "aircraftId", "onSelectAircraft"],
+    nestedKey: "aircraft",
+    nestedFields: [
+      "callsign",
+      "icao24",
+      "flightRouteLabel",
+      "flightRoute",
+      "distanceNm",
+      "altitude",
+      "onGround",
+      "flight_position_source",
+      "positionQuality",
+    ],
+  }),
+);
 
 function AircraftIdentityCell({
   callsign,

--- a/src/components/sidebar/AirportRow.tsx
+++ b/src/components/sidebar/AirportRow.tsx
@@ -9,6 +9,7 @@ import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplay
 import { airportCityName, airportDisplayName } from "@/utils/airport";
 import { countryName } from "@/utils/flag";
 import { formatAltitude } from "@/utils/units";
+import { rowPropsEqual } from "./rowPropsEqual";
 
 // Airport equivalent of AircraftRow — same column rhythm so an
 // "airports & aircraft" mixed list reads as one coherent table.
@@ -98,32 +99,21 @@ function AirportRow({
 
 // Memoized (field-based, like AircraftRow) so poll-driven re-renders of the
 // list don't re-render every airport row when its displayed data is unchanged.
-function airportRowPropsEqual(
-  prev: Record<string, any>,
-  next: Record<string, any>,
-) {
-  if (
-    prev.selected !== next.selected ||
-    prev.airportId !== next.airportId ||
-    prev.onSelectAirport !== next.onSelectAirport
-  ) {
-    return false;
-  }
-  const a = prev.airport || {};
-  const b = next.airport || {};
-  if (a === b) return true;
-  return (
-    a.icao === b.icao &&
-    a.iata === b.iata &&
-    a.city === b.city &&
-    a.country === b.country &&
-    a.distanceNm === b.distanceNm &&
-    a.elevationFt === b.elevationFt &&
-    a.routeEndpointRole === b.routeEndpointRole
-  );
-}
-
-export default memo(AirportRow, airportRowPropsEqual);
+export default memo(AirportRow, (prev, next) =>
+  rowPropsEqual(prev, next, {
+    scalarKeys: ["selected", "airportId", "onSelectAirport"],
+    nestedKey: "airport",
+    nestedFields: [
+      "icao",
+      "iata",
+      "city",
+      "country",
+      "distanceNm",
+      "elevationFt",
+      "routeEndpointRole",
+    ],
+  }),
+);
 
 // Mirrors AircraftRow.NumberWithUnit — virtualization bounds the instance
 // count, so NumberFlow's digit-level animation is affordable here too.

--- a/src/components/sidebar/rowPropsEqual.ts
+++ b/src/components/sidebar/rowPropsEqual.ts
@@ -1,0 +1,26 @@
+// Shared React.memo comparator for the sidebar list rows (AircraftRow,
+// AirportRow). The poll pipeline hands down fresh object identities every
+// tick (trace tracker + the per-poll distance re-map), so referential memo
+// can't bail — rows compare by value instead: the scalar props (selection,
+// id, click handler) plus the rendered fields of the nested entity object.
+//
+// IMPORTANT: `nestedFields` must list every field of the entity that the
+// row renders. If you add a rendered field to a row, add it here too, or
+// the memo will show stale data until some other field changes.
+export function rowPropsEqual(
+  prev: Record<string, any>,
+  next: Record<string, any>,
+  {
+    scalarKeys,
+    nestedKey,
+    nestedFields,
+  }: { scalarKeys: string[]; nestedKey: string; nestedFields: string[] },
+) {
+  for (const key of scalarKeys) {
+    if (prev[key] !== next[key]) return false;
+  }
+  const a = prev[nestedKey] || {};
+  const b = next[nestedKey] || {};
+  if (a === b) return true;
+  return nestedFields.every((key) => a[key] === b[key]);
+}

--- a/src/features/aircraft/trace/aircraftTraceModel.ts
+++ b/src/features/aircraft/trace/aircraftTraceModel.ts
@@ -126,9 +126,9 @@ export function createAircraftTraceTracker(options = {}) {
         const point = normalizeTracePoint(item, nowMs);
 
         if (!id || !point) {
-          const emitted = { ...item, traceHistory: [] };
-          if (lastResult[index] !== emitted) changedFromLast = true;
-          return emitted;
+          // No id to cache under → a fresh object every tick, always a change.
+          changedFromLast = true;
+          return { ...item, traceHistory: [] };
         }
 
         activeIds.add(id);


### PR DESCRIPTION
`/simplify` pass over the re-render perf work (#417/#418). Pure cleanup, no behavior change.

- **Dedupe the two `React.memo` comparators** — `AircraftRow` and `AirportRow` had the same field-compare scaffold copy-pasted. Extracted `rowPropsEqual(prev, next, { scalarKeys, nestedKey, nestedFields })`; field lists stay explicit at each call site, and the helper's doc comment flags that they must track the rendered fields (addresses the maintenance-coupling note from the altitude review).
- **`aircraftTraceModel.update()` no-id branch** — it built a fresh object every tick, so the `lastResult[index] !== emitted` check was always true; replaced with `changedFromLast = true` directly.

Skipped (out of scope / intentional): pre-existing `toFiniteNumber`/`toNumber`/`NumberWithUnit`/`traceLabel` duplication outside this diff; `emittedMatchesItem`'s key-count guard kept (it correctly handles a field disappearing between snapshots); the double-`filter` merge and upstream `aircraftWithDist` identity refactor are behavior-sensitive.

**Validation:** `next build` green; 100 test files pass; `tsc` clean on touched files.