### PR TITLE
[codex] Canonicalize traffic realtime channels

### DIFF
--- a/services/data-service/src/channels/ChannelManager.test.ts
+++ b/services/data-service/src/channels/ChannelManager.test.ts
@@ -39,7 +39,7 @@ class FakeSocket extends EventEmitter {
     "message",
     JSON.stringify({
       type: "subscribe",
-      channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
+      channel: "traffic:center:42.3656:-71.0096:40",
     }),
   );
   socket.emit(

--- a/services/data-service/src/channels/channelTypes.test.ts
+++ b/services/data-service/src/channels/channelTypes.test.ts
@@ -5,9 +5,9 @@ import {
 } from "./channelTypes";
 
 {
-  const channel = normalizeChannelName(" traffic:airport:kbos:42.365:-71.009:37.8 ");
+  const channel = normalizeChannelName(" traffic:center:42.365:-71.009:37.8 ");
   assert.equal(channel.ok, true);
-  assert.equal(channel.channel, "traffic:airport:KBOS:42.4:-71:38");
+  assert.equal(channel.channel, "traffic:center:42.4:-71:38");
   assert.equal(channel.type, "traffic");
   assert.deepEqual(buildChannelPollingTarget(channel.channel), {
     kind: "positions",
@@ -75,6 +75,10 @@ import {
   );
   assert.equal(
     normalizeChannelName("traffic:airport:kbos:42.365:-71.009:40:extra").ok,
+    false,
+  );
+  assert.equal(
+    normalizeChannelName("traffic:airport:kbos:42.365:-71.009:40").ok,
     false,
   );
   assert.equal(

--- a/services/data-service/src/channels/channelTypes.ts
+++ b/services/data-service/src/channels/channelTypes.ts
@@ -69,27 +69,6 @@ function normalizeCallsignChannel(value: string): ChannelResult {
 
 function normalizeTrafficChannel(value: string): ChannelResult {
   const [anchor, ...parts] = value.split(":");
-  if (anchor === "airport") {
-    if (parts.length !== 4) {
-      return { ok: false, error: "Invalid traffic airport channel" };
-    }
-    const [rawIcao, rawLat, rawLon, rawDist] = parts;
-    const icao = normalizeAirportIcao(rawIcao);
-    const lat = toNumber(rawLat);
-    const lon = toNumber(rawLon);
-    if (!icao || !isLatitude(lat) || !isLongitude(lon)) {
-      return { ok: false, error: "Invalid traffic airport channel" };
-    }
-    const roundedLat = roundToGrid(lat);
-    const roundedLon = roundToGrid(lon);
-    const distNm = clampRangeNm(rawDist);
-    return {
-      ok: true,
-      channel: `traffic:airport:${icao}:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}:${distNm}`,
-      type: "traffic",
-    };
-  }
-
   if (anchor === "center") {
     if (parts.length !== 3) {
       return { ok: false, error: "Invalid traffic center channel" };
@@ -192,16 +171,7 @@ export function normalizeChannelName(input: unknown): ChannelResult {
 
 function parseTrafficChannel(channel: string): PollingTarget {
   const [, anchor, ...parts] = channel.split(":");
-  if (anchor === "airport") {
-    const [, rawLat, rawLon, rawDist] = parts;
-    return {
-      kind: "positions",
-      lat: Number(rawLat),
-      lon: Number(rawLon),
-      distNm: clampRangeNm(rawDist),
-    };
-  }
-
+  if (anchor !== "center") throw new Error("Invalid traffic channel anchor");
   const [rawLat, rawLon, rawDist] = parts;
   return {
     kind: "positions",

--- a/services/data-service/src/metrics/MetricsRegistry.test.ts
+++ b/services/data-service/src/metrics/MetricsRegistry.test.ts
@@ -27,8 +27,8 @@ import { DataServiceMetrics } from "./MetricsRegistry";
     uptimeSec: 10,
     channels: [
       {
-        key: "traffic:airport:KBOS:42.4:-71:40",
-        channel: "traffic:airport:KBOS:42.4:-71:40",
+        key: "traffic:center:42.4:-71:40",
+        channel: "traffic:center:42.4:-71:40",
         type: "traffic",
         subscriberCount: 2,
         currentIntervalMs: 5_000,

--- a/services/data-service/src/polling/PollingScheduler.test.ts
+++ b/services/data-service/src/polling/PollingScheduler.test.ts
@@ -26,11 +26,11 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   const first: unknown[] = [];
   const second: unknown[] = [];
   const unsubscribeFirst = scheduler.subscribe({
-    channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
+    channel: "traffic:center:42.3656:-71.0096:40",
     send: (event) => first.push(event),
   });
   const unsubscribeSecond = scheduler.subscribe({
-    channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
+    channel: "traffic:center:42.3656:-71.0096:40",
     send: (event) => second.push(event),
   });
 
@@ -72,7 +72,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   });
 
   const unsubscribeFirst = scheduler.subscribe({
-    channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
+    channel: "traffic:center:42.3656:-71.0096:40",
     send: (event) => first.push(event),
   });
   const unsubscribeSecond = scheduler.subscribe({
@@ -118,13 +118,13 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   });
 
   const unsubscribe = scheduler.subscribe({
-    channel: "traffic:airport:KBOS:42.3656:-71.0096:40",
+    channel: "traffic:center:42.3656:-71.0096:40",
     send: () => {},
   });
   assert.throws(
     () =>
       scheduler.subscribe({
-        channel: "traffic:airport:KSFO:37.6213:-122.379:40",
+        channel: "traffic:center:37.6213:-122.379:40",
         send: () => {},
       }),
     /active channel limit/i,

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -15,7 +15,6 @@ import {
 import ExplorerMapMenu from "@/components/explorer/ExplorerMapMenu";
 import {
   resolveAirportExplorerSelection,
-  resolveAirportExplorerTrafficAnchor,
   resolveAirportProfile,
 } from "@/features/airport/explorer/airportExplorerModel";
 import { resolveSpottingMetricZoomState } from "@/features/airport/explorer/airportExplorerUiModel";
@@ -128,13 +127,8 @@ function AirportExplorerContent({
   const metarIcao = nearMe
     ? nearbyAirports.airports?.[0]?.icao || ""
     : airportProfile.icao;
-  const trafficAnchor = resolveAirportExplorerTrafficAnchor({
-    mode,
-    airportProfile,
-  });
   const { weather, traffic } = useAirportExplorerData(airportProfile, {
     metarIcao,
-    trafficAnchor,
   });
   const userLocationActive = Boolean(userLocation);
   const userLocationAudioActive =

--- a/src/features/airport/explorer/airportExplorerModel.test.ts
+++ b/src/features/airport/explorer/airportExplorerModel.test.ts
@@ -3,7 +3,6 @@ import assert from "node:assert/strict";
 import {
   enrichAircraftWithRoutes,
   mergeTrackedAircraftIntoNearby,
-  resolveAirportExplorerTrafficAnchor,
   resolveAirportProfile,
   resolveAirportExplorerSelection,
 } from "./airportExplorerModel";
@@ -42,28 +41,6 @@ const localizedProfile = resolveAirportProfile({
   },
 });
 assert.equal(localizedProfile.localizedName, "上海浦东国际机场");
-
-assert.equal(
-  resolveAirportExplorerTrafficAnchor({
-    mode: "airport",
-    airportProfile: fallbackProfile,
-  }),
-  "airport",
-);
-assert.equal(
-  resolveAirportExplorerTrafficAnchor({
-    mode: "nearMe",
-    airportProfile: { icao: "", lat: 42.36, lon: -71.01 },
-  }),
-  "center",
-);
-assert.equal(
-  resolveAirportExplorerTrafficAnchor({
-    mode: "airport",
-    airportProfile: { icao: "", lat: 42.36, lon: -71.01 },
-  }),
-  "center",
-);
 
 const enriched = enrichAircraftWithRoutes({
   airportProfile: fallbackProfile,

--- a/src/features/airport/explorer/airportExplorerModel.ts
+++ b/src/features/airport/explorer/airportExplorerModel.ts
@@ -26,14 +26,6 @@ export function resolveAirportProfile({ icao = "", airport = null }: AirportExpl
   };
 }
 
-export function resolveAirportExplorerTrafficAnchor({
-  mode = "airport",
-  airportProfile = {},
-}: AirportExplorerRecord = {}): "airport" | "center" {
-  if (mode === "nearMe") return "center";
-  return airportProfile?.icao ? "airport" : "center";
-}
-
 export function enrichAircraftWithRoutes({
   aircraft = [],
   routesByCallsign = {},

--- a/src/features/airport/explorer/useAirportExplorerData.ts
+++ b/src/features/airport/explorer/useAirportExplorerData.ts
@@ -13,7 +13,7 @@ import { enrichAircraftWithRoutes } from "./airportExplorerModel";
 
 export function useAirportExplorerData(
   airportProfile,
-  options: { metarIcao?: string; trafficAnchor?: "airport" | "center" } = {},
+  options: { metarIcao?: string } = {},
 ) {
   const { enabled: flightAwareEnabled, resolved: flightAwareResolved } = useFlightAwareEnabled();
   const routeProvider = resolveRouteProvider({ flightAwareEnabled });
@@ -48,7 +48,6 @@ export function useAirportExplorerData(
     airportProfile.icao,
     airportProfile.lat,
     airportProfile.lon,
-    { trafficAnchor: options.trafficAnchor || "airport" },
   );
   const {
     routesByCallsign,

--- a/src/hooks/useAircraftPositions.ts
+++ b/src/hooks/useAircraftPositions.ts
@@ -34,7 +34,7 @@ function normalizeRealtimeAircraftPayload(data: unknown) {
 }
 
 export function useAircraftPositions(
-  icao: unknown,
+  _icao: unknown,
   lat: unknown,
   lon: unknown,
   options: Record<string, any> = {},
@@ -55,13 +55,11 @@ export function useAircraftPositions(
   const realtimeRequest = useMemo(() => {
     if (!hasActiveQuery) return null;
     return buildAircraftTrafficChannel({
-      anchor: options?.trafficAnchor === "airport" ? "airport" : "center",
-      icao,
       lat: queryLat,
       lon: queryLon,
       distNm,
     });
-  }, [distNm, hasActiveQuery, icao, options?.trafficAnchor, queryLat, queryLon]);
+  }, [distNm, hasActiveQuery, queryLat, queryLon]);
 
   const realtime = useRealtimeAircraftChannel({
     channel: realtimeRequest?.channel || "",

--- a/src/lib/realtime/realtimeChannels.test.ts
+++ b/src/lib/realtime/realtimeChannels.test.ts
@@ -1,18 +1,10 @@
 import assert from "node:assert/strict";
 import {
   buildAircraftTrafficChannel,
-  buildAirportTrafficChannel,
   buildCenterTrafficChannel,
   buildRouteChannel,
   normalizeRealtimeChannel,
 } from "./realtimeChannels";
-
-{
-  assert.deepEqual(buildAirportTrafficChannel("kbos", 42.3656, -71.0096), {
-    channel: "traffic:airport:KBOS:42.4:-71:40",
-    params: {},
-  });
-}
 
 {
   assert.deepEqual(
@@ -40,27 +32,12 @@ import {
 {
   assert.deepEqual(
     buildAircraftTrafficChannel({
-      anchor: "center",
-      icao: "TEST",
       lat: 42.3656,
       lon: -71.0096,
       distNm: 30,
     }),
     {
       channel: "traffic:center:42.4:-71:30",
-      params: {},
-    },
-  );
-  assert.deepEqual(
-    buildAircraftTrafficChannel({
-      anchor: "airport",
-      icao: "kbos",
-      lat: 42.3656,
-      lon: -71.0096,
-      distNm: 30,
-    }),
-    {
-      channel: "traffic:airport:KBOS:42.4:-71:30",
       params: {},
     },
   );
@@ -98,6 +75,10 @@ import {
   );
   assert.equal(
     normalizeRealtimeChannel("traffic:airport:kbos:42.3656:-71.0096:40:extra"),
+    "",
+  );
+  assert.equal(
+    normalizeRealtimeChannel("traffic:airport:kbos:42.3656:-71.0096:40"),
     "",
   );
 }

--- a/src/lib/realtime/realtimeChannels.ts
+++ b/src/lib/realtime/realtimeChannels.ts
@@ -53,27 +53,6 @@ function normalizeCallsign(value: unknown) {
   return /^[A-Z0-9]{2,12}$/.test(callsign) ? callsign : "";
 }
 
-export function buildAirportTrafficChannel(
-  icao: unknown,
-  lat: unknown,
-  lon: unknown,
-  distNm: unknown = DEFAULT_AIRPORT_RANGE_NM,
-): RealtimeChannelRequest | null {
-  const code = normalizeAirportCode(icao);
-  const normalizedLat = toFiniteNumber(lat);
-  const normalizedLon = toFiniteNumber(lon);
-  if (!code || !isLatitude(normalizedLat) || !isLongitude(normalizedLon)) {
-    return null;
-  }
-  const roundedLat = roundToGrid(normalizedLat);
-  const roundedLon = roundToGrid(normalizedLon);
-  const normalizedDist = normalizeRangeNm(distNm);
-  return {
-    channel: `traffic:airport:${code}:${formatNumber(roundedLat)}:${formatNumber(roundedLon)}:${normalizedDist}`,
-    params: {},
-  };
-}
-
 export function buildCenterTrafficChannel({
   lat,
   lon,
@@ -96,21 +75,14 @@ export function buildCenterTrafficChannel({
 }
 
 export function buildAircraftTrafficChannel({
-  anchor = "center",
-  icao,
   lat,
   lon,
   distNm,
 }: {
-  anchor?: "airport" | "center";
-  icao?: unknown;
   lat: unknown;
   lon: unknown;
   distNm?: unknown;
 }): RealtimeChannelRequest | null {
-  if (anchor === "airport") {
-    return buildAirportTrafficChannel(icao, lat, lon, distNm);
-  }
   return buildCenterTrafficChannel({ lat, lon, distNm });
 }
 
@@ -131,11 +103,6 @@ function normalizeRouteContext(routeContext: Record<string, unknown> = {}) {
 
 function normalizeTrafficChannel(value: string) {
   const [anchor, ...parts] = value.split(":");
-  if (anchor === "airport") {
-    if (parts.length !== 4) return "";
-    const [icao, lat, lon, distNm] = parts;
-    return buildAirportTrafficChannel(icao, lat, lon, distNm)?.channel || "";
-  }
   if (anchor === "center") {
     if (parts.length !== 3) return "";
     const [lat, lon, distNm] = parts;


### PR DESCRIPTION
## Summary
- Canonicalize ADS-B traffic realtime channels to `traffic:center:<lat>:<lon>:<radius>`.
- Remove airport-specific traffic anchors from the airport explorer path and realtime channel parsing.
- Keep airport context for route lookups intact while updating tests and metrics fixtures.

## Validation
- `pnpm test`
- `pnpm --dir services/data-service build`
- `pnpm lint` (0 errors; existing warnings remain)
- `pnpm build`