### PR TITLE
[codex] Gate Plane Hunter by client device

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -23,6 +23,10 @@ import PlaneHunterStudio from "./PlaneHunterStudio";
 import RouteFeedbackModal from "./RouteFeedbackModal";
 import { useSelectedAircraftTrace } from "@/components/aircraft/trace/SelectedAircraftTraceContext";
 import { useAircraftPhoto } from "@/features/aircraft/preview/useAircraftPhoto";
+import {
+  getPlaneHunterClientDevice,
+  shouldEnablePlaneHunterForClientDevice,
+} from "@/features/aircraft/preview/planeHunterDeviceModel";
 import { useAircraftTraceAsyncStatus } from "@/features/aircraft/trace/useAircraftTraceAsyncStatus";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel";
@@ -139,7 +143,9 @@ export default function AircraftPreviewCard({
     !isNavaid &&
     Boolean(aircraftCallsign) &&
     typeof onApplyTemporaryRoute === "function";
-  const showPlaneHunterTrigger = isAircraftPreview && Boolean(entity);
+  const planeHunterDeviceAllowed = usePlaneHunterDeviceAllowed();
+  const showPlaneHunterTrigger =
+    planeHunterDeviceAllowed && isAircraftPreview && Boolean(entity);
   const showMobilePlaneHunterTrigger = showMobile && showPlaneHunterTrigger;
   const mobileFeedbackLabel = aircraft?.flightRouteLabel
     ? t("routeFeedback.suggestCorrection")
@@ -316,6 +322,18 @@ export default function AircraftPreviewCard({
       )}
     </>
   );
+}
+
+function usePlaneHunterDeviceAllowed() {
+  const [allowed, setAllowed] = useState(false);
+
+  useEffect(() => {
+    setAllowed(
+      shouldEnablePlaneHunterForClientDevice(getPlaneHunterClientDevice()),
+    );
+  }, []);
+
+  return allowed;
 }
 
 function usePhotoTone(src) {

--- a/src/features/aircraft/preview/planeHunterDeviceModel.test.ts
+++ b/src/features/aircraft/preview/planeHunterDeviceModel.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+
+import { shouldEnablePlaneHunterForClientDevice } from "./planeHunterDeviceModel";
+
+{
+  assert.equal(
+    shouldEnablePlaneHunterForClientDevice({
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+      platform: "MacIntel",
+      maxTouchPoints: 0,
+      userAgentData: { mobile: false, platform: "macOS" },
+    }),
+    false,
+    "desktop macOS should not expose Plane Hunter",
+  );
+}
+
+{
+  assert.equal(
+    shouldEnablePlaneHunterForClientDevice({
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1",
+      platform: "iPhone",
+      maxTouchPoints: 5,
+      userAgentData: { mobile: true, platform: "iOS" },
+    }),
+    true,
+    "mobile system fields should expose Plane Hunter",
+  );
+}
+
+{
+  assert.equal(
+    shouldEnablePlaneHunterForClientDevice({
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/142.0.0.0 Mobile/15E148 Safari/604.1",
+      platform: "MacIntel",
+      maxTouchPoints: 0,
+      userAgentData: { mobile: false, platform: "macOS" },
+    }),
+    true,
+    "Chrome mobile emulation should expose Plane Hunter through the emulated UA",
+  );
+}
+
+{
+  assert.equal(
+    shouldEnablePlaneHunterForClientDevice({
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15",
+      platform: "MacIntel",
+      maxTouchPoints: 5,
+    }),
+    true,
+    "iPadOS desktop-style UA should still expose Plane Hunter",
+  );
+}

--- a/src/features/aircraft/preview/planeHunterDeviceModel.ts
+++ b/src/features/aircraft/preview/planeHunterDeviceModel.ts
@@ -1,0 +1,63 @@
+export type PlaneHunterNavigatorUserAgentData = {
+  mobile?: boolean;
+  platform?: string;
+};
+
+export type PlaneHunterClientDevice = {
+  userAgent?: string;
+  platform?: string;
+  maxTouchPoints?: number;
+  userAgentData?: PlaneHunterNavigatorUserAgentData | null;
+};
+
+export function shouldEnablePlaneHunterForClientDevice(
+  device: PlaneHunterClientDevice | null | undefined,
+) {
+  const userAgentData = device?.userAgentData;
+  if (userAgentData?.mobile === true) return true;
+
+  const userAgent = String(device?.userAgent || "").toLowerCase();
+  const platform = String(userAgentData?.platform || device?.platform || "").toLowerCase();
+  const maxTouchPoints = Number(device?.maxTouchPoints || 0);
+
+  if (
+    /\b(mobile|iphone|ipod|android|windows phone|iemobile|blackberry|bb10|opera mini)\b/.test(
+      userAgent,
+    )
+  ) {
+    return true;
+  }
+
+  if (/\b(iphone|ipad|ipod|android)\b/.test(platform)) {
+    return true;
+  }
+
+  if (userAgent.includes("ipad")) return true;
+
+  // iPadOS can request the desktop Safari UA, reporting "Macintosh" with touch.
+  return (
+    maxTouchPoints > 1 &&
+    (platform === "macintel" || platform === "macos") &&
+    userAgent.includes("macintosh")
+  );
+}
+
+export function getPlaneHunterClientDevice(): PlaneHunterClientDevice | null {
+  if (typeof navigator === "undefined") return null;
+
+  const clientNavigator = navigator as Navigator & {
+    userAgentData?: PlaneHunterNavigatorUserAgentData;
+  };
+
+  return {
+    userAgent: clientNavigator.userAgent,
+    platform: clientNavigator.platform,
+    maxTouchPoints: clientNavigator.maxTouchPoints,
+    userAgentData: clientNavigator.userAgentData
+      ? {
+          mobile: clientNavigator.userAgentData.mobile,
+          platform: clientNavigator.userAgentData.platform,
+        }
+      : null,
+  };
+}


### PR DESCRIPTION
## Summary
- Gate Plane Hunter availability behind client device/system fields instead of viewport width.
- Share the same gate across desktop and mobile aircraft preview entry points, including the studio mount.
- Add model coverage for macOS desktop, mobile UA, Chrome mobile emulation, and iPadOS desktop-style UA.

## Validation
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm test`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/pnpm lint` (0 errors, 3 existing warnings)
- `git diff --check`
- Local browser `/airport/KBOS`: desktop Mac UA selected aircraft showed no Plane Hunter button.
- Local browser `/airport/KBOS`: iPhone UA at 390x844 selected aircraft showed Plane Hunter and opened the studio dialog.
