### PR TITLE
[codex] Enforce route provider source consistency

### DIFF
--- a/src/app/api/dao/routeFeedbackReports.dao.ts
+++ b/src/app/api/dao/routeFeedbackReports.dao.ts
@@ -38,13 +38,9 @@ function createRouteFeedbackReportsRepository({
   if (!queryClient) return null;
 
   return {
-    // Newest active, non-expired, non-soft-deleted feedback override for
-    // a callsign. We deliberately ignore cache_key on read: the stored key
-    // (callsign + airport context) is retained for analysis, but a
-    // correction the user submitted while looking at KBOS should also win
-    // on /aircraft/DAL977 where there is no airport context to namespace
-    // against. The handler treats a hit as "use this route instead of
-    // asking adsbdb" — see the lookup order in flightRoutes.mechanism.js.
+    // Newest active, non-expired, non-soft-deleted feedback report for a
+    // callsign. The route lookup path no longer uses this as a provider
+    // override; reads are retained for audit/admin workflows.
     async readActiveOverride({ normalizedCallsign }: RouteFeedbackRecord) {
       if (!normalizedCallsign) return null;
 

--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.ts
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.ts
@@ -63,7 +63,7 @@ export async function GET(request, { params }) {
             }),
             // Expose the resolved upstream so the Network tab makes it
             // obvious which provider answered ("flightaware", "adsbdb",
-            // "community-feedback", or "none" on a miss).
+            // or "none" on a miss).
             "X-Route-Source": body?.source || "none",
           },
           { varyOrigin: false },

--- a/src/app/api/route-feedback/routeFeedbackHandlerModel.ts
+++ b/src/app/api/route-feedback/routeFeedbackHandlerModel.ts
@@ -92,10 +92,8 @@ export function normalizeRouteFeedbackInput(rawBody: RouteFeedbackHandlerRecord 
   };
 }
 
-// Builds the canonical insert spec for the Postgres write *and* the route
-// payload the handler echoes back to the client. Keeping these two
-// derivations together guarantees that what is stored is exactly what the
-// UI will paint into the in-memory cache.
+// Builds the canonical insert spec for the Postgres write and the route
+// payload the handler echoes back to the client for acknowledgement.
 export function buildRouteFeedbackInsertSpec({
   input,
   originAirport,

--- a/src/features/airport/explorer/useAirportExplorerData.ts
+++ b/src/features/airport/explorer/useAirportExplorerData.ts
@@ -5,10 +5,7 @@ import { useAircraftPositions } from "@/hooks/useAircraftPositions";
 import { useFlightRoutes } from "@/hooks/useFlightRoutes";
 import { useMetar } from "@/hooks/useMetar";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled";
-import {
-  ROUTE_PROVIDER,
-  resolveRouteProvider,
-} from "@/features/aviation/sourceDisplayModel";
+import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel";
 import { resolveRouteLookupEnabled } from "@/features/aviation/flight-routes/flightRouteLookupModel";
 import { enrichAircraftWithRoutes } from "./airportExplorerModel";
 
@@ -59,8 +56,7 @@ export function useAirportExplorerData(
     enabled: resolveRouteLookupEnabled({
       featureFlagsResolved: flightAwareResolved,
     }),
-    routeProvider:
-      routeProvider === ROUTE_PROVIDER.FLIGHTAWARE ? routeProvider : "",
+    routeProvider,
   });
 
   const aircraftWithRoutes = useMemo(

--- a/src/features/aviation/flight-routes/communityFeedbackRouteModel.ts
+++ b/src/features/aviation/flight-routes/communityFeedbackRouteModel.ts
@@ -3,10 +3,9 @@ import {
   sanitizeAirportCode,
 } from "./flightRouteCallsign";
 
-// Community feedback gives us a temporary override that the UI labels with
-// a `*` suffix and an "expires in 12h" tooltip. Keeping the constants here
-// — alongside the builder — keeps the route shape and its UI contract in
-// one place so the handler, normalizer, and renderer can't drift.
+// Community feedback records keep the route shape we store for audit and
+// review. They no longer participate in provider route lookup, so rendered
+// route source remains exclusively flightaware or adsbdb.
 const COMMUNITY_FEEDBACK_TTL_MS = 12 * 60 * 60 * 1000;
 const COMMUNITY_FEEDBACK_SOURCE = "community-feedback";
 const COMMUNITY_FEEDBACK_DISPLAY_SUFFIX = "*";

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
@@ -136,6 +136,7 @@ const route = {
       origin: { icao: "EPWA", iata: "WAW" },
       destination: { icao: "KMIA", iata: "MIA" },
       route: { icao: "EPWA-KMIA", iata: "WAW-MIA" },
+      source: "adsbdb",
     },
     now,
     { lat: 42.32, lon: -71.56, routeProvider: "adsbdb" },
@@ -156,6 +157,76 @@ const route = {
       cache,
       inFlight: new Set(),
       routeContext: { lat: 42.42, lon: -71.36, routeProvider: "adsbdb" },
+      now,
+      maxLookups: 3,
+    }),
+    [],
+  );
+}
+
+{
+  const cache = new Map();
+  const adsbdbRoute = {
+    callsign: "DAL123",
+    source: "adsbdb",
+    origin: { icao: "KATL", iata: "ATL" },
+    destination: { icao: "KBOS", iata: "BOS" },
+    route: { icao: "KATL-KBOS", iata: "ATL-BOS" },
+  };
+  writeRouteCacheEntry(cache, "DAL123", adsbdbRoute, now, {
+    routeProvider: "flightaware",
+  });
+
+  assert.deepEqual(
+    buildRoutesByCallsign({
+      aircraft: [{ callsign: "DAL123" }],
+      cache,
+      now,
+      routeContext: { routeProvider: "flightaware" },
+    }),
+    {},
+  );
+  assert.deepEqual(
+    resolvePendingRouteLookups({
+      aircraft: [{ callsign: "DAL123" }],
+      cache,
+      inFlight: new Set(),
+      routeContext: { routeProvider: "flightaware" },
+      now,
+      maxLookups: 3,
+    }),
+    [],
+  );
+}
+
+{
+  const cache = new Map();
+  const flightAwareRoute = {
+    callsign: "AAL1234",
+    source: "flightaware",
+    origin: { icao: "KBOS", iata: "BOS" },
+    destination: { icao: "KLAX", iata: "LAX" },
+    route: { icao: "KBOS-KLAX", iata: "BOS-LAX" },
+  };
+  writeRouteCacheEntry(cache, "AAL1234", flightAwareRoute, now, {
+    routeProvider: "adsbdb",
+  });
+
+  assert.deepEqual(
+    buildRoutesByCallsign({
+      aircraft: [{ callsign: "AAL1234" }],
+      cache,
+      now,
+      routeContext: { routeProvider: "adsbdb" },
+    }),
+    {},
+  );
+  assert.deepEqual(
+    resolvePendingRouteLookups({
+      aircraft: [{ callsign: "AAL1234" }],
+      cache,
+      inFlight: new Set(),
+      routeContext: { routeProvider: "adsbdb" },
       now,
       maxLookups: 3,
     }),
@@ -291,6 +362,23 @@ const route = {
   });
 }
 
