### PR TITLE
Suppress lost-signal toast after iOS resume

### DIFF
--- a/src/components/aircraft/tracking/LostSignalToast.tsx
+++ b/src/components/aircraft/tracking/LostSignalToast.tsx
@@ -1,14 +1,23 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import {
   LOST_SIGNAL_TOAST_ID,
+  LOST_SIGNAL_RESUME_GRACE_MS,
   buildLostSignalToastOptions,
+  resolveLostSignalToastDelayMs,
 } from "@/features/aircraft/tracking/lostSignalToastModel";
 
 const LOST_SIGNAL_TOAST_DELAY_MS = 45_000;
+
+function isPageHidden() {
+  return (
+    typeof document !== "undefined" &&
+    (document.hidden || document.visibilityState === "hidden")
+  );
+}
 
 export default function LostSignalToast({
   active = false,
@@ -16,11 +25,63 @@ export default function LostSignalToast({
   onStay,
   onBackHome,
   delayMs = LOST_SIGNAL_TOAST_DELAY_MS,
+  resumeGraceMs = LOST_SIGNAL_RESUME_GRACE_MS,
 }) {
   const { t } = useI18n();
+  const [visibilityVersion, setVisibilityVersion] = useState(0);
+  const wasHiddenRef = useRef(false);
+  const resumeGraceUntilRef = useRef(0);
 
   useEffect(() => {
-    if (!active) {
+    const markHidden = () => {
+      wasHiddenRef.current = true;
+      toast.dismiss(LOST_SIGNAL_TOAST_ID);
+      setVisibilityVersion((value) => value + 1);
+    };
+    const markVisible = () => {
+      if (wasHiddenRef.current) {
+        wasHiddenRef.current = false;
+        resumeGraceUntilRef.current =
+          Date.now() + Math.max(0, Number(resumeGraceMs) || 0);
+        toast.dismiss(LOST_SIGNAL_TOAST_ID);
+      }
+      setVisibilityVersion((value) => value + 1);
+    };
+    const handleVisibility = () => {
+      if (isPageHidden()) markHidden();
+      else markVisible();
+    };
+    const handlePageShow = () => {
+      if (!isPageHidden()) {
+        wasHiddenRef.current = false;
+        resumeGraceUntilRef.current =
+          Date.now() + Math.max(0, Number(resumeGraceMs) || 0);
+        toast.dismiss(LOST_SIGNAL_TOAST_ID);
+        setVisibilityVersion((value) => value + 1);
+      }
+    };
+
+    if (isPageHidden()) wasHiddenRef.current = true;
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("pagehide", markHidden);
+    window.addEventListener("pageshow", handlePageShow);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("pagehide", markHidden);
+      window.removeEventListener("pageshow", handlePageShow);
+    };
+  }, [resumeGraceMs]);
+
+  useEffect(() => {
+    const toastDelay = resolveLostSignalToastDelayMs({
+      active,
+      hidden: isPageHidden(),
+      delayMs,
+      nowMs: Date.now(),
+      resumeGraceUntilMs: resumeGraceUntilRef.current,
+    });
+
+    if (toastDelay == null) {
       toast.dismiss(LOST_SIGNAL_TOAST_ID);
       return undefined;
     }
@@ -32,11 +93,20 @@ export default function LostSignalToast({
       onBackHome,
     });
     const timer = window.setTimeout(() => {
+      if (isPageHidden()) return;
       toast.warning(title, options);
-    }, Math.max(0, Number(delayMs) || 0));
+    }, toastDelay);
 
     return () => window.clearTimeout(timer);
-  }, [active, callsign, delayMs, onBackHome, onStay, t]);
+  }, [
+    active,
+    callsign,
+    delayMs,
+    onBackHome,
+    onStay,
+    t,
+    visibilityVersion,
+  ]);
 
   return null;
 }

--- a/src/features/aircraft/tracking/lostSignalToastModel.test.ts
+++ b/src/features/aircraft/tracking/lostSignalToastModel.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   LOST_SIGNAL_TOAST_ID,
   buildLostSignalToastOptions,
