### PR TITLE
Refine realtime traffic and route channels

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,12 +30,28 @@ Global airport context is sourced from [OpenAIP](https://www.openaip.net/) throu
 
 ### Realtime data service
 
-High-frequency aircraft positions, tracked-aircraft updates, viewport traffic,
-airport traffic, and callsign route labels are served first through the
+High-frequency aircraft positions, tracked-aircraft updates, traffic around a
+current map center, and callsign route labels are served first through the
 WebSocket backend under `services/data-service`. It is deployed as a Railway
 service, shares one polling loop per active channel, applies provider fallback
 and backoff centrally, and exposes `/health`, `/debug/channels`, `/metrics`,
 and `/ws`.
+
+Realtime channel keys encode the polling target instead of hiding it in
+subscription params. This keeps shared loops correct when three product anchors
+are active:
+
+| Product anchor | Traffic channel | Route channel |
+|---|---|---|
+| Airport page | `traffic:airport:{icao}:{lat}:{lon}:{distNm}` | `route:{callsign}:airport:{icao}` |
+| Here / user location | `traffic:center:{lat}:{lon}:{distNm}` | `route:{callsign}:center:{lat}:{lon}` |
+| Tracking page | `traffic:center:{aircraftLat}:{aircraftLon}:{distNm}` | `route:{callsign}:center:{aircraftLat}:{aircraftLon}` |
+
+The service rounds center coordinates before accepting a channel so many users
+share the same loop instead of creating one-off subscriptions. `route:*` remains
+separate from `traffic:*` because route lookup cadence and cache lifetime are
+much slower than ADS-B positions, and because the route display context changes
+with the current center for here/tracking flows.
 
 The frontend discovers it through `NEXT_PUBLIC_ADSBAO_REALTIME_URL`. Realtime
 surfaces do not start their own external-provider polling when the WebSocket is

--- a/services/data-service/src/channels/ChannelManager.test.ts
+++ b/services/data-service/src/channels/ChannelManager.test.ts
@@ -39,8 +39,7 @@ class FakeSocket extends EventEmitter {
     "message",
     JSON.stringify({
       type: "subscribe",
-      channel: "airport:KBOS",
-      params: { lat: 42.3656, lon: -71.0096, distNm: 40 },
+      channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
     }),
   );
   socket.emit(
@@ -62,7 +61,7 @@ class FakeSocket extends EventEmitter {
   );
   assert.match(
     output,
-    /adsbao_ws_subscribe_total\{channel_type="airport",result="ok"\} 1/,
+    /adsbao_ws_subscribe_total\{channel_type="traffic",result="ok"\} 1/,
   );
   assert.match(
     output,

--- a/services/data-service/src/channels/channelTypes.test.ts
+++ b/services/data-service/src/channels/channelTypes.test.ts
@@ -5,10 +5,16 @@ import {
 } from "./channelTypes";
 
 {
-  const channel = normalizeChannelName(" airport:kbos ");
+  const channel = normalizeChannelName(" traffic:airport:kbos:42.365:-71.009:37.8 ");
   assert.equal(channel.ok, true);
-  assert.equal(channel.channel, "airport:KBOS");
-  assert.equal(channel.type, "airport");
+  assert.equal(channel.channel, "traffic:airport:KBOS:42.4:-71:38");
+  assert.equal(channel.type, "traffic");
+  assert.deepEqual(buildChannelPollingTarget(channel.channel), {
+    kind: "positions",
+    lat: 42.4,
+    lon: -71,
+    distNm: 38,
+  });
 }
 
 {
@@ -19,26 +25,35 @@ import {
 }
 
 {
-  const channel = normalizeChannelName("route:aal123");
+  const channel = normalizeChannelName("route:aal123:airport:kbos");
   assert.equal(channel.ok, true);
-  assert.equal(channel.channel, "route:AAL123");
+  assert.equal(channel.channel, "route:AAL123:airport:KBOS");
   assert.equal(channel.type, "route");
   assert.deepEqual(buildChannelPollingTarget(channel.channel), {
     kind: "route",
     callsign: "AAL123",
+    context: { type: "airport", icao: "KBOS" },
   });
 }
 
 {
-  const channel = normalizeChannelName("viewport:42.365:-71.009:40");
+  const channel = normalizeChannelName("route:aal123:center:42.365:-71.009");
   assert.equal(channel.ok, true);
-  assert.equal(channel.channel, "viewport:42.4:-71:40");
-  assert.equal(channel.type, "viewport");
-  const target = buildChannelPollingTarget(channel.channel, {
-    lat: 42.365,
-    lon: -71.009,
-    distNm: 40,
+  assert.equal(channel.channel, "route:AAL123:center:42.4:-71");
+  assert.equal(channel.type, "route");
+  assert.deepEqual(buildChannelPollingTarget(channel.channel), {
+    kind: "route",
+    callsign: "AAL123",
+    context: { type: "center", lat: 42.4, lon: -71 },
   });
+}
+
+{
+  const channel = normalizeChannelName("traffic:center:42.365:-71.009:40");
+  assert.equal(channel.ok, true);
+  assert.equal(channel.channel, "traffic:center:42.4:-71:40");
+  assert.equal(channel.type, "traffic");
+  const target = buildChannelPollingTarget(channel.channel);
   assert.deepEqual(target, {
     kind: "positions",
     lat: 42.4,
@@ -48,21 +63,34 @@ import {
 }
 
 {
-  const channel = normalizeChannelName("bbox:42.1,-71.2,42.7,-70.5");
+  const channel = normalizeChannelName("traffic:center:42.365:-71.009:900");
   assert.equal(channel.ok, true);
-  assert.equal(channel.type, "bbox");
-  assert.equal(channel.channel, "bbox:42,-71.25,42.75,-70.5");
-  const target = buildChannelPollingTarget(channel.channel);
-  assert.equal(target.kind, "positions");
-  assert.equal(target.lat, 42.375);
-  assert.equal(target.lon, -70.875);
-  assert.equal(target.distNm > 0, true);
+  assert.equal(channel.channel, "traffic:center:42.4:-71:250");
 }
 
 {
-  const channel = normalizeChannelName("bbox:-80,-170,80,170");
+  assert.equal(
+    normalizeChannelName("traffic:center:42.365:-71.009:40:extra").ok,
+    false,
+  );
+  assert.equal(
+    normalizeChannelName("traffic:airport:kbos:42.365:-71.009:40:extra").ok,
+    false,
+  );
+  assert.equal(
+    normalizeChannelName("route:aal123:center:42.365:-71.009:extra").ok,
+    false,
+  );
+  assert.equal(
+    normalizeChannelName("route:aal123:airport:kbos:extra").ok,
+    false,
+  );
+}
+
+{
+  const channel = normalizeChannelName("airport:KBOS");
   assert.equal(channel.ok, false);
-  assert.match(channel.error, /too large/i);
+  assert.match(channel.error, /unsupported/i);
 }
 
 {

--- a/services/data-service/src/channels/channelTypes.ts
+++ b/services/data-service/src/channels/channelTypes.ts
@@ -6,10 +6,7 @@ import type {
 
 const MAX_AIRCRAFT_RANGE_NM = 250;
 const DEFAULT_AIRPORT_RANGE_NM = 40;
-const VIEWPORT_GRID_DEGREES = 0.1;
-const BBOX_GRID_DEGREES = 0.25;
-const MAX_BBOX_SPAN_DEGREES = 5;
-const EARTH_RADIUS_NM = 3440.065;
+const CENTER_GRID_DEGREES = 0.1;
 
 type ChannelResult =
   | {
@@ -41,45 +38,17 @@ function clampRangeNm(value: unknown, fallback = DEFAULT_AIRPORT_RANGE_NM) {
   return Math.max(1, Math.min(MAX_AIRCRAFT_RANGE_NM, Math.round(next)));
 }
 
-function roundToGrid(value: number, grid: number) {
+function roundToGrid(value: number, grid = CENTER_GRID_DEGREES) {
   return Number((Math.round(value / grid) * grid).toFixed(4));
-}
-
-function floorToGrid(value: number, grid: number) {
-  return Number((Math.floor(value / grid) * grid).toFixed(4));
-}
-
-function ceilToGrid(value: number, grid: number) {
-  return Number((Math.ceil(value / grid) * grid).toFixed(4));
 }
 
 function formatNumber(value: number) {
   return String(Number(value.toFixed(4)));
 }
 
-function haversineNm(
-  firstLat: number,
-  firstLon: number,
-  secondLat: number,
-  secondLon: number,
-) {
-  const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
-  const dLat = toRadians(secondLat - firstLat);
-  const dLon = toRadians(secondLon - firstLon);
-  const lat1 = toRadians(firstLat);
-  const lat2 = toRadians(secondLat);
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
-  return 2 * EARTH_RADIUS_NM * Math.asin(Math.sqrt(a));
-}
-
-function normalizeAirportChannel(value: string): ChannelResult {
-  const icao = value.trim().toUpperCase();
-  if (!/^[A-Z0-9]{3,6}$/.test(icao)) {
-    return { ok: false, error: "Invalid airport channel ICAO" };
-  }
-  return { ok: true, channel: `airport:${icao}`, type: "airport" };
+function normalizeAirportIcao(value: unknown) {
+  const icao = String(value || "").trim().toUpperCase();
+  return /^[A-Z][A-Z0-9]{3}$/.test(icao) ? icao : "";
 }
 
 function normalizeAircraftChannel(value: string): ChannelResult {
@@ -98,66 +67,98 @@ function normalizeCallsignChannel(value: string): ChannelResult {
   return { ok: true, channel: `callsign:${callsign}`, type: "callsign" };
 }
 
+function normalizeTrafficChannel(value: string): ChannelResult {
+  const [anchor, ...parts] = value.split(":");
+  if (anchor === "airport") {
+    if (parts.length !== 4) {
+      return { ok: false, error: "Invalid traffic airport channel" };
+    }
+    const [rawIcao, rawLat, rawLon, rawDist] = parts;
+    const icao = normalizeAirportIcao(rawIcao);
+    const lat = toNumber(rawLat);
+    const lon = toNumber(rawLon);
+    if (!icao || !isLatitude(lat) || !isLongitude(lon)) {
+      return { ok: false, error: "Invalid traffic airport channel" };
+    }
+    const roundedLat = roundToGrid(lat);
+    const roundedLon = roundToGrid(lon);
+    const distNm = clampRangeNm(rawDist);
+    return {
+      ok: true,
+      channel: `traffic:airport:${icao}:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}:${distNm}`,
+      type: "traffic",
+    };
+  }
+
+  if (anchor === "center") {
+    if (parts.length !== 3) {
+      return { ok: false, error: "Invalid traffic center channel" };
+    }
+    const [rawLat, rawLon, rawDist] = parts;
+    const lat = toNumber(rawLat);
+    const lon = toNumber(rawLon);
+    if (!isLatitude(lat) || !isLongitude(lon)) {
+      return { ok: false, error: "Invalid traffic center channel" };
+    }
+    const roundedLat = roundToGrid(lat);
+    const roundedLon = roundToGrid(lon);
+    const distNm = clampRangeNm(rawDist);
+    return {
+      ok: true,
+      channel: `traffic:center:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}:${distNm}`,
+      type: "traffic",
+    };
+  }
+
+  return { ok: false, error: "Invalid traffic channel anchor" };
+}
+
+function normalizeRouteCallsign(value: unknown) {
+  const callsign = String(value || "").trim().toUpperCase().replace(/\s+/g, "");
+  return /^[A-Z][A-Z0-9]{2,7}$/.test(callsign) ? callsign : "";
+}
+
 function normalizeRouteChannel(value: string): ChannelResult {
-  const callsign = value.trim().toUpperCase().replace(/\s+/g, "");
-  if (!/^[A-Z][A-Z0-9]{2,7}$/.test(callsign)) {
-    return { ok: false, error: "Invalid route channel callsign" };
-  }
-  return { ok: true, channel: `route:${callsign}`, type: "route" };
-}
+  const [rawCallsign, anchor, ...parts] = value.split(":");
+  const callsign = normalizeRouteCallsign(rawCallsign);
+  if (!callsign) return { ok: false, error: "Invalid route channel callsign" };
 
-function normalizeViewportChannel(value: string): ChannelResult {
-  const [rawLat, rawLon, rawDist] = value.split(":");
-  const lat = toNumber(rawLat);
-  const lon = toNumber(rawLon);
-  if (!isLatitude(lat) || !isLongitude(lon)) {
-    return { ok: false, error: "Invalid viewport channel coordinates" };
-  }
-  const roundedLat = roundToGrid(lat, VIEWPORT_GRID_DEGREES);
-  const roundedLon = roundToGrid(lon, VIEWPORT_GRID_DEGREES);
-  const distNm = clampRangeNm(rawDist);
-  return {
-    ok: true,
-    channel: `viewport:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}:${distNm}`,
-    type: "viewport",
-  };
-}
-
-function normalizeBboxChannel(value: string): ChannelResult {
-  const parts = value.split(",").map((item) => toNumber(item.trim()));
-  if (parts.length !== 4) {
-    return { ok: false, error: "Invalid bbox channel shape" };
+  if (!anchor) {
+    return { ok: true, channel: `route:${callsign}`, type: "route" };
   }
 
-  const [rawSouth, rawWest, rawNorth, rawEast] = parts;
-  if (
-    !isLatitude(rawSouth) ||
-    !isLatitude(rawNorth) ||
-    !isLongitude(rawWest) ||
-    !isLongitude(rawEast) ||
-    rawSouth >= rawNorth ||
-    rawWest >= rawEast
-  ) {
-    return { ok: false, error: "Invalid bbox channel coordinates" };
+  if (anchor === "airport") {
+    if (parts.length !== 1) {
+      return { ok: false, error: "Invalid route airport context" };
+    }
+    const icao = normalizeAirportIcao(parts[0]);
+    if (!icao) return { ok: false, error: "Invalid route airport context" };
+    return {
+      ok: true,
+      channel: `route:${callsign}:airport:${icao}`,
+      type: "route",
+    };
   }
 
-  const south = floorToGrid(rawSouth, BBOX_GRID_DEGREES);
-  const west = floorToGrid(rawWest, BBOX_GRID_DEGREES);
-  const north = ceilToGrid(rawNorth, BBOX_GRID_DEGREES);
-  const east = ceilToGrid(rawEast, BBOX_GRID_DEGREES);
-
-  if (
-    north - south > MAX_BBOX_SPAN_DEGREES ||
-    east - west > MAX_BBOX_SPAN_DEGREES
-  ) {
-    return { ok: false, error: "Bbox channel is too large" };
+  if (anchor === "center") {
+    if (parts.length !== 2) {
+      return { ok: false, error: "Invalid route center context" };
+    }
+    const lat = toNumber(parts[0]);
+    const lon = toNumber(parts[1]);
+    if (!isLatitude(lat) || !isLongitude(lon)) {
+      return { ok: false, error: "Invalid route center context" };
+    }
+    const roundedLat = roundToGrid(lat);
+    const roundedLon = roundToGrid(lon);
+    return {
+      ok: true,
+      channel: `route:${callsign}:center:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}`,
+      type: "route",
+    };
   }
 
-  return {
-    ok: true,
-    channel: `bbox:${formatNumber(south)},${formatNumber(west)},${formatNumber(north)},${formatNumber(east)}`,
-    type: "bbox",
-  };
+  return { ok: false, error: "Invalid route channel context" };
 }
 
 function normalizeScopedChannel(
@@ -180,72 +181,68 @@ export function normalizeChannelName(input: unknown): ChannelResult {
 
   const type = raw.slice(0, separatorIndex).toLowerCase();
   const value = raw.slice(separatorIndex + 1);
-  if (type === "airport") return normalizeAirportChannel(value);
   if (type === "aircraft") return normalizeAircraftChannel(value);
-  if (type === "bbox") return normalizeBboxChannel(value);
   if (type === "callsign") return normalizeCallsignChannel(value);
   if (type === "camera") return normalizeScopedChannel("camera", value);
   if (type === "route") return normalizeRouteChannel(value);
   if (type === "session") return normalizeScopedChannel("session", value);
-  if (type === "viewport") return normalizeViewportChannel(value);
+  if (type === "traffic") return normalizeTrafficChannel(value);
   return { ok: false, error: `Unsupported channel type: ${type}` };
 }
 
-function parseViewportChannel(channel: string): PollingTarget {
-  const [, rawLat, rawLon, rawDist] = channel.split(":");
-  const lat = Number(rawLat);
-  const lon = Number(rawLon);
+function parseTrafficChannel(channel: string): PollingTarget {
+  const [, anchor, ...parts] = channel.split(":");
+  if (anchor === "airport") {
+    const [, rawLat, rawLon, rawDist] = parts;
+    return {
+      kind: "positions",
+      lat: Number(rawLat),
+      lon: Number(rawLon),
+      distNm: clampRangeNm(rawDist),
+    };
+  }
+
+  const [rawLat, rawLon, rawDist] = parts;
   return {
     kind: "positions",
-    lat,
-    lon,
+    lat: Number(rawLat),
+    lon: Number(rawLon),
     distNm: clampRangeNm(rawDist),
   };
 }
 
-function parseBboxChannel(channel: string): PollingTarget {
-  const [, payload] = channel.split(":");
-  const [south, west, north, east] = payload
-    .split(",")
-    .map((item) => Number(item));
-  const lat = Number(((south + north) / 2).toFixed(4));
-  const lon = Number(((west + east) / 2).toFixed(4));
-  const radiusNm = Math.ceil(haversineNm(south, west, north, east) / 2);
-  return {
-    kind: "positions",
-    lat,
-    lon,
-    distNm: Math.max(1, Math.min(MAX_AIRCRAFT_RANGE_NM, radiusNm)),
-  };
+function parseRouteChannel(channel: string): PollingTarget {
+  const [, callsign, anchor, ...parts] = channel.split(":");
+  if (anchor === "airport") {
+    return {
+      kind: "route",
+      callsign,
+      context: { type: "airport", icao: parts[0] },
+    };
+  }
+  if (anchor === "center") {
+    return {
+      kind: "route",
+      callsign,
+      context: {
+        type: "center",
+        lat: Number(parts[0]),
+        lon: Number(parts[1]),
+      },
+    };
+  }
+  return { kind: "route", callsign };
 }
 
 export function buildChannelPollingTarget(
   input: string,
-  params: SubscribeParams = {},
+  _params: SubscribeParams = {},
 ): PollingTarget {
   const normalized = normalizeChannelName(input);
   if (normalized.ok !== true) throw new Error(normalized.error);
 
-  if (normalized.type === "airport") {
-    const lat = toNumber(params.lat);
-    const lon = toNumber(params.lon);
-    if (!isLatitude(lat) || !isLongitude(lon)) {
-      throw new Error("Airport channel requires lat/lon subscription params");
-    }
-    return {
-      kind: "positions",
-      lat,
-      lon,
-      distNm: clampRangeNm(params.distNm),
-    };
-  }
-
-  if (normalized.type === "viewport") {
-    return parseViewportChannel(normalized.channel);
-  }
-
-  if (normalized.type === "bbox") {
-    return parseBboxChannel(normalized.channel);
+  if (normalized.type === "traffic") {
+    return parseTrafficChannel(normalized.channel);
   }
 
   if (normalized.type === "callsign") {
@@ -263,10 +260,7 @@ export function buildChannelPollingTarget(
   }
 
   if (normalized.type === "route") {
-    return {
-      kind: "route",
-      callsign: normalized.channel.slice("route:".length),
-    };
+    return parseRouteChannel(normalized.channel);
   }
 
   throw new Error(`${normalized.type} channel does not have an active polling target`);
@@ -279,11 +273,8 @@ export function getChannelType(channel: string): RealtimeChannelType {
 }
 
 export function getChannelBaseIntervalMs(type: RealtimeChannelType) {
-  if (type === "airport" || type === "aircraft" || type === "callsign") {
+  if (type === "aircraft" || type === "callsign" || type === "traffic") {
     return 3_000;
-  }
-  if (type === "bbox" || type === "viewport") {
-    return 5_000;
   }
   if (type === "route") {
     return 30 * 60_000;

--- a/services/data-service/src/metrics/MetricsRegistry.test.ts
+++ b/services/data-service/src/metrics/MetricsRegistry.test.ts
@@ -9,9 +9,9 @@ import { DataServiceMetrics } from "./MetricsRegistry";
     type: "subscribe",
     result: "ok",
   });
-  metrics.recordWsSubscribe({ channelType: "airport", result: "ok" });
+  metrics.recordWsSubscribe({ channelType: "traffic", result: "ok" });
   metrics.recordPoll({
-    channelType: "airport",
+    channelType: "traffic",
     source: "adsb.lol",
     result: "success",
     durationMs: 123,
@@ -27,9 +27,9 @@ import { DataServiceMetrics } from "./MetricsRegistry";
     uptimeSec: 10,
     channels: [
       {
-        key: "airport:KBOS|42.3656|-71.0096|40",
-        channel: "airport:KBOS",
-        type: "airport",
+        key: "traffic:airport:KBOS:42.4:-71:40",
+        channel: "traffic:airport:KBOS:42.4:-71:40",
+        type: "traffic",
         subscriberCount: 2,
         currentIntervalMs: 5_000,
         lastFetchedAt: new Date(0).toISOString(),
@@ -61,19 +61,19 @@ import { DataServiceMetrics } from "./MetricsRegistry";
   );
   assert.match(
     output,
-    /adsbao_ws_subscribe_total\{channel_type="airport",result="ok"\} 1/,
+    /adsbao_ws_subscribe_total\{channel_type="traffic",result="ok"\} 1/,
   );
   assert.match(
     output,
-    /adsbao_active_channels_current\{channel_type="airport"\} 1/,
+    /adsbao_active_channels_current\{channel_type="traffic"\} 1/,
   );
   assert.match(
     output,
-    /adsbao_subscriptions_current\{channel_type="airport"\} 2/,
+    /adsbao_subscriptions_current\{channel_type="traffic"\} 2/,
   );
   assert.match(
     output,
-    /adsbao_poll_requests_total\{channel_type="airport",result="success",source="adsb.lol"\} 1/,
+    /adsbao_poll_requests_total\{channel_type="traffic",result="success",source="adsb.lol"\} 1/,
   );
   assert.match(
     output,

--- a/services/data-service/src/metrics/MetricsRegistry.ts
+++ b/services/data-service/src/metrics/MetricsRegistry.ts
@@ -92,13 +92,7 @@ function metricLine(name: string, labels: Labels, value: number) {
 }
 
 function classifyEndpoint(channelType: RealtimeChannelType) {
-  if (
-    channelType === "airport" ||
-    channelType === "bbox" ||
-    channelType === "viewport"
-  ) {
-    return "positions";
-  }
+  if (channelType === "traffic") return "positions";
   if (channelType === "callsign") return "callsign";
   if (channelType === "aircraft") return "aircraft";
   if (channelType === "route") return "route";

--- a/services/data-service/src/polling/PollingScheduler.test.ts
+++ b/services/data-service/src/polling/PollingScheduler.test.ts
@@ -26,13 +26,11 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   const first: unknown[] = [];
   const second: unknown[] = [];
   const unsubscribeFirst = scheduler.subscribe({
-    channel: "airport:KBOS",
-    params: { lat: 42.3656, lon: -71.0096, distNm: 40 },
+    channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
     send: (event) => first.push(event),
   });
   const unsubscribeSecond = scheduler.subscribe({
-    channel: "airport:KBOS",
-    params: { lat: 42.3656, lon: -71.0096, distNm: 40 },
+    channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
     send: (event) => second.push(event),
   });
 
@@ -74,13 +72,11 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   });
 
   const unsubscribeFirst = scheduler.subscribe({
-    channel: "airport:KBOS",
-    params: { lat: 42.3656, lon: -71.0096, distNm: 40 },
+    channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
     send: (event) => first.push(event),
   });
   const unsubscribeSecond = scheduler.subscribe({
-    channel: "airport:KBOS",
-    params: { lat: 33.9425, lon: -118.4081, distNm: 40 },
+    channel: "traffic:center:33.9425:-118.4081:40",
     send: (event) => second.push(event),
   });
 
@@ -88,16 +84,16 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   assert.equal(
     scheduler.getDebugChannels().length,
     2,
-    "airport subscriptions with different targets must not share one loop",
+    "traffic subscriptions with different centers must not share one loop",
   );
-  assert.equal(targetKeys.has("42.3656,-71.0096,40"), true);
-  assert.equal(targetKeys.has("33.9425,-118.4081,40"), true);
+  assert.equal(targetKeys.has("42.4,-71,40"), true);
+  assert.equal(targetKeys.has("33.9,-118.4,40"), true);
   assert.equal(
-    first.every((event) => event.data.targetKey === "42.3656,-71.0096,40"),
+    first.every((event) => event.data.targetKey === "42.4,-71,40"),
     true,
   );
   assert.equal(
-    second.every((event) => event.data.targetKey === "33.9425,-118.4081,40"),
+    second.every((event) => event.data.targetKey === "33.9,-118.4,40"),
     true,
   );
 
@@ -122,15 +118,13 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   });
 
   const unsubscribe = scheduler.subscribe({
-    channel: "airport:KBOS",
-    params: { lat: 42.3656, lon: -71.0096 },
+    channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
     send: () => {},
   });
   assert.throws(
     () =>
       scheduler.subscribe({
-        channel: "airport:KSFO",
-        params: { lat: 37.6213, lon: -122.379 },
+        channel: "traffic:airport:KSFO:37.6213:-122.379:40",
         send: () => {},
       }),
     /active channel limit/i,

--- a/services/data-service/src/polling/PollingScheduler.ts
+++ b/services/data-service/src/polling/PollingScheduler.ts
@@ -51,22 +51,12 @@ type PollingSchedulerOptions = {
   now?: () => number;
 };
 
-function formatTargetNumber(value: number) {
-  return String(Number(value.toFixed(4)));
-}
-
 function buildChannelStateKey(
   channel: string,
-  type: RealtimeChannelType,
-  target: PollingTarget,
+  _type: RealtimeChannelType,
+  _target: PollingTarget,
 ) {
-  if (type !== "airport" || target.kind !== "positions") return channel;
-  return [
-    channel,
-    formatTargetNumber(target.lat),
-    formatTargetNumber(target.lon),
-    String(target.distNm),
-  ].join("|");
+  return channel;
 }
 
 export class PollingScheduler {

--- a/services/data-service/src/types.ts
+++ b/services/data-service/src/types.ts
@@ -1,12 +1,10 @@
 export type RealtimeChannelType =
-  | "airport"
   | "aircraft"
-  | "bbox"
   | "callsign"
   | "camera"
   | "route"
   | "session"
-  | "viewport";
+  | "traffic";
 
 export type RealtimeEventType =
   | "aircraft:update"
@@ -42,6 +40,14 @@ export type PollingTarget =
   | {
       kind: "route";
       callsign: string;
+      context?: {
+        type: "airport";
+        icao: string;
+      } | {
+        type: "center";
+        lat: number;
+        lon: number;
+      };
     };
 
 export type SubscribeParams = {

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -26,7 +26,9 @@ import {
   mapSettingsToExplorerLayers,
   mapSettingsToUserLocationPreferences,
   normalizeMapSettings,
+  resolveMapSettingsHydrationCommit,
   resolveMapSettingsHydration,
+  resolveMapSettingsPersistenceTargets,
 } from "@/features/airport/map-settings/mapSettingsModel";
 import {
   readStoredMapSettings,
@@ -347,6 +349,7 @@ function airportExplorerUiReducer(state, action) {
 export function ExplorerUiProvider({ children }) {
   const { isLoaded, isSignedIn } = useUser();
   const hasHydratedMapSettingsRef = useRef(false);
+  const pendingMapSettingsHydrationRef = useRef(null);
   const persistedMapSettingsRef = useRef("");
   const [mapSettingsHydrated, setMapSettingsHydrated] = useState(false);
   const [mapSettingsSaveStatus, setMapSettingsSaveStatus] = useState("idle");
@@ -381,6 +384,16 @@ export function ExplorerUiProvider({ children }) {
   } = state;
   const isMobile = sidebarMode === "mobile";
   const mapSettingsDevice = mapSettingsDeviceForSidebarMode(sidebarMode);
+  const queueMapSettingsHydration = useCallback((settings) => {
+    const normalizedSettings = normalizeMapSettings(settings);
+    pendingMapSettingsHydrationRef.current = normalizedSettings;
+    hasHydratedMapSettingsRef.current = false;
+    setMapSettingsHydrated(false);
+    dispatch({
+      type: "hydrateMapSettings",
+      settings: normalizedSettings,
+    });
+  }, []);
 
   useEffect(() => {
     const syncSidebarMode = () => {
@@ -397,42 +410,74 @@ export function ExplorerUiProvider({ children }) {
   }, []);
 
   useEffect(() => {
+    setMapSettingsSaveStatus("idle");
+    const cachedSettings = readStoredMapSettings(mapSettingsDevice);
+    const hydratedSettings = resolveMapSettingsHydration({
+      signedIn: false,
+      userSettings: null,
+      cachedSettings,
+    });
+
+    if (hydratedSettings.settings) {
+      queueMapSettingsHydration(hydratedSettings.settings);
+      return;
+    }
+
+    const effectiveSettings = hydratedSettings.settings
+      ? hydratedSettings.settings
+      : normalizeMapSettings(DEFAULT_MAP_SETTINGS);
+    persistedMapSettingsRef.current = JSON.stringify(effectiveSettings);
+    hasHydratedMapSettingsRef.current = true;
+    setMapSettingsHydrated(true);
+  }, [
+    mapSettingsDevice,
+    queueMapSettingsHydration,
+  ]);
+
+  useEffect(() => {
     if (!isLoaded) return undefined;
+    const targets = resolveMapSettingsPersistenceTargets({
+      authLoaded: isLoaded,
+      signedIn: isSignedIn,
+    });
+    if (!targets.readDatabase) return undefined;
+
     let cancelled = false;
 
-    const hydrateMapSettings = async () => {
+    const hydrateUserMapSettings = async () => {
       hasHydratedMapSettingsRef.current = false;
       setMapSettingsSaveStatus("idle");
-      const cachedSettings = readStoredMapSettings(mapSettingsDevice);
+      const cachedSettings = targets.readCache
+        ? readStoredMapSettings(mapSettingsDevice)
+        : null;
       let userSettings = null;
 
-      if (isSignedIn) {
-        try {
-          const response = await fetch(`/api/map-settings?device=${mapSettingsDevice}`, {
-            cache: "no-store",
-          });
-          if (response.ok) {
-            const payload = await response.json();
-            userSettings = payload?.settings
-              ? normalizeMapSettings(payload.settings)
-              : null;
-          }
-        } catch {
-          userSettings = null;
+      try {
+        const response = await fetch(`/api/map-settings?device=${mapSettingsDevice}`, {
+          cache: "no-store",
+        });
+        if (response.ok) {
+          const payload = await response.json();
+          userSettings = payload?.settings
+            ? normalizeMapSettings(payload.settings)
+            : null;
         }
+      } catch {
+        userSettings = null;
       }
 
       if (cancelled) return;
       const hydratedSettings = resolveMapSettingsHydration({
-        signedIn: isSignedIn,
+        signedIn: true,
         userSettings,
         cachedSettings,
       });
       if (hydratedSettings.settings) {
-        dispatch({
-          type: "hydrateMapSettings",
-          settings: hydratedSettings.settings,
-        });
+        queueMapSettingsHydration(hydratedSettings.settings);
+        if (hydratedSettings.source === "user" && targets.writeCache) {
+          writeStoredMapSettings(hydratedSettings.settings, mapSettingsDevice);
+        }
+        return;
       }
 
       const effectiveSettings = hydratedSettings.settings
@@ -443,7 +488,7 @@ export function ExplorerUiProvider({ children }) {
       if (!cancelled) setMapSettingsHydrated(true);
     };
 
-    hydrateMapSettings();
+    hydrateUserMapSettings();
 
     return () => {
       cancelled = true;
@@ -452,11 +497,26 @@ export function ExplorerUiProvider({ children }) {
     isLoaded,
     isSignedIn,
     mapSettingsDevice,
+    queueMapSettingsHydration,
   ]);
 
   useEffect(() => {
+    const hydrationCommit = resolveMapSettingsHydrationCommit({
+      pendingSettings: pendingMapSettingsHydrationRef.current,
+      currentSettings: mapSettings,
+    });
+    if (hydrationCommit.pending) {
+      return undefined;
+    }
+    if (hydrationCommit.committed) {
+      pendingMapSettingsHydrationRef.current = null;
+      persistedMapSettingsRef.current = hydrationCommit.serialized;
+      hasHydratedMapSettingsRef.current = true;
+      setMapSettingsHydrated(true);
+      return undefined;
+    }
+
     if (
-      !isLoaded ||
       !hasHydratedMapSettingsRef.current
     ) {
       return undefined;
@@ -464,9 +524,16 @@ export function ExplorerUiProvider({ children }) {
     const nextSettings = normalizeMapSettings(mapSettings);
     const serialized = JSON.stringify(nextSettings);
     if (serialized === persistedMapSettingsRef.current) return undefined;
+    const targets = resolveMapSettingsPersistenceTargets({
+      authLoaded: isLoaded,
+      signedIn: isSignedIn,
+    });
 
-    if (!isSignedIn) {
+    if (targets.writeCache) {
       writeStoredMapSettings(nextSettings, mapSettingsDevice);
+    }
+
+    if (!targets.writeDatabase) {
       persistedMapSettingsRef.current = serialized;
       return undefined;
     }
@@ -496,6 +563,9 @@ export function ExplorerUiProvider({ children }) {
           : nextSettings;
         const savedSerialized = JSON.stringify(savedSettings);
         if (cancelled) return;
+        if (targets.writeCache) {
+          writeStoredMapSettings(savedSettings, mapSettingsDevice);
+        }
         persistedMapSettingsRef.current = savedSerialized;
         if (savedSerialized !== serialized) {
           dispatch({

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -414,6 +414,8 @@ function FlightExplorerContent({ callsign }) {
     loadingCount: routeLoadingCount,
     applyTemporaryRoute,
   } = useFlightRoutes(rawAircraft, {
+    lat: contextLat,
+    lon: contextLon,
     routeProvider,
   });
 

--- a/src/features/airport/explorer/useAirportExplorerData.ts
+++ b/src/features/airport/explorer/useAirportExplorerData.ts
@@ -47,6 +47,7 @@ export function useAirportExplorerData(
     airportProfile.icao,
     airportProfile.lat,
     airportProfile.lon,
+    { trafficAnchor: "airport" },
   );
   const {
     routesByCallsign,

--- a/src/features/airport/map-settings/mapSettingsModel.test.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  DEFAULT_MAP_SETTINGS,
   MAP_LAYER_KEYS,
   MAP_MODE_IDS,
   buildCustomMapSettings,
@@ -12,7 +13,9 @@ import {
   mergeMapSettings,
   normalizeMapSettings,
   normalizeMapSettingsDevice,
+  resolveMapSettingsHydrationCommit,
   resolveMapSettingsHydration,
+  resolveMapSettingsPersistenceTargets,
 } from "./mapSettingsModel";
 
 {
@@ -161,7 +164,7 @@ import {
 {
   assert.equal(
     getSelectableMapModeOptions().some(
-      (mode) => mode.id === "immersive",
+      (mode) => String(mode.id) === "immersive",
     ),
     false,
   );
@@ -251,6 +254,86 @@ import {
 
   assert.equal(hydrated.source, "cache");
   assert.equal(hydrated.settings.selectedMode, MAP_MODE_IDS.SPOTTING);
+}
+
+{
+  assert.deepEqual(
+    resolveMapSettingsPersistenceTargets({
+      authLoaded: false,
+      signedIn: false,
+    }),
+    {
+      readCache: true,
+      readDatabase: false,
+      writeCache: true,
+      writeDatabase: false,
+    },
+    "pending auth should still rely on the local cache",
+  );
+  assert.deepEqual(
+    resolveMapSettingsPersistenceTargets({
+      authLoaded: true,
+      signedIn: true,
+    }),
+    {
+      readCache: true,
+      readDatabase: true,
+      writeCache: true,
+      writeDatabase: true,
+    },
+    "signed-in settings should use both cache and database",
+  );
+  assert.deepEqual(
+    resolveMapSettingsPersistenceTargets({
+      authLoaded: true,
+      signedIn: false,
+    }),
+    {
+      readCache: true,
+      readDatabase: false,
+      writeCache: true,
+      writeDatabase: false,
+    },
+    "guest settings should only use the local cache",
+  );
+}
+
+{
+  const pending = resolveMapSettingsHydrationCommit({
+    pendingSettings: {
+      selectedMode: MAP_MODE_IDS.RADIO,
+      baseMode: MAP_MODE_IDS.RADIO,
+      hasSelectedMode: true,
+    },
+    currentSettings: DEFAULT_MAP_SETTINGS,
+  });
+
+  assert.equal(
+    pending.pending,
+    true,
+    "settings persistence should pause while cache hydration is still pending in state",
+  );
+  assert.equal(pending.committed, false);
+
+  const committed = resolveMapSettingsHydrationCommit({
+    pendingSettings: {
+      selectedMode: MAP_MODE_IDS.RADIO,
+      baseMode: MAP_MODE_IDS.RADIO,
+      hasSelectedMode: true,
+    },
+    currentSettings: {
+      selectedMode: MAP_MODE_IDS.RADIO,
+      baseMode: MAP_MODE_IDS.RADIO,
+      hasSelectedMode: true,
+    },
+  });
+
+  assert.equal(committed.pending, false);
+  assert.equal(
+    committed.committed,
+    true,
+    "settings hydration should commit once state matches the pending settings",
+  );
 }
 
 {

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -294,6 +294,38 @@ export function resolveMapSettingsHydration({
   return { source: "empty", settings: null };
 }
 
+export function resolveMapSettingsPersistenceTargets({
+  authLoaded = false,
+  signedIn = false,
+}: MapSettingsOptions = {}) {
+  const hasSignedInUser = authLoaded === true && signedIn === true;
+  return {
+    readCache: true,
+    readDatabase: hasSignedInUser,
+    writeCache: true,
+    writeDatabase: hasSignedInUser,
+  };
+}
+
+export function resolveMapSettingsHydrationCommit({
+  pendingSettings = null,
+  currentSettings = DEFAULT_MAP_SETTINGS,
+}: MapSettingsOptions = {}) {
+  if (!pendingSettings) {
+    return { pending: false, committed: false, serialized: "" };
+  }
+
+  const pendingSerialized = JSON.stringify(normalizeMapSettings(pendingSettings));
+  const currentSerialized = JSON.stringify(normalizeMapSettings(currentSettings));
+  const committed = pendingSerialized === currentSerialized;
+
+  return {
+    pending: !committed,
+    committed,
+    serialized: pendingSerialized,
+  };
+}
+
 function hasOwnSetting(settings: MapSettingsRecord, key: string) {
   return Object.prototype.hasOwnProperty.call(settings || {}, key);
 }
@@ -477,4 +509,3 @@ export function mapSettingsToUserLocationPreferences(
       enabled && layers[MAP_LAYER_KEYS.USER_LOCATION_AUDIO] === true,
   };
 }
-

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
@@ -35,6 +35,14 @@ const route = {
       routeProvider: "flightaware",
     }),
   );
+  assert.equal(
+    buildRouteCacheKey("dal123", { lat: 42.3656, lon: -71.0096 }),
+    "DAL123|CENTER|42.4|-71",
+  );
+  assert.notEqual(
+    buildRouteCacheKey("dal123", { lat: 42.3656, lon: -71.0096 }),
+    buildRouteCacheKey("dal123", { lat: 40.6413, lon: -73.7781 }),
+  );
 
   const cache = new Map([
     ["DAL123|KBOS|BOS", { route, time: now - 1_000 }],

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.ts
@@ -70,13 +70,22 @@ const routeContextCode = (value: unknown) =>
     .toUpperCase()
     .replace(/[^A-Z0-9]/g, "");
 
+const centerContextNumber = (value: unknown) => {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return "";
+  return String(Number((Math.round(number / 0.1) * 0.1).toFixed(4)));
+};
+
 export function buildRouteCacheKey(callsign: unknown, routeContext: RouteContext = {}) {
   const normalizedCallsign = normalizeCallsign(callsign);
   if (!normalizedCallsign) return "";
   const airportIcao = routeContextCode(routeContext.icao);
   const airportIata = routeContextCode(routeContext.iata);
   const routeProvider = routeContextCode(routeContext.routeProvider);
-  const suffix = [airportIcao, airportIata, routeProvider]
+  const centerLat = airportIcao || airportIata ? "" : centerContextNumber(routeContext.lat);
+  const centerLon = airportIcao || airportIata ? "" : centerContextNumber(routeContext.lon);
+  const centerParts = centerLat && centerLon ? ["CENTER", centerLat, centerLon] : [];
+  const suffix = [airportIcao, airportIata, ...centerParts, routeProvider]
     .filter(Boolean)
     .join("|");
   return suffix ? `${normalizedCallsign}|${suffix}` : normalizedCallsign;

--- a/src/hooks/useAircraftPositions.ts
+++ b/src/hooks/useAircraftPositions.ts
@@ -14,10 +14,7 @@ import {
   normalizeLongitude,
 } from "../features/aircraft/tracking/flightTrackingContextModel";
 import { useRealtimeAircraftChannel } from "./useRealtimeAircraftChannel";
-import {
-  buildAirportAircraftChannel,
-  buildViewportAircraftChannel,
-} from "../lib/realtime/realtimeChannels";
+import { buildAircraftTrafficChannel } from "../lib/realtime/realtimeChannels";
 
 const MAX_AIRCRAFT_RANGE_NM = 250;
 
@@ -56,11 +53,14 @@ export function useAircraftPositions(
 
   const realtimeRequest = useMemo(() => {
     if (!hasActiveQuery) return null;
-    return (
-      buildAirportAircraftChannel(icao, queryLat, queryLon, distNm) ||
-      buildViewportAircraftChannel({ lat: queryLat, lon: queryLon, distNm })
-    );
-  }, [distNm, hasActiveQuery, icao, queryLat, queryLon]);
+    return buildAircraftTrafficChannel({
+      anchor: options?.trafficAnchor === "airport" ? "airport" : "center",
+      icao,
+      lat: queryLat,
+      lon: queryLon,
+      distNm,
+    });
+  }, [distNm, hasActiveQuery, icao, options?.trafficAnchor, queryLat, queryLon]);
 
   const realtime = useRealtimeAircraftChannel({
     channel: realtimeRequest?.channel || "",

--- a/src/hooks/useFlightRoutes.ts
+++ b/src/hooks/useFlightRoutes.ts
@@ -26,12 +26,19 @@ export function useFlightRoutes(
   const routeUnsubscribersRef = useRef(new Map<string, () => void>());
   const routeContext = useMemo(
     () => ({
-      // Coordinates rank pending route channels only. The route cache key is
-      // callsign-only so airport and flight pages share the same realtime loop.
+      icao: routeContextInput?.icao,
+      iata: routeContextInput?.iata,
       lat: Number(routeContextInput?.lat),
       lon: Number(routeContextInput?.lon),
+      routeProvider: routeContextInput?.routeProvider,
     }),
-    [routeContextInput?.lat, routeContextInput?.lon],
+    [
+      routeContextInput?.iata,
+      routeContextInput?.icao,
+      routeContextInput?.lat,
+      routeContextInput?.lon,
+      routeContextInput?.routeProvider,
+    ],
   );
 
   useEffect(() => {
@@ -87,7 +94,7 @@ export function useFlightRoutes(
   useEffect(() => {
     const wanted = new Set(
       pendingCallsigns
-        .map((callsign) => buildRouteChannel(callsign)?.channel || "")
+        .map((callsign) => buildRouteChannel(callsign, routeContext)?.channel || "")
         .filter(Boolean),
     );
 
@@ -99,7 +106,7 @@ export function useFlightRoutes(
     }
 
     for (const callsign of pendingCallsigns) {
-      const request = buildRouteChannel(callsign);
+      const request = buildRouteChannel(callsign, routeContext);
       if (!request || routeUnsubscribersRef.current.has(request.channel)) continue;
       const unsubscribe = client.subscribe({
         channel: request.channel,

--- a/src/hooks/useRealtimeAircraftChannel.ts
+++ b/src/hooks/useRealtimeAircraftChannel.ts
@@ -8,9 +8,9 @@ import {
 } from "@/lib/realtime/adsbaoRealtimeClient";
 import { shouldUseRealtimeFallback } from "@/lib/realtime/realtimeFallbackModel";
 import {
-  buildAirportAircraftChannel,
+  buildAirportTrafficChannel,
   buildCallsignChannel,
-  buildViewportAircraftChannel,
+  buildCenterTrafficChannel,
 } from "@/lib/realtime/realtimeChannels";
 
 const INITIAL_REALTIME_GRACE_MS = 8_000;
@@ -140,7 +140,7 @@ export function useAirportAircraftRealtime({
   enabled?: boolean;
 }) {
   const request = useMemo(
-    () => buildAirportAircraftChannel(icao, lat, lon, distNm),
+    () => buildAirportTrafficChannel(icao, lat, lon, distNm),
     [distNm, icao, lat, lon],
   );
   return useRealtimeAircraftChannel({
@@ -162,7 +162,7 @@ export function useViewportAircraftRealtime({
   enabled?: boolean;
 }) {
   const request = useMemo(
-    () => buildViewportAircraftChannel({ lat, lon, distNm }),
+    () => buildCenterTrafficChannel({ lat, lon, distNm }),
     [distNm, lat, lon],
   );
   return useRealtimeAircraftChannel({

--- a/src/lib/realtime/realtimeChannels.test.ts
+++ b/src/lib/realtime/realtimeChannels.test.ts
@@ -1,48 +1,69 @@
 import assert from "node:assert/strict";
 import {
-  buildAirportAircraftChannel,
+  buildAircraftTrafficChannel,
+  buildAirportTrafficChannel,
+  buildCenterTrafficChannel,
   buildRouteChannel,
-  buildViewportAircraftChannel,
   normalizeRealtimeChannel,
 } from "./realtimeChannels";
 
 {
-  assert.deepEqual(buildAirportAircraftChannel("kbos", 42.3656, -71.0096), {
-    channel: "airport:KBOS",
-    params: {
-      lat: 42.3656,
-      lon: -71.0096,
-      distNm: 40,
-    },
+  assert.deepEqual(buildAirportTrafficChannel("kbos", 42.3656, -71.0096), {
+    channel: "traffic:airport:KBOS:42.4:-71:40",
+    params: {},
   });
 }
 
 {
   assert.deepEqual(
-    buildViewportAircraftChannel({
+    buildCenterTrafficChannel({
       lat: 42.3656,
       lon: -71.0096,
       distNm: 37.8,
     }),
     {
-      channel: "viewport:42.4:-71:38",
-      params: {
-        lat: 42.4,
-        lon: -71,
-        distNm: 38,
-      },
+      channel: "traffic:center:42.4:-71:38",
+      params: {},
     },
   );
 }
 
 {
-  const broad = buildViewportAircraftChannel({
+  const broad = buildCenterTrafficChannel({
     lat: 42.3656,
     lon: -71.0096,
     distNm: 900,
   });
-  assert.equal(broad.channel, "viewport:42.4:-71:250");
-  assert.equal(broad.params.distNm, 250);
+  assert.equal(broad.channel, "traffic:center:42.4:-71:250");
+}
+
+{
+  assert.deepEqual(
+    buildAircraftTrafficChannel({
+      anchor: "center",
+      icao: "TEST",
+      lat: 42.3656,
+      lon: -71.0096,
+      distNm: 30,
+    }),
+    {
+      channel: "traffic:center:42.4:-71:30",
+      params: {},
+    },
+  );
+  assert.deepEqual(
+    buildAircraftTrafficChannel({
+      anchor: "airport",
+      icao: "kbos",
+      lat: 42.3656,
+      lon: -71.0096,
+      distNm: 30,
+    }),
+    {
+      channel: "traffic:airport:KBOS:42.4:-71:30",
+      params: {},
+    },
+  );
 }
 
 {
@@ -51,11 +72,34 @@ import {
 }
 
 {
-  assert.deepEqual(buildRouteChannel(" aal123 "), {
-    channel: "route:AAL123",
+  assert.deepEqual(buildRouteChannel(" aal123 ", { icao: "kbos" }), {
+    channel: "route:AAL123:airport:KBOS",
     params: {},
   });
-  assert.equal(normalizeRealtimeChannel(" route:aal123 "), "route:AAL123");
+  assert.deepEqual(
+    buildRouteChannel(" aal123 ", { lat: 42.3656, lon: -71.0096 }),
+    {
+      channel: "route:AAL123:center:42.4:-71",
+      params: {},
+    },
+  );
+  assert.equal(
+    normalizeRealtimeChannel(" route:aal123:center:42.3656:-71.0096 "),
+    "route:AAL123:center:42.4:-71",
+  );
+  assert.equal(
+    normalizeRealtimeChannel("route:aal123:center:42.3656:-71.0096:extra"),
+    "",
+  );
+  assert.equal(normalizeRealtimeChannel("route:aal123:airport:kbos:extra"), "");
+  assert.equal(
+    normalizeRealtimeChannel("traffic:center:42.3656:-71.0096:40:extra"),
+    "",
+  );
+  assert.equal(
+    normalizeRealtimeChannel("traffic:airport:kbos:42.3656:-71.0096:40:extra"),
+    "",
+  );
 }
 
 console.log("realtimeChannels.test.ts ok");

--- a/src/lib/realtime/realtimeChannels.ts
+++ b/src/lib/realtime/realtimeChannels.ts
@@ -9,7 +9,7 @@ type RealtimeChannelRequest = {
 
 const MAX_AIRCRAFT_RANGE_NM = 250;
 const DEFAULT_AIRPORT_RANGE_NM = 40;
-const VIEWPORT_GRID_DEGREES = 0.1;
+const CENTER_GRID_DEGREES = 0.1;
 
 function toFiniteNumber(value: unknown) {
   const number = Number(value);
@@ -22,7 +22,15 @@ function normalizeRangeNm(value: unknown, fallback = DEFAULT_AIRPORT_RANGE_NM) {
   return Math.max(1, Math.min(MAX_AIRCRAFT_RANGE_NM, Math.round(next)));
 }
 
-function roundToGrid(value: number, grid = VIEWPORT_GRID_DEGREES) {
+function isLatitude(value: number | null): value is number {
+  return value != null && value >= -90 && value <= 90;
+}
+
+function isLongitude(value: number | null): value is number {
+  return value != null && value >= -180 && value <= 180;
+}
+
+function roundToGrid(value: number, grid = CENTER_GRID_DEGREES) {
   return Number((Math.round(value / grid) * grid).toFixed(4));
 }
 
@@ -45,7 +53,7 @@ function normalizeCallsign(value: unknown) {
   return /^[A-Z0-9]{2,12}$/.test(callsign) ? callsign : "";
 }
 
-export function buildAirportAircraftChannel(
+export function buildAirportTrafficChannel(
   icao: unknown,
   lat: unknown,
   lon: unknown,
@@ -54,18 +62,19 @@ export function buildAirportAircraftChannel(
   const code = normalizeAirportCode(icao);
   const normalizedLat = toFiniteNumber(lat);
   const normalizedLon = toFiniteNumber(lon);
-  if (!code || normalizedLat == null || normalizedLon == null) return null;
+  if (!code || !isLatitude(normalizedLat) || !isLongitude(normalizedLon)) {
+    return null;
+  }
+  const roundedLat = roundToGrid(normalizedLat);
+  const roundedLon = roundToGrid(normalizedLon);
+  const normalizedDist = normalizeRangeNm(distNm);
   return {
-    channel: `airport:${code}`,
-    params: {
-      lat: normalizedLat,
-      lon: normalizedLon,
-      distNm: normalizeRangeNm(distNm),
-    },
+    channel: `traffic:airport:${code}:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}:${normalizedDist}`,
+    params: {},
   };
 }
 
-export function buildViewportAircraftChannel({
+export function buildCenterTrafficChannel({
   lat,
   lon,
   distNm = DEFAULT_AIRPORT_RANGE_NM,
@@ -76,18 +85,33 @@ export function buildViewportAircraftChannel({
 }): RealtimeChannelRequest | null {
   const normalizedLat = toFiniteNumber(lat);
   const normalizedLon = toFiniteNumber(lon);
-  if (normalizedLat == null || normalizedLon == null) return null;
+  if (!isLatitude(normalizedLat) || !isLongitude(normalizedLon)) return null;
   const roundedLat = roundToGrid(normalizedLat);
   const roundedLon = roundToGrid(normalizedLon);
   const normalizedDist = normalizeRangeNm(distNm);
   return {
-    channel: `viewport:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}:${normalizedDist}`,
-    params: {
-      lat: roundedLat,
-      lon: roundedLon,
-      distNm: normalizedDist,
-    },
+    channel: `traffic:center:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}:${normalizedDist}`,
+    params: {},
   };
+}
+
+export function buildAircraftTrafficChannel({
+  anchor = "center",
+  icao,
+  lat,
+  lon,
+  distNm,
+}: {
+  anchor?: "airport" | "center";
+  icao?: unknown;
+  lat: unknown;
+  lon: unknown;
+  distNm?: unknown;
+}): RealtimeChannelRequest | null {
+  if (anchor === "airport") {
+    return buildAirportTrafficChannel(icao, lat, lon, distNm);
+  }
+  return buildCenterTrafficChannel({ lat, lon, distNm });
 }
 
 export function buildAircraftHexChannel(hex: unknown) {
@@ -100,10 +124,56 @@ export function buildCallsignChannel(callsign: unknown) {
   return normalized ? `callsign:${normalized}` : "";
 }
 
-export function buildRouteChannel(callsign: unknown): RealtimeChannelRequest | null {
+function normalizeRouteContext(routeContext: Record<string, unknown> = {}) {
+  const airportIcao = normalizeAirportCode(routeContext.icao);
+  if (airportIcao) return `airport:${airportIcao}`;
+
+  const lat = toFiniteNumber(routeContext.lat);
+  const lon = toFiniteNumber(routeContext.lon);
+  if (!isLatitude(lat) || !isLongitude(lon)) return "";
+  return `center:${formatNumber(roundToGrid(lat))}:${formatNumber(roundToGrid(lon))}`;
+}
+
+function normalizeTrafficChannel(value: string) {
+  const [anchor, ...parts] = value.split(":");
+  if (anchor === "airport") {
+    if (parts.length !== 4) return "";
+    const [icao, lat, lon, distNm] = parts;
+    return buildAirportTrafficChannel(icao, lat, lon, distNm)?.channel || "";
+  }
+  if (anchor === "center") {
+    if (parts.length !== 3) return "";
+    const [lat, lon, distNm] = parts;
+    return buildCenterTrafficChannel({ lat, lon, distNm })?.channel || "";
+  }
+  return "";
+}
+
+function normalizeRouteChannel(value: string) {
+  const [rawCallsign, anchor, ...parts] = value.split(":");
+  const normalized = normalizeCallsign(rawCallsign);
+  if (!normalized || !/^[A-Z][A-Z0-9]{2,7}$/.test(normalized)) return "";
+  if (anchor === "airport") {
+    if (parts.length !== 1) return "";
+    const context = normalizeRouteContext({ icao: parts[0] });
+    return context ? `route:${normalized}:${context}` : "";
+  }
+  if (anchor === "center") {
+    if (parts.length !== 2) return "";
+    const context = normalizeRouteContext({ lat: parts[0], lon: parts[1] });
+    return context ? `route:${normalized}:${context}` : "";
+  }
+  return parts.length === 0 && !anchor ? `route:${normalized}` : "";
+}
+
+export function buildRouteChannel(
+  callsign: unknown,
+  routeContext: Record<string, unknown> = {},
+): RealtimeChannelRequest | null {
   const normalized = normalizeCallsign(callsign);
   if (!normalized || !/^[A-Z][A-Z0-9]{2,7}$/.test(normalized)) return null;
-  return { channel: `route:${normalized}`, params: {} };
+  const context = normalizeRouteContext(routeContext);
+  return { channel: `route:${normalized}${context ? `:${context}` : ""}`, params: {} };
 }
 
 export function normalizeRealtimeChannel(channel: unknown) {
@@ -112,10 +182,6 @@ export function normalizeRealtimeChannel(channel: unknown) {
   if (separatorIndex <= 0) return "";
   const type = raw.slice(0, separatorIndex).toLowerCase();
   const value = raw.slice(separatorIndex + 1);
-  if (type === "airport") {
-    const code = normalizeAirportCode(value);
-    return code ? `airport:${code}` : "";
-  }
   if (type === "aircraft") {
     const hex = normalizeAircraftHex(value);
     return hex ? `aircraft:${hex}` : "";
@@ -125,13 +191,10 @@ export function normalizeRealtimeChannel(channel: unknown) {
     return callsign ? `callsign:${callsign}` : "";
   }
   if (type === "route") {
-    return buildRouteChannel(value)?.channel || "";
+    return normalizeRouteChannel(value);
   }
-  if (type === "viewport") {
-    const [lat, lon, distNm] = value.split(":");
-    return (
-      buildViewportAircraftChannel({ lat, lon, distNm })?.channel || ""
-    );
+  if (type === "traffic") {
+    return normalizeTrafficChannel(value);
   }
   return "";
 }


### PR DESCRIPTION
## Summary
- replace airport/viewport position channels with explicit traffic anchors for airport, here, and tracking flows
- encode route context in route channels and cache keys so moving-center tracking stays isolated
- preserve local + user map-settings persistence behavior for signed-in users and local-only behavior for signed-out users

## Validation
- pnpm test
- pnpm build
- pnpm lint (passes with existing warnings)
- pnpm exec tsc --noEmit --pretty false
- pnpm --dir services/data-service test
- pnpm --dir services/data-service build
- local WS smoke: traffic:airport:KBOS:42.4:-71:40 and route:DAL123:airport:KBOS