### PR TITLE
Improve list swap motion and PWA scope

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,7 @@ export const metadata = {
   },
   description: SITE_DESCRIPTION,
   applicationName: SITE_NAME,
+  manifest: "/manifest.webmanifest",
   keywords: SITE_KEYWORDS,
   authors: [{ name: "Chen Liang" }],
   creator: "Chen Liang",

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,38 @@
+import type { MetadataRoute } from "next";
+import {
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_TITLE,
+} from "@/config/site";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    id: "/",
+    name: SITE_TITLE,
+    short_name: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    lang: "en",
+    dir: "ltr",
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    display_override: ["standalone", "browser"],
+    background_color: "#f2f0ea",
+    theme_color: "#f2f0ea",
+    categories: ["travel", "navigation", "utilities"],
+    icons: [
+      {
+        src: "/icon.svg",
+        sizes: "256x256",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/apple-icon.png",
+        sizes: "180x180",
+        type: "image/png",
+        purpose: "any",
+      },
+    ],
+  };
+}

--- a/src/components/effects/useContentSwap.ts
+++ b/src/components/effects/useContentSwap.ts
@@ -94,8 +94,10 @@ export function useContentSwap({
 
   return {
     displayedValue,
+    phase,
     replacing: phase !== "idle",
     contentPhaseClass,
+    replaceDelaySeconds: replaceDelay,
     style: { "--content-swap-delay": `${replaceDelay}s` },
   };
 }

--- a/src/components/sidebar/CardFlipSlot.tsx
+++ b/src/components/sidebar/CardFlipSlot.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { useLayoutEffect, useRef } from "react";
+import gsap from "gsap";
+import { EASE } from "@/animations/gsap";
 import { useContentSwap } from "@/components/effects/useContentSwap";
 
-// A fixed-position list slot whose CONTENT card-flips in place when its
-// occupant changes (i.e. the list re-sorts), instead of the row sliding to
-// a new row position. The hold-old → swap → reveal-new timing is handled by
-// useContentSwap; the 3D rotateX flip styling lives on `.card-flip-slot`'s
-// content-swap phase classes in style.css.
+// A fixed-position list slot whose CONTENT swaps in place when its occupant
+// changes (i.e. the list re-sorts), instead of the row sliding to a new row
+// position. useContentSwap owns the hold-old -> swap -> reveal-new timing;
+// GSAP only animates autoAlpha so it does not fight row positioning transforms.
 //
 // Slots are keyed by POSITION (index), so a given slot's occupant only
 // changes on a real re-sort — scrolling a virtualized list changes which
@@ -26,12 +28,60 @@ export default function CardFlipSlot({
   delaySeconds?: number;
   children: (displayed: any) => ReactNode;
 }) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const swap = useContentSwap({
     identityKey: swapKey,
     value,
     delaySeconds,
     disabled,
   });
+
+  useLayoutEffect(() => {
+    const target = contentRef.current;
+    if (!target) return undefined;
+
+    gsap.killTweensOf(target);
+
+    if (disabled) {
+      gsap.set(target, { clearProps: "opacity,visibility" });
+      return undefined;
+    }
+
+    if (swap.phase === "erasing") {
+      gsap.fromTo(
+        target,
+        { autoAlpha: 1 },
+        {
+          autoAlpha: 0,
+          delay: swap.replaceDelaySeconds,
+          duration: 0.14,
+          ease: EASE.out,
+          overwrite: true,
+        },
+      );
+    } else if (swap.phase === "hidden") {
+      gsap.set(target, { autoAlpha: 0 });
+    } else if (swap.phase === "revealing") {
+      gsap.fromTo(
+        target,
+        { autoAlpha: 0 },
+        {
+          autoAlpha: 1,
+          clearProps: "opacity,visibility",
+          duration: 0.18,
+          ease: EASE.out,
+          overwrite: true,
+        },
+      );
+    } else {
+      gsap.set(target, { clearProps: "opacity,visibility" });
+    }
+
+    return () => {
+      gsap.killTweensOf(target);
+    };
+  }, [disabled, swap.phase, swap.replaceDelaySeconds]);
+
   return (
     <div
       className={`content-swap card-flip-slot ${
@@ -39,7 +89,10 @@ export default function CardFlipSlot({
       }`}
       style={swap.style}
     >
-      <div className={`content-swap__content ${swap.contentPhaseClass}`}>
+      <div
+        ref={contentRef}
+        className={`content-swap__content ${swap.contentPhaseClass}`}
+      >
         {children(swap.displayedValue)}
       </div>
     </div>

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -153,7 +153,11 @@ function NearbyVirtualRow({
         transform: `translateY(${start}px)`,
       }}
     >
-      <CardFlipSlot swapKey={item.id} value={item}>
+      <CardFlipSlot
+        swapKey={item.id}
+        value={item}
+        disabled={shouldAnimateEnter}
+      >
         {(displayed) => (
           <div className={entering ? "nearby-row-enter" : ""}>
             {displayed.type === "aircraft" ? (

--- a/src/style.css
+++ b/src/style.css
@@ -4206,7 +4206,7 @@ body {
     --content-swap-delay: 0s;
 }
 
-.content-swap__content {
+.content-swap--replacing .content-swap__content {
     will-change: opacity;
 }
 
@@ -4279,65 +4279,26 @@ body {
     }
 }
 
-/* Card-flip variant for the re-sortable browse list. The slot stays put;
-   when its occupant changes the content rotates out around its horizontal
-   axis, the value is swapped while edge-on (handled by useContentSwap),
-   then the new content rotates back in — a card flip in place rather than
-   the row sliding to a new position. Scoped to .card-flip-slot so the
-   pinned-row content swap keeps its plain cross-fade. */
-.card-flip-slot {
-    perspective: 720px;
-}
-
-.card-flip-slot .content-swap__content {
-    transform-style: preserve-3d;
-    backface-visibility: hidden;
-    transform-origin: center center;
-    will-change: transform, opacity;
-}
-
+/* Re-sortable browse list swap. The slot stays put; when its occupant changes
+   GSAP fades the content out/in while useContentSwap swaps the value between
+   phases. This avoids transform contention with virtualized row positioning
+   and nearby-row enter animations. */
 .card-flip-slot .content-swap__content--erasing {
-    animation: card-flip-out 150ms ease-in var(--content-swap-delay, 0s) both;
+    animation: none;
 }
 
 .card-flip-slot .content-swap__content--hidden {
-    transform: rotateX(90deg);
     opacity: 0;
 }
 
 .card-flip-slot .content-swap__content--revealing {
-    animation: card-flip-in 200ms ease-out both;
-}
-
-@keyframes card-flip-out {
-    from {
-        transform: rotateX(0deg);
-        opacity: 1;
-    }
-    to {
-        transform: rotateX(90deg);
-        opacity: 0;
-    }
-}
-
-@keyframes card-flip-in {
-    from {
-        transform: rotateX(-90deg);
-        opacity: 0;
-    }
-    to {
-        transform: rotateX(0deg);
-        opacity: 1;
-    }
+    animation: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
     .card-flip-slot .content-swap__content--erasing,
     .card-flip-slot .content-swap__content--revealing {
         animation: none;
-    }
-    .card-flip-slot .content-swap__content--hidden {
-        transform: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the re-sortable list card 3D flip with GSAP-driven `autoAlpha` content swaps so row positioning transforms do not conflict with card replacement animation.
- Limit `will-change` to active replacement phases and disable slot swap animation while virtual rows are running their enter animation.
- Add an explicit web app manifest with `id`, `start_url`, and `scope` set to `/`, then link it from root metadata so iOS/Chrome iOS home-screen installs keep ADSBao navigation inside the standalone app shell.

## Root Cause
- The list swap animation was rotating content with CSS 3D transforms while the virtualized row layer also used transforms for positioning, so live re-sorts could stack animation work on the same frame.
- ADSBao relied on legacy Apple web-app meta tags but had no Web App Manifest. When installed from or navigated through a deep airport route, iOS could treat `/` as outside the installed app scope and open the home link in browser chrome instead of the standalone web app.

## Validation
- `pnpm lint` (passes; existing warnings only)
- `pnpm test` (100 test files passed)
- `pnpm build` (passes; confirms `/manifest.webmanifest` static route)
- Local manifest check: `/manifest.webmanifest` returns `id: "/"`, `start_url: "/"`, `scope: "/"`, `display: "standalone"`
- Local airport page check: `/airport/KBOS` renders `<link rel="manifest" href="/manifest.webmanifest">`
- Browser interaction check: live KBOS list replacement phase uses `transform: none`, animated opacity, and returns `will-change` to `auto` after completion
