### PR TITLE
[codex] Optimize list reorder motion

### DIFF
--- a/src/animations/useListReorderMotion.ts
+++ b/src/animations/useListReorderMotion.ts
@@ -10,8 +10,35 @@ const DEFAULT_ITEM_SELECTOR = "[data-gsap-reorder-key]";
 type ListReorderMotionOptions = {
   disabled?: boolean;
   itemSelector?: string;
+  maxAnimatedItems?: number;
+  viewportMarginPx?: number;
   resetKey?: unknown;
 };
+
+type ReorderDelta = {
+  x: number;
+  y: number;
+};
+
+const DEFAULT_MAX_ANIMATED_ITEMS = 40;
+const DEFAULT_VIEWPORT_MARGIN_PX = 96;
+
+function clearMotionTargets(elements: HTMLElement[]) {
+  if (elements.length === 0) return;
+  gsap.killTweensOf(elements);
+  gsap.set(elements, { clearProps: "transform,willChange" });
+}
+
+function isNearViewport(rect: DOMRect, marginPx: number) {
+  const height = window.innerHeight || document.documentElement.clientHeight;
+  const width = window.innerWidth || document.documentElement.clientWidth;
+  return (
+    rect.bottom >= -marginPx &&
+    rect.top <= height + marginPx &&
+    rect.right >= -marginPx &&
+    rect.left <= width + marginPx
+  );
+}
 
 export function useListReorderMotion<T extends HTMLElement>(
   containerRef: RefObject<T | null>,
@@ -19,15 +46,28 @@ export function useListReorderMotion<T extends HTMLElement>(
   {
     disabled = false,
     itemSelector = DEFAULT_ITEM_SELECTOR,
+    maxAnimatedItems = DEFAULT_MAX_ANIMATED_ITEMS,
+    viewportMarginPx = DEFAULT_VIEWPORT_MARGIN_PX,
     resetKey,
   }: ListReorderMotionOptions = {},
 ) {
   const previousRectsRef = useRef<Map<string, DOMRect>>(new Map());
   const previousResetKeyRef = useRef(resetKey);
+  const activeElementsRef = useRef<HTMLElement[]>([]);
+
+  useLayoutEffect(() => {
+    return () => {
+      clearMotionTargets(activeElementsRef.current);
+      activeElementsRef.current = [];
+    };
+  }, []);
 
   useLayoutEffect(() => {
     const container = containerRef.current;
     if (!container) return undefined;
+
+    clearMotionTargets(activeElementsRef.current);
+    activeElementsRef.current = [];
 
     const elements = Array.from(
       container.querySelectorAll<HTMLElement>(itemSelector),
@@ -49,46 +89,62 @@ export function useListReorderMotion<T extends HTMLElement>(
       prefersReducedMotion ||
       previousRectsRef.current.size === 0
     ) {
-      if (elements.length > 0) {
-        gsap.killTweensOf(elements);
-        gsap.set(elements, { clearProps: "transform" });
-      }
       previousRectsRef.current = nextRects;
       return undefined;
     }
 
+    const movingElements: HTMLElement[] = [];
+    const deltaByElement = new WeakMap<HTMLElement, ReorderDelta>();
+
     for (const element of elements) {
+      if (movingElements.length >= maxAnimatedItems) break;
       const key = element.dataset.gsapReorderKey;
       if (!key) continue;
       const previousRect = previousRectsRef.current.get(key);
       const nextRect = nextRects.get(key);
       if (!previousRect || !nextRect) continue;
+      if (!isNearViewport(nextRect, viewportMarginPx)) continue;
 
       const deltaX = previousRect.left - nextRect.left;
       const deltaY = previousRect.top - nextRect.top;
       if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) continue;
 
-      gsap.fromTo(
-        element,
-        { x: deltaX, y: deltaY },
-        {
-          x: 0,
-          y: 0,
-          clearProps: "transform",
-          duration: MOTION.slow,
-          ease: EASE.snap,
-          overwrite: "auto",
-        },
-      );
+      movingElements.push(element);
+      deltaByElement.set(element, { x: deltaX, y: deltaY });
     }
 
     previousRectsRef.current = nextRects;
+    activeElementsRef.current = movingElements;
 
-    return () => {
-      if (elements.length > 0) {
-        gsap.killTweensOf(elements);
-        gsap.set(elements, { clearProps: "transform" });
-      }
-    };
-  }, [containerRef, disabled, itemSelector, resetKey, triggerKey]);
+    if (movingElements.length === 0) return undefined;
+
+    gsap.set(movingElements, {
+      willChange: "transform",
+      x: (_index, target) => deltaByElement.get(target)?.x ?? 0,
+      y: (_index, target) => deltaByElement.get(target)?.y ?? 0,
+    });
+    gsap.to(movingElements, {
+      x: 0,
+      y: 0,
+      clearProps: "transform,willChange",
+      duration: MOTION.slow,
+      ease: EASE.snap,
+      overwrite: true,
+      onComplete: () => {
+        activeElementsRef.current = activeElementsRef.current.filter(
+          (element) => !movingElements.includes(element),
+        );
+      },
+    });
+
+    return undefined;
+  }, [
+    containerRef,
+    disabled,
+    itemSelector,
+    maxAnimatedItems,
+    resetKey,
+    triggerKey,
+    viewportMarginPx,
+  ]);
 }

