### PR TITLE
Add data-service observability metrics

### DIFF
--- a/services/data-service/src/channels/ChannelManager.test.ts
+++ b/services/data-service/src/channels/ChannelManager.test.ts
@@ -53,7 +53,15 @@ class FakeSocket extends EventEmitter {
   assert.match(output, /adsbao_ws_connections_total 1/);
   assert.match(
     output,
+    /adsbao_ws_disconnects_total\{close_code="unknown",result="closed"\} 1/,
+  );
+  assert.match(
+    output,
     /adsbao_ws_messages_total\{direction="inbound",result="ok",type="subscribe"\} 2/,
+  );
+  assert.match(
+    output,
+    /adsbao_ws_message_bytes_bucket\{direction="inbound",le="\+Inf",result="ok",type="subscribe"\} 2/,
   );
   assert.match(
     output,

--- a/services/data-service/src/channels/ChannelManager.ts
+++ b/services/data-service/src/channels/ChannelManager.ts
@@ -11,12 +11,14 @@ type ChannelManagerOptions = {
 };
 
 type SocketState = {
+  openedAtMs: number;
   subscriptions: Map<string, () => void>;
 };
 
-function sendJson(socket: WebSocket, payload: unknown) {
-  if (socket.readyState !== socket.OPEN) return;
-  socket.send(JSON.stringify(payload));
+function rawMessageBytes(raw: unknown) {
+  if (Buffer.isBuffer(raw)) return raw.byteLength;
+  if (typeof raw === "string") return Buffer.byteLength(raw, "utf8");
+  return 0;
 }
 
 function parseClientMessage(raw: unknown): ClientMessage | null {
@@ -48,6 +50,7 @@ export class ChannelManager {
 
   attach(socket: WebSocket) {
     const state: SocketState = {
+      openedAtMs: Date.now(),
       subscriptions: new Map(),
     };
     this.sockets.set(socket, state);
@@ -67,6 +70,7 @@ export class ChannelManager {
       const message = parseClientMessage(raw);
       if (!message) {
         this.metrics?.recordWsMessage({
+          bytes: rawMessageBytes(raw),
           direction: "inbound",
           type: "invalid",
           result: "error",
@@ -75,6 +79,7 @@ export class ChannelManager {
         return;
       }
       this.metrics?.recordWsMessage({
+        bytes: rawMessageBytes(raw),
         direction: "inbound",
         type: message.type,
         result: "ok",
@@ -82,21 +87,40 @@ export class ChannelManager {
       this.handleMessage(socket, state, message);
     });
 
-    socket.on("close", () => {
-      this.detach(socket);
+    socket.on("close", (code) => {
+      this.detach(socket, {
+        code,
+        result: "closed",
+      });
     });
     socket.on("error", () => {
-      this.detach(socket);
+      this.detach(socket, {
+        code: "error",
+        result: "error",
+      });
     });
   }
 
-  detach(socket: WebSocket) {
+  detach(
+    socket: WebSocket,
+    {
+      code = "unknown",
+      result = "closed",
+    }: {
+      code?: number | string | null;
+      result?: "closed" | "error";
+    } = {},
+  ) {
     const state = this.sockets.get(socket);
     if (!state) return;
     for (const unsubscribe of state.subscriptions.values()) unsubscribe();
     state.subscriptions.clear();
     this.sockets.delete(socket);
-    this.metrics?.recordWsConnectionClosed();
+    this.metrics?.recordWsConnectionClosed({
+      code,
+      durationMs: Date.now() - state.openedAtMs,
+      result,
+    });
   }
 
   private handleMessage(socket: WebSocket, state: SocketState, message: ClientMessage) {
@@ -107,11 +131,27 @@ export class ChannelManager {
 
     if (message.type === "unsubscribe") {
       const normalized = normalizeChannelName(message.channel);
-      if (!normalized.ok) return;
+      if (!normalized.ok) {
+        this.metrics?.recordWsUnsubscribe({
+          channelType: "unknown",
+          result: "invalid",
+        });
+        return;
+      }
       const unsubscribe = state.subscriptions.get(normalized.channel);
-      if (!unsubscribe) return;
+      if (!unsubscribe) {
+        this.metrics?.recordWsUnsubscribe({
+          channelType: normalized.type,
+          result: "invalid",
+        });
+        return;
+      }
       unsubscribe();
       state.subscriptions.delete(normalized.channel);
+      this.metrics?.recordWsUnsubscribe({
+        channelType: normalized.type,
+        result: "ok",
+      });
       this.sendJson(socket, {
         type: "subscribed:removed",
         channel: normalized.channel,
@@ -190,15 +230,18 @@ export class ChannelManager {
   }
 
   private sendJson(socket: WebSocket, payload: unknown) {
+    const serialized = JSON.stringify(payload);
     const type =
       payload && typeof payload === "object" && "type" in payload
         ? String((payload as { type?: unknown }).type || "unknown")
         : "unknown";
     this.metrics?.recordWsMessage({
+      bytes: Buffer.byteLength(serialized, "utf8"),
       direction: "outbound",
       type,
       result: socket.readyState === socket.OPEN ? "ok" : "error",
     });
-    sendJson(socket, payload);
+    if (socket.readyState !== socket.OPEN) return;
+    socket.send(serialized);
   }
 }

--- a/services/data-service/src/metrics/MetricsRegistry.test.ts
+++ b/services/data-service/src/metrics/MetricsRegistry.test.ts
@@ -3,13 +3,21 @@ import { DataServiceMetrics } from "./MetricsRegistry";
 
 {
   const metrics = new DataServiceMetrics();
+  metrics.recordWsUpgrade({ reason: "ok", result: "accepted" });
   metrics.recordWsConnectionOpened();
+  metrics.recordWsConnectionClosed({
+    code: 1000,
+    durationMs: 1_250,
+    result: "closed",
+  });
   metrics.recordWsMessage({
+    bytes: 64,
     direction: "inbound",
     type: "subscribe",
     result: "ok",
   });
   metrics.recordWsSubscribe({ channelType: "traffic", result: "ok" });
+  metrics.recordWsUnsubscribe({ channelType: "traffic", result: "ok" });
   metrics.recordPoll({
     channelType: "traffic",
     source: "adsb.lol",
@@ -20,6 +28,7 @@ import { DataServiceMetrics } from "./MetricsRegistry";
     provider: "adsb.lol",
     endpoint: "positions",
     result: "success",
+    status: 200,
     durationMs: 123,
   });
 
@@ -35,8 +44,8 @@ import { DataServiceMetrics } from "./MetricsRegistry";
         lastFetchedAt: new Date(0).toISOString(),
         lastError: null,
         source: "adsb.lol",
-        stale: false,
-        consecutiveFailures: 0,
+        stale: true,
+        consecutiveFailures: 2,
       },
       {
         key: "route:DAL44",
@@ -54,10 +63,26 @@ import { DataServiceMetrics } from "./MetricsRegistry";
   });
 
   assert.match(output, /^# HELP adsbao_ws_connections_current/m);
-  assert.match(output, /adsbao_ws_connections_current 1/);
+  assert.match(output, /adsbao_ws_connections_current 0/);
+  assert.match(
+    output,
+    /adsbao_ws_upgrades_total\{reason="ok",result="accepted"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_ws_disconnects_total\{close_code="1000",result="closed"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_ws_connection_duration_seconds_bucket\{close_code="1000",le="2.5",result="closed"\} 1/,
+  );
   assert.match(
     output,
     /adsbao_ws_messages_total\{direction="inbound",result="ok",type="subscribe"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_ws_message_bytes_bucket\{direction="inbound",le="128",result="ok",type="subscribe"\} 1/,
   );
   assert.match(
     output,
@@ -65,7 +90,23 @@ import { DataServiceMetrics } from "./MetricsRegistry";
   );
   assert.match(
     output,
+    /adsbao_ws_unsubscribe_total\{channel_type="traffic",result="ok"\} 1/,
+  );
+  assert.match(
+    output,
     /adsbao_active_channels_current\{channel_type="traffic"\} 1/,
+  );
+  assert.match(
+    output,
+    /adsbao_channel_consecutive_failures_current\{channel_type="traffic"\} 2/,
+  );
+  assert.match(
+    output,
+    /adsbao_channel_poll_interval_seconds\{channel_type="traffic"\} 5/,
+  );
+  assert.match(
+    output,
+    /adsbao_stale_channels_current\{channel_type="traffic"\} 1/,
   );
   assert.match(
     output,
@@ -77,15 +118,15 @@ import { DataServiceMetrics } from "./MetricsRegistry";
   );
   assert.match(
     output,
-    /adsbao_external_requests_total\{endpoint="positions",provider="adsb.lol",result="success"\} 1/,
+    /adsbao_external_requests_total\{endpoint="positions",provider="adsb.lol",result="success",status="200",status_class="2xx"\} 1/,
   );
   assert.match(
     output,
-    /adsbao_external_request_duration_seconds_bucket\{endpoint="positions",le="0.25",provider="adsb.lol",result="success"\} 1/,
+    /adsbao_external_request_duration_seconds_bucket\{endpoint="positions",le="0.25",provider="adsb.lol",result="success",status="200",status_class="2xx"\} 1/,
   );
   assert.match(
     output,
-    /adsbao_external_request_duration_seconds_bucket\{endpoint="positions",le="\+Inf",provider="adsb.lol",result="success"\} 1/,
+    /adsbao_external_request_duration_seconds_bucket\{endpoint="positions",le="\+Inf",provider="adsb.lol",result="success",status="200",status_class="2xx"\} 1/,
   );
   assert.equal(output.endsWith("\n"), true);
 }

--- a/services/data-service/src/metrics/MetricsRegistry.ts
+++ b/services/data-service/src/metrics/MetricsRegistry.ts
@@ -1,4 +1,8 @@
-import type { DebugChannel, RealtimeChannelType } from "../types.js";
+import type {
+  DebugChannel,
+  ExternalRequestMetricInput,
+  RealtimeChannelType,
+} from "../types.js";
 
 type LabelValue = string | number | boolean | null | undefined;
 type Labels = Record<string, LabelValue>;
@@ -12,6 +16,18 @@ type WsMessageInput = {
   direction: "inbound" | "outbound";
   type: string;
   result: "ok" | "error";
+  bytes?: number;
+};
+
+type WsConnectionCloseInput = {
+  code?: number | string | null;
+  durationMs?: number;
+  result?: "closed" | "error";
+};
+
+type WsUpgradeInput = {
+  reason: "ok" | "path" | "origin";
+  result: "accepted" | "rejected";
 };
 
 type WsSubscribeInput = {
@@ -22,13 +38,6 @@ type WsSubscribeInput = {
 type PollInput = {
   channelType: RealtimeChannelType;
   source: string;
-  result: "success" | "error";
-  durationMs: number;
-};
-
-type ExternalRequestInput = {
-  provider: string;
-  endpoint: "positions" | "callsign" | "aircraft" | "route" | "unknown";
   result: "success" | "error";
   durationMs: number;
 };
@@ -57,6 +66,17 @@ const DURATION_BUCKETS = Object.freeze([
   5,
   10,
   30,
+]);
+
+const MESSAGE_BYTE_BUCKETS = Object.freeze([
+  128,
+  512,
+  1024,
+  4 * 1024,
+  16 * 1024,
+  64 * 1024,
+  256 * 1024,
+  1024 * 1024,
 ]);
 
 function normalizeLabelValue(value: LabelValue) {
@@ -99,30 +119,75 @@ function classifyEndpoint(channelType: RealtimeChannelType) {
   return "unknown";
 }
 
+function classifyStatus(status: ExternalRequestMetricInput["status"], result: string) {
+  if (typeof status === "number" && Number.isFinite(status)) {
+    return `${Math.floor(status / 100)}xx`;
+  }
+  const normalized = normalizeLabelValue(status).toLowerCase();
+  if (normalized !== "unknown") return normalized;
+  return result === "success" ? "ok" : "unknown";
+}
+
 export class DataServiceMetrics {
   private wsConnectionsCurrent = 0;
   private readonly counters = new Map<string, CounterState>();
   private readonly histograms = new Map<string, HistogramState>();
+
+  recordWsUpgrade({ reason, result }: WsUpgradeInput) {
+    this.increment("adsbao_ws_upgrades_total", { reason, result });
+  }
 
   recordWsConnectionOpened() {
     this.wsConnectionsCurrent += 1;
     this.increment("adsbao_ws_connections_total", {});
   }
 
-  recordWsConnectionClosed() {
+  recordWsConnectionClosed({
+    code = "unknown",
+    durationMs = 0,
+    result = "closed",
+  }: WsConnectionCloseInput = {}) {
     this.wsConnectionsCurrent = Math.max(0, this.wsConnectionsCurrent - 1);
+    const labels = {
+      close_code: code,
+      result,
+    };
+    this.increment("adsbao_ws_disconnects_total", labels);
+    if (durationMs > 0) {
+      this.observe(
+        "adsbao_ws_connection_duration_seconds",
+        labels,
+        durationMs / 1000,
+      );
+    }
   }
 
-  recordWsMessage({ direction, type, result }: WsMessageInput) {
-    this.increment("adsbao_ws_messages_total", {
+  recordWsMessage({ bytes, direction, type, result }: WsMessageInput) {
+    const labels = {
       direction,
       result,
       type,
-    });
+    };
+    this.increment("adsbao_ws_messages_total", labels);
+    if (typeof bytes === "number" && bytes >= 0) {
+      this.observe(
+        "adsbao_ws_message_bytes",
+        labels,
+        bytes,
+        MESSAGE_BYTE_BUCKETS,
+      );
+    }
   }
 
   recordWsSubscribe({ channelType, result }: WsSubscribeInput) {
     this.increment("adsbao_ws_subscribe_total", {
+      channel_type: channelType,
+      result,
+    });
+  }
+
+  recordWsUnsubscribe({ channelType, result }: WsSubscribeInput) {
+    this.increment("adsbao_ws_unsubscribe_total", {
       channel_type: channelType,
       result,
     });
@@ -138,11 +203,13 @@ export class DataServiceMetrics {
     this.observe("adsbao_poll_duration_seconds", labels, durationMs / 1000);
   }
 
-  recordExternalRequest(input: ExternalRequestInput) {
+  recordExternalRequest(input: ExternalRequestMetricInput) {
     const labels = {
       endpoint: input.endpoint,
       provider: input.provider,
       result: input.result,
+      status: input.status ?? "unknown",
+      status_class: classifyStatus(input.status, input.result),
     };
     this.increment("adsbao_external_requests_total", labels);
     this.observe(
@@ -199,20 +266,25 @@ export class DataServiceMetrics {
     this.counters.set(key, { labels, name, value });
   }
 
-  private observe(name: string, labels: Labels, value: number) {
+  private observe(
+    name: string,
+    labels: Labels,
+    value: number,
+    buckets: readonly number[] = DURATION_BUCKETS,
+  ) {
     const key = seriesKey(name, labels);
     let state = this.histograms.get(key);
     if (!state) {
       state = {
         labels,
-        buckets: new Map(DURATION_BUCKETS.map((bucket) => [bucket, 0])),
+        buckets: new Map(buckets.map((bucket) => [bucket, 0])),
         count: 0,
         name,
         sum: 0,
       };
       this.histograms.set(key, state);
     }
-    for (const bucket of DURATION_BUCKETS) {
+    for (const bucket of state.buckets.keys()) {
       if (value <= bucket) {
         state.buckets.set(bucket, (state.buckets.get(bucket) || 0) + 1);
       }
@@ -242,9 +314,23 @@ export class DataServiceMetrics {
 
   private renderDynamicChannelGauges(lines: string[], channels: DebugChannel[]) {
     const activeByType = new Map<string, number>();
+    const failureSumByType = new Map<string, number>();
+    const maxIntervalByType = new Map<string, number>();
+    const staleByType = new Map<string, number>();
     const subscribersByType = new Map<string, number>();
     for (const channel of channels) {
       activeByType.set(channel.type, (activeByType.get(channel.type) || 0) + 1);
+      failureSumByType.set(
+        channel.type,
+        (failureSumByType.get(channel.type) || 0) + channel.consecutiveFailures,
+      );
+      maxIntervalByType.set(
+        channel.type,
+        Math.max(maxIntervalByType.get(channel.type) || 0, channel.currentIntervalMs),
+      );
+      if (channel.stale) {
+        staleByType.set(channel.type, (staleByType.get(channel.type) || 0) + 1);
+      }
       subscribersByType.set(
         channel.type,
         (subscribersByType.get(channel.type) || 0) + channel.subscriberCount,
@@ -262,6 +348,30 @@ export class DataServiceMetrics {
       name: "adsbao_subscriptions_current",
       help: "Current active subscriptions by channel type.",
       values: [...subscribersByType].map(([channelType, value]) => ({
+        labels: { channel_type: channelType },
+        value,
+      })),
+    });
+    this.renderGauge(lines, {
+      name: "adsbao_channel_consecutive_failures_current",
+      help: "Current sum of consecutive polling failures by channel type.",
+      values: [...failureSumByType].map(([channelType, value]) => ({
+        labels: { channel_type: channelType },
+        value,
+      })),
+    });
+    this.renderGauge(lines, {
+      name: "adsbao_channel_poll_interval_seconds",
+      help: "Current maximum polling interval in seconds by channel type.",
+      values: [...maxIntervalByType].map(([channelType, value]) => ({
+        labels: { channel_type: channelType },
+        value: Number((value / 1000).toFixed(3)),
+      })),
+    });
+    this.renderGauge(lines, {
+      name: "adsbao_stale_channels_current",
+      help: "Current stale polling channels by channel type.",
+      values: [...staleByType].map(([channelType, value]) => ({
         labels: { channel_type: channelType },
         value,
       })),
@@ -294,7 +404,7 @@ export class DataServiceMetrics {
     )) {
       lines.push(`# HELP ${state.name} Histogram for ${state.name}.`);
       lines.push(`# TYPE ${state.name} histogram`);
-      for (const bucket of DURATION_BUCKETS) {
+      for (const bucket of state.buckets.keys()) {
         lines.push(
           metricLine(
             `${state.name}_bucket`,

--- a/services/data-service/src/polling/PollingScheduler.test.ts
+++ b/services/data-service/src/polling/PollingScheduler.test.ts
@@ -164,10 +164,6 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
     output,
     /adsbao_poll_requests_total\{channel_type="route",result="success",source="adsbdb"\} 1/,
   );
-  assert.match(
-    output,
-    /adsbao_external_requests_total\{endpoint="route",provider="adsbdb",result="success"\} 1/,
-  );
 
   unsubscribe();
   scheduler.dispose();

--- a/services/data-service/src/polling/PollingScheduler.ts
+++ b/services/data-service/src/polling/PollingScheduler.ts
@@ -234,6 +234,7 @@ export class PollingScheduler {
       const event = await this.fetchChannel({
         channel: state.channel,
         channelType: state.type,
+        metrics: this.metrics || undefined,
         target: state.target,
         params: state.params,
       });
@@ -293,12 +294,6 @@ export class PollingScheduler {
     this.metrics.recordPoll({
       channelType: state.type,
       source,
-      result,
-      durationMs,
-    });
-    this.metrics.recordExternalRequestForPoll({
-      channelType: state.type,
-      provider: source,
       result,
       durationMs,
     });

--- a/services/data-service/src/server.ts
+++ b/services/data-service/src/server.ts
@@ -74,6 +74,7 @@ const server = createServer((request, response) => {
 attachWebSocketServer({
   server,
   channelManager,
+  metrics,
   allowedOrigins: parseCsv(process.env.ALLOWED_WS_ORIGINS),
 });
 

--- a/services/data-service/src/sources/adsbClient.test.ts
+++ b/services/data-service/src/sources/adsbClient.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { DataServiceMetrics } from "../metrics/MetricsRegistry";
 import { fetchAdsbChannel } from "./adsbClient";
 
 function jsonResponse(payload: unknown) {
@@ -13,6 +14,7 @@ function jsonResponse(payload: unknown) {
 {
   const originalFetch = globalThis.fetch;
   const requestedUrls: string[] = [];
+  const metrics = new DataServiceMetrics();
   try {
     globalThis.fetch = (async (url: RequestInfo | URL) => {
       const href = String(url);
@@ -39,6 +41,7 @@ function jsonResponse(payload: unknown) {
     const event = await fetchAdsbChannel({
       channel: "callsign:DAL58",
       channelType: "callsign",
+      metrics,
       target: {
         kind: "callsign",
         callsign: "DAL58",
@@ -56,6 +59,15 @@ function jsonResponse(payload: unknown) {
     assert.equal(event.data.ac.length, 1);
     assert.equal(event.data.ac[0].type, "adsc");
     assert.equal(requestedUrls.length, 2);
+    const output = metrics.render({ uptimeSec: 1, channels: [] });
+    assert.match(
+      output,
+      /adsbao_external_requests_total\{endpoint="callsign",provider="adsb.lol",result="success",status="200",status_class="2xx"\} 1/,
+    );
+    assert.match(
+      output,
+      /adsbao_external_requests_total\{endpoint="callsign",provider="airplanes.live",result="success",status="200",status_class="2xx"\} 1/,
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/services/data-service/src/sources/adsbClient.ts
+++ b/services/data-service/src/sources/adsbClient.ts
@@ -1,4 +1,8 @@
-import type { FetchChannelInput, RealtimeEvent } from "../types.js";
+import type {
+  ExternalRequestEndpoint,
+  FetchChannelInput,
+  RealtimeEvent,
+} from "../types.js";
 import { fetchWithProviderFallback } from "./providerFallback.js";
 
 const DEFAULT_TIMEOUT_MS = 2_800;
@@ -69,36 +73,77 @@ function isEmptyAircraftPayload(payload: Record<string, unknown>) {
   return !Array.isArray(payload.ac) || payload.ac.length === 0;
 }
 
-async function fetchProviderJson(url: string, timeoutMs = DEFAULT_TIMEOUT_MS) {
-  let response: Response;
+async function fetchProviderPayload({
+  endpoint,
+  input,
+  provider,
+  url,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}: {
+  endpoint: ExternalRequestEndpoint;
+  input: FetchChannelInput;
+  provider: Provider;
+  url: string;
+  timeoutMs?: number;
+}) {
+  const startedAt = Date.now();
+  let status: number | string | null = null;
   try {
-    response = await fetch(url, {
+    const response = await fetch(url, {
       headers: {
         Accept: "application/json",
         "User-Agent": USER_AGENT,
       },
       signal: AbortSignal.timeout(timeoutMs),
     });
-  } catch (error) {
-    throw new AdsbProviderError(
-      error instanceof Error ? error.message : "network error",
-      "ERR",
+    status = response.status;
+
+    if (!response.ok) {
+      throw new AdsbProviderError(`HTTP ${response.status}`, response.status);
+    }
+
+    const text = await response.text();
+    if (Buffer.byteLength(text, "utf8") > MAX_AIRCRAFT_BYTES) {
+      status = "SIZE";
+      throw new AdsbProviderError("ADS-B response too large", status);
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      status = "PARSE";
+      throw new AdsbProviderError("Invalid ADS-B JSON", status);
+    }
+
+    const normalized = normalizeProviderPayload(
+      provider,
+      payload as Record<string, unknown>,
     );
-  }
-
-  if (!response.ok) {
-    throw new AdsbProviderError(`HTTP ${response.status}`, response.status);
-  }
-
-  const text = await response.text();
-  if (Buffer.byteLength(text, "utf8") > MAX_AIRCRAFT_BYTES) {
-    throw new AdsbProviderError("ADS-B response too large", "SIZE");
-  }
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    throw new AdsbProviderError("Invalid ADS-B JSON", "PARSE");
+    input.metrics?.recordExternalRequest({
+      provider: provider.id,
+      endpoint,
+      result: "success",
+      status,
+      durationMs: Date.now() - startedAt,
+    });
+    return normalized;
+  } catch (error) {
+    const providerError =
+      error instanceof AdsbProviderError
+        ? error
+        : new AdsbProviderError(
+            error instanceof Error ? error.message : "network error",
+            "ERR",
+          );
+    input.metrics?.recordExternalRequest({
+      provider: provider.id,
+      endpoint,
+      result: "error",
+      status: providerError.status ?? status ?? "ERR",
+      durationMs: Date.now() - startedAt,
+    });
+    throw providerError;
   }
 }
 
@@ -128,7 +173,12 @@ async function fetchPositions(input: FetchChannelInput) {
         distanceNm: target.distNm,
       });
       if (!url) throw new AdsbProviderError("Provider has no position URL");
-      return normalizeProviderPayload(provider, await fetchProviderJson(url));
+      return fetchProviderPayload({
+        endpoint: "positions",
+        input,
+        provider,
+        url,
+      });
     },
   });
 }
@@ -146,7 +196,12 @@ async function fetchCallsign(input: FetchChannelInput) {
         callsign: target.callsign,
       });
       if (!url) throw new AdsbProviderError("Provider has no callsign URL");
-      return normalizeProviderPayload(provider, await fetchProviderJson(url));
+      return fetchProviderPayload({
+        endpoint: "callsign",
+        input,
+        provider,
+        url,
+      });
     },
     shouldRetryPayload: isEmptyAircraftPayload,
   });
@@ -165,7 +220,12 @@ async function fetchAircraft(input: FetchChannelInput) {
         hex: target.hex,
       });
       if (!url) throw new AdsbProviderError("Provider has no aircraft URL");
-      return normalizeProviderPayload(provider, await fetchProviderJson(url));
+      return fetchProviderPayload({
+        endpoint: "aircraft",
+        input,
+        provider,
+        url,
+      });
     },
     shouldRetryPayload: isEmptyAircraftPayload,
   });

--- a/services/data-service/src/sources/routeClient.test.ts
+++ b/services/data-service/src/sources/routeClient.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { DataServiceMetrics } from "../metrics/MetricsRegistry";
 import { fetchRouteChannel } from "./routeClient";
 
 function jsonResponse(payload: unknown, status = 200) {
@@ -13,9 +14,11 @@ function jsonResponse(payload: unknown, status = 200) {
 
 {
   const calls: string[] = [];
+  const metrics = new DataServiceMetrics();
   const event = await fetchRouteChannel({
     channel: "route:DAL123",
     channelType: "route",
+    metrics,
     target: { kind: "route", callsign: "DAL123" },
     params: {},
     waitForTurn: async () => {},
@@ -54,12 +57,19 @@ function jsonResponse(payload: unknown, status = 200) {
   const data = event.data as any;
   assert.equal(data.route.callsign, "DAL123");
   assert.equal(data.route.route.iata, "ATL-BOS");
+  const output = metrics.render({ uptimeSec: 1, channels: [] });
+  assert.match(
+    output,
+    /adsbao_external_requests_total\{endpoint="route",provider="adsbdb",result="success",status="200",status_class="2xx"\} 1/,
+  );
 }
 
 {
+  const metrics = new DataServiceMetrics();
   const event = await fetchRouteChannel({
     channel: "route:NOPE123",
     channelType: "route",
+    metrics,
     target: { kind: "route", callsign: "NOPE123" },
     params: {},
     waitForTurn: async () => {},
@@ -69,6 +79,11 @@ function jsonResponse(payload: unknown, status = 200) {
   assert.equal(event.type, "route:update");
   const data = event.data as any;
   assert.equal(data.route, null);
+  const output = metrics.render({ uptimeSec: 1, channels: [] });
+  assert.match(
+    output,
+    /adsbao_external_requests_total\{endpoint="route",provider="adsbdb",result="success",status="404",status_class="4xx"\} 1/,
+  );
 }
 
 console.log("routeClient.test.ts ok");

--- a/services/data-service/src/sources/routeClient.ts
+++ b/services/data-service/src/sources/routeClient.ts
@@ -103,6 +103,7 @@ async function readJson(response: Response) {
 
 export async function fetchRouteChannel({
   channel,
+  metrics,
   target,
   fetchImpl = fetch,
   waitForTurn: waitForTurnImpl = waitForRouteTurn,
@@ -110,18 +111,42 @@ export async function fetchRouteChannel({
   if (target.kind !== "route") throw new Error("Expected route polling target");
   await waitForTurnImpl();
   const url = `${ADSBDB_BASE}/callsign/${encodeURIComponent(target.callsign)}`;
-  const response = await fetchImpl(url, {
-    headers: {
-      Accept: "application/json",
-      "User-Agent": USER_AGENT,
-    },
-    signal: AbortSignal.timeout(ROUTE_TIMEOUT_MS),
-  });
-  if (!response.ok && response.status !== 404) {
-    throw new Error(`adsbdb route HTTP ${response.status}`);
+  const startedAt = Date.now();
+  let status: number | string | null = null;
+  let route: ReturnType<typeof normalizeRoute> | null = null;
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": USER_AGENT,
+      },
+      signal: AbortSignal.timeout(ROUTE_TIMEOUT_MS),
+    });
+    status = response.status;
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`adsbdb route HTTP ${response.status}`);
+    }
+    route =
+      response.status === 404
+        ? null
+        : normalizeRoute(target.callsign, await readJson(response));
+    metrics?.recordExternalRequest({
+      provider: "adsbdb",
+      endpoint: "route",
+      result: "success",
+      status,
+      durationMs: Date.now() - startedAt,
+    });
+  } catch (error) {
+    metrics?.recordExternalRequest({
+      provider: "adsbdb",
+      endpoint: "route",
+      result: "error",
+      status: status ?? "ERR",
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
   }
-  const route =
-    response.status === 404 ? null : normalizeRoute(target.callsign, await readJson(response));
   return {
     type: "route:update",
     channel,

--- a/services/data-service/src/types.ts
+++ b/services/data-service/src/types.ts
@@ -57,11 +57,31 @@ export type SubscribeParams = {
   [key: string]: unknown;
 };
 
+export type ExternalRequestEndpoint =
+  | "positions"
+  | "callsign"
+  | "aircraft"
+  | "route"
+  | "unknown";
+
+export type ExternalRequestMetricInput = {
+  provider: string;
+  endpoint: ExternalRequestEndpoint;
+  result: "success" | "error";
+  durationMs: number;
+  status?: number | string | null;
+};
+
+export type DataServiceMetricsSink = {
+  recordExternalRequest(input: ExternalRequestMetricInput): void;
+};
+
 export type FetchChannelInput = {
   channel: string;
   channelType: RealtimeChannelType;
   target: PollingTarget;
   params: SubscribeParams;
+  metrics?: DataServiceMetricsSink;
 };
 
 export type FetchChannel = (

--- a/services/data-service/src/ws.ts
+++ b/services/data-service/src/ws.ts
@@ -1,6 +1,7 @@
 import type { Server } from "node:http";
 import { WebSocketServer } from "ws";
 import { ChannelManager } from "./channels/ChannelManager.js";
+import type { DataServiceMetrics } from "./metrics/MetricsRegistry.js";
 
 const DEFAULT_ALLOWED_ORIGINS = new Set([
   "http://localhost:3000",
@@ -52,11 +53,13 @@ export function isAllowedWebSocketOrigin(
 export function attachWebSocketServer({
   server,
   channelManager,
+  metrics,
   path = "/ws",
   allowedOrigins = [],
 }: {
   server: Server;
   channelManager: ChannelManager;
+  metrics?: DataServiceMetrics;
   path?: string;
   allowedOrigins?: readonly string[];
 }) {
@@ -65,15 +68,18 @@ export function attachWebSocketServer({
   server.on("upgrade", (request, socket, head) => {
     const url = new URL(request.url || "/", "http://localhost");
     if (url.pathname !== path) {
+      metrics?.recordWsUpgrade({ reason: "path", result: "rejected" });
       socket.destroy();
       return;
     }
     if (!isAllowedWebSocketOrigin(request.headers.origin, allowedOrigins)) {
+      metrics?.recordWsUpgrade({ reason: "origin", result: "rejected" });
       socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
       socket.destroy();
       return;
     }
 
+    metrics?.recordWsUpgrade({ reason: "ok", result: "accepted" });
     wss.handleUpgrade(request, socket, head, (ws) => {
       channelManager.attach(ws);
     });


### PR DESCRIPTION
## Summary
- add richer Prometheus metrics for WebSocket upgrades, disconnects, message sizes, unsubscribes, and channel health
- record each outbound provider contact from ADS-B and route clients with provider, endpoint, result, status, status class, and duration
- pass the data-service metrics sink through polling into source clients so fallback provider attempts are visible
- deploy Railway Prometheus service and configure it to scrape adsbao-data-service over Railway private networking

## Validation
- pnpm --dir services/data-service test
- pnpm --dir services/data-service build
- pnpm test
- pnpm lint (passes with existing warnings)
- pnpm build
- Railway Prometheus targets: prometheus and adsbao-data-service both up
