### PR TITLE
[codex] Restore vector basemap

### DIFF
--- a/src/components/map/MapAttribution.tsx
+++ b/src/components/map/MapAttribution.tsx
@@ -10,7 +10,7 @@ export default function MapAttribution({ color, shadowColor, hidden = false }) {
         textShadow: `0 0 6px ${shadowColor}`,
       }}
     >
-      © OpenStreetMap contributors © CARTO
+      OpenFreeMap / OpenMapTiles / OpenStreetMap
     </div>
   );
 }

--- a/src/components/map/MapTileLayers.tsx
+++ b/src/components/map/MapTileLayers.tsx
@@ -2,34 +2,22 @@
 
 import { useEffect, useRef } from "react";
 import L from "leaflet";
+import "@maplibre/maplibre-gl-leaflet";
 import { useMapInstance } from "./MapContext";
-import { shouldLogMapTileLayerFailure } from "@/features/airport/map/mapTileLayerModel";
+import {
+  shouldAttemptMapLibreTiles,
+  shouldLogMapTileLayerFailure,
+  shouldSuppressMapLibreTileError,
+} from "@/features/airport/map/mapTileLayerModel";
 import { isLightMapTheme } from "@/features/airport/map/airportMapModel";
 
-// Raster base tiles (CARTO) instead of the MapLibre GL vector layer.
-//
-// Why: the frosted-glass panels rely on `backdrop-filter: blur()`, and Chrome
-// cannot blur a MapLibre/WebGL <canvas> backdrop — the GL canvas composites on
-// a separate layer that the filter can't sample, so panels showed the map
-// sharp ("see-through but no blur"). Raster <img> tiles are rasterized into the
-// normal paint tree, so the panels' backdrop-filter blurs them correctly.
-//
-// Light theme uses CARTO's colored "voyager" style (green land, blue water)
-// so the basemap keeps natural color; dark theme uses CARTO dark-matter
-// (CARTO has no colored dark variant). The `.atc-tile-base` filter in
-// style.css only lightly tones these now so the green/blue reads through.
-//
-// Labels are intentionally OFF in every mode (CARTO `*_nolabels`): the map is
-// a clean base for the frosted panels + aircraft/airport overlays.
-
-function rasterTileUrl(theme: string) {
-  return isLightMapTheme(theme)
-    ? `https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}{r}.png`
-    : `https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png`;
-}
+const MAP_STYLE_THEME_REVISION = "standard-detail-v10";
 
 export default function MapTileLayers({
   theme = "dark",
+  locale = "en",
+  showLabels = true,
+  baseLayer = "terrain",
   selectionActive = false,
 }: Record<string, any>) {
   const map = useMapInstance();
@@ -42,42 +30,129 @@ export default function MapTileLayers({
 
   useEffect(() => {
     if (!hasTilePane(map)) return undefined;
-    removeLayer(layerRef.current, map);
-
-    let nextLayer = null;
-    try {
-      nextLayer = L.tileLayer(rasterTileUrl(theme), {
-        subdomains: "abcd",
-        maxZoom: 20,
-        detectRetina: true,
-        updateWhenIdle: false,
-        keepBuffer: 4,
-        className: "atc-tile-base",
-        attribution:
-          '© OpenStreetMap contributors © CARTO',
-      });
-      nextLayer.addTo(map);
-      layerRef.current = nextLayer;
-      setSelectionOpacity(layerRef.current, theme, selectionActiveRef.current);
-    } catch (error) {
-      removeLayer(nextLayer, map);
-      layerRef.current = null;
-      if (shouldLogMapTileLayerFailure(error)) {
-        console.error("[airport-map] failed to initialize map tiles", error);
-      }
+    if (
+      !shouldAttemptMapLibreTiles({
+        userAgent: navigator.userAgent,
+        webGlAvailable: hasWebGlContext(),
+      })
+    ) {
+      return undefined;
     }
+    const abort = new AbortController();
+    let cancelled = false;
+
+    loadLocalizedMapStyle({
+      theme,
+      locale,
+      showLabels,
+      baseLayer,
+      signal: abort.signal,
+    })
+      .then((style) => {
+        if (cancelled || !hasTilePane(map)) return;
+        removeLayer(layerRef.current, map);
+        let nextLayer = null;
+        try {
+          nextLayer = L.maplibreGL({
+            style,
+            interactive: false,
+            attributionControl: false,
+            className: "atc-maplibre-base",
+          } as any);
+          guardMapLibreLayerLifecycle(nextLayer);
+          nextLayer.addTo(map);
+          attachMapLibreErrorHandler(nextLayer);
+          layerRef.current = nextLayer;
+          layerRef.current.getContainer()?.classList.add("atc-tile-base");
+          const maplibreMap = nextLayer.getMaplibreMap?.();
+          if (
+            maplibreMap &&
+            typeof maplibreMap.setMaxTileCacheSize === "function"
+          ) {
+            maplibreMap.setMaxTileCacheSize(512);
+          }
+          setSelectionOpacity(
+            layerRef.current,
+            theme,
+            selectionActiveRef.current,
+          );
+        } catch (error) {
+          removeLayer(nextLayer, map);
+          layerRef.current = null;
+          if (shouldLogMapTileLayerFailure(error)) {
+            console.error("[airport-map] failed to initialize map tiles", error);
+          }
+        }
+      })
+      .catch((error) => {
+        if (error?.name === "AbortError") return;
+        console.error("[airport-map] failed to load localized map tiles", error);
+      });
 
     return () => {
+      cancelled = true;
+      abort.abort();
       removeLayer(layerRef.current, map);
       layerRef.current = null;
     };
-  }, [map, theme]);
+  }, [map, theme, locale, showLabels, baseLayer]);
 
   useEffect(() => {
     setSelectionOpacity(layerRef.current, theme, selectionActive);
   }, [selectionActive, theme]);
 
   return null;
+}
+
+async function loadLocalizedMapStyle({
+  theme,
+  locale,
+  showLabels,
+  baseLayer,
+  signal,
+}: Record<string, any>) {
+  const params = new URLSearchParams({
+    locale,
+    labels: showLabels ? "1" : "0",
+    v: MAP_STYLE_THEME_REVISION,
+  });
+  if (baseLayer) params.set("baseLayer", baseLayer);
+  return requestJson(`/api/proxy/map-style/${theme}?${params}`, { signal });
+}
+
+async function requestJson(url: string, { signal }: Record<string, any> = {}) {
+  if (typeof fetch === "function") {
+    const response = await fetch(url, { signal });
+    if (!response.ok) {
+      throw new Error(`OpenFreeMap style request failed: ${response.status}`);
+    }
+    return response.json();
+  }
+
+  return requestJsonWithXhr(url, { signal });
+}
+
+function requestJsonWithXhr(url: string, { signal }: Record<string, any> = {}) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("GET", url, true);
+    xhr.responseType = "json";
+    xhr.onload = () => {
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(new Error(`OpenFreeMap style request failed: ${xhr.status}`));
+        return;
+      }
+      resolve(xhr.response || JSON.parse(xhr.responseText));
+    };
+    xhr.onerror = () => {
+      reject(new Error("OpenFreeMap style request failed"));
+    };
+    xhr.onabort = () => {
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", () => xhr.abort(), { once: true });
+    xhr.send();
+  });
 }
 
 function hasTilePane(map: any) {
@@ -106,4 +181,49 @@ function setSelectionOpacity(layer, theme, selectionActive) {
     return;
   }
   container.style.opacity = "1";
+}
+
+function guardMapLibreLayerLifecycle(layer: any) {
+  if (!layer) return;
+  const guardMethod = (name: string) => {
+    const original = layer[name];
+    if (typeof original !== "function") return;
+    layer[name] = function guardedMapLibreHandler(...args) {
+      if (!this?._map || !this?._glMap) return undefined;
+      return original.apply(this, args);
+    };
+  };
+
+  guardMethod("_pinchZoom");
+  guardMethod("_animateZoom");
+  guardMethod("_zoomStart");
+  guardMethod("_zoomEnd");
+  guardMethod("_transitionEnd");
+  guardMethod("_update");
+  if (typeof layer._throttledUpdate === "function") {
+    const originalThrottledUpdate = layer._throttledUpdate;
+    layer._throttledUpdate = function guardedMapLibreThrottledUpdate(...args) {
+      if (!this?._map || !this?._glMap) return undefined;
+      return originalThrottledUpdate.apply(this, args);
+    };
+  }
+}
+
+function attachMapLibreErrorHandler(layer: any) {
+  const maplibreMap = layer?.getMaplibreMap?.();
+  if (!maplibreMap || typeof maplibreMap.on !== "function") return;
+
+  maplibreMap.on("error", (event) => {
+    if (shouldSuppressMapLibreTileError(event)) return;
+    console.error("[airport-map] map tile error", event?.error || event);
+  });
+}
+
+function hasWebGlContext() {
+  const canvas = document.createElement("canvas");
+  const context =
+    canvas.getContext("webgl2") ||
+    canvas.getContext("webgl") ||
+    canvas.getContext("experimental-webgl");
+  return Boolean(context);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1463,7 +1463,7 @@ body:has(.app-detail-shell) {
     mix-blend-mode: normal;
 }
 
-/* Standard base map (CARTO voyager) runs hot out of the box — pull the
+/* Standard base map runs hot out of the box — pull the
    saturation well down so greens/blues read as a muted manual-paper
    wash that the frosted glass sits over, not a candy basemap. */
 :root[data-theme="light"] .atc-tile-base {


### PR DESCRIPTION
## Summary

- restores the airport map base layer from CARTO raster tiles back to the MapLibre/OpenFreeMap vector style path
- passes `locale`, `showLabels`, and `baseLayer` through the style proxy again so Standard/Terrain and map label settings take effect
- updates the visible map attribution and stale CSS comment to match the restored OpenFreeMap/OpenMapTiles source

## Why

The CARTO raster fallback made the liquid-glass blur work better, but it also removed the richer vector basemap detail such as ferry, waterway, rail, and transportation layers. This PR restores the previous vector basemap so the Standard map can show those details again.

## Risk / trade-off

Chrome still cannot backdrop-blur the MapLibre WebGL canvas as cleanly as raster image tiles, so frosted panels may look less blurred over the map. This PR is intended as a previewable comparison branch.

## Validation

- `pnpm lint` — passes with existing warnings only (`PlaneHunterStudio` img, `VirtualNearbyList` TanStack Virtual, `useWeatherSlides` missing dependency)
- `pnpm test` — 102 test files passed
- local browser: checked `http://localhost:3000/airport/KBOS?locale=en`; confirmed MapLibre canvas renders and attribution reads `OpenFreeMap / OpenMapTiles / OpenStreetMap`
- API smoke: `/api/proxy/map-style/light?locale=en&labels=1&baseLayer=standard&v=standard-detail-v10` returns `openmaptiles`, no CARTO URL, and includes `ferry`, `waterway-river`, `railway`, and `railway-transit` layers; `labels=0` hides all text symbol layers