--- a/src/components/effects/useContentSwap.ts
+++ b/src/components/effects/useContentSwap.ts
@@ -4,9 +4,9 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
 
 const ERASE_MS = 140;
-const HOLD_MS = 100;
-const REVEAL_MS = 220;
-const SETTLE_MS = 30;
+const HOLD_MS = 40;
+const REVEAL_MS = 180;
+const SETTLE_MS = 20;
 
 export function useContentSwap({
   identityKey,
@@ -45,7 +45,17 @@ export function useContentSwap({
   useEffect(() => () => clearTimers(), [clearTimers]);
 
   useLayoutEffect(() => {
-    if (identityKey === lastKeyRef.current) return undefined;
+    if (identityKey === lastKeyRef.current) {
+      if ((disabled || reducedMotion) && phaseRef.current !== "idle") {
+        const nextValue = liveValueRef.current;
+        clearTimers();
+        setDisplayedValue(nextValue);
+        previousValueRef.current = nextValue;
+        setReplaceDelay(0);
+        setPhase("idle");
+      }
+      return undefined;
+    }
     const previousValue = previousValueRef.current;
     lastKeyRef.current = identityKey;
     clearTimers();

--- a/src/components/sidebar/AircraftList.tsx
+++ b/src/components/sidebar/AircraftList.tsx
@@ -22,14 +22,16 @@ export default function AircraftList({
               swapKey={getAircraftIdentity(item) || `aircraft:${index}`}
               value={item}
             >
-              {(displayed) => {
+              {(displayed, swapState) => {
                 const aircraftId = getAircraftIdentity(displayed);
                 return (
                   <AircraftRow
                     aircraft={displayed}
                     aircraftId={aircraftId}
                     selected={
-                      Boolean(aircraftId) && aircraftId === selectedAircraftId
+                      swapState.phase !== "erasing" &&
+                      Boolean(aircraftId) &&
+                      aircraftId === selectedAircraftId
                     }
                     onSelectAircraft={onSelectAircraft}
                   />

--- a/src/components/sidebar/CardFlipSlot.tsx
+++ b/src/components/sidebar/CardFlipSlot.tsx
@@ -26,7 +26,10 @@ export default function CardFlipSlot({
   value: unknown;
   disabled?: boolean;
   delaySeconds?: number;
-  children: (displayed: any) => ReactNode;
+  children: (
+    displayed: any,
+    state: { phase: string; replacing: boolean },
+  ) => ReactNode;
 }) {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const swap = useContentSwap({
@@ -93,7 +96,10 @@ export default function CardFlipSlot({
         ref={contentRef}
         className={`content-swap__content ${swap.contentPhaseClass}`}
       >
-        {children(swap.displayedValue)}
+        {children(swap.displayedValue, {
+          phase: swap.phase,
+          replacing: swap.replacing,
+        })}
       </div>
     </div>
   );

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -156,15 +156,18 @@ function NearbyVirtualRow({
       <CardFlipSlot
         swapKey={item.id}
         value={item}
-        disabled={shouldAnimateEnter}
+        disabled={entering || shouldAnimateEnter}
       >
-        {(displayed) => (
+        {(displayed, swapState) => (
           <div className={entering ? "nearby-row-enter" : ""}>
             {displayed.type === "aircraft" ? (
               <AircraftRow
                 aircraft={displayed.data}
                 aircraftId={displayed.id}
-                selected={displayed.id === selectedAircraftId}
+                selected={
+                  swapState.phase !== "erasing" &&
+                  displayed.id === selectedAircraftId
+                }
                 onSelectAircraft={onSelectAircraft}
               />
             ) : (


### PR DESCRIPTION
## Summary
- Batch GSAP list reorder motion so moved rows animate together, only near the viewport, and clear `transform` / `will-change` after completion.
- Tighten content swap timing and interruption cleanup so fade phases do not linger or conflict with enter animations.
- Keep clicked aircraft from briefly rendering the selected glass capsule during the erase phase; the row now flips directly and applies selected styling after the swap settles.

## Validation
- `/opt/homebrew/bin/pnpm lint` (passes with existing warnings)
- `/opt/homebrew/bin/pnpm build`
- Local browser check on `http://localhost:3000/airport/KBOS` for desktop virtual list and mobile overlay list interactions
