### PR TITLE
[codex] Disclose adsbdb route uncertainty

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewIdentity.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewIdentity.tsx
@@ -4,7 +4,10 @@ import AirlineLogo from "./AirlineLogo";
 import AircraftPreviewType from "./AircraftPreviewType";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { getAircraftPreviewTypeDisplay } from "@/features/aircraft/preview/aircraftPreviewTypeModel";
-import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay";
+import {
+  getFlightRouteAccuracyNotice,
+  getFlightRouteAirlineIconUrl,
+} from "@/utils/flightRouteDisplay";
 
 // Callsign + parsed route. Mirrors the sidebar row's identity cell so the
 // hover state feels like a richer continuation rather than new data.
@@ -14,6 +17,9 @@ export default function AircraftPreviewIdentity({ aircraft }) {
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
   const route = aircraft?.flightRouteLabel || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
+  const routeAccuracyNotice = getFlightRouteAccuracyNotice(aircraft?.flightRoute)
+    ? t("aircraft.adsbdbRouteAccuracyNotice")
+    : "";
   const typeDisplay = getAircraftPreviewTypeDisplay(aircraft);
 
   return (
@@ -33,7 +39,7 @@ export default function AircraftPreviewIdentity({ aircraft }) {
           <span
             className="notranslate inline-flex min-w-0 items-center gap-1.5 overflow-hidden font-mono text-[11px] tracking-[0.04em] text-atc-dim md:gap-[5px] md:text-[9px]"
             translate="no"
-            title={route}
+            title={routeAccuracyNotice || route}
           >
             <AirlineLogo
               src={airlineIconUrl}

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -7,7 +7,10 @@ import NumberFlow from "@number-flow/react";
 import { Plane } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toFiniteNumber } from "@/utils/math";
-import { getFlightRouteAirlineIconUrl } from "@/utils/flightRouteDisplay";
+import {
+  getFlightRouteAccuracyNotice,
+  getFlightRouteAirlineIconUrl,
+} from "@/utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { resolveAircraftDisplayModel } from "@/features/aircraft/aircraftTypeDisplayModel";
@@ -96,6 +99,9 @@ export default function AircraftPreviewMobileCard({
         );
   const route = aircraft?.flightRouteLabel || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
+  const routeAccuracyNotice = getFlightRouteAccuracyNotice(aircraft?.flightRoute)
+    ? t("aircraft.adsbdbRouteAccuracyNotice")
+    : "";
 
   const speed = toFiniteNumber(aircraft?.velocity);
   const altitude = toFiniteNumber(aircraft?.altitude);
@@ -164,7 +170,10 @@ export default function AircraftPreviewMobileCard({
         <MobilePreviewRuleRow
           left={
             route ? (
-              <span className="inline-flex min-w-0 max-w-full items-center gap-[6px] align-baseline">
+              <span
+                className="inline-flex min-w-0 max-w-full items-center gap-[6px] align-baseline"
+                title={routeAccuracyNotice || route}
+              >
                 <AirlineLogo src={airlineIconUrl} />
                 <span className="min-w-0 truncate whitespace-nowrap">{route}</span>
               </span>

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -9,7 +9,6 @@ export default function ExplorerMapMenu({
   feedSource = "",
   feedStatus = "live",
   lastUpdated = null,
-  routeProvider = "",
   loadingStatus = "",
   realtimeStatus = "",
   userLocationActive = false,
@@ -100,7 +99,6 @@ export default function ExplorerMapMenu({
         feedSource={feedSource}
         feedStatus={feedStatus}
         lastUpdated={lastUpdated}
-        routeProvider={routeProvider}
         loadingStatus={loadingStatus}
         realtimeStatus={realtimeStatus}
         wakeLockActive={wakeLockState.active}

--- a/src/components/explorer/MobileMapSourceStatus.tsx
+++ b/src/components/explorer/MobileMapSourceStatus.tsx
@@ -1,19 +1,15 @@
 import MapSourceStatusDisplay from "@/components/map/MapSourceStatusDisplay";
-import {
-  ROUTE_PROVIDER,
-  buildMapSourceStatusDisplay,
-} from "@/features/aviation/sourceDisplayModel";
+import { buildMapSourceStatusDisplay } from "@/features/aviation/sourceDisplayModel";
 
 export default function MobileMapSourceStatus({
   feedSource = "",
   feedStatus = "live",
   lastUpdated = null,
-  routeProvider = ROUTE_PROVIDER.ADSBDB,
   loadingStatus = "",
   realtimeStatus = "",
   wakeLockActive = false,
 }) {
-  const status = buildMapSourceStatusDisplay({ feedSource, routeProvider });
+  const status = buildMapSourceStatusDisplay({ feedSource });
   const updatedLabel = formatUpdated(lastUpdated);
 
   return (
@@ -21,7 +17,6 @@ export default function MobileMapSourceStatus({
       feedSource={status.feedSource}
       feedStatus={feedStatus}
       updatedLabel={updatedLabel}
-      routeProviderLabel={status.routeProvider}
       loadingStatus={loadingStatus}
       realtimeStatus={realtimeStatus}
       placement="map-corner"

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -69,7 +69,6 @@ export default function MapSourceStatusDisplay({
   feedSource = "",
   feedStatus = "live",
   updatedLabel = "",
-  routeProviderLabel = "",
   loadingStatus = "",
   realtimeStatus = "",
   placement = "mobile-map",
@@ -96,7 +95,6 @@ export default function MapSourceStatusDisplay({
   if (
     !feedSource &&
     !updatedLabel &&
-    !routeProviderLabel &&
     !loadingStatus &&
     !displayedLoadingStatus &&
     !realtimeStatusLabel &&
@@ -109,7 +107,6 @@ export default function MapSourceStatusDisplay({
   const isInfer = feedStatus === "infer";
   const hasPrimary =
     feedSource ||
-    routeProviderLabel ||
     updatedLabel ||
     realtimeStatusLabel ||
     wakeLockActive;
@@ -133,7 +130,7 @@ export default function MapSourceStatusDisplay({
                 />
                 <span>{realtimeStatusLabel}</span>
               </StatusSpan>
-              {(wakeLockActive || feedSource || routeProviderLabel || updatedLabel) ? (
+              {(wakeLockActive || feedSource || updatedLabel) ? (
                 <span
                   aria-hidden="true"
                   className={diamondClassName}
@@ -146,7 +143,7 @@ export default function MapSourceStatusDisplay({
               <StatusSpan className="flex-none tabular-nums text-atc-orange">
                 ☕ Keep awake
               </StatusSpan>
-              {(feedSource || routeProviderLabel || updatedLabel) ? (
+              {(feedSource || updatedLabel) ? (
                 <span
                   aria-hidden="true"
                   className={diamondClassName}
@@ -161,18 +158,7 @@ export default function MapSourceStatusDisplay({
               {feedSource}
             </StatusSpan>
           ) : null}
-          {feedSource && routeProviderLabel ? (
-            <span
-              aria-hidden="true"
-              className={diamondClassName}
-            />
-          ) : null}
-          {routeProviderLabel ? (
-            <StatusSpan className="flex-none notranslate">
-              {routeProviderLabel}
-            </StatusSpan>
-          ) : null}
-          {(feedSource || routeProviderLabel) && updatedLabel ? (
+          {feedSource && updatedLabel ? (
             <span
               aria-hidden="true"
               className={diamondClassName}

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -6,6 +6,7 @@ import { Plane } from "lucide-react";
 import NumberFlow from "@number-flow/react";
 import {
   formatFlightRouteMunicipalityLabel,
+  getFlightRouteAccuracyNotice,
   getFlightRouteAirlineIconUrl,
 } from "../../utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
@@ -53,6 +54,9 @@ function AircraftRow({
   const callsign = aircraft.callsign?.trim() || aircraft.icao24 || "-";
   const route = aircraft.flightRouteLabel || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft.flightRoute);
+  const routeAccuracyNotice = getFlightRouteAccuracyNotice(aircraft.flightRoute)
+    ? t("aircraft.adsbdbRouteAccuracyNotice")
+    : "";
   // Municipality labels come from route providers as source-data city names.
   // Keep them in every locale so the code/name cycle remains available.
   const routeMunicipalities = formatFlightRouteMunicipalityLabel(
@@ -97,6 +101,7 @@ function AircraftRow({
         airlineIconUrl={airlineIconUrl}
         routeMunicipalities={routeMunicipalities}
         hasRouteMunicipalities={hasRouteMunicipalities}
+        routeAccuracyNotice={routeAccuracyNotice}
       />
       <div className="aircraft-table-cell aircraft-table-cell--distance text-right font-mono text-[12px] font-semibold text-atc-text">
         {!distanceDisplay ? (
@@ -157,6 +162,7 @@ function AircraftIdentityCell({
   airlineIconUrl,
   routeMunicipalities,
   hasRouteMunicipalities,
+  routeAccuracyNotice,
 }: Record<string, any>) {
   const hasRoute = Boolean(route);
   const hadRoute = useRef(hasRoute);
@@ -188,6 +194,10 @@ function AircraftIdentityCell({
     );
   }
 
+  const routeTitle =
+    routeAccuracyNotice ||
+    (hasRouteMunicipalities ? `${routeMunicipalities}\n${route}` : route);
+
   return (
     <div
       className={`aircraft-table-identity aircraft-table-identity--routed min-w-0 ${
@@ -206,6 +216,7 @@ function AircraftIdentityCell({
           className="aircraft-table-airline-logo"
         />
         <div
+          title={routeTitle}
           className={`aircraft-table-route-cycle min-w-0 flex-1 ${
             hasRouteMunicipalities ? "aircraft-table-route-cycle--alternate" : ""
           }`}

--- a/src/components/sidebar/FlightSidebar.tsx
+++ b/src/components/sidebar/FlightSidebar.tsx
@@ -9,6 +9,7 @@ import { SidebarMetricCard, SidebarMetricGrid } from "./SidebarMetric";
 import SidebarShell from "./SidebarShell";
 import {
   formatFlightRouteLabel,
+  getFlightRouteAccuracyNotice,
   getFlightRouteAirlineIconUrl,
 } from "@/utils/flightRouteDisplay";
 import { getAircraftPositionSourceBadge } from "@/features/aviation/sourceDisplayModel";
@@ -46,6 +47,7 @@ export default function FlightSidebar({
   onMap = null,
   onClose = null,
 }) {
+  const { t } = useI18n();
   const isMobileOverlay = Boolean(onClose);
   const displayCallsign =
     (aircraft?.callsign || callsign || "").trim() || "—";
@@ -53,6 +55,9 @@ export default function FlightSidebar({
   const typeDisplay = resolveAircraftDisplayModel(aircraft || {});
   const route = formatFlightRouteLabel(aircraft?.flightRoute) || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
+  const routeAccuracyNotice = getFlightRouteAccuracyNotice(aircraft?.flightRoute)
+    ? t("aircraft.adsbdbRouteAccuracyNotice")
+    : "";
   const speed = toFiniteNumber(aircraft?.velocity);
   const altitude = toFiniteNumber(aircraft?.altitude);
   const vs = toFiniteNumber(aircraft?.baroRate);
@@ -70,6 +75,7 @@ export default function FlightSidebar({
         typeDisplay={typeDisplay}
         route={route}
         airlineIconUrl={airlineIconUrl}
+        routeAccuracyNotice={routeAccuracyNotice}
         positionSourceBadge={positionSourceBadge}
       />
       <FlightTelemetryGrid
@@ -119,6 +125,7 @@ function FlightIdentity({
   typeDisplay,
   route,
   airlineIconUrl,
+  routeAccuracyNotice,
   positionSourceBadge,
 }) {
   const { t } = useI18n();
@@ -153,6 +160,7 @@ function FlightIdentity({
         <div
           className="notranslate mt-2 flex items-center gap-2 font-mono text-[12px] tracking-[0.04em] text-atc-dim"
           translate="no"
+          title={routeAccuracyNotice || route}
         >
           {airlineIconUrl && (
             <img

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -313,6 +313,8 @@ const en = {
   },
   aircraft: {
     noRoute: "No route",
+    adsbdbRouteAccuracyNotice:
+      "This route may be inaccurate: adsbdb uses callsign reference data that may not match today's actual origin and destination.",
     airborne: "Airborne",
     ground: "Ground",
     gnd: "GND",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -308,6 +308,8 @@ const zhCN = {
   },
   aircraft: {
     noRoute: "无航路",
+    adsbdbRouteAccuracyNotice:
+      "该航路可能不准确: adsbdb 使用 callsign 参考数据,可能不是今天实际执行的起降机场。",
     airborne: "空中",
     ground: "地面",
     gnd: "地面",

--- a/src/features/aviation/sourceDisplayModel.test.ts
+++ b/src/features/aviation/sourceDisplayModel.test.ts
@@ -67,7 +67,6 @@ assert.deepEqual(
   }),
   {
     feedSource: "ads-b",
-    routeProvider: "flightaware",
   },
 );
 
@@ -78,7 +77,6 @@ assert.deepEqual(
   }),
   {
     feedSource: "custom-feed",
-    routeProvider: "adsbdb",
   },
 );
 
@@ -89,7 +87,6 @@ assert.deepEqual(
   }),
   {
     feedSource: "",
-    routeProvider: "",
   },
 );
 

--- a/src/features/aviation/sourceDisplayModel.ts
+++ b/src/features/aviation/sourceDisplayModel.ts
@@ -41,11 +41,6 @@ const AIRCRAFT_POSITION_SOURCE_LABELS = Object.freeze({
   unknown: "",
 });
 
-const ROUTE_PROVIDER_LABELS = Object.freeze({
-  [ROUTE_PROVIDER.ADSBDB]: DATA_SOURCE_LABELS[DATA_SOURCE.ADSBDB],
-  [ROUTE_PROVIDER.FLIGHTAWARE]: DATA_SOURCE_LABELS[DATA_SOURCE.FLIGHTAWARE],
-});
-
 function normalizeKey(value) {
   return String(value || "").trim().toLowerCase();
 }
@@ -54,12 +49,6 @@ function getDataSourceDisplayName(source) {
   const raw = String(source || "").trim();
   if (!raw) return "";
   return DATA_SOURCE_LABELS[normalizeKey(raw)] || raw;
-}
-
-function getRouteProviderDisplayName(provider) {
-  const raw = String(provider || "").trim();
-  if (!raw) return "";
-  return ROUTE_PROVIDER_LABELS[normalizeKey(raw)] || raw;
 }
 
 function getAircraftLocationProviderDisplayName(source) {
@@ -117,10 +106,8 @@ export function getAircraftPositionSourceBadge(quality: Record<string, any> = {}
 
 export function buildMapSourceStatusDisplay({
   feedSource = "",
-  routeProvider = "",
 } = {}) {
   return {
     feedSource: getAircraftLocationProviderDisplayName(feedSource),
-    routeProvider: getRouteProviderDisplayName(routeProvider),
   };
 }

--- a/src/utils/flightRouteDisplay.test.ts
+++ b/src/utils/flightRouteDisplay.test.ts
@@ -3,15 +3,43 @@ import assert from 'node:assert/strict'
 import {
   formatFlightRouteLabel,
   formatFlightRouteMunicipalityLabel,
+  getFlightRouteAccuracyNotice,
 } from './flightRouteDisplay'
 
 {
   const label = formatFlightRouteLabel({
     origin: { iata: 'JFK', icao: 'KJFK' },
     destination: { iata: 'LHR', icao: 'EGLL' },
+    source: 'flightaware',
   })
 
   assert.equal(label, 'JFK -> LHR')
+}
+
+{
+  const adsbdbRoute = {
+    origin: { iata: 'BOS', icao: 'KBOS', municipality: 'Boston' },
+    destination: { iata: 'SFO', icao: 'KSFO', municipality: 'San Francisco' },
+    source: 'adsbdb',
+  }
+
+  assert.equal(formatFlightRouteLabel(adsbdbRoute), 'BOS -> SFO*')
+  assert.equal(
+    formatFlightRouteMunicipalityLabel(adsbdbRoute),
+    'Boston -> San Francisco*',
+  )
+  assert.ok(getFlightRouteAccuracyNotice(adsbdbRoute).includes('adsbdb'))
+}
+
+{
+  const flightAwareRoute = {
+    origin: { iata: 'BOS', icao: 'KBOS' },
+    destination: { iata: 'SFO', icao: 'KSFO' },
+    source: 'flightaware',
+  }
+
+  assert.equal(formatFlightRouteLabel(flightAwareRoute), 'BOS -> SFO')
+  assert.equal(getFlightRouteAccuracyNotice(flightAwareRoute), '')
 }
 
 {

--- a/src/utils/flightRouteDisplay.ts
+++ b/src/utils/flightRouteDisplay.ts
@@ -25,12 +25,24 @@ const sameAirport = (a, b) => {
 const routeDisplaySuffix = (route) =>
   String(route?.displaySuffix || '').trim()
 
+const normalizedRouteSource = (route) =>
+  String(route?.source || '').trim().toLowerCase()
+
+const routeAccuracySuffix = (route) =>
+  normalizedRouteSource(route) === 'adsbdb' ? '*' : ''
+
+const combinedRouteSuffix = (route) => {
+  const suffixes = [routeDisplaySuffix(route), routeAccuracySuffix(route)]
+    .filter(Boolean)
+  return [...new Set(suffixes)].join('')
+}
+
 export const formatFlightRouteLabel = (route) => {
   const origin = airportCode(route?.origin)
   const destination = airportCode(route?.destination)
   if (!origin || !destination) return ''
   if (sameAirport(route.origin, route.destination)) return ''
-  return `${origin} -> ${destination}${routeDisplaySuffix(route)}`
+  return `${origin} -> ${destination}${combinedRouteSuffix(route)}`
 }
 
 export const formatFlightRouteMunicipalityLabel = (route) => {
@@ -38,5 +50,10 @@ export const formatFlightRouteMunicipalityLabel = (route) => {
   const destination = airportMunicipality(route?.destination)
   if (!origin || !destination) return ''
   if (sameAirport(route.origin, route.destination)) return ''
-  return `${origin} -> ${destination}${routeDisplaySuffix(route)}`
+  return `${origin} -> ${destination}${combinedRouteSuffix(route)}`
 }
+
+export const getFlightRouteAccuracyNotice = (route) =>
+  normalizedRouteSource(route) === 'adsbdb'
+    ? "This route may be inaccurate: adsbdb uses callsign reference data that may not match today's actual origin and destination."
+    : ''


### PR DESCRIPTION
## Summary
- Stop showing the route provider in the map source status text; the status line now reflects the backend aircraft feed source plus freshness/connection state.
- Mark adsbdb-sourced aircraft routes with `*` in shared route formatting and add a localized hover title explaining that adsbdb callsign reference data may not match today's actual origin/destination.
- Reuse the backend-returned `route.source` across airport rows, preview cards, mobile preview, and flight sidebar route text; FlightAware-sourced routes do not receive the marker.

## Root cause
The status text was still wired to the frontend-selected route provider, while route display did not expose the lower-confidence adsbdb source returned on route payloads.

## Validation
- `pnpm exec tsx src/features/aviation/sourceDisplayModel.test.ts`
- `pnpm exec tsx src/utils/flightRouteDisplay.test.ts`
- `pnpm exec tsx src/features/airport/explorer/airportExplorerModel.test.ts`
- `pnpm exec tsx src/features/aviation/flight-routes/flightRouteLookupModel.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm lint` (0 errors; existing warnings in PlaneHunterStudio, VirtualNearbyList, useWeatherSlides)
- Local browser: `http://localhost:3000/airport/KBOS?locale=zh-CN` with local data-service on `:8080`; verified 7 adsbdb route labels had `*`, all 7 had the localized adsbdb accuracy title, and source status showed `ads-b` + timestamp without `adsbdb`/`flightaware`.
