### PR TITLE
fix: render full OurAirports airport names over truncated OpenAIP data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.4.3",
+  "version": "2.4.4",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
@@ -10,6 +10,7 @@
     "knip": "knip",
     "ff": "tsx scripts/feature-flags.ts",
     "import:facilities": "tsx scripts/import-airport-facilities.ts",
+    "import:airports": "tsx scripts/import-airports.ts",
     "generate:watching-spots": "tsx scripts/generate-candidate-watching-spots.ts",
     "import:runways": "tsx scripts/import-runway-geometries.ts",
     "test": "tsx scripts/run-tests.ts",

--- a/scripts/import-airports.ts
+++ b/scripts/import-airports.ts
@@ -1,0 +1,170 @@
+import { createClient } from "@supabase/supabase-js";
+
+const AIRPORTS_URL =
+  process.env.OURAIRPORTS_AIRPORTS_URL ||
+  "https://davidmegginson.github.io/ourairports-data/airports.csv";
+
+const AIRPORTS_TABLE = "airports";
+const CHUNK_SIZE = 1000;
+
+const parseCsvRows = (text: string) => {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let quoted = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+
+    if (quoted) {
+      if (char === "\"" && next === "\"") {
+        field += "\"";
+        index += 1;
+      } else if (char === "\"") {
+        quoted = false;
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      quoted = true;
+    } else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else if (char !== "\r") {
+      field += char;
+    }
+  }
+
+  if (field || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  const [header = [], ...records] = rows;
+  return records
+    .filter((record) => record.length > 1)
+    .map((record) =>
+      Object.fromEntries(header.map((key, index) => [key, record[index] ?? ""])),
+    );
+};
+
+const numberOrNull = (value: unknown) => {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const numeric = Number(text);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const normalizeIdent = (value: unknown) =>
+  String(value ?? "")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+const mapAirportRow = (row: Record<string, string>) => {
+  const ident = normalizeIdent(row.ident);
+  const name = String(row.name || "").trim();
+  // Names are the whole point of this table; skip rows that can't be keyed or
+  // that carry no usable name.
+  if (!ident || !name) return null;
+  return {
+    ident,
+    ourairports_id: numberOrNull(row.id),
+    type: String(row.type || "").trim(),
+    name,
+    latitude_deg: numberOrNull(row.latitude_deg),
+    longitude_deg: numberOrNull(row.longitude_deg),
+    iso_country: String(row.iso_country || "").trim().toUpperCase(),
+    municipality: String(row.municipality || "").trim(),
+    icao_code: normalizeIdent(row.icao_code),
+    iata_code: normalizeIdent(row.iata_code),
+  };
+};
+
+const requireEnv = (name: string, value: string | undefined) => {
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
+
+async function fetchCsvRows(url: string) {
+  const response = await fetch(url, {
+    headers: { Accept: "text/csv" },
+  });
+  if (!response.ok) {
+    throw new Error(`OurAirports download failed: ${url} HTTP ${response.status}`);
+  }
+  return parseCsvRows(await response.text());
+}
+
+async function replaceRows({
+  supabase,
+  rows,
+}: {
+  supabase: any;
+  rows: Record<string, any>[];
+}) {
+  console.log(`[import-airports] Clearing ${AIRPORTS_TABLE}`);
+  const tableQuery = supabase.from(AIRPORTS_TABLE) as any;
+  // `ident` is the text primary key and is never empty, so this clears the table.
+  const { error: deleteError } = await tableQuery.delete().neq("ident", "");
+  if (deleteError) throw new Error(`${AIRPORTS_TABLE} clear failed: ${deleteError.message}`);
+
+  let imported = 0;
+  for (let index = 0; index < rows.length; index += CHUNK_SIZE) {
+    const chunk = rows.slice(index, index + CHUNK_SIZE);
+    const { error } = await tableQuery.upsert(chunk, { onConflict: "ident" });
+    if (error) throw new Error(`${AIRPORTS_TABLE} upsert failed: ${error.message}`);
+    imported += chunk.length;
+    console.log(`[import-airports] Imported ${imported}/${rows.length} ${AIRPORTS_TABLE}`);
+  }
+}
+
+async function main() {
+  const supabaseUrl = requireEnv(
+    "NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL",
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  );
+  const serviceKey = requireEnv(
+    "SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SECRET_KEY",
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY,
+  );
+
+  console.log(`[import-airports] Fetching ${AIRPORTS_URL}`);
+  const airportRows = (await fetchCsvRows(AIRPORTS_URL))
+    .map(mapAirportRow)
+    .filter(Boolean) as Record<string, any>[];
+
+  // De-duplicate on the primary key so a single upsert chunk never carries two
+  // rows with the same ident (OurAirports occasionally repeats identifiers).
+  const byIdent = new Map<string, Record<string, any>>();
+  for (const row of airportRows) byIdent.set(row.ident, row);
+  const dedupedRows = [...byIdent.values()];
+
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: {
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+      persistSession: false,
+    },
+  });
+
+  await replaceRows({ supabase, rows: dedupedRows });
+
+  console.log(
+    `[import-airports] Done. Imported ${dedupedRows.length} airports.`,
+  );
+}
+
+main().catch((error) => {
+  console.error("[import-airports] failed:", error);
+  process.exit(1);
+});

--- a/src/app/api/dao/airportNames.dao.test.ts
+++ b/src/app/api/dao/airportNames.dao.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+
+import { createAirportNameRepositoryFromEnv } from "./airportNames.dao";
+
+const AIRPORTS_TABLE = "airports";
+
+function createFakeSupabaseClient(tableData: Record<string, any[]> = {}) {
+  const calls: Array<Record<string, any>> = [];
+
+  const createQuery = (table: string) => {
+    const query: Record<string, any> = {
+      select(columns: string) {
+        calls.push({ type: "select", table, columns });
+        return query;
+      },
+      or(filter: string) {
+        calls.push({ type: "or", table, filter });
+        return query;
+      },
+      then(resolve: (value: any) => void) {
+        return Promise.resolve({ data: tableData[table] || [], error: null }).then(resolve);
+      },
+    };
+    return query;
+  };
+
+  const createClientImpl = (supabaseUrl: string, supabaseKey: string, options: any) => {
+    calls.push({ type: "createClient", supabaseUrl, supabaseKey, options });
+    return {
+      from(table: string) {
+        calls.push({ type: "from", table });
+        return createQuery(table);
+      },
+    };
+  };
+
+  return { calls, createClientImpl };
+}
+
+const repositoryWith = (rows: any[], createClientImpl: any) =>
+  createAirportNameRepositoryFromEnv({
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SECRET_KEY: "sb_secret_test",
+    },
+    createClientImpl,
+  });
+
+// readNamesByIdents builds an ICAO/ident-keyed Map and skips empty names.
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient({
+    [AIRPORTS_TABLE]: [
+      {
+        ident: "KBOS",
+        icao_code: "KBOS",
+        iata_code: "BOS",
+        name: "General Edward Lawrence Logan International Airport",
+        municipality: "Boston",
+      },
+      // Empty-name row is dropped entirely.
+      { ident: "KZZZ", icao_code: "KZZZ", iata_code: "", name: "   ", municipality: "" },
+    ],
+  });
+  const repository = repositoryWith([], createClientImpl);
+
+  const byIdent = await repository.readNamesByIdents([" kbos ", "kzzz"]);
+
+  assert.equal(byIdent.size, 1);
+  assert.deepEqual(byIdent.get("KBOS"), {
+    name: "General Edward Lawrence Logan International Airport",
+    city: "Boston",
+  });
+  // The query selects from the airports table and filters by both columns.
+  const orCall = calls.find((call) => call.type === "or");
+  assert.ok(orCall, "expected an or() filter call");
+  assert.equal(orCall.filter, "icao_code.in.(KBOS,KZZZ),ident.in.(KBOS,KZZZ)");
+}
+
+// Empty input short-circuits without touching the client.
+{
+  const { calls, createClientImpl } = createFakeSupabaseClient();
+  const repository = repositoryWith([], createClientImpl);
+  const byIdent = await repository.readNamesByIdents([]);
+  assert.equal(byIdent.size, 0);
+  assert.ok(!calls.some((call) => call.type === "from"), "should not query on empty input");
+}
+
+// getNameByIdent resolves a single normalized identifier.
+{
+  const { createClientImpl } = createFakeSupabaseClient({
+    [AIRPORTS_TABLE]: [
+      { ident: "EGLL", icao_code: "EGLL", iata_code: "LHR", name: "London Heathrow Airport", municipality: "London" },
+    ],
+  });
+  const repository = repositoryWith([], createClientImpl);
+  const match = await repository.getNameByIdent("egll");
+  assert.deepEqual(match, { name: "London Heathrow Airport", city: "London" });
+}
+
+console.log("airportNames.dao.test.ts passed");

--- a/src/app/api/dao/airportNames.dao.ts
+++ b/src/app/api/dao/airportNames.dao.ts
@@ -1,0 +1,101 @@
+import { createServerSupabaseClient } from "./supabaseClient";
+
+type AirportNameRecord = Record<string, any>;
+
+// OurAirports static reference table, restored to provide the full, mixed-case
+// airport name that OpenAIP truncates. Keyed by identifier; we read names only.
+const AIRPORTS_TABLE = "airports";
+
+const SELECT_COLUMNS = ["ident", "icao_code", "iata_code", "name", "municipality"].join(",");
+
+const normalizeIdent = (value: unknown) =>
+  String(value || "")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+const mapAirportNameRow = (row: AirportNameRecord | null | undefined) => {
+  if (!row) return null;
+  const name = String(row.name || "").trim();
+  if (!name) return null;
+  return {
+    ident: normalizeIdent(row.ident),
+    icao: normalizeIdent(row.icao_code),
+    iata: normalizeIdent(row.iata_code),
+    name,
+    city: String(row.municipality || "").trim(),
+  };
+};
+
+function createAirportNameRepository({
+  supabaseUrl,
+  supabaseKey,
+  createClientImpl,
+}: {
+  supabaseUrl?: string;
+  supabaseKey?: string;
+  createClientImpl?: any;
+} = {}) {
+  const client = createServerSupabaseClient({
+    supabaseUrl,
+    supabaseKey,
+    createClientImpl,
+  });
+  if (!client) return null;
+
+  // Returns a Map keyed by every identifier a caller might hold (ICAO code and
+  // OurAirports `ident`, which usually coincide) so a lookup by the OpenAIP
+  // ICAO resolves regardless of which column carried the match.
+  const readNamesByIdents = async (idents: unknown[] = []) => {
+    const normalizedIdents = [...new Set(idents.map(normalizeIdent).filter(Boolean))];
+    const byIdent = new Map<string, { name: string; city: string }>();
+    if (normalizedIdents.length === 0) return byIdent;
+
+    const list = normalizedIdents.join(",");
+    const { data, error } = await client
+      .from(AIRPORTS_TABLE)
+      .select(SELECT_COLUMNS)
+      .or(`icao_code.in.(${list}),ident.in.(${list})`);
+
+    if (error) {
+      throw new Error(`Airport name read failed (${error.message})`);
+    }
+
+    for (const row of data || []) {
+      const mapped = mapAirportNameRow(row);
+      if (!mapped) continue;
+      const value = { name: mapped.name, city: mapped.city };
+      if (mapped.icao) byIdent.set(mapped.icao, value);
+      // `ident` only fills a slot the ICAO code didn't already claim, so an
+      // exact ICAO match always wins over an ident-only collision.
+      if (mapped.ident && !byIdent.has(mapped.ident)) byIdent.set(mapped.ident, value);
+    }
+    return byIdent;
+  };
+
+  return {
+    async getNameByIdent(ident: unknown) {
+      const byIdent = await readNamesByIdents([ident]);
+      return byIdent.get(normalizeIdent(ident)) || null;
+    },
+    readNamesByIdents,
+  };
+}
+
+export function createAirportNameRepositoryFromEnv({
+  env = process.env,
+  createClientImpl,
+}: {
+  env?: Record<string, string | undefined>;
+  createClientImpl?: any;
+} = {}) {
+  return createAirportNameRepository({
+    supabaseUrl: env.NEXT_PUBLIC_SUPABASE_URL || env.SUPABASE_URL,
+    supabaseKey:
+      env.SUPABASE_SECRET_KEY ||
+      env.SUPABASE_SERVICE_ROLE_KEY ||
+      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
+      env.SUPABASE_PUBLISHABLE_KEY,
+    createClientImpl,
+  });
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -7,6 +7,18 @@
 
 export const CHANGELOG = [
   {
+    version: "v2.4.4",
+    kind: "patch",
+    title: "Full airport names",
+    summary:
+      "Airport names now render in full instead of OpenAIP's truncated, all-caps form.",
+    highlights: [
+      "Restored an OurAirports name table to override OpenAIP's ~40-character truncated names",
+      "Airport headers and nearby lists show full mixed-case names (e.g. \"Boston Logan International Airport\")",
+      "Backfills the city label when OpenAIP leaves it blank",
+    ],
+  },
+  {
     version: "v2.4.3",
     kind: "patch",
     title: "Manrope typography",

--- a/src/features/airport/directory/airportNameModel.test.ts
+++ b/src/features/airport/directory/airportNameModel.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+
+import { applyOurAirportsAirport, chooseAirportName } from "./airportNameModel";
+
+// chooseAirportName: OurAirports wins when present, else the OpenAIP value.
+{
+  assert.equal(
+    chooseAirportName(
+      "GENERAL EDWARD LAWRENCE LOGAN INTERNATIO",
+      "General Edward Lawrence Logan International Airport",
+    ),
+    "General Edward Lawrence Logan International Airport",
+  );
+}
+
+{
+  // No OurAirports name -> keep the OpenAIP value verbatim.
+  assert.equal(chooseAirportName("KBOS", ""), "KBOS");
+  assert.equal(chooseAirportName("KBOS", "   "), "KBOS");
+  assert.equal(chooseAirportName("KBOS", null), "KBOS");
+}
+
+// applyOurAirportsAirport: overrides the truncated name and fills an empty city.
+{
+  const airport = {
+    icao: "KBOS",
+    name: "GENERAL EDWARD LAWRENCE LOGAN INTERNATIO",
+    city: "",
+    country: "US",
+  };
+  const merged = applyOurAirportsAirport(airport, {
+    name: "General Edward Lawrence Logan International Airport",
+    city: "Boston",
+  });
+  assert.equal(merged.name, "General Edward Lawrence Logan International Airport");
+  assert.equal(merged.city, "Boston");
+  // Untouched fields survive.
+  assert.equal(merged.country, "US");
+  assert.equal(merged.icao, "KBOS");
+}
+
+{
+  // A city OpenAIP already provided is never clobbered by the override.
+  const merged = applyOurAirportsAirport(
+    { icao: "KBOS", name: "OLD", city: "Existing City" },
+    { name: "New Name", city: "Boston" },
+  );
+  assert.equal(merged.city, "Existing City");
+  assert.equal(merged.name, "New Name");
+}
+
+{
+  // No override -> the record passes through unchanged (same reference).
+  const airport = { icao: "KBOS", name: "GENERAL EDWARD LAWRENCE LOGAN INTERNATIO" };
+  assert.equal(applyOurAirportsAirport(airport, null), airport);
+  assert.equal(applyOurAirportsAirport(airport, undefined), airport);
+}
+
+{
+  // Null airport is tolerated.
+  assert.equal(applyOurAirportsAirport(null, { name: "x" }), null);
+}
+
+console.log("airportNameModel.test.ts passed");

--- a/src/features/airport/directory/airportNameModel.ts
+++ b/src/features/airport/directory/airportNameModel.ts
@@ -1,0 +1,30 @@
+// Decides how an OurAirports override (full, mixed-case name + municipality)
+// combines with a normalized OpenAIP airport record. OpenAIP names are
+// pre-uppercased and truncated to ~40 chars, so when OurAirports has a name we
+// prefer it; otherwise the OpenAIP value (which already falls back to the
+// airport code) stands. City is additive: OpenAIP leaves it blank, so we fill
+// it from the override without ever clobbering a city OpenAIP did provide.
+
+type AirportRecord = Record<string, any>;
+type AirportNameOverride = { name?: string; city?: string } | null | undefined;
+
+export const chooseAirportName = (
+  openAipName: unknown,
+  ourAirportsName: unknown,
+) => {
+  const ourAirports = String(ourAirportsName ?? "").trim();
+  if (ourAirports) return ourAirports;
+  return String(openAipName ?? "").trim();
+};
+
+export const applyOurAirportsAirport = <T extends AirportRecord | null | undefined>(
+  airport: T,
+  override: AirportNameOverride,
+): T => {
+  if (!airport || !override) return airport;
+  const name = chooseAirportName(airport.name, override.name);
+  const currentCity = String(airport.city ?? "").trim();
+  const overrideCity = String(override.city ?? "").trim();
+  const city = currentCity || overrideCity;
+  return { ...airport, name, city };
+};

--- a/src/features/airport/openaip/openAipDirectory.test.ts
+++ b/src/features/airport/openaip/openAipDirectory.test.ts
@@ -4,6 +4,7 @@ import { getOpenAipAirportPage, searchOpenAipAirports } from "./openAipDirectory
 
 const airports = await searchOpenAipAirports({
   query: "shanghai",
+  ourAirportsNameRepository: null,
   client: {
     async listAirports() {
       return {
@@ -52,6 +53,7 @@ assert.ok(airports.every((airport) => airport.ident.length <= 4));
     radiusNm: 60,
     nearbyLimit: 12,
     runwayGeometryRepository: null,
+    ourAirportsNameRepository: null,
     facilityRepository: {
       async readFrequenciesByAirportIdent() {
         return [

--- a/src/features/airport/openaip/openAipDirectory.ts
+++ b/src/features/airport/openaip/openAipDirectory.ts
@@ -15,10 +15,12 @@ import { createOpenAipClientFromEnv } from "./openAipClient";
 import { AirportDirectoryConfigurationError } from "../directory/airportDirectory.models";
 import { createAirportFacilityRepositoryFromEnv } from "../../../app/api/dao/airportFacilities.dao";
 import { createRunwayGeometryRepositoryFromEnv } from "../../../app/api/dao/runwayGeometries.dao";
+import { createAirportNameRepositoryFromEnv } from "../../../app/api/dao/airportNames.dao";
 import {
   mergeAirportFrequencies,
   mergeNearbyNavaids,
 } from "../directory/airportFacilityModel";
+import { applyOurAirportsAirport } from "../directory/airportNameModel";
 import { buildRunwayMapFromGeometries } from "../runways/runwayGeometryMap";
 
 type OpenAipDirectoryRecord = Record<string, any>;
@@ -191,6 +193,47 @@ const getAirportFacilityRepository = (
   return createAirportFacilityRepositoryFromEnv();
 };
 
+const getAirportNameRepository = (
+  repository: OpenAipDirectoryRecord | null | undefined,
+) => {
+  if (repository !== undefined) return repository;
+  return createAirportNameRepositoryFromEnv();
+};
+
+// Reads full OurAirports names for a set of airports and returns a Map keyed by
+// ICAO/ident. Mirrors `readRunwayGeometryMaps`: failures degrade to an empty
+// map so a missing or misconfigured table never breaks airport lookup.
+const readOurAirportsNames = async ({
+  repository,
+  airports = [],
+}: OpenAipDirectoryRecord = {}) => {
+  if (!repository?.readNamesByIdents) return new Map();
+  const idents = [...new Set(
+    airports
+      .map((airport: OpenAipDirectoryRecord) => normalizeCode(airport?.icao || airport?.ident))
+      .filter(Boolean),
+  )];
+  if (idents.length === 0) return new Map();
+
+  try {
+    return await repository.readNamesByIdents(idents);
+  } catch (error: any) {
+    console.warn("[openaip] OurAirports name read failed:", error?.message || error);
+    return new Map();
+  }
+};
+
+const applyOurAirportsNames = (
+  airports: OpenAipDirectoryRecord[],
+  nameMap: Map<string, { name: string; city: string }>,
+) =>
+  airports.map((airport) =>
+    applyOurAirportsAirport(
+      airport,
+      nameMap.get(normalizeCode(airport?.icao || airport?.ident)),
+    ),
+  );
+
 const readRunwayGeometryMaps = async ({
   repository,
   airports = [],
@@ -287,7 +330,10 @@ async function searchOpenAipAirportDocuments({
 
 export async function searchOpenAipAirports(options: OpenAipDirectoryRecord = {}) {
   const documents = await searchOpenAipAirportDocuments(options);
-  return documents.map(mapOpenAipAirport).filter(Boolean);
+  const airports = documents.map(mapOpenAipAirport).filter(Boolean);
+  const nameRepository = getAirportNameRepository(options.ourAirportsNameRepository);
+  const nameMap = await readOurAirportsNames({ repository: nameRepository, airports });
+  return applyOurAirportsNames(airports, nameMap);
 }
 
 async function findOpenAipAirportByIdent({
@@ -318,10 +364,12 @@ export async function getOpenAipAirportPage({
   client,
   runwayGeometryRepository,
   facilityRepository,
+  ourAirportsNameRepository,
 }: OpenAipDirectoryRecord = {}) {
   const openAip = getClient(client);
   const runwayRepository = getRunwayGeometryRepository(runwayGeometryRepository);
   const airportFacilityRepository = getAirportFacilityRepository(facilityRepository);
+  const nameRepository = getAirportNameRepository(ourAirportsNameRepository);
   const airportMatch = await findOpenAipAirportByIdent({ ident, client: openAip });
   if (!airportMatch?._id) {
     return {
@@ -410,14 +458,26 @@ export async function getOpenAipAirportPage({
     .filter(Boolean)
     .sort((left: OpenAipDirectoryRecord, right: OpenAipDirectoryRecord) => left.distanceNm - right.distanceNm)
     .slice(0, limit);
-  const runwayMaps = await readRunwayGeometryMaps({
-    repository: runwayRepository,
-    airports: [airport, ...nearbyAirportsBase],
-  });
-  const nearbyAirports = nearbyAirportsBase.map((item: OpenAipDirectoryRecord) => ({
-    ...item,
-    runwayMap: runwayMaps.get(item.icao) || null,
-  }));
+  const [runwayMaps, nameMap] = await Promise.all([
+    readRunwayGeometryMaps({
+      repository: runwayRepository,
+      airports: [airport, ...nearbyAirportsBase],
+    }),
+    readOurAirportsNames({
+      repository: nameRepository,
+      airports: [airport, ...nearbyAirportsBase],
+    }),
+  ]);
+  const namedAirport = applyOurAirportsAirport(
+    airport,
+    nameMap.get(normalizeCode(airport.icao || airport.ident)),
+  );
+  const nearbyAirports = applyOurAirportsNames(nearbyAirportsBase, nameMap).map(
+    (item: OpenAipDirectoryRecord) => ({
+      ...item,
+      runwayMap: runwayMaps.get(item.icao) || null,
+    }),
+  );
   const openAipFrequencies = (airportDocument.frequencies || [])
     .map((frequency: OpenAipDirectoryRecord) => mapOpenAipFrequency(frequency, airportDocument))
     .filter(Boolean);
@@ -436,7 +496,7 @@ export async function getOpenAipAirportPage({
   ]);
 
   return {
-    airport,
+    airport: namedAirport,
     runways: (airportDocument.runways || [])
       .map((runway: OpenAipDirectoryRecord) => mapOpenAipRunway(runway, airportDocument))
       .filter(Boolean),
@@ -463,9 +523,11 @@ export async function getOpenAipNearbyAirports({
   query,
   client,
   runwayGeometryRepository,
+  ourAirportsNameRepository,
 }: OpenAipDirectoryRecord = {}) {
   const openAip = getClient(client);
   const runwayRepository = getRunwayGeometryRepository(runwayGeometryRepository);
+  const nameRepository = getAirportNameRepository(ourAirportsNameRepository);
   const lat = toFiniteNumber(query?.lat);
   const lon = toFiniteNumber(query?.lon);
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
@@ -497,14 +559,22 @@ export async function getOpenAipNearbyAirports({
     .filter(Boolean)
     .sort((left: OpenAipDirectoryRecord, right: OpenAipDirectoryRecord) => left.distanceNm - right.distanceNm)
     .slice(0, limit);
-  const runwayMaps = await readRunwayGeometryMaps({
-    repository: runwayRepository,
-    airports: airportsBase,
-  });
-  const airports = airportsBase.map((airport: OpenAipDirectoryRecord) => ({
-    ...airport,
-    runwayMap: runwayMaps.get(airport.icao) || null,
-  }));
+  const [runwayMaps, nameMap] = await Promise.all([
+    readRunwayGeometryMaps({
+      repository: runwayRepository,
+      airports: airportsBase,
+    }),
+    readOurAirportsNames({
+      repository: nameRepository,
+      airports: airportsBase,
+    }),
+  ]);
+  const airports = applyOurAirportsNames(airportsBase, nameMap).map(
+    (airport: OpenAipDirectoryRecord) => ({
+      ...airport,
+      runwayMap: runwayMaps.get(airport.icao) || null,
+    }),
+  );
 
   return {
     airports,

--- a/supabase/migrations/20260611120000_restore_ourairports_airport_names.sql
+++ b/supabase/migrations/20260611120000_restore_ourairports_airport_names.sql
@@ -1,0 +1,48 @@
+-- Restore a narrow OurAirports `airports` table used to augment OpenAIP airport
+-- names. OpenAIP remains the primary airport directory, but its `name` values
+-- are pre-uppercased and truncated (~40 chars), so long names render cut off
+-- mid-word (e.g. "GENERAL EDWARD LAWRENCE LOGAN INTERNATIO"). This table
+-- provides the full, mixed-case OurAirports name (and municipality) keyed by
+-- identifier so the directory layer can override the truncated OpenAIP value.
+--
+-- Refreshed by the `pnpm import:airports` script using the service_role key.
+-- Anon clients have read-only access; only service_role can write.
+
+create table if not exists public.airports (
+  ident text primary key,
+  ourairports_id bigint,
+  type text not null default '',
+  name text not null default '',
+  latitude_deg double precision,
+  longitude_deg double precision,
+  iso_country text not null default '',
+  municipality text not null default '',
+  icao_code text not null default '',
+  iata_code text not null default '',
+  source text not null default 'ourairports',
+  imported_at timestamptz not null default timezone('utc', now()),
+  constraint airports_latitude_range check (
+    latitude_deg is null or latitude_deg between -90 and 90
+  ),
+  constraint airports_longitude_range check (
+    longitude_deg is null or longitude_deg between -180 and 180
+  )
+);
+
+create index if not exists airports_icao_code_idx
+  on public.airports (icao_code)
+  where icao_code <> '';
+
+create index if not exists airports_iata_code_idx
+  on public.airports (iata_code)
+  where iata_code <> '';
+
+-- RLS: anon may read; only service_role may write.
+alter table public.airports enable row level security;
+
+grant select on table public.airports to anon, authenticated;
+grant select, insert, update, delete on table public.airports to service_role;
+
+drop policy if exists "Airports are readable by everyone" on public.airports;
+create policy "Airports are readable by everyone"
+on public.airports for select to anon, authenticated using (true);


### PR DESCRIPTION
## Problem

OpenAIP's airport `name` is pre-uppercased and truncated to ~40 characters, so long names rendered cut off mid-word in the sidebar header (e.g. **GENERAL EDWARD LAWRENCE LOGAN INTERNATIO**). The all-caps look came from the same upstream data.

The OurAirports `airports` table that held full mixed-case names was dropped in the OpenAIP migration (`20260531205346`); the later "restore facilities" migration only brought back frequencies + navaids. So the names weren't joinable anymore.

## Change

Restore a narrow OurAirports `airports` table and join the full name back in server-side.

- **Migration** `20260611120000_restore_ourairports_airport_names.sql` — narrow `public.airports` (name, municipality, icao_code, ident PK), anon-read RLS, service_role write.
- **`scripts/import-airports.ts`** + `pnpm import:airports` — downloads OurAirports `airports.csv`, dedupes on ident, replaces the table. Mirrors the existing `import:facilities` / `import:runways` importers.
- **`airportNames.dao.ts`** — reads names by ICAO/ident into a Map; degrades to an empty map on any error so a missing/misconfigured table never breaks airport lookup.
- **`airportNameModel.ts`** — pure, tested merge logic: OurAirports name wins when present, OpenAIP value (which falls back to the code) otherwise; city is filled only when OpenAIP left it blank.
- **`openAipDirectory.ts`** — enriches names in search, airport detail (primary + nearby), and nearby-airport lookups, read in parallel with the existing runway-geometry read.
- Bump to **v2.4.4** + changelog entry.

## Validation

Mode 3 (local test) + live verification:
- `tsx scripts/run-tests.ts` — **102 test files passed** (incl. new `airportNameModel.test.ts` and `airportNames.dao.test.ts`).
- `next build --webpack` — clean.
- Migration applied to Supabase + `pnpm import:airports` run: **85,569 airports** imported.
- `GET /api/airport/KBOS` now returns `airport.name = "Boston Logan International Airport"`, `city = "Boston"` (was the truncated all-caps string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)