+  resolveLostSignalToastDelayMs,
 } from "./lostSignalToastModel";
 
 let stayed = false;
@@ -40,5 +41,60 @@ options.cancel.onClick();
 options.action.onClick();
 assert.equal(stayed, true);
 assert.equal(wentHome, true);
+
+assert.equal(
+  resolveLostSignalToastDelayMs({
+    active: false,
+    hidden: false,
+    delayMs: 45_000,
+    nowMs: 100_000,
+    resumeGraceUntilMs: 0,
+  }),
+  null,
+);
+
+assert.equal(
+  resolveLostSignalToastDelayMs({
+    active: true,
+    hidden: true,
+    delayMs: 45_000,
+    nowMs: 100_000,
+    resumeGraceUntilMs: 0,
+  }),
+  null,
+);
+
+assert.equal(
+  resolveLostSignalToastDelayMs({
+    active: true,
+    hidden: false,
+    delayMs: 45_000,
+    nowMs: 100_000,
+    resumeGraceUntilMs: 0,
+  }),
+  45_000,
+);
+
+assert.equal(
+  resolveLostSignalToastDelayMs({
+    active: true,
+    hidden: false,
+    delayMs: 45_000,
+    nowMs: 100_000,
+    resumeGraceUntilMs: 180_000,
+  }),
+  80_000,
+);
+
+assert.equal(
+  resolveLostSignalToastDelayMs({
+    active: true,
+    hidden: false,
+    delayMs: 45_000,
+    nowMs: 150_000,
+    resumeGraceUntilMs: 180_000,
+  }),
+  45_000,
+);
 
 console.log("lostSignalToastModel.test.ts ok");

--- a/src/features/aircraft/tracking/lostSignalToastModel.ts
+++ b/src/features/aircraft/tracking/lostSignalToastModel.ts
@@ -1,4 +1,5 @@
 export const LOST_SIGNAL_TOAST_ID = "tracked-flight-lost-signal";
+export const LOST_SIGNAL_RESUME_GRACE_MS = 90_000;
 
 type LostSignalTranslator = (
   key: string,
@@ -42,4 +43,24 @@ export function buildLostSignalToastOptions({
       },
     },
   };
+}
+
+export function resolveLostSignalToastDelayMs({
+  active = false,
+  hidden = false,
+  delayMs = 45_000,
+  nowMs = Date.now(),
+  resumeGraceUntilMs = 0,
+} = {}) {
+  if (!active || hidden) return null;
+
+  const normalizedDelay = Math.max(0, Number(delayMs) || 0);
+  const normalizedNow = Number(nowMs);
+  const normalizedGraceUntil = Number(resumeGraceUntilMs);
+  const graceRemaining =
+    Number.isFinite(normalizedNow) && Number.isFinite(normalizedGraceUntil)
+      ? Math.max(0, normalizedGraceUntil - normalizedNow)
+      : 0;
+
+  return Math.max(normalizedDelay, graceRemaining);
 }


### PR DESCRIPTION
## Summary
- suppress the lost-signal toast while the page is hidden
- add a resume grace window after iOS/Safari `visibilitychange` / `pagehide` / `pageshow`
- cover the delay decision in the lost-signal toast model test

## Root Cause
When iOS Safari backgrounds the tab/app, timers and WebSocket delivery can pause. The lost-signal toast timer could remain armed while hidden, then fire immediately or too soon when the page resumes even though the realtime connection is reconnecting or fresh updates are about to arrive.

## Validation
- `pnpm exec tsx src/features/aircraft/tracking/lostSignalToastModel.test.ts`
- `pnpm exec tsx src/features/aircraft/tracking/lostSignalTrackingModel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test`
- `pnpm lint` (existing warnings only)
- `pnpm build`
- local Chrome mobile viewport on `/aircraft/DAL44?locale=zh-CN`: no lost-signal toast, status line shows realtime connection state
