### PR TITLE
Quiet realtime reconnect UI

### DIFF
--- a/src/components/aircraft/tracking/LostSignalToast.tsx
+++ b/src/components/aircraft/tracking/LostSignalToast.tsx
@@ -8,11 +8,14 @@ import {
   buildLostSignalToastOptions,
 } from "@/features/aircraft/tracking/lostSignalToastModel";
 
+const LOST_SIGNAL_TOAST_DELAY_MS = 45_000;
+
 export default function LostSignalToast({
   active = false,
   callsign = "",
   onStay,
   onBackHome,
+  delayMs = LOST_SIGNAL_TOAST_DELAY_MS,
 }) {
   const { t } = useI18n();
 
@@ -28,10 +31,12 @@ export default function LostSignalToast({
       onStay,
       onBackHome,
     });
-    toast.warning(title, options);
+    const timer = window.setTimeout(() => {
+      toast.warning(title, options);
+    }, Math.max(0, Number(delayMs) || 0));
 
-    return undefined;
-  }, [active, callsign, onBackHome, onStay, t]);
+    return () => window.clearTimeout(timer);
+  }, [active, callsign, delayMs, onBackHome, onStay, t]);
 
   return null;
 }

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -57,8 +57,8 @@ function AirportExplorerContent({
   onBack,
   // "airport" (default) = standard airport detail view with full
   // metric cards, candidate watching spots, ATC, etc.
-  // "nearMe" = user-location centered view: metric cards (weather,
-  // spotting, dep/arr) become non-interactive read-only displays,
+  // "nearMe" = user-location centered view: metric cards collapse to
+  // weather + nearby traffic, airport-specific surfaces are skipped,
   // candidate-spots / ATC fetches are skipped, METAR temp comes from
   // the closest nearby airport, sidebar identity reads "Your location".
   mode = "airport",
@@ -457,9 +457,8 @@ function AirportExplorerContent({
     metarStatusCode: weather.metarStatusCode ?? null,
     aircraft: traffic.aircraft,
     airports: nearbyAirports.airports,
-    // In near-me mode there's no airport identity so frequencies /
-    // candidate watching spots are intentionally empty; the sidebar
-    // surfaces those metric cards as non-interactive "—" placeholders.
+    // In near-me mode there's no airport identity, so airport-specific
+    // frequencies stay empty and the metric grid only shows weather + nearby.
     frequencies: nearMe ? [] : airport?.frequencies || [],
     candidateWatchingSpots: candidateWatchingSpots.spots,
     focusLat: airportProfile.lat,
@@ -528,6 +527,7 @@ function AirportExplorerContent({
               lastUpdated={traffic.lastUpdated}
               routeProvider={traffic.routeProvider}
               loadingStatus={sourceLoadingStatus}
+              realtimeStatus={traffic.realtimeStatus}
               userLocationActive={userLocationEnabled || userLocationActive}
               userLocationAudioActive={
                 userLocationAudioEnabled || userLocationAudioActive

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -11,6 +11,7 @@ export default function ExplorerMapMenu({
   lastUpdated = null,
   routeProvider = "",
   loadingStatus = "",
+  realtimeStatus = "",
   userLocationActive = false,
   userLocationAudioActive = false,
   userLocationPending = false,
@@ -101,6 +102,7 @@ export default function ExplorerMapMenu({
         lastUpdated={lastUpdated}
         routeProvider={routeProvider}
         loadingStatus={loadingStatus}
+        realtimeStatus={realtimeStatus}
         wakeLockActive={wakeLockState.active}
       />
     </div>

--- a/src/components/explorer/MobileMapSourceStatus.tsx
+++ b/src/components/explorer/MobileMapSourceStatus.tsx
@@ -10,6 +10,7 @@ export default function MobileMapSourceStatus({
   lastUpdated = null,
   routeProvider = ROUTE_PROVIDER.ADSBDB,
   loadingStatus = "",
+  realtimeStatus = "",
   wakeLockActive = false,
 }) {
   const status = buildMapSourceStatusDisplay({ feedSource, routeProvider });
@@ -22,6 +23,7 @@ export default function MobileMapSourceStatus({
       updatedLabel={updatedLabel}
       routeProviderLabel={status.routeProvider}
       loadingStatus={loadingStatus}
+      realtimeStatus={realtimeStatus}
       placement="map-corner"
       wakeLockActive={wakeLockActive}
     />

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -142,6 +142,7 @@ function FlightExplorerContent({ callsign }) {
     pollVersion: trackedPollVersion,
     visibilityRefreshVersion: trackedVisibilityRefreshVersion,
     trackingState,
+    realtimeStatus,
   } = useTrackedAircraft(callsign);
   const [cachedTrackedMetadata, setCachedTrackedMetadata] = useState(null);
   const [contextTiles, setContextTiles] = useState({
@@ -800,6 +801,7 @@ function FlightExplorerContent({ callsign }) {
               lastUpdated={lastUpdated}
               routeProvider={routeProvider}
               loadingStatus={sourceLoadingStatus}
+              realtimeStatus={realtimeStatus}
               onFitToTrace={routeEndpointAirportsOnly ? null : fitToTrace}
               zoomDisabled={flightDisplayContext.zoomDisabled}
             />
@@ -871,7 +873,7 @@ function FlightExplorerContent({ callsign }) {
           )}
 
           <LostSignalToast
-            active={lostSignal && !lostSignalDismissed}
+            active={lostSignal && !lostSignalDismissed && !realtimeStatus}
             callsign={callsign}
             onStay={() => setLostSignalDismissed(true)}
             onBackHome={handleBack}

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -71,10 +71,12 @@ export default function MapSourceStatusDisplay({
   updatedLabel = "",
   routeProviderLabel = "",
   loadingStatus = "",
+  realtimeStatus = "",
   placement = "mobile-map",
   wakeLockActive = false,
 }) {
   const loadingActive = Boolean(loadingStatus);
+  const realtimeStatusLabel = String(realtimeStatus || "").trim().toUpperCase();
   const [displayedLoadingStatus, setDisplayedLoadingStatus] = useState(
     loadingStatus,
   );
@@ -97,6 +99,7 @@ export default function MapSourceStatusDisplay({
     !routeProviderLabel &&
     !loadingStatus &&
     !displayedLoadingStatus &&
+    !realtimeStatusLabel &&
     !wakeLockActive
   ) {
     return null;
@@ -104,7 +107,12 @@ export default function MapSourceStatusDisplay({
 
   const isMapCorner = placement === "map-corner";
   const isInfer = feedStatus === "infer";
-  const hasPrimary = feedSource || routeProviderLabel || updatedLabel || wakeLockActive;
+  const hasPrimary =
+    feedSource ||
+    routeProviderLabel ||
+    updatedLabel ||
+    realtimeStatusLabel ||
+    wakeLockActive;
 
   return (
     <div
@@ -116,6 +124,23 @@ export default function MapSourceStatusDisplay({
     >
       {hasPrimary ? (
         <span className={lineClassName}>
+          {realtimeStatusLabel ? (
+            <>
+              <StatusSpan className="inline-flex flex-none items-center gap-1.5 font-mono text-atc-orange">
+                <span
+                  aria-hidden="true"
+                  className="size-1.5 rounded-full bg-atc-orange opacity-80 motion-safe:animate-pulse [.airport-map-kit_&]:size-1"
+                />
+                <span>{realtimeStatusLabel}</span>
+              </StatusSpan>
+              {(wakeLockActive || feedSource || routeProviderLabel || updatedLabel) ? (
+                <span
+                  aria-hidden="true"
+                  className={diamondClassName}
+                />
+              ) : null}
+            </>
+          ) : null}
           {wakeLockActive ? (
             <>
               <StatusSpan className="flex-none tabular-nums text-atc-orange">

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -41,9 +41,7 @@ export default function AirportSidebar({
   loadingStatus = "",
   // When true the explorer is centered on the user (not an airport).
   // The identity hero swaps to a "Your location" header and the
-  // weather / spotting / ATC / dep+arr metric cards become
-  // read-only "—" placeholders (weather still shows the live temp,
-  // but doesn't switch to a briefing view on click).
+  // metric cards collapse to weather + nearby traffic.
   nearMe = false,
   nearMeRefresh,
   onSelectAircraft,

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -23,9 +23,9 @@ export default function SidebarViewSwitch({
   candidateSpotCount = 0,
   onOpenSpotting,
   // Near-me mode: the explorer is centered on the user's location
-  // (not an airport). ATC / Spotting / Departures / Arrivals
-  // surface as non-interactive "—" placeholders. Weather and
-  // Flights stay interactive — weather shows the hourly forecast.
+  // (not an airport). Keep the metric surface to weather + nearby
+  // aircraft because airport-specific ATC, spotting, and movement
+  // buckets do not apply.
   nearMe = false,
   // When feature flags haven't resolved yet, hold the layout stable
   // at its pre-resolution state. Prevents dep/arr cards from
@@ -43,17 +43,16 @@ export default function SidebarViewSwitch({
     ? "—"
     : (metar?.flightCategory?.toUpperCase() || "WX");
   const showMovementCards =
-    nearMe ||
-    (featureFlagsResolved && routeProvider === ROUTE_PROVIDER.FLIGHTAWARE);
+    featureFlagsResolved && routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
   const atcCount = Array.isArray(frequencies) ? frequencies.length : 0;
   const spottingCount = Number(candidateSpotCount) || 0;
-  const showAtcCard = nearMe || atcCount > 0;
+  const showAtcCard = atcCount > 0;
 
   // Pre-compute departure / arrival counts only when FlightAware is on.
   // The aircraft.movement field is already resolved upstream by
   // enrichAircraftWithRoutes, so this is just two filters.
   const { departureCount, arrivalCount } = useMemo(() => {
-    if (nearMe || routeProvider !== ROUTE_PROVIDER.FLIGHTAWARE) {
+    if (routeProvider !== ROUTE_PROVIDER.FLIGHTAWARE) {
       return { departureCount: 0, arrivalCount: 0 };
     }
     let dep = 0;
@@ -63,7 +62,28 @@ export default function SidebarViewSwitch({
       else if (item?.movement === ARRIVAL) arr += 1;
     }
     return { departureCount: dep, arrivalCount: arr };
-  }, [aircraft, nearMe, routeProvider]);
+  }, [aircraft, routeProvider]);
+
+  if (nearMe) {
+    return (
+      <SidebarMetricGrid label={t("sidebar.airportViews")}>
+        <SidebarMetricCard
+          label={t("sidebar.weather")}
+          value={temperature.value}
+          unit={temperature.unit}
+          active={activeView === "briefing"}
+          onClick={() => onViewChange?.("briefing")}
+        />
+        <SidebarMetricCard
+          label={t("sidebar.nearby")}
+          value={<NumberFlow value={aircraft.length} />}
+          unit={`${rule} / ADS-B`}
+          active={activeView === "traffic"}
+          onClick={() => onViewChange?.("traffic")}
+        />
+      </SidebarMetricGrid>
+    );
+  }
 
   return (
     <SidebarMetricGrid label={t("sidebar.airportViews")}>
@@ -84,34 +104,34 @@ export default function SidebarViewSwitch({
       {showAtcCard && (
         <SidebarMetricCard
           label={t("sidebar.atc")}
-          value={nearMe ? "—" : <NumberFlow value={atcCount} />}
+          value={<NumberFlow value={atcCount} />}
           unit={t("sidebar.metricUnits.frequency")}
-          active={!nearMe && activeView === "atc"}
-          onClick={nearMe ? undefined : () => onViewChange?.("atc")}
+          active={activeView === "atc"}
+          onClick={() => onViewChange?.("atc")}
         />
       )}
       <SidebarMetricCard
         label={t("sidebar.spotting")}
-        value={nearMe ? "—" : <NumberFlow value={spottingCount} />}
+        value={<NumberFlow value={spottingCount} />}
         unit={t("sidebar.metricUnits.spots")}
-        active={!nearMe && activeView === "spotting"}
-        onClick={nearMe ? undefined : onOpenSpotting}
+        active={activeView === "spotting"}
+        onClick={onOpenSpotting}
       />
       {showMovementCards && (
         <>
           <SidebarMetricCard
             label={t("sidebar.departures")}
-            value={nearMe ? "—" : <NumberFlow value={departureCount} />}
+            value={<NumberFlow value={departureCount} />}
             unit={t("sidebar.metricUnits.flights")}
-            active={!nearMe && activeView === "departures"}
-            onClick={nearMe ? undefined : () => onViewChange?.("departures")}
+            active={activeView === "departures"}
+            onClick={() => onViewChange?.("departures")}
           />
           <SidebarMetricCard
             label={t("sidebar.arrivals")}
-            value={nearMe ? "—" : <NumberFlow value={arrivalCount} />}
+            value={<NumberFlow value={arrivalCount} />}
             unit={t("sidebar.metricUnits.flights")}
-            active={!nearMe && activeView === "arrivals"}
-            onClick={nearMe ? undefined : () => onViewChange?.("arrivals")}
+            active={activeView === "arrivals"}
+            onClick={() => onViewChange?.("arrivals")}
           />
         </>
       )}

--- a/src/features/airport/explorer/useAirportExplorerData.ts
+++ b/src/features/airport/explorer/useAirportExplorerData.ts
@@ -43,6 +43,7 @@ export function useAirportExplorerData(
     lastUpdated,
     feedStatus,
     feedSource,
+    realtimeStatus,
   } = useAircraftPositions(
     airportProfile.icao,
     airportProfile.lat,
@@ -85,6 +86,7 @@ export function useAirportExplorerData(
       lastUpdated,
       feedStatus,
       feedSource,
+      realtimeStatus,
       routeProvider,
       routeLoadingCount,
       aircraftLoadingOverlayActive,

--- a/src/hooks/useAircraftPositions.ts
+++ b/src/hooks/useAircraftPositions.ts
@@ -15,6 +15,7 @@ import {
 } from "../features/aircraft/tracking/flightTrackingContextModel";
 import { useRealtimeAircraftChannel } from "./useRealtimeAircraftChannel";
 import { buildAircraftTrafficChannel } from "../lib/realtime/realtimeChannels";
+import { resolveRealtimeStatusLabel } from "../lib/realtime/realtimeStatusModel";
 
 const MAX_AIRCRAFT_RANGE_NM = 250;
 
@@ -121,6 +122,11 @@ export function useAircraftPositions(
 
   const waitingForRealtime =
     hasActiveQuery && (!settled || realtime.fallbackActive);
+  const realtimeStatus = resolveRealtimeStatusLabel({
+    available: realtime.available,
+    connectionState: realtime.connectionState,
+    settled,
+  });
 
   return {
     aircraft,
@@ -134,5 +140,6 @@ export function useAircraftPositions(
     feedStatus,
     feedSource,
     realtimeActive: realtime.connected && !realtime.fallbackActive,
+    realtimeStatus,
   };
 }

--- a/src/hooks/useFlightRoutes.ts
+++ b/src/hooks/useFlightRoutes.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
 import { FLIGHT_ROUTE_LOOKUP_CONFIG } from "../config/aviation";
 import { normalizeCallsign } from "../utils/callsign";
 import { flightRouteScheduler } from "../features/aviation/flight-routes/flightRouteScheduler";
@@ -11,15 +10,12 @@ import { buildRouteChannel } from "../lib/realtime/realtimeChannels";
 
 type FlightRouteHookRecord = Record<string, any>;
 
-const ROUTE_TOAST_ID = "adsbao-realtime-route-issue";
-
 export function useFlightRoutes(
   aircraft: FlightRouteHookRecord[],
   routeContextInput: FlightRouteHookRecord = {},
 ) {
   const enabled = routeContextInput?.enabled !== false;
   const client = useMemo(() => getAdsbaoRealtimeClient(), []);
-  const [connectionState, setConnectionState] = useState(client.state);
   const [version, setVersion] = useState(0);
   const mountedRef = useRef(true);
   const routeDisplayBatcherRef = useRef<any>(null);
@@ -59,13 +55,6 @@ export function useFlightRoutes(
       routeUnsubscribers.clear();
     };
   }, []);
-
-  useEffect(() => {
-    const unsubscribe = client.onConnectionState(setConnectionState);
-    return () => {
-      unsubscribe();
-    };
-  }, [client]);
 
   useEffect(() => {
     const unsubscribe = flightRouteScheduler.subscribe((state) => {
@@ -121,32 +110,11 @@ export function useFlightRoutes(
             );
             return;
           }
-          if (event.type === "channel:error" || event.type === "subscribe:error") {
-            toast.error("Realtime route lookup is unavailable.", {
-              id: ROUTE_TOAST_ID,
-              description: "Route labels are waiting for the ADSBao data service.",
-              duration: 8_000,
-            });
-          }
         },
       });
       routeUnsubscribersRef.current.set(request.channel, unsubscribe);
     }
   }, [client, pendingCallsigns, routeContext]);
-
-  useEffect(() => {
-    if (!enabled || pendingCallsigns.length === 0) return undefined;
-    const timer = window.setTimeout(() => {
-      if (!client.enabled || connectionState !== "open") {
-        toast.error("Realtime route lookup is unavailable.", {
-          id: ROUTE_TOAST_ID,
-          description: "Route labels are waiting for the ADSBao data service.",
-          duration: 8_000,
-        });
-      }
-    }, 8_000);
-    return () => window.clearTimeout(timer);
-  }, [client.enabled, connectionState, enabled, pendingCallsigns.length]);
 
   const routesByCallsign = useMemo(() => {
     version;

--- a/src/hooks/useRealtimeAircraftChannel.ts
+++ b/src/hooks/useRealtimeAircraftChannel.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
 import {
   type AdsbaoRealtimeEvent,
   getAdsbaoRealtimeClient,
@@ -15,7 +14,6 @@ import {
 
 const INITIAL_REALTIME_GRACE_MS = 8_000;
 const EMPTY_REALTIME_PARAMS: Record<string, unknown> = Object.freeze({});
-const REALTIME_ISSUE_TOAST_ID = "adsbao-realtime-issue";
 
 type RealtimeHookOptions = {
   channel?: string;
@@ -81,15 +79,6 @@ export function useRealtimeAircraftChannel({
     hasEvent: Boolean(event),
     hasEventData: Boolean(event?.data),
   });
-
-  useEffect(() => {
-    if (!fallbackActive || !available) return;
-    toast.error("Realtime data connection is unavailable.", {
-      id: REALTIME_ISSUE_TOAST_ID,
-      description: "Live ADS-B updates are waiting for the ADSBao data service.",
-      duration: 8_000,
-    });
-  }, [available, fallbackActive]);
 
   useEffect(() => {
     if (process.env.NODE_ENV === "production") return;

--- a/src/hooks/useTrackedAircraft.ts
+++ b/src/hooks/useTrackedAircraft.ts
@@ -14,6 +14,7 @@ import {
 import {
   getAdsbaoRealtimeClient,
 } from "../lib/realtime/adsbaoRealtimeClient";
+import { resolveRealtimeStatusLabel } from "../lib/realtime/realtimeStatusModel";
 import { useAircraftTrackingRealtime } from "./useRealtimeAircraftChannel";
 
 function normalizeRealtimeTrackedPayload(data: unknown) {
@@ -147,6 +148,11 @@ export function useTrackedAircraft(callsign: unknown) {
 
   const waitingForRealtime =
     hasActiveQuery && (!settled || realtime.fallbackActive);
+  const realtimeStatus = resolveRealtimeStatusLabel({
+    available: realtime.available,
+    connectionState: realtime.connectionState,
+    settled,
+  });
 
   return {
     aircraft,
@@ -163,6 +169,7 @@ export function useTrackedAircraft(callsign: unknown) {
     visibilityRefreshVersion: 0,
     trackingState,
     flightAwareFallback,
+    realtimeStatus,
     retry,
   };
 }

--- a/src/lib/realtime/realtimeStatusModel.test.ts
+++ b/src/lib/realtime/realtimeStatusModel.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { resolveRealtimeStatusLabel } from "./realtimeStatusModel";
+
+assert.equal(
+  resolveRealtimeStatusLabel({
+    available: true,
+    connectionState: "connecting",
+    settled: false,
+  }),
+  "CONNECTING",
+);
+assert.equal(
+  resolveRealtimeStatusLabel({
+    available: true,
+    connectionState: "closed",
+    settled: true,
+  }),
+  "RECONNECTING",
+);
+assert.equal(
+  resolveRealtimeStatusLabel({
+    available: true,
+    connectionState: "open",
+    settled: true,
+  }),
+  "",
+);
+assert.equal(
+  resolveRealtimeStatusLabel({
+    available: false,
+    connectionState: "closed",
+    settled: true,
+  }),
+  "",
+);
+
+console.log("realtimeStatusModel.test.ts ok");

--- a/src/lib/realtime/realtimeStatusModel.ts
+++ b/src/lib/realtime/realtimeStatusModel.ts
@@ -1,0 +1,14 @@
+export function resolveRealtimeStatusLabel({
+  available,
+  connectionState,
+  settled,
+}: {
+  available: boolean;
+  connectionState: string;
+  settled: boolean;
+}) {
+  if (!available || connectionState === "disabled" || connectionState === "open") {
+    return "";
+  }
+  return settled ? "RECONNECTING" : "CONNECTING";
+}


### PR DESCRIPTION
## Summary
- remove realtime fallback toast popups for aircraft traffic and route lookups
- show CONNECTING/RECONNECTING in the map data source status line instead
- delay lost-signal toast and suppress it while realtime is reconnecting
- collapse /here metrics to Weather + Nearby only

## Validation
- pnpm exec tsx src/lib/realtime/realtimeStatusModel.test.ts
- pnpm exec tsx src/lib/realtime/realtimeFallbackModel.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm test
- pnpm lint (passes with existing warnings)
- local headless Chrome checked /here, /airport/KBOS, and /aircraft/DAL44 with offline local realtime: status text shown, no realtime toast, /here metric card count = 2