### PR TITLE
Restore data service Fly deploy workflow

### DIFF
--- a/.github/workflows/data-service.yml
+++ b/.github/workflows/data-service.yml
@@ -1,0 +1,72 @@
+name: Data Service
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/data-service.yml"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "services/data-service/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/data-service.yml"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "services/data-service/**"
+  workflow_dispatch:
+
+concurrency:
+  group: data-service-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate data service
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test data service
+        run: pnpm --dir services/data-service test
+
+      - name: Build data service
+        run: pnpm --dir services/data-service build
+
+  deploy:
+    name: Deploy data service
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    concurrency:
+      group: data-service-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        working-directory: services/data-service
+        run: flyctl deploy --remote-only --config fly.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- restore the scoped Data Service GitHub Actions workflow
- validate the Fly data service on PRs with pnpm test/build
- deploy services/data-service to Fly.io on main pushes or manual dispatch

## Validation
- pnpm --dir services/data-service test
- pnpm --dir services/data-service build
- ruby YAML parse for .github/workflows/data-service.yml
- git diff --check -- .github/workflows/data-service.yml

## Notes
Fly dashboard GitHub attachment did not persist for adsbao-data-service: the Fly GraphQL API returned hasDeploymentSource=false after the dashboard update and after PR #433 merged to main. This workflow keeps backend deploys reliable without touching the frontend app.