### PR TITLE
[codex] Add data service Prometheus metrics

### DIFF
--- a/services/data-service/fly.toml
+++ b/services/data-service/fly.toml
@@ -12,6 +12,10 @@ primary_region = "sjc"
   MAX_POLL_INTERVAL_MS = "1800000"
   POLL_JITTER_RATIO = "0.1"
 
+[metrics]
+  port = 8080
+  path = "/metrics"
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/services/data-service/package.json
+++ b/services/data-service/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/server.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
-    "test": "tsx src/channels/channelTypes.test.ts && tsx src/polling/PollingScheduler.test.ts && tsx src/sources/routeClient.test.ts && tsx src/ws.test.ts"
+    "test": "tsx src/channels/channelTypes.test.ts && tsx src/channels/ChannelManager.test.ts && tsx src/metrics/MetricsRegistry.test.ts && tsx src/polling/PollingScheduler.test.ts && tsx src/sources/routeClient.test.ts && tsx src/ws.test.ts"
   },
   "dependencies": {
     "ws": "^8.18.3"

--- a/services/data-service/src/channels/ChannelManager.test.ts
+++ b/services/data-service/src/channels/ChannelManager.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { DataServiceMetrics } from "../metrics/MetricsRegistry";
+import { ChannelManager } from "./ChannelManager";
+
+class FakeSocket extends EventEmitter {
+  OPEN = 1;
+  readyState = 1;
+  sent: string[] = [];
+
+  send(payload: string) {
+    this.sent.push(payload);
+  }
+}
+
+{
+  const metrics = new DataServiceMetrics();
+  const socket = new FakeSocket();
+  const manager = new ChannelManager({
+    maxSubscriptionsPerSocket: 1,
+    metrics,
+    scheduler: {
+      subscribe({ channel, send }: any) {
+        send({
+          type: "aircraft:update",
+          channel,
+          source: "test-provider",
+          fetchedAt: new Date(0).toISOString(),
+          stale: false,
+          data: [],
+        });
+        return () => {};
+      },
+    } as any,
+  });
+
+  manager.attach(socket as any);
+  socket.emit(
+    "message",
+    JSON.stringify({
+      type: "subscribe",
+      channel: "airport:KBOS",
+      params: { lat: 42.3656, lon: -71.0096, distNm: 40 },
+    }),
+  );
+  socket.emit(
+    "message",
+    JSON.stringify({ type: "subscribe", channel: "route:DAL44" }),
+  );
+  socket.emit("close");
+
+  const output = metrics.render({ uptimeSec: 1, channels: [] });
+  assert.match(output, /adsbao_ws_connections_current 0/);
+  assert.match(output, /adsbao_ws_connections_total 1/);
+  assert.match(
+    output,
+    /adsbao_ws_messages_total\{direction="inbound",result="ok",type="subscribe"\} 2/,
+  );
+  assert.match(
+    output,
+    /adsbao_ws_messages_total\{direction="outbound",result="ok",type="connection:ready"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_ws_subscribe_total\{channel_type="airport",result="ok"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_ws_subscribe_total\{channel_type="route",result="limit"\} 1/,
+  );
+}
+
+console.log("ChannelManager.test.ts ok");

--- a/services/data-service/src/channels/ChannelManager.ts
+++ b/services/data-service/src/channels/ChannelManager.ts
@@ -1,11 +1,13 @@
 import type { WebSocket } from "ws";
 import { normalizeChannelName } from "./channelTypes.js";
+import type { DataServiceMetrics } from "../metrics/MetricsRegistry.js";
 import { PollingScheduler } from "../polling/PollingScheduler.js";
 import type { ClientMessage, RealtimeEvent, SubscribeParams } from "../types.js";
 
 type ChannelManagerOptions = {
   scheduler: PollingScheduler;
   maxSubscriptionsPerSocket?: number;
+  metrics?: DataServiceMetrics;
 };
 
 type SocketState = {
@@ -31,14 +33,17 @@ function parseClientMessage(raw: unknown): ClientMessage | null {
 export class ChannelManager {
   private readonly scheduler: PollingScheduler;
   private readonly maxSubscriptionsPerSocket: number;
+  private readonly metrics: DataServiceMetrics | null;
   private readonly sockets = new WeakMap<WebSocket, SocketState>();
 
   constructor({
     scheduler,
     maxSubscriptionsPerSocket = 96,
+    metrics = undefined,
   }: ChannelManagerOptions) {
     this.scheduler = scheduler;
     this.maxSubscriptionsPerSocket = maxSubscriptionsPerSocket;
+    this.metrics = metrics || null;
   }
 
   attach(socket: WebSocket) {
@@ -46,7 +51,8 @@ export class ChannelManager {
       subscriptions: new Map(),
     };
     this.sockets.set(socket, state);
-    sendJson(socket, {
+    this.metrics?.recordWsConnectionOpened();
+    this.sendJson(socket, {
       type: "connection:ready",
       channel: "session",
       source: "adsbao-data-service",
@@ -60,9 +66,19 @@ export class ChannelManager {
     socket.on("message", (raw) => {
       const message = parseClientMessage(raw);
       if (!message) {
-        sendJson(socket, { type: "error", error: "Invalid JSON message" });
+        this.metrics?.recordWsMessage({
+          direction: "inbound",
+          type: "invalid",
+          result: "error",
+        });
+        this.sendJson(socket, { type: "error", error: "Invalid JSON message" });
         return;
       }
+      this.metrics?.recordWsMessage({
+        direction: "inbound",
+        type: message.type,
+        result: "ok",
+      });
       this.handleMessage(socket, state, message);
     });
 
@@ -79,11 +95,13 @@ export class ChannelManager {
     if (!state) return;
     for (const unsubscribe of state.subscriptions.values()) unsubscribe();
     state.subscriptions.clear();
+    this.sockets.delete(socket);
+    this.metrics?.recordWsConnectionClosed();
   }
 
   private handleMessage(socket: WebSocket, state: SocketState, message: ClientMessage) {
     if (message.type === "ping") {
-      sendJson(socket, { type: "pong", now: new Date().toISOString() });
+      this.sendJson(socket, { type: "pong", now: new Date().toISOString() });
       return;
     }
 
@@ -94,7 +112,7 @@ export class ChannelManager {
       if (!unsubscribe) return;
       unsubscribe();
       state.subscriptions.delete(normalized.channel);
-      sendJson(socket, {
+      this.sendJson(socket, {
         type: "subscribed:removed",
         channel: normalized.channel,
       });
@@ -102,13 +120,17 @@ export class ChannelManager {
     }
 
     if (message.type !== "subscribe") {
-      sendJson(socket, { type: "error", error: "Unsupported message type" });
+      this.sendJson(socket, { type: "error", error: "Unsupported message type" });
       return;
     }
 
     const normalized = normalizeChannelName(message.channel);
     if (normalized.ok !== true) {
-      sendJson(socket, {
+      this.metrics?.recordWsSubscribe({
+        channelType: "unknown",
+        result: "invalid",
+      });
+      this.sendJson(socket, {
         type: "subscribe:error",
         channel: message.channel,
         error: normalized.error,
@@ -116,14 +138,22 @@ export class ChannelManager {
       return;
     }
     if (state.subscriptions.has(normalized.channel)) {
-      sendJson(socket, {
+      this.metrics?.recordWsSubscribe({
+        channelType: normalized.type,
+        result: "duplicate",
+      });
+      this.sendJson(socket, {
         type: "subscribed:ready",
         channel: normalized.channel,
       });
       return;
     }
     if (state.subscriptions.size >= this.maxSubscriptionsPerSocket) {
-      sendJson(socket, {
+      this.metrics?.recordWsSubscribe({
+        channelType: normalized.type,
+        result: "limit",
+      });
+      this.sendJson(socket, {
         type: "subscribe:error",
         channel: normalized.channel,
         error: "Socket subscription limit reached",
@@ -135,19 +165,40 @@ export class ChannelManager {
       const unsubscribe = this.scheduler.subscribe({
         channel: normalized.channel,
         params: message.params || ({} as SubscribeParams),
-        send: (event: RealtimeEvent) => sendJson(socket, event),
+        send: (event: RealtimeEvent) => this.sendJson(socket, event),
       });
       state.subscriptions.set(normalized.channel, unsubscribe);
-      sendJson(socket, {
+      this.metrics?.recordWsSubscribe({
+        channelType: normalized.type,
+        result: "ok",
+      });
+      this.sendJson(socket, {
         type: "subscribed:ready",
         channel: normalized.channel,
       });
     } catch (error) {
-      sendJson(socket, {
+      this.metrics?.recordWsSubscribe({
+        channelType: normalized.type,
+        result: "error",
+      });
+      this.sendJson(socket, {
         type: "subscribe:error",
         channel: normalized.channel,
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  private sendJson(socket: WebSocket, payload: unknown) {
+    const type =
+      payload && typeof payload === "object" && "type" in payload
+        ? String((payload as { type?: unknown }).type || "unknown")
+        : "unknown";
+    this.metrics?.recordWsMessage({
+      direction: "outbound",
+      type,
+      result: socket.readyState === socket.OPEN ? "ok" : "error",
+    });
+    sendJson(socket, payload);
   }
 }

--- a/services/data-service/src/metrics/MetricsRegistry.test.ts
+++ b/services/data-service/src/metrics/MetricsRegistry.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { DataServiceMetrics } from "./MetricsRegistry";
+
+{
+  const metrics = new DataServiceMetrics();
+  metrics.recordWsConnectionOpened();
+  metrics.recordWsMessage({
+    direction: "inbound",
+    type: "subscribe",
+    result: "ok",
+  });
+  metrics.recordWsSubscribe({ channelType: "airport", result: "ok" });
+  metrics.recordPoll({
+    channelType: "airport",
+    source: "adsb.lol",
+    result: "success",
+    durationMs: 123,
+  });
+  metrics.recordExternalRequest({
+    provider: "adsb.lol",
+    endpoint: "positions",
+    result: "success",
+    durationMs: 123,
+  });
+
+  const output = metrics.render({
+    uptimeSec: 10,
+    channels: [
+      {
+        key: "airport:KBOS|42.3656|-71.0096|40",
+        channel: "airport:KBOS",
+        type: "airport",
+        subscriberCount: 2,
+        currentIntervalMs: 5_000,
+        lastFetchedAt: new Date(0).toISOString(),
+        lastError: null,
+        source: "adsb.lol",
+        stale: false,
+        consecutiveFailures: 0,
+      },
+      {
+        key: "route:DAL44",
+        channel: "route:DAL44",
+        type: "route",
+        subscriberCount: 1,
+        currentIntervalMs: 1_800_000,
+        lastFetchedAt: null,
+        lastError: null,
+        source: null,
+        stale: false,
+        consecutiveFailures: 0,
+      },
+    ],
+  });
+
+  assert.match(output, /^# HELP adsbao_ws_connections_current/m);
+  assert.match(output, /adsbao_ws_connections_current 1/);
+  assert.match(
+    output,
+    /adsbao_ws_messages_total\{direction="inbound",result="ok",type="subscribe"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_ws_subscribe_total\{channel_type="airport",result="ok"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_active_channels_current\{channel_type="airport"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_subscriptions_current\{channel_type="airport"\} 2/,
+  );
+  assert.match(
+    output,
+    /adsbao_poll_requests_total\{channel_type="airport",result="success",source="adsb.lol"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_external_requests_total\{endpoint="positions",provider="adsb.lol",result="success"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_external_request_duration_seconds_bucket\{endpoint="positions",le="0.25",provider="adsb.lol",result="success"\} 1/,
+  );
+  assert.equal(output.endsWith("\n"), true);
+}
+
+console.log("MetricsRegistry.test.ts ok");

--- a/services/data-service/src/metrics/MetricsRegistry.ts
+++ b/services/data-service/src/metrics/MetricsRegistry.ts
@@ -1,0 +1,317 @@
+import type { DebugChannel, RealtimeChannelType } from "../types.js";
+
+type LabelValue = string | number | boolean | null | undefined;
+type Labels = Record<string, LabelValue>;
+
+type RenderInput = {
+  uptimeSec: number;
+  channels: DebugChannel[];
+};
+
+type WsMessageInput = {
+  direction: "inbound" | "outbound";
+  type: string;
+  result: "ok" | "error";
+};
+
+type WsSubscribeInput = {
+  channelType: RealtimeChannelType | "unknown";
+  result: "ok" | "duplicate" | "invalid" | "limit" | "error";
+};
+
+type PollInput = {
+  channelType: RealtimeChannelType;
+  source: string;
+  result: "success" | "error";
+  durationMs: number;
+};
+
+type ExternalRequestInput = {
+  provider: string;
+  endpoint: "positions" | "callsign" | "aircraft" | "route" | "unknown";
+  result: "success" | "error";
+  durationMs: number;
+};
+
+type HistogramState = {
+  buckets: Map<number, number>;
+  count: number;
+  sum: number;
+};
+
+const DURATION_BUCKETS = Object.freeze([
+  0.05,
+  0.1,
+  0.25,
+  0.5,
+  1,
+  2.5,
+  5,
+  10,
+  30,
+]);
+
+function normalizeLabelValue(value: LabelValue) {
+  return String(value ?? "unknown")
+    .trim()
+    .replace(/[^a-zA-Z0-9_.:-]+/g, "_")
+    .slice(0, 80) || "unknown";
+}
+
+function labelKey(labels: Labels) {
+  return Object.keys(labels)
+    .sort()
+    .map((key) => `${key}=${normalizeLabelValue(labels[key])}`)
+    .join(",");
+}
+
+function labelText(labels: Labels) {
+  const keys = Object.keys(labels).sort();
+  if (keys.length === 0) return "";
+  return `{${keys
+    .map((key) => {
+      const value = normalizeLabelValue(labels[key])
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"');
+      return `${key}="${value}"`;
+    })
+    .join(",")}}`;
+}
+
+function metricLine(name: string, labels: Labels, value: number) {
+  return `${name}${labelText(labels)} ${Number.isFinite(value) ? value : 0}`;
+}
+
+function classifyEndpoint(channelType: RealtimeChannelType) {
+  if (
+    channelType === "airport" ||
+    channelType === "bbox" ||
+    channelType === "viewport"
+  ) {
+    return "positions";
+  }
+  if (channelType === "callsign") return "callsign";
+  if (channelType === "aircraft") return "aircraft";
+  if (channelType === "route") return "route";
+  return "unknown";
+}
+
+export class DataServiceMetrics {
+  private wsConnectionsCurrent = 0;
+  private readonly counters = new Map<string, number>();
+  private readonly histograms = new Map<string, HistogramState>();
+
+  recordWsConnectionOpened() {
+    this.wsConnectionsCurrent += 1;
+    this.increment("adsbao_ws_connections_total", {});
+  }
+
+  recordWsConnectionClosed() {
+    this.wsConnectionsCurrent = Math.max(0, this.wsConnectionsCurrent - 1);
+  }
+
+  recordWsMessage({ direction, type, result }: WsMessageInput) {
+    this.increment("adsbao_ws_messages_total", {
+      direction,
+      result,
+      type,
+    });
+  }
+
+  recordWsSubscribe({ channelType, result }: WsSubscribeInput) {
+    this.increment("adsbao_ws_subscribe_total", {
+      channel_type: channelType,
+      result,
+    });
+  }
+
+  recordPoll({ channelType, source, result, durationMs }: PollInput) {
+    const labels = {
+      channel_type: channelType,
+      result,
+      source,
+    };
+    this.increment("adsbao_poll_requests_total", labels);
+    this.observe("adsbao_poll_duration_seconds", labels, durationMs / 1000);
+  }
+
+  recordExternalRequest(input: ExternalRequestInput) {
+    const labels = {
+      endpoint: input.endpoint,
+      provider: input.provider,
+      result: input.result,
+    };
+    this.increment("adsbao_external_requests_total", labels);
+    this.observe(
+      "adsbao_external_request_duration_seconds",
+      labels,
+      input.durationMs / 1000,
+    );
+  }
+
+  recordExternalRequestForPoll({
+    channelType,
+    provider,
+    result,
+    durationMs,
+  }: {
+    channelType: RealtimeChannelType;
+    provider: string;
+    result: "success" | "error";
+    durationMs: number;
+  }) {
+    this.recordExternalRequest({
+      provider,
+      endpoint: classifyEndpoint(channelType),
+      result,
+      durationMs,
+    });
+  }
+
+  render({ uptimeSec, channels }: RenderInput) {
+    const lines: string[] = [];
+    this.renderGauge(lines, {
+      name: "adsbao_uptime_seconds",
+      help: "Process uptime in seconds.",
+      values: [{ labels: {}, value: Math.round(uptimeSec) }],
+    });
+    this.renderGauge(lines, {
+      name: "adsbao_ws_connections_current",
+      help: "Current open WebSocket connections.",
+      values: [{ labels: {}, value: this.wsConnectionsCurrent }],
+    });
+    this.renderDynamicChannelGauges(lines, channels);
+    this.renderCounters(lines);
+    this.renderHistograms(lines);
+    return `${lines.join("\n")}\n`;
+  }
+
+  private increment(name: string, labels: Labels, value = 1) {
+    const key = `${name}|${labelKey(labels)}`;
+    this.counters.set(key, (this.counters.get(key) || 0) + value);
+  }
+
+  private observe(name: string, labels: Labels, value: number) {
+    const key = `${name}|${labelKey(labels)}`;
+    let state = this.histograms.get(key);
+    if (!state) {
+      state = {
+        buckets: new Map(DURATION_BUCKETS.map((bucket) => [bucket, 0])),
+        count: 0,
+        sum: 0,
+      };
+      this.histograms.set(key, state);
+    }
+    for (const bucket of DURATION_BUCKETS) {
+      if (value <= bucket) {
+        state.buckets.set(bucket, (state.buckets.get(bucket) || 0) + 1);
+      }
+    }
+    state.count += 1;
+    state.sum += value;
+  }
+
+  private renderGauge(
+    lines: string[],
+    {
+      name,
+      help,
+      values,
+    }: {
+      name: string;
+      help: string;
+      values: Array<{ labels: Labels; value: number }>;
+    },
+  ) {
+    lines.push(`# HELP ${name} ${help}`);
+    lines.push(`# TYPE ${name} gauge`);
+    for (const item of values) {
+      lines.push(metricLine(name, item.labels, item.value));
+    }
+  }
+
+  private renderDynamicChannelGauges(lines: string[], channels: DebugChannel[]) {
+    const activeByType = new Map<string, number>();
+    const subscribersByType = new Map<string, number>();
+    for (const channel of channels) {
+      activeByType.set(channel.type, (activeByType.get(channel.type) || 0) + 1);
+      subscribersByType.set(
+        channel.type,
+        (subscribersByType.get(channel.type) || 0) + channel.subscriberCount,
+      );
+    }
+    this.renderGauge(lines, {
+      name: "adsbao_active_channels_current",
+      help: "Current active polling channels by channel type.",
+      values: [...activeByType].map(([channelType, value]) => ({
+        labels: { channel_type: channelType },
+        value,
+      })),
+    });
+    this.renderGauge(lines, {
+      name: "adsbao_subscriptions_current",
+      help: "Current active subscriptions by channel type.",
+      values: [...subscribersByType].map(([channelType, value]) => ({
+        labels: { channel_type: channelType },
+        value,
+      })),
+    });
+  }
+
+  private renderCounters(lines: string[]) {
+    const grouped = new Map<string, Array<{ labels: Labels; value: number }>>();
+    for (const [key, value] of this.counters) {
+      const [name, rawLabels = ""] = key.split("|");
+      const labels = labelsFromKey(rawLabels);
+      const entries = grouped.get(name) || [];
+      entries.push({ labels, value });
+      grouped.set(name, entries);
+    }
+    for (const [name, entries] of [...grouped].sort(([a], [b]) =>
+      a.localeCompare(b),
+    )) {
+      lines.push(`# HELP ${name} Counter for ${name}.`);
+      lines.push(`# TYPE ${name} counter`);
+      for (const entry of entries.sort((a, b) =>
+        labelKey(a.labels).localeCompare(labelKey(b.labels)),
+      )) {
+        lines.push(metricLine(name, entry.labels, entry.value));
+      }
+    }
+  }
+
+  private renderHistograms(lines: string[]) {
+    for (const [key, state] of [...this.histograms].sort(([a], [b]) =>
+      a.localeCompare(b),
+    )) {
+      const [name, rawLabels = ""] = key.split("|");
+      const labels = labelsFromKey(rawLabels);
+      lines.push(`# HELP ${name} Histogram for ${name}.`);
+      lines.push(`# TYPE ${name} histogram`);
+      for (const bucket of DURATION_BUCKETS) {
+        lines.push(
+          metricLine(
+            `${name}_bucket`,
+            { ...labels, le: String(bucket) },
+            state.buckets.get(bucket) || 0,
+          ),
+        );
+      }
+      lines.push(
+        metricLine(`${name}_bucket`, { ...labels, le: "+Inf" }, state.count),
+      );
+      lines.push(metricLine(`${name}_sum`, labels, Number(state.sum.toFixed(6))));
+      lines.push(metricLine(`${name}_count`, labels, state.count));
+    }
+  }
+}
+
+function labelsFromKey(raw: string): Labels {
+  if (!raw) return {};
+  return Object.fromEntries(
+    raw.split(",").map((entry) => {
+      const [key, ...rest] = entry.split("=");
+      return [key, rest.join("=")];
+    }),
+  );
+}

--- a/services/data-service/src/polling/PollingScheduler.test.ts
+++ b/services/data-service/src/polling/PollingScheduler.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { DataServiceMetrics } from "../metrics/MetricsRegistry";
 import { PollingScheduler } from "./PollingScheduler";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -134,6 +135,46 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
       }),
     /active channel limit/i,
   );
+  unsubscribe();
+  scheduler.dispose();
+}
+
+{
+  const metrics = new DataServiceMetrics();
+  const scheduler = new PollingScheduler({
+    minIntervalMs: 25,
+    maxActiveChannels: 10,
+    jitterRatio: 0,
+    metrics,
+    fetchChannel: async ({ channel }) => ({
+      type: "route:update",
+      channel,
+      source: "adsbdb",
+      fetchedAt: new Date(0).toISOString(),
+      stale: false,
+      data: { callsign: "DAL44", route: null },
+    }),
+  });
+
+  const unsubscribe = scheduler.subscribe({
+    channel: "route:DAL44",
+    send: () => {},
+  });
+
+  await sleep(40);
+  const output = metrics.render({
+    uptimeSec: 1,
+    channels: scheduler.getDebugChannels(),
+  });
+  assert.match(
+    output,
+    /adsbao_poll_requests_total\{channel_type="route",result="success",source="adsbdb"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_external_requests_total\{endpoint="route",provider="adsbdb",result="success"\} 1/,
+  );
+
   unsubscribe();
   scheduler.dispose();
 }

--- a/services/data-service/src/polling/PollingScheduler.ts
+++ b/services/data-service/src/polling/PollingScheduler.ts
@@ -5,6 +5,7 @@ import {
   normalizeChannelName,
 } from "../channels/channelTypes.js";
 import { MemoryTtlCache } from "../cache/memoryCache.js";
+import type { DataServiceMetrics } from "../metrics/MetricsRegistry.js";
 import type {
   DebugChannel,
   FetchChannel,
@@ -46,6 +47,7 @@ type PollingSchedulerOptions = {
   maxActiveChannels?: number;
   jitterRatio?: number;
   cacheTtlMs?: number;
+  metrics?: DataServiceMetrics;
   now?: () => number;
 };
 
@@ -74,6 +76,7 @@ export class PollingScheduler {
   private readonly maxActiveChannels: number;
   private readonly jitterRatio: number;
   private readonly cache: MemoryTtlCache<RealtimeEvent>;
+  private readonly metrics: DataServiceMetrics | null;
   private readonly channels = new Map<string, ChannelState>();
   private subscriberId = 0;
 
@@ -84,6 +87,7 @@ export class PollingScheduler {
     maxActiveChannels = 250,
     jitterRatio = 0.1,
     cacheTtlMs = 15_000,
+    metrics = undefined,
     now = Date.now,
   }: PollingSchedulerOptions) {
     this.fetchChannel = fetchChannel;
@@ -92,6 +96,7 @@ export class PollingScheduler {
     this.maxActiveChannels = maxActiveChannels;
     this.jitterRatio = jitterRatio;
     this.cache = new MemoryTtlCache<RealtimeEvent>({ ttlMs: cacheTtlMs, now });
+    this.metrics = metrics || null;
   }
 
   subscribe({
@@ -234,6 +239,7 @@ export class PollingScheduler {
   private async poll(state: ChannelState) {
     if (state.inFlight || state.disposed) return;
     state.inFlight = true;
+    const startedAt = Date.now();
     try {
       const event = await this.fetchChannel({
         channel: state.channel,
@@ -248,6 +254,12 @@ export class PollingScheduler {
       state.source = event.source || null;
       state.stale = Boolean(event.stale);
       this.cache.set(state.key, event);
+      this.recordPollMetrics({
+        state,
+        source: event.source || "unknown",
+        result: "success",
+        durationMs: Date.now() - startedAt,
+      });
       this.broadcast(state, event);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -263,11 +275,43 @@ export class PollingScheduler {
         data: state.lastEvent?.data ?? null,
         error: message,
       };
+      this.recordPollMetrics({
+        state,
+        source: state.source || "failed",
+        result: "error",
+        durationMs: Date.now() - startedAt,
+      });
       this.broadcast(state, staleEvent);
     } finally {
       state.inFlight = false;
       this.scheduleNext(state);
     }
+  }
+
+  private recordPollMetrics({
+    state,
+    source,
+    result,
+    durationMs,
+  }: {
+    state: ChannelState;
+    source: string;
+    result: "success" | "error";
+    durationMs: number;
+  }) {
+    if (!this.metrics) return;
+    this.metrics.recordPoll({
+      channelType: state.type,
+      source,
+      result,
+      durationMs,
+    });
+    this.metrics.recordExternalRequestForPoll({
+      channelType: state.type,
+      provider: source,
+      result,
+      durationMs,
+    });
   }
 
   private broadcast(state: ChannelState, event: RealtimeEvent) {

--- a/services/data-service/src/server.ts
+++ b/services/data-service/src/server.ts
@@ -1,11 +1,13 @@
 import { createServer, type ServerResponse } from "node:http";
 import { ChannelManager } from "./channels/ChannelManager.js";
+import { DataServiceMetrics } from "./metrics/MetricsRegistry.js";
 import { PollingScheduler } from "./polling/PollingScheduler.js";
 import { fetchAdsbChannel } from "./sources/adsbClient.js";
 import { fetchRouteChannel } from "./sources/routeClient.js";
 import { attachWebSocketServer } from "./ws.js";
 
 const port = Number(process.env.PORT || 8080);
+const metrics = new DataServiceMetrics();
 const scheduler = new PollingScheduler({
   fetchChannel: (input) =>
     input.channelType === "route" ? fetchRouteChannel(input) : fetchAdsbChannel(input),
@@ -13,10 +15,12 @@ const scheduler = new PollingScheduler({
   maxIntervalMs: Number(process.env.MAX_POLL_INTERVAL_MS || 30 * 60_000),
   maxActiveChannels: Number(process.env.MAX_ACTIVE_CHANNELS || 250),
   jitterRatio: Number(process.env.POLL_JITTER_RATIO || 0.1),
+  metrics,
 });
 const channelManager = new ChannelManager({
   scheduler,
   maxSubscriptionsPerSocket: Number(process.env.MAX_SOCKET_SUBSCRIPTIONS || 96),
+  metrics,
 });
 
 function parseCsv(value: string | undefined) {
@@ -54,16 +58,13 @@ const server = createServer((request, response) => {
   if (request.method === "GET" && url.pathname === "/metrics") {
     const channels = scheduler.getDebugChannels();
     response.writeHead(200, {
-      "Content-Type": "text/plain; charset=utf-8",
+      "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
       "Cache-Control": "no-store",
     });
-    response.end(
-      [
-        `adsbao_active_channels ${channels.length}`,
-        `adsbao_subscribers ${channels.reduce((sum: number, item) => sum + item.subscriberCount, 0)}`,
-        "",
-      ].join("\n"),
-    );
+    response.end(metrics.render({
+      channels,
+      uptimeSec: process.uptime(),
+    }));
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add Prometheus metrics for the Fly.io data-service WebSocket layer, polling loop, and provider endpoint calls.
- Expose the metrics through `/metrics` with Fly `[metrics]` scrape config.
- Add focused tests for metrics rendering, WebSocket subscription accounting, and polling/external request counters.

## Metrics Added
- `adsbao_ws_connections_current` / `adsbao_ws_connections_total`
- `adsbao_ws_messages_total{direction,type,result}`
- `adsbao_ws_subscribe_total{channel_type,result}`
- `adsbao_active_channels_current{channel_type}`
- `adsbao_subscriptions_current{channel_type}`
- `adsbao_poll_requests_total{channel_type,source,result}`
- `adsbao_poll_duration_seconds_*{channel_type,source,result}`
- `adsbao_external_requests_total{provider,endpoint,result}`
- `adsbao_external_request_duration_seconds_*{provider,endpoint,result}`

## Validation
- `pnpm --dir services/data-service test`
- `pnpm --dir services/data-service build`
- `pnpm test`
- `pnpm lint` (existing warnings only)
- `pnpm build`
- Local data-service runtime check on `ws://localhost:8080/ws` subscribed to `airport:KBOS` and `route:DAL44`, then verified `/metrics` emitted WS, poll, and external endpoint counters.
