### PR TITLE
[codex] Wait for route feature flags before lookup

### DIFF
--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -30,6 +30,7 @@ import {
   resolveFlightTrackingDisplayContext,
 } from "@/features/aircraft/tracking/flightTrackingDisplayModel";
 import { resolveFocusedFlightAwareRouteArcPath } from "@/features/aviation/flight-routes/flightRouteArcModel";
+import { resolveRouteLookupEnabled } from "@/features/aviation/flight-routes/flightRouteLookupModel";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled";
 import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel";
 import { mergeTrackedAircraftIntoNearby } from "@/features/airport/explorer/airportExplorerModel";
@@ -88,7 +89,10 @@ export default function FlightExplorer({ callsign = "" }) {
 
 function FlightExplorerContent({ callsign }) {
   const router = useRouter();
-  const { enabled: flightAwareEnabled } = useFlightAwareEnabled();
+  const {
+    enabled: flightAwareEnabled,
+    resolved: flightAwareResolved,
+  } = useFlightAwareEnabled();
   const routeProvider = resolveRouteProvider({ flightAwareEnabled });
   const {
     desktopSidebarWidth,
@@ -415,6 +419,9 @@ function FlightExplorerContent({ callsign }) {
     loadingCount: routeLoadingCount,
     applyTemporaryRoute,
   } = useFlightRoutes(rawAircraft, {
+    enabled: resolveRouteLookupEnabled({
+      featureFlagsResolved: flightAwareResolved,
+    }),
     lat: contextLat,
     lon: contextLon,
     routeProvider,

--- a/src/features/airport/explorer/useAirportExplorerData.ts
+++ b/src/features/airport/explorer/useAirportExplorerData.ts
@@ -9,6 +9,7 @@ import {
   ROUTE_PROVIDER,
   resolveRouteProvider,
 } from "@/features/aviation/sourceDisplayModel";
+import { resolveRouteLookupEnabled } from "@/features/aviation/flight-routes/flightRouteLookupModel";
 import { enrichAircraftWithRoutes } from "./airportExplorerModel";
 
 export function useAirportExplorerData(
@@ -55,6 +56,9 @@ export function useAirportExplorerData(
     applyTemporaryRoute,
   } = useFlightRoutes(aircraft, {
     ...airportProfile,
+    enabled: resolveRouteLookupEnabled({
+      featureFlagsResolved: flightAwareResolved,
+    }),
     routeProvider:
       routeProvider === ROUTE_PROVIDER.FLIGHTAWARE ? routeProvider : "",
   });

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
@@ -6,6 +6,7 @@ import {
   buildRoutesByCallsign,
   getRouteLookupStats,
   resolvePendingRouteLookups,
+  resolveRouteLookupEnabled,
   resolveRouteLookupTransport,
   writeRouteCacheEntry,
 } from "./flightRouteLookupModel";
@@ -18,6 +19,9 @@ const route = {
 };
 
 {
+  assert.equal(resolveRouteLookupEnabled({ featureFlagsResolved: false }), false);
+  assert.equal(resolveRouteLookupEnabled({ featureFlagsResolved: true }), true);
+  assert.equal(resolveRouteLookupEnabled(), true);
   assert.equal(
     resolveRouteLookupTransport({ routeProvider: "flightaware" }),
     "proxy",

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.ts
@@ -95,6 +95,14 @@ export function resolveRouteLookupTransport(routeContext: RouteContext = {}) {
     : ROUTE_LOOKUP_TRANSPORT.REALTIME;
 }
 
+export function resolveRouteLookupEnabled({
+  featureFlagsResolved = true,
+}: {
+  featureFlagsResolved?: unknown;
+} = {}) {
+  return featureFlagsResolved !== false;
+}
+
 export function buildRouteProxyRequest(
   callsign: unknown,
   routeContext: RouteContext = {},


### PR DESCRIPTION
## Summary
- Delay route lookups until the FlightAware feature flag request has resolved.
- Applies to both airport pages and flight tracking pages, so FlightAware-enabled sessions do not send an initial adsbdb/realtime route burst before switching to the FlightAware proxy path.
- Keeps the default enabled behavior for callers that do not depend on feature flags.

## Root Cause
After PR #444, FlightAware mode correctly used the Next.js route proxy, but the page still started route lookups before `useFlightAwareEnabled()` resolved. During that pre-resolution window, `routeProvider` was effectively adsbdb/default, causing initial `route:*` WebSocket subscriptions before the page switched to FlightAware proxy requests.

## Validation
- `pnpm exec tsx src/features/aviation/flight-routes/flightRouteLookupModel.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm lint` (passes with 3 existing warnings)