### PR TITLE
feat: card-flip the browse list on re-sort (fixed slots, content flips in place)

### DIFF
--- a/src/components/sidebar/AircraftList.tsx
+++ b/src/components/sidebar/AircraftList.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import type { CSSProperties } from "react";
-import { useMemo, useRef } from "react";
-import { useListReorderMotion } from "@/animations/useListReorderMotion";
 import { getAircraftIdentity } from "../../features/airport/context/airportContextUiModel";
 import AircraftRow from "./AircraftRow";
+import CardFlipSlot from "./CardFlipSlot";
 
 export default function AircraftList({
   aircraft = [],
@@ -12,40 +10,32 @@ export default function AircraftList({
   selectedAircraftId = "",
   onSelectAircraft,
 }) {
-  const listRef = useRef<HTMLUListElement | null>(null);
-  const motionKey = useMemo(
-    () =>
-      aircraft
-        .map((item, index) => getAircraftIdentity(item) || `aircraft:${index}`)
-        .join("|"),
-    [aircraft],
-  );
-  useListReorderMotion(listRef, motionKey, { resetKey });
-
   return (
-    <ul
-      key={resetKey}
-      ref={listRef}
-      className="app-list-motion divide-y divide-atc-line"
-    >
+    <ul key={resetKey} className="app-list-motion divide-y divide-atc-line">
       {aircraft.map((item, index) => {
-        const aircraftId = getAircraftIdentity(item);
-        const motionStyle = {
-          "--motion-order": Math.min(index, 5),
-        } as CSSProperties;
+        // Position-keyed slot: when the list re-sorts, this slot's occupant
+        // changes and its content card-flips in place (CardFlipSlot) instead
+        // of the row sliding to a new row.
         return (
-          <li
-            key={aircraftId || index}
-            data-gsap-reorder-key={aircraftId || `aircraft:${index}`}
-            className="relative list-none [perspective:800px]"
-            style={motionStyle}
-          >
-            <AircraftRow
-              aircraft={item}
-              aircraftId={aircraftId}
-              selected={Boolean(aircraftId) && aircraftId === selectedAircraftId}
-              onSelectAircraft={onSelectAircraft}
-            />
+          <li key={index} className="relative list-none">
+            <CardFlipSlot
+              swapKey={getAircraftIdentity(item) || `aircraft:${index}`}
+              value={item}
+            >
+              {(displayed) => {
+                const aircraftId = getAircraftIdentity(displayed);
+                return (
+                  <AircraftRow
+                    aircraft={displayed}
+                    aircraftId={aircraftId}
+                    selected={
+                      Boolean(aircraftId) && aircraftId === selectedAircraftId
+                    }
+                    onSelectAircraft={onSelectAircraft}
+                  />
+                );
+              }}
+            </CardFlipSlot>
           </li>
         );
       })}

--- a/src/components/sidebar/CardFlipSlot.tsx
+++ b/src/components/sidebar/CardFlipSlot.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useContentSwap } from "@/components/effects/useContentSwap";
+
+// A fixed-position list slot whose CONTENT card-flips in place when its
+// occupant changes (i.e. the list re-sorts), instead of the row sliding to
+// a new row position. The hold-old → swap → reveal-new timing is handled by
+// useContentSwap; the 3D rotateX flip styling lives on `.card-flip-slot`'s
+// content-swap phase classes in style.css.
+//
+// Slots are keyed by POSITION (index), so a given slot's occupant only
+// changes on a real re-sort — scrolling a virtualized list changes which
+// indices render, not the occupant at a persisting index, so it never
+// triggers a spurious flip.
+export default function CardFlipSlot({
+  swapKey,
+  value,
+  disabled = false,
+  delaySeconds = 0,
+  children,
+}: {
+  swapKey: string;
+  value: unknown;
+  disabled?: boolean;
+  delaySeconds?: number;
+  children: (displayed: any) => ReactNode;
+}) {
+  const swap = useContentSwap({
+    identityKey: swapKey,
+    value,
+    delaySeconds,
+    disabled,
+  });
+  return (
+    <div
+      className={`content-swap card-flip-slot ${
+        swap.replacing ? "content-swap--replacing" : ""
+      }`}
+      style={swap.style}
+    >
+      <div className={`content-swap__content ${swap.contentPhaseClass}`}>
+        {children(swap.displayedValue)}
+      </div>
+    </div>
+  );
+}

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
-import { useListReorderMotion } from "@/animations/useListReorderMotion";
 import AircraftRow from "./AircraftRow";
 import AirportRow from "./AirportRow";
+import CardFlipSlot from "./CardFlipSlot";
 
 // Initial guess only — the actual row height is measured per element by
 // virtualizer.measureElement and may differ across breakpoints (the
@@ -35,7 +35,10 @@ export default function VirtualNearbyList({
     getScrollElement: () => parentRef.current,
     estimateSize: () => ROW_HEIGHT_ESTIMATE_PX,
     overscan: OVERSCAN_ROWS,
-    getItemKey: (index) => items[index]?.id ?? index,
+    // Position-keyed slots: a slot's occupant only changes on a real
+    // re-sort (scrolling changes which indices render, not items[index]),
+    // which is what drives the in-place card flip.
+    getItemKey: (index) => index,
   });
 
   // Track which item ids were present in the previous render so we can mark
@@ -71,11 +74,6 @@ export default function VirtualNearbyList({
 
   const virtualRows = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
-  const motionKey = useMemo(
-    () => items.map((item) => item.id).join("|"),
-    [items],
-  );
-  useListReorderMotion(parentRef, motionKey, { resetKey: resetSignal });
 
   return (
     <div ref={parentRef} className="app-virtual-list-motion h-full overflow-y-auto">
@@ -89,7 +87,7 @@ export default function VirtualNearbyList({
           return (
             <NearbyVirtualRow
               ref={virtualizer.measureElement}
-              key={virtualRow.key}
+              key={virtualRow.index}
               index={virtualRow.index}
               start={virtualRow.start}
               isFirst={isFirst}
@@ -150,30 +148,32 @@ function NearbyVirtualRow({
       data-index={index}
       className={`absolute left-0 top-0 w-full ${
         isFirst ? "" : "border-t border-atc-line"
-      } [perspective:800px]`}
+      }`}
       style={{
         transform: `translateY(${start}px)`,
       }}
     >
-      <div data-gsap-reorder-key={item.id}>
-        <div className={entering ? "nearby-row-enter" : ""}>
-          {item.type === "aircraft" ? (
-            <AircraftRow
-              aircraft={item.data}
-              aircraftId={item.id}
-              selected={item.id === selectedAircraftId}
-              onSelectAircraft={onSelectAircraft}
-            />
-          ) : (
-            <AirportRow
-              airport={item.data}
-              airportId={item.data?.icao}
-              selected={item.data?.icao === selectedAirportIcao}
-              onSelectAirport={onSelectAirport}
-            />
-          )}
-        </div>
-      </div>
+      <CardFlipSlot swapKey={item.id} value={item}>
+        {(displayed) => (
+          <div className={entering ? "nearby-row-enter" : ""}>
+            {displayed.type === "aircraft" ? (
+              <AircraftRow
+                aircraft={displayed.data}
+                aircraftId={displayed.id}
+                selected={displayed.id === selectedAircraftId}
+                onSelectAircraft={onSelectAircraft}
+              />
+            ) : (
+              <AirportRow
+                airport={displayed.data}
+                airportId={displayed.data?.icao}
+                selected={displayed.data?.icao === selectedAirportIcao}
+                onSelectAirport={onSelectAirport}
+              />
+            )}
+          </div>
+        )}
+      </CardFlipSlot>
     </div>
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -4279,6 +4279,68 @@ body {
     }
 }
 
+/* Card-flip variant for the re-sortable browse list. The slot stays put;
+   when its occupant changes the content rotates out around its horizontal
+   axis, the value is swapped while edge-on (handled by useContentSwap),
+   then the new content rotates back in — a card flip in place rather than
+   the row sliding to a new position. Scoped to .card-flip-slot so the
+   pinned-row content swap keeps its plain cross-fade. */
+.card-flip-slot {
+    perspective: 720px;
+}
+
+.card-flip-slot .content-swap__content {
+    transform-style: preserve-3d;
+    backface-visibility: hidden;
+    transform-origin: center center;
+    will-change: transform, opacity;
+}
+
+.card-flip-slot .content-swap__content--erasing {
+    animation: card-flip-out 150ms ease-in var(--content-swap-delay, 0s) both;
+}
+
+.card-flip-slot .content-swap__content--hidden {
+    transform: rotateX(90deg);
+    opacity: 0;
+}
+
+.card-flip-slot .content-swap__content--revealing {
+    animation: card-flip-in 200ms ease-out both;
+}
+
+@keyframes card-flip-out {
+    from {
+        transform: rotateX(0deg);
+        opacity: 1;
+    }
+    to {
+        transform: rotateX(90deg);
+        opacity: 0;
+    }
+}
+
+@keyframes card-flip-in {
+    from {
+        transform: rotateX(-90deg);
+        opacity: 0;
+    }
+    to {
+        transform: rotateX(0deg);
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .card-flip-slot .content-swap__content--erasing,
+    .card-flip-slot .content-swap__content--revealing {
+        animation: none;
+    }
+    .card-flip-slot .content-swap__content--hidden {
+        transform: none;
+    }
+}
+
 @keyframes preview-text-settle {
     0%,
     40% {


### PR DESCRIPTION
Replaces the slide-to-new-row reorder with an in-place card flip, per request: when the list re-sorts, a slot stays put and its **content** flips (rotateX out → swap while edge-on → rotateX in) instead of the row travelling to a new position.

### How
- **`CardFlipSlot`** wraps each row and drives the swap through the existing `useContentSwap` engine (hold-old → swap → reveal-new). The 3D flip is a `.card-flip-slot` variant of the `content-swap` phase classes in `style.css`; the pinned-row swap keeps its plain cross-fade.
- **`VirtualNearbyList` + `AircraftList`** now key slots by **index** instead of identity. The key realization: with index keys a slot's occupant only changes on a real re-sort — scrolling a virtualized list changes *which indices render*, not `items[index]` — so scrolling never triggers a spurious flip and no `isScrolling` guard is needed.
- Dropped `useListReorderMotion` from these two lists (still used by the separate route-endpoint airport list in `AircraftTable`).
- Respects `prefers-reduced-motion` (instant swap, no flip).

### ⚠️ Needs a visual once-over before merge
This is a transient animation — `next build` is green, 100 tests pass, and `tsc` is clean, but I can't meaningfully screenshot a mid-flip frame (and the sandbox dev server is flaky), so please preview it: open an airport's traffic list and watch a re-sort, plus scroll the list (should NOT flip on scroll). Things to eyeball: flip timing/feel, that fast re-sorts don't stutter, and that selection + NumberFlow still read correctly through the flip.

If the feel needs tuning, the knobs are the `ERASE_MS`/`HOLD_MS`/`REVEAL_MS` timers in `useContentSwap.ts` and the `card-flip-out`/`card-flip-in` durations/easing in `style.css`.