### PR TITLE
[codex] Invert brand logo in light theme

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -4882,6 +4882,11 @@ body {
     transform-origin: center;
 }
 
+:root[data-theme="light"] .brand-logo__image {
+    filter: invert(1) drop-shadow(0 1px 1px rgb(31 39 49 / 0.16))
+        drop-shadow(0 2px 2px rgb(31 39 49 / 0.08));
+}
+
 .brand-logo--animated .brand-logo__mark {
     animation: brand-logo-mark-enter 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }


### PR DESCRIPTION
## Summary
- Invert the raster brand logo only in the light theme so the mark reads as a dark circle with a light aircraft.
- Keep the dark theme using the original Firefly logo treatment and existing tighter drop shadow.

## Validation
- Browser local check: desktop light theme computed filter includes invert(1).
- Browser local check: desktop dark theme removes invert and keeps the original drop-shadow treatment.
- Browser local check: mobile 390x844 light theme keeps the logo visible with invert(1).
- pnpm lint
- git diff --check