+{
+  const routes = buildRoutesByCallsign({
+    aircraft: [
+      {
+        callsign: "VIR26Q",
+        origin: "KJFK",
+        destination: "EGLL",
+      },
+    ],
+    cache: new Map(),
+    routeContext: { routeProvider: "adsbdb" },
+    now,
+  });
+
+  assert.deepEqual(routes, {});
+}
+
 // rankCandidatesByDistance: aircraft farthest from focal airport rank first.
 // KBOS focal -> JBU123 over Lisbon (~3000nm) outranks DAL123 over NYC (~190nm)
 // outranks UAL456 directly over KBOS (~0nm).
@@ -397,14 +485,7 @@ const route = {
   });
 
   assert.deepEqual(pending, ["DAL123"]);
-  assert.deepEqual(routes.AAL100, {
-    callsign: "AAL100",
-    origin: { icao: "KJFK" },
-    destination: { icao: "KLAX" },
-    route: { icao: "KJFK-KLAX" },
-    source: "aircraft-metadata",
-    confidence: "position-metadata",
-  });
+  assert.equal(routes.AAL100, undefined);
 }
 
 {

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.ts
@@ -75,8 +75,37 @@ const routeContextCode = (value: unknown) =>
     .toUpperCase()
     .replace(/[^A-Z0-9]/g, "");
 
+const routeSourceCode = (value: unknown) =>
+  String(value || "").trim().toLowerCase();
+
 const isFlightAwareRouteContext = (routeContext: RouteContext = {}) =>
   routeContextCode(routeContext.routeProvider) === "FLIGHTAWARE";
+
+function routeProviderSource(routeContext: RouteContext = {}) {
+  const provider = routeSourceCode(routeContext.routeProvider);
+  return provider === "flightaware" || provider === "adsbdb" ? provider : "";
+}
+
+function routeMatchesProviderSource(
+  route: FlightRoute | null | undefined,
+  routeContext: RouteContext = {},
+) {
+  const requiredSource = routeProviderSource(routeContext);
+  if (!requiredSource) return true;
+  return routeSourceCode(route?.source) === requiredSource;
+}
+
+function normalizeRouteForProviderSource(
+  route: FlightRoute | null,
+  routeContext: RouteContext = {},
+) {
+  if (!route) return null;
+  return routeMatchesProviderSource(route, routeContext) ? route : null;
+}
+
+function shouldUseAircraftMetadataFallback(routeContext: RouteContext = {}) {
+  return !routeProviderSource(routeContext);
+}
 
 const centerContextNumber = (value: unknown) => {
   const number = Number(value);
@@ -153,7 +182,10 @@ function getFreshRouteCacheEntry(
   let firstMiss: RouteCacheEntry | null = null;
   for (const cacheKey of [...new Set(cacheKeys)]) {
     const cached = getFreshRouteCacheEntryByKey(cache, cacheKey, now);
-    if (cached?.route) return cached;
+    if (cached?.route) {
+      if (routeMatchesProviderSource(cached.route, routeContext)) return cached;
+      continue;
+    }
     if (cached && !firstMiss) firstMiss = cached;
   }
   return firstMiss;
@@ -182,11 +214,17 @@ export function writeRouteCacheEntry(
   time: number,
   routeContext: RouteContext = {},
 ) {
+  const routeForContext = normalizeRouteForProviderSource(route, routeContext);
   const exclusiveProvider =
     isFlightAwareRouteContext(routeContext) ||
-    String(route?.source || "").trim().toLowerCase() === "flightaware";
+    routeSourceCode(routeForContext?.source) === "flightaware";
   const cacheKeys = new Set(
-    [callsign, route?.callsign, route?.callsignIcao, route?.callsignIata]
+    [
+      callsign,
+      routeForContext?.callsign,
+      routeForContext?.callsignIcao,
+      routeForContext?.callsignIata,
+    ]
       .flatMap((value) =>
         exclusiveProvider
           ? [buildRouteCacheKey(value, routeContext)]
@@ -196,7 +234,7 @@ export function writeRouteCacheEntry(
   );
 
   for (const cacheKey of cacheKeys) {
-    cache.set(cacheKey, { route, time });
+    cache.set(cacheKey, { route: routeForContext, time });
   }
 }
 
@@ -377,7 +415,11 @@ export function buildRoutesByCallsign({
   for (const item of aircraft || []) {
     const callsign = normalizeCallsign(item.callsign);
     const cached = getFreshRouteCacheEntry(cache, callsign, now, routeContext);
-    const route = cached?.route || buildRouteFromAircraftMetadata(item);
+    const route =
+      cached?.route ||
+      (shouldUseAircraftMetadataFallback(routeContext)
+        ? buildRouteFromAircraftMetadata(item)
+        : null);
     if (route) routes[callsign] = route;
   }
   return routes;

--- a/src/features/aviation/flight-routes/flightRouteScheduler.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteScheduler.test.ts
@@ -11,6 +11,7 @@ const lot29Route = {
   origin: { icao: "EPWA", iata: "WAW" },
   destination: { icao: "KMIA", iata: "MIA" },
   route: { icao: "EPWA-KMIA", iata: "WAW-MIA" },
+  source: "adsbdb",
 };
 
 {
@@ -80,6 +81,7 @@ const lot29Route = {
     callsignIata: "VS26Q",
     origin: { icao: "KJFK", iata: "JFK" },
     destination: { icao: "EGLL", iata: "LHR" },
+    source: "adsbdb",
   };
 
   scheduler.applyTemporaryRoute("VIR26Q", route, { routeProvider: "adsbdb" });

--- a/src/features/aviation/flight-routes/flightRoutes.mechanism.test.ts
+++ b/src/features/aviation/flight-routes/flightRoutes.mechanism.test.ts
@@ -34,9 +34,9 @@ const OVERRIDE_ROUTE = Object.freeze({
     },
   });
 
-  assert.equal(route, OVERRIDE_ROUTE);
-  assert.equal(accessChecks, 0);
-  assert.equal(providerCalls, 0);
+  assert.equal(route, FLIGHTAWARE_ROUTE);
+  assert.equal(accessChecks, 1);
+  assert.equal(providerCalls, 1);
 }
 
 {
@@ -105,6 +105,27 @@ const OVERRIDE_ROUTE = Object.freeze({
   const calls = [];
   const route = await resolveFlightRoute({
     callsign: "AAL1234",
+    feedbackRepository: null,
+    shouldUseFlightAwareRouteProvider: async () => true,
+    fetchFlightAwareRoute: async () => {
+      calls.push("flightaware");
+      return FLIGHTAWARE_ROUTE;
+    },
+    fetchAdsbdbRoute: async () => {
+      calls.push("adsbdb");
+      return ADSBDB_ROUTE;
+    },
+  });
+
+  assert.equal(route, FLIGHTAWARE_ROUTE);
+  assert.deepEqual(calls, ["flightaware"]);
+}
+
+{
+  const calls = [];
+  const route = await resolveFlightRoute({
+    callsign: "AAL1234",
+    requestedProvider: "adsbdb",
     feedbackRepository: null,
     shouldUseFlightAwareRouteProvider: async () => true,
     fetchFlightAwareRoute: async () => {

--- a/src/features/aviation/flight-routes/flightRoutes.mechanism.ts
+++ b/src/features/aviation/flight-routes/flightRoutes.mechanism.ts
@@ -2,7 +2,6 @@ import {
   readResponseJson,
   readResponseText,
 } from "../../../app/api/_shared/apiProxySecurity";
-import { createRouteFeedbackReportsRepositoryFromEnv } from "../../../app/api/dao/routeFeedbackReports.dao";
 import { createOpenAipAirportQueriesFromEnv } from "../../airport/openaip/openAipDirectory";
 import {
   ADSBDB_USER_AGENT,
@@ -126,42 +125,13 @@ async function fetchFlightAwareRoute(
   });
 }
 
-async function readCommunityFeedbackOverride({
-  feedbackRepository,
-  normalizedCallsign,
-}: FlightRouteMechanismRecord) {
-  if (!feedbackRepository) return null;
-  try {
-    const row = await feedbackRepository.readActiveOverride({
-      normalizedCallsign,
-    });
-    return row?.route_payload || null;
-  } catch (err: any) {
-    console.warn(
-      `[route-feedback] override read failed for ${normalizedCallsign}:`,
-      err.message,
-    );
-    return null;
-  }
-}
-
 // Lookup order:
-//   1. Active persisted community feedback override (always wins so a
-//      user-submitted correction can temporarily fix a wrong route
-//      inside the 12-hour TTL). Override is keyed by callsign only —
-//      submissions made under any airport context apply universally
-//      to the same flight number.
-//   2. If the current Clerk user has flightAwareEnabled, FlightAware
-//      is the EXCLUSIVE provider. We return whatever the scraper gives
-//      us (route data or null), no adsbdb fallback. This guarantees
-//      that FlightAware-tier users always see FA-sourced metadata —
-//      origin / destination / airline are pulled from the live
-//      flightaware.com page, not from adsbdb's static dataset.
-//   3. All other users → adsbdb.
+//   1. If the current Clerk user has flightAwareEnabled, FlightAware is the
+//      exclusive provider. We return whatever the scraper gives us (route data
+//      or null), no adsbdb/community fallback.
+//   2. All other users use adsbdb exclusively.
 export const resolveFlightRoute = async ({
   callsign,
-  requestedProvider = "",
-  feedbackRepository = createRouteFeedbackReportsRepositoryFromEnv(),
   shouldUseFlightAwareRouteProvider = isFlightAwareRouteProviderEnabled,
   fetchFlightAwareRoute: fetchFlightAwareRouteImpl = fetchFlightAwareRoute,
   fetchAdsbdbRoute: fetchAdsbdbRouteImpl = fetchAdsbdbRoute,
@@ -169,13 +139,6 @@ export const resolveFlightRoute = async ({
   const normalizedCallsign = normalizeRouteCallsign(callsign);
   if (!normalizedCallsign) return null;
 
-  const override = await readCommunityFeedbackOverride({
-    feedbackRepository,
-    normalizedCallsign,
-  });
-  if (override) return override;
-
-  const provider = String(requestedProvider || "").trim().toLowerCase();
   let flightAwareAllowed = false;
   try {
     flightAwareAllowed = Boolean(
@@ -188,10 +151,7 @@ export const resolveFlightRoute = async ({
     );
   }
 
-  const useFlightAware =
-    flightAwareAllowed && (provider === "flightaware" || provider === "");
-
-  if (useFlightAware) {
+  if (flightAwareAllowed) {
     return fetchFlightAwareRouteImpl(normalizedCallsign);
   }
 

--- a/src/features/aviation/flight-routes/flightRoutes.models.ts
+++ b/src/features/aviation/flight-routes/flightRoutes.models.ts
@@ -1,6 +1,5 @@
-// Lookup hits cache aggressively at the edge; misses use a shorter TTL so
-// a freshly-submitted community-feedback record can supplant the empty
-// result without waiting for the long hit-cache to expire.
+// Lookup hits cache aggressively at the edge; misses use a shorter TTL so a
+// provider miss can be retried quickly without hammering the upstream.
 const ROUTE_CACHE_TTL_SECONDS = 60 * 60;
 const ROUTE_MISS_CACHE_TTL_SECONDS = 5 * 60;
 const ROUTE_STALE_WHILE_REVALIDATE_SECONDS = 10 * 60;
@@ -15,9 +14,9 @@ export function buildRouteCacheHeaders(body, { bypassSharedCache = false } = {})
     return { "Cache-Control": "no-store" };
   }
 
-  // Community-feedback routes are temporary by design; we deliberately do
-  // not let the CDN cache them for the long TTL we use for adsbdb hits.
-  // The client hook still caches them in-memory until the local TTL lapses.
+  // Temporary routes should never land in the shared CDN cache. The current
+  // provider lookup path does not return them, but keep the guard local to the
+  // cache policy in case another endpoint reuses this helper.
   if (body && body.temporary) {
     return { "Cache-Control": "no-store" };
   }

--- a/src/utils/flightRouteDisplay.test.ts
+++ b/src/utils/flightRouteDisplay.test.ts
@@ -103,20 +103,20 @@ import {
   )
 }
 
-// Community-feedback routes are displayed with their `*` suffix on the
-// route label only (callsign stays clean). Both the ICAO-coded and
-// municipality variants carry the suffix so the sidebar and the preview
-// card agree.
+// The `*` marker is reserved for adsbdb accuracy warnings; legacy
+// displaySuffix values from other route sources are not rendered as route
+// accuracy markers.
 {
   const communityRoute = {
     origin: { iata: 'JFK', icao: 'KJFK', municipality: 'New York' },
     destination: { iata: 'BOS', icao: 'KBOS', municipality: 'Boston' },
+    source: 'community-feedback',
     displaySuffix: '*',
     temporary: true,
   }
-  assert.equal(formatFlightRouteLabel(communityRoute), 'JFK -> BOS*')
+  assert.equal(formatFlightRouteLabel(communityRoute), 'JFK -> BOS')
   assert.equal(
     formatFlightRouteMunicipalityLabel(communityRoute),
-    'New York -> Boston*',
+    'New York -> Boston',
   )
 }

--- a/src/utils/flightRouteDisplay.ts
+++ b/src/utils/flightRouteDisplay.ts
@@ -19,30 +19,18 @@ const sameAirport = (a, b) => {
   return [...aCodes].some((code) => bCodes.has(code))
 }
 
-// Community-feedback routes carry a `displaySuffix` (currently "*") so the
-// renderer can mark them as user-supplied at a glance. Suffix only attaches
-// when we *have* a renderable route — an empty label stays empty.
-const routeDisplaySuffix = (route) =>
-  String(route?.displaySuffix || '').trim()
-
 const normalizedRouteSource = (route) =>
   String(route?.source || '').trim().toLowerCase()
 
 const routeAccuracySuffix = (route) =>
   normalizedRouteSource(route) === 'adsbdb' ? '*' : ''
 
-const combinedRouteSuffix = (route) => {
-  const suffixes = [routeDisplaySuffix(route), routeAccuracySuffix(route)]
-    .filter(Boolean)
-  return [...new Set(suffixes)].join('')
-}
-
 export const formatFlightRouteLabel = (route) => {
   const origin = airportCode(route?.origin)
   const destination = airportCode(route?.destination)
   if (!origin || !destination) return ''
   if (sameAirport(route.origin, route.destination)) return ''
-  return `${origin} -> ${destination}${combinedRouteSuffix(route)}`
+  return `${origin} -> ${destination}${routeAccuracySuffix(route)}`
 }
 
 export const formatFlightRouteMunicipalityLabel = (route) => {
@@ -50,7 +38,7 @@ export const formatFlightRouteMunicipalityLabel = (route) => {
   const destination = airportMunicipality(route?.destination)
   if (!origin || !destination) return ''
   if (sameAirport(route.origin, route.destination)) return ''
-  return `${origin} -> ${destination}${combinedRouteSuffix(route)}`
+  return `${origin} -> ${destination}${routeAccuracySuffix(route)}`
 }
 
 export const getFlightRouteAccuracyNotice = (route) =>


### PR DESCRIPTION
## Summary
- Make route proxy resolution exclusive: FlightAware-enabled users always get FlightAware/null, everyone else gets adsbdb/null.
- Filter client route cache/display by the active route provider source and stop explicit provider views from falling back to aircraft metadata.
- Reserve the route `*` marker and hover notice for adsbdb routes only.

## Root Cause
- Community feedback overrides could win before the backend provider decision.
- The client could display cached or metadata routes whose `source` did not match the active provider context.

## Validation
- `pnpm test`
- `pnpm lint`
- `pnpm build`