### PR TITLE
[codex] Fix FlightAware route lookup transport

### DIFF
--- a/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 
 import {
+  buildRouteProxyRequest,
   buildRouteCacheKey,
   buildRoutesByCallsign,
   getRouteLookupStats,
   resolvePendingRouteLookups,
+  resolveRouteLookupTransport,
   writeRouteCacheEntry,
 } from "./flightRouteLookupModel";
 
@@ -14,6 +16,32 @@ const route = {
   origin: { icao: "KATL" },
   destination: { icao: "KBOS" },
 };
+
+{
+  assert.equal(
+    resolveRouteLookupTransport({ routeProvider: "flightaware" }),
+    "proxy",
+  );
+  assert.equal(
+    resolveRouteLookupTransport({ routeProvider: "adsbdb" }),
+    "realtime",
+  );
+  assert.deepEqual(
+    buildRouteProxyRequest(" aal 1234 ", { routeProvider: "flightaware" }),
+    {
+      callsign: "AAL1234",
+      url: "/api/proxy/flight-routes/callsign/AAL1234?provider=flightaware",
+    },
+  );
+  assert.deepEqual(buildRouteProxyRequest("aal1234", {}), {
+    callsign: "AAL1234",
+    url: "/api/proxy/flight-routes/callsign/AAL1234",
+  });
+  assert.equal(
+    buildRouteProxyRequest("bad-call", { routeProvider: "flightaware" }),
+    null,
+  );
+}
 
 {
   assert.equal(
@@ -69,7 +97,7 @@ const route = {
       now,
       routeContext: { icao: "KBOS", iata: "BOS", routeProvider: "flightaware" },
     }),
-    { DAL123: route },
+    {},
   );
   assert.deepEqual(
     buildRoutesByCallsign({
@@ -128,6 +156,43 @@ const route = {
       maxLookups: 3,
     }),
     [],
+  );
+}
+
+{
+  const cache = new Map();
+  const flightAwareRoute = {
+    callsign: "AAL1234",
+    source: "flightaware",
+    origin: { icao: "KBOS", iata: "BOS" },
+    destination: { icao: "KLAX", iata: "LAX" },
+    route: { icao: "KBOS-KLAX", iata: "BOS-LAX" },
+  };
+  writeRouteCacheEntry(cache, "AAL1234", flightAwareRoute, now, {
+    icao: "KBOS",
+    iata: "BOS",
+    routeProvider: "flightaware",
+  });
+
+  assert.equal(cache.has("AAL1234"), false);
+  assert.equal(cache.has("AAL1234|KBOS|BOS|FLIGHTAWARE"), true);
+  assert.deepEqual(
+    buildRoutesByCallsign({
+      aircraft: [{ callsign: "AAL1234" }],
+      cache,
+      now,
+      routeContext: { icao: "KBOS", iata: "BOS" },
+    }),
+    {},
+  );
+  assert.deepEqual(
+    buildRoutesByCallsign({
+      aircraft: [{ callsign: "AAL1234" }],
+      cache,
+      now,
+      routeContext: { icao: "KBOS", iata: "BOS", routeProvider: "flightaware" },
+    }).AAL1234?.source,
+    "flightaware",
   );
 }
 

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.ts
@@ -64,11 +64,19 @@ type RoutesByCallsignOptions = {
   now?: number;
 };
 
+export const ROUTE_LOOKUP_TRANSPORT = Object.freeze({
+  REALTIME: "realtime",
+  PROXY: "proxy",
+});
+
 const routeContextCode = (value: unknown) =>
   String(value || "")
     .trim()
     .toUpperCase()
     .replace(/[^A-Z0-9]/g, "");
+
+const isFlightAwareRouteContext = (routeContext: RouteContext = {}) =>
+  routeContextCode(routeContext.routeProvider) === "FLIGHTAWARE";
 
 const centerContextNumber = (value: unknown) => {
   const number = Number(value);
@@ -79,6 +87,31 @@ const centerContextNumber = (value: unknown) => {
 function routeContextWithoutProvider(routeContext: RouteContext = {}) {
   const { routeProvider: _routeProvider, ...rest } = routeContext;
   return rest;
+}
+
+export function resolveRouteLookupTransport(routeContext: RouteContext = {}) {
+  return isFlightAwareRouteContext(routeContext)
+    ? ROUTE_LOOKUP_TRANSPORT.PROXY
+    : ROUTE_LOOKUP_TRANSPORT.REALTIME;
+}
+
+export function buildRouteProxyRequest(
+  callsign: unknown,
+  routeContext: RouteContext = {},
+) {
+  const normalizedCallsign = normalizeCallsign(callsign);
+  if (!normalizedCallsign || !isLookupCallsign(normalizedCallsign)) return null;
+  const params = new URLSearchParams();
+  if (isFlightAwareRouteContext(routeContext)) {
+    params.set("provider", "flightaware");
+  }
+  const query = params.toString();
+  return {
+    callsign: normalizedCallsign,
+    url: `/api/proxy/flight-routes/callsign/${encodeURIComponent(normalizedCallsign)}${
+      query ? `?${query}` : ""
+    }`,
+  };
 }
 
 export function buildRouteCacheKey(callsign: unknown, routeContext: RouteContext = {}) {
@@ -102,11 +135,13 @@ function getFreshRouteCacheEntry(
   now = Date.now(),
   routeContext: RouteContext = {},
 ) {
-  const cacheKeys = [
-    buildRouteCacheKey(callsign, routeContext),
-    buildRouteCacheKey(callsign, routeContextWithoutProvider(routeContext)),
-    buildRouteCacheKey(callsign),
-  ].filter(Boolean);
+  const cacheKeys = isFlightAwareRouteContext(routeContext)
+    ? [buildRouteCacheKey(callsign, routeContext)].filter(Boolean)
+    : [
+        buildRouteCacheKey(callsign, routeContext),
+        buildRouteCacheKey(callsign, routeContextWithoutProvider(routeContext)),
+        buildRouteCacheKey(callsign),
+      ].filter(Boolean);
   let firstMiss: RouteCacheEntry | null = null;
   for (const cacheKey of [...new Set(cacheKeys)]) {
     const cached = getFreshRouteCacheEntryByKey(cache, cacheKey, now);
@@ -139,12 +174,16 @@ export function writeRouteCacheEntry(
   time: number,
   routeContext: RouteContext = {},
 ) {
+  const exclusiveProvider =
+    isFlightAwareRouteContext(routeContext) ||
+    String(route?.source || "").trim().toLowerCase() === "flightaware";
   const cacheKeys = new Set(
     [callsign, route?.callsign, route?.callsignIcao, route?.callsignIata]
-      .flatMap((value) => [
-        buildRouteCacheKey(value, routeContext),
-        buildRouteCacheKey(value),
-      ])
+      .flatMap((value) =>
+        exclusiveProvider
+          ? [buildRouteCacheKey(value, routeContext)]
+          : [buildRouteCacheKey(value, routeContext), buildRouteCacheKey(value)],
+      )
       .filter(Boolean),
   );
 

--- a/src/hooks/useFlightRoutes.ts
+++ b/src/hooks/useFlightRoutes.ts
@@ -9,6 +9,12 @@ import type {
   FlightRoute,
   RouteContext,
 } from "../features/aviation/flight-routes/flightRouteLookupModel";
+import {
+  ROUTE_LOOKUP_TRANSPORT,
+  buildRouteCacheKey,
+  buildRouteProxyRequest,
+  resolveRouteLookupTransport,
+} from "../features/aviation/flight-routes/flightRouteLookupModel";
 import { createRouteDisplayBatcher } from "../features/aviation/flight-routes/flightRouteDisplayBatchModel";
 import { getAdsbaoRealtimeClient } from "../lib/realtime/adsbaoRealtimeClient";
 import { buildRouteChannel } from "../lib/realtime/realtimeChannels";
@@ -22,6 +28,15 @@ type RouteEventData = {
   route?: FlightRoute | null;
 };
 
+async function readRouteProxyResult(response: Response) {
+  if (!response.ok) {
+    throw new Error(`Route proxy HTTP ${response.status}`);
+  }
+  const text = await response.text();
+  if (!text) return null;
+  return JSON.parse(text) as FlightRoute | null;
+}
+
 export function useFlightRoutes(
   aircraft: AircraftRouteCandidate[],
   routeContextInput: FlightRouteHookContext = {},
@@ -34,6 +49,7 @@ export function useFlightRoutes(
     null,
   );
   const routeUnsubscribersRef = useRef(new Map<string, () => void>());
+  const proxyControllersRef = useRef(new Map<string, AbortController>());
   const routeContext = useMemo(
     () => ({
       icao: routeContextInput?.icao,
@@ -50,10 +66,15 @@ export function useFlightRoutes(
       routeContextInput?.routeProvider,
     ],
   );
+  const routeTransport = useMemo(
+    () => resolveRouteLookupTransport(routeContext),
+    [routeContext],
+  );
 
   useEffect(() => {
     mountedRef.current = true;
     const routeUnsubscribers = routeUnsubscribersRef.current;
+    const proxyControllers = proxyControllersRef.current;
     routeDisplayBatcherRef.current = createRouteDisplayBatcher({
       publish: (routeVersion) => {
         if (!mountedRef.current) return;
@@ -67,6 +88,8 @@ export function useFlightRoutes(
       routeDisplayBatcherRef.current = null;
       for (const unsubscribe of routeUnsubscribers.values()) unsubscribe();
       routeUnsubscribers.clear();
+      for (const controller of proxyControllers.values()) controller.abort();
+      proxyControllers.clear();
     };
   }, []);
 
@@ -95,6 +118,14 @@ export function useFlightRoutes(
   );
 
   useEffect(() => {
+    if (routeTransport !== ROUTE_LOOKUP_TRANSPORT.REALTIME) {
+      for (const unsubscribe of routeUnsubscribersRef.current.values()) {
+        unsubscribe();
+      }
+      routeUnsubscribersRef.current.clear();
+      return;
+    }
+
     const wanted = new Set(
       pendingCallsigns
         .map((callsign) => buildRouteChannel(callsign, routeContext)?.channel || "")
@@ -128,7 +159,63 @@ export function useFlightRoutes(
       });
       routeUnsubscribersRef.current.set(request.channel, unsubscribe);
     }
-  }, [client, pendingCallsigns, routeContext]);
+  }, [client, pendingCallsigns, routeContext, routeTransport]);
+
+  useEffect(() => {
+    const proxyControllers = proxyControllersRef.current;
+    if (routeTransport !== ROUTE_LOOKUP_TRANSPORT.PROXY) {
+      for (const controller of proxyControllers.values()) controller.abort();
+      proxyControllers.clear();
+      return;
+    }
+
+    const wanted = new Set<string>();
+    for (const callsign of pendingCallsigns) {
+      const request = buildRouteProxyRequest(callsign, routeContext);
+      if (!request) continue;
+      const key = buildRouteCacheKey(request.callsign, routeContext) || request.url;
+      wanted.add(key);
+      if (proxyControllers.has(key)) continue;
+
+      const controller = new AbortController();
+      proxyControllers.set(key, controller);
+      fetch(request.url, {
+        cache: "no-store",
+        credentials: "same-origin",
+        signal: controller.signal,
+      })
+        .then(readRouteProxyResult)
+        .then((route) => {
+          if (!mountedRef.current || controller.signal.aborted) return;
+          flightRouteScheduler.applyRouteResult(
+            request.callsign,
+            route || null,
+            routeContext,
+          );
+        })
+        .catch((error) => {
+          if (controller.signal.aborted) return;
+          if (process.env.NODE_ENV !== "production") {
+            console.warn(
+              `[flight-route-proxy] lookup failed for ${request.callsign}:`,
+              error,
+            );
+          }
+        })
+        .finally(() => {
+          if (proxyControllers.get(key) === controller) {
+            proxyControllers.delete(key);
+          }
+        });
+    }
+
+    for (const [key, controller] of proxyControllers) {
+      if (!wanted.has(key)) {
+        controller.abort();
+        proxyControllers.delete(key);
+      }
+    }
+  }, [pendingCallsigns, routeContext, routeTransport]);
 
   const routesByCallsign = useMemo(() => {
     version;


### PR DESCRIPTION
## Summary
- Route lookups now use the Next.js route proxy when the resolved route provider is FlightAware, keeping Clerk/feature-flag authorization on the server side instead of sending FlightAware through the unauthenticated realtime service.
- adsbdb lookups continue to use the realtime `route:*` WebSocket channels.
- FlightAware route cache entries are isolated from providerless adsbdb cache keys so FlightAware mode cannot reuse stale adsbdb routes or leak FlightAware results into adsbdb mode.

## Root Cause
Airport and flight pages resolved `routeProvider=flightaware` from the feature flag, but `useFlightRoutes()` always subscribed to realtime `route:*` channels. The data service route client only queried adsbdb, so FlightAware-enabled users could still receive adsbdb routes over WebSocket.

## Validation
- `pnpm exec tsx src/features/aviation/flight-routes/flightRouteLookupModel.test.ts`
- `pnpm exec tsx src/features/aviation/flight-routes/flightRouteScheduler.test.ts`
- `pnpm exec tsx src/features/aviation/flight-routes/flightRoutes.mechanism.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm lint` (passes with 3 existing warnings)
- `pnpm --dir services/data-service test`
- `pnpm --dir services/data-service build`