### PR TITLE
[codex] Fix FlightAware trackpoll refresh

### DIFF
--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -153,7 +153,10 @@ function FlightExplorerContent({ callsign }) {
     visibilityRefreshVersion: trackedVisibilityRefreshVersion,
     trackingState,
     realtimeStatus,
-  } = useTrackedAircraft(callsign);
+  } = useTrackedAircraft(callsign, {
+    flightAwareEnabled,
+    flightAwareResolved,
+  });
   const [cachedTrackedMetadata, setCachedTrackedMetadata] = useState(null);
   const [contextTiles, setContextTiles] = useState({
     airspaces: [],

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.ts
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.test.ts
@@ -88,6 +88,13 @@ const arrivedHtml = `
   </script>
 `;
 
+const activeHtmlWithTrackpoll = `
+  ${activeHtml}
+  <script>
+    var trackpollGlobals = {"TOKEN":"track-token","INTERVAL":60,"SINGLE_FLIGHT":true};
+  </script>
+`;
+
 const getFallbackFromHtml = async (callsign, html) =>
   getFlightAwareFallbackByCallsign(callsign, {
     env: { FLIGHTAWARE_FALLBACK_ENABLED: "true" },
@@ -126,6 +133,66 @@ const getFallbackFromHtml = async (callsign, html) =>
   assert.equal(result.position.quality.isEstimated, true);
   assert.equal(result.position.quality.sourceUpdatedAt, "2026-05-25T01:21:06.000Z");
   assert.equal("raw" in result, false);
+}
+
+{
+  const urls = [];
+  const trackpollJson = JSON.stringify({
+    version: "2.24",
+    summary: false,
+    flights: {
+      "AAL100-2": {
+        ident: "AAL100",
+        displayIdent: "AAL100",
+        flightStatus: "enroute",
+        historical: false,
+        coord: null,
+        altitude: 380,
+        groundspeed: 510,
+        heading: 80,
+        timestamp: null,
+        origin: { icao: "KJFK" },
+        destination: { icao: "EGLL" },
+        flightPlan: { speed: 488, altitude: 380, route: "NATV DOGAL" },
+        track: [
+          {
+            timestamp: 1779672308,
+            coord: [-46.1666, 47.4667],
+            alt: null,
+            gs: null,
+            type: "TP",
+            isolated: false,
+          },
+        ],
+        updateType: "predicted",
+      },
+    },
+  });
+  const result = await getFlightAwareFallbackByCallsign("AAL100", {
+    env: { FLIGHTAWARE_FALLBACK_ENABLED: "true" },
+    fetchImpl: async (url) => {
+      urls.push(String(url));
+      if (String(url).includes("/ajax/trackpoll.rvt")) {
+        return new Response(trackpollJson, { status: 200 });
+      }
+      return new Response(activeHtmlWithTrackpoll, { status: 200 });
+    },
+    now: () => Date.parse(fetchedAt),
+    cacheStore: new Map(),
+  });
+
+  assert.equal(urls[0], "https://www.flightaware.com/live/flight/AAL100");
+  assert.match(urls[1], /\/ajax\/trackpoll\.rvt\?/);
+  assert.match(urls[1], /token=track-token/);
+  assert.equal(result.ok, true);
+  assert.equal(result.hasPosition, true);
+  assert.equal(result.position.lat, 47.4667);
+  assert.equal(result.position.lon, -46.1666);
+  assert.equal(result.position.quality.kind, "predicted");
+  assert.equal(
+    result.position.quality.sourceUpdatedAt,
+    "2026-05-25T01:25:08.000Z",
+  );
 }
 
 {

--- a/src/features/aircraft/flightaware/flightAwareFallbackProvider.ts
+++ b/src/features/aircraft/flightaware/flightAwareFallbackProvider.ts
@@ -3,6 +3,7 @@ import { buildAdsbaoUserAgent } from "../../../config/siteMeta";
 import { normalizeRouteCallsign } from "../../aviation/flight-routes/flightRouteCallsign";
 
 const FLIGHTAWARE_FALLBACK_BASE = "https://www.flightaware.com/live/flight";
+const FLIGHTAWARE_TRACKPOLL_PATH = "/ajax/trackpoll.rvt";
 const FLIGHTAWARE_FALLBACK_CACHE_TTL_MS = 60_000;
 const FLIGHTAWARE_FALLBACK_TIMEOUT_MS = 7_000;
 const FLIGHTAWARE_FALLBACK_USER_AGENT =
@@ -151,6 +152,21 @@ function extractAssignedJson(html: unknown, name: string) {
     }
   }
   return null;
+}
+
+function parseAssignedJson(html: unknown, name: string) {
+  const jsonText = extractAssignedJson(html, name);
+  if (!jsonText) return null;
+  try {
+    return JSON.parse(jsonText);
+  } catch {
+    return null;
+  }
+}
+
+function extractTrackpollToken(html: unknown) {
+  const globals = parseAssignedJson(html, "trackpollGlobals");
+  return cleanString(globals?.TOKEN);
 }
 
 function readCoord(value: unknown) {
@@ -302,18 +318,36 @@ function buildFlightAwareFallbackUrl(callsign: unknown) {
   return `${FLIGHTAWARE_FALLBACK_BASE}/${encodeURIComponent(normalized)}`;
 }
 
+function buildFlightAwareTrackpollUrl(pageUrl: string, token: string) {
+  const url = new URL(FLIGHTAWARE_TRACKPOLL_PATH, FLIGHTAWARE_FALLBACK_BASE);
+  try {
+    const page = new URL(pageUrl);
+    page.searchParams.forEach((value, key) => {
+      url.searchParams.set(key, value);
+    });
+  } catch {
+    // Keep the plain trackpoll endpoint if the page URL is unexpectedly invalid.
+  }
+  url.searchParams.set("token", token);
+  url.searchParams.set("locale", "en_US");
+  url.searchParams.set("summary", "0");
+  return url.toString();
+}
+
 function isFlightAwareFallbackEnabled(env: EnvLike = process.env) {
   return String(env?.FLIGHTAWARE_FALLBACK_ENABLED || "true").toLowerCase() !== "false";
 }
 
-function parseFlightAwareFallbackPage({
+function parseFlightAwarePayload({
   callsign,
-  html,
+  payload,
   fetchedAt,
+  html = "",
 }: {
   callsign?: unknown;
-  html?: unknown;
+  payload?: FlightAwareRecord | null;
   fetchedAt?: string;
+  html?: unknown;
 } = {}): FlightAwareFallbackResult {
   const normalizedCallsign = normalizeRouteCallsign(callsign);
   const fetched = fetchedAt || new Date().toISOString();
@@ -321,25 +355,7 @@ function parseFlightAwareFallbackPage({
     return errorResult("invalid_callsign", { fetchedAt: fetched });
   }
 
-  const jsonText = extractAssignedJson(html, "trackpollBootstrap");
-  if (!jsonText) {
-    return errorResult("parse_failed", {
-      message: "trackpollBootstrap not found",
-      fetchedAt: fetched,
-    });
-  }
-
-  let bootstrap;
-  try {
-    bootstrap = JSON.parse(jsonText);
-  } catch (error) {
-    return errorResult("parse_failed", {
-      message: error.message,
-      fetchedAt: fetched,
-    });
-  }
-
-  const flight = selectBestFlight(bootstrap?.flights);
+  const flight = selectBestFlight(payload?.flights);
   if (!flight) {
     return errorResult("parse_failed", {
       message: "No flight entries found",
@@ -401,6 +417,64 @@ function parseFlightAwareFallbackPage({
       },
     },
   };
+}
+
+function parseFlightAwareFallbackPage({
+  callsign,
+  html,
+  fetchedAt,
+}: {
+  callsign?: unknown;
+  html?: unknown;
+  fetchedAt?: string;
+} = {}): FlightAwareFallbackResult {
+  const jsonText = extractAssignedJson(html, "trackpollBootstrap");
+  if (!jsonText) {
+    return errorResult("parse_failed", {
+      message: "trackpollBootstrap not found",
+      fetchedAt,
+    });
+  }
+
+  try {
+    return parseFlightAwarePayload({
+      callsign,
+      payload: JSON.parse(jsonText),
+      fetchedAt,
+      html,
+    });
+  } catch (error) {
+    return errorResult("parse_failed", {
+      message: error.message,
+      fetchedAt,
+    });
+  }
+}
+
+function parseFlightAwareTrackpollResponse({
+  callsign,
+  text,
+  fetchedAt,
+  html,
+}: {
+  callsign?: unknown;
+  text?: unknown;
+  fetchedAt?: string;
+  html?: unknown;
+} = {}) {
+  try {
+    return parseFlightAwarePayload({
+      callsign,
+      payload: JSON.parse(String(text || "")),
+      fetchedAt,
+      html,
+    });
+  } catch (error) {
+    return errorResult("parse_failed", {
+      message: error.message,
+      fetchedAt,
+    });
+  }
 }
 
 function checkRateLimit(
@@ -489,6 +563,47 @@ export async function getFlightAwareFallbackByCallsign(callsign: unknown, {
       label: "flightaware fallback page",
       maxBytes: MAX_HTML_BYTES,
     });
+
+    const trackpollToken = extractTrackpollToken(html);
+    if (trackpollToken) {
+      try {
+        const trackpollResponse = await fetchImpl(
+          buildFlightAwareTrackpollUrl(url, trackpollToken),
+          {
+            headers: {
+              Accept: "application/json, text/javascript, */*; q=0.01",
+              Referer: url,
+              "User-Agent": FLIGHTAWARE_FALLBACK_USER_AGENT,
+              "X-Requested-With": "XMLHttpRequest",
+            },
+            signal:
+              typeof AbortSignal !== "undefined" && AbortSignal.timeout
+                ? AbortSignal.timeout(timeoutMs)
+                : undefined,
+          },
+        );
+        if (trackpollResponse.ok) {
+          const text = await readResponseText(trackpollResponse, {
+            label: "flightaware trackpoll response",
+            maxBytes: MAX_HTML_BYTES,
+          });
+          const trackpollResult = parseFlightAwareTrackpollResponse({
+            callsign: normalizedCallsign,
+            text,
+            fetchedAt,
+            html,
+          });
+          if (trackpollResult.ok) {
+            cacheFallbackResult(cacheStore, normalizedCallsign, trackpollResult, nowMs);
+            return trackpollResult;
+          }
+        }
+      } catch {
+        // The public page bootstrap remains a valid fallback when the private
+        // trackpoll request is blocked, expired, or changes shape.
+      }
+    }
+
     const result = parseFlightAwareFallbackPage({
       callsign: normalizedCallsign,
       html,

--- a/src/hooks/useTrackedAircraft.ts
+++ b/src/hooks/useTrackedAircraft.ts
@@ -2,6 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  AIRCRAFT_TRAFFIC_CONFIG,
+  AVIATION_PROXY_BASES,
+} from "../config/aviation";
+import {
   normalizeAdsbAircraft,
   resolveLastSuccessfulPositionDate,
 } from "../features/aircraft/positions/aircraftPositionsModel";
@@ -25,7 +29,26 @@ function normalizeRealtimeTrackedPayload(data: unknown) {
   return { ac: [] };
 }
 
-export function useTrackedAircraft(callsign: unknown) {
+function normalizeTrackedPayload(data: unknown) {
+  return normalizeRealtimeTrackedPayload(data);
+}
+
+function shouldHoldFlightAwarePosition(trackingState: unknown) {
+  return (
+    String((trackingState as any)?.status || "").trim() === "flightaware_active"
+  );
+}
+
+export function useTrackedAircraft(
+  callsign: unknown,
+  {
+    flightAwareEnabled = false,
+    flightAwareResolved = true,
+  }: {
+    flightAwareEnabled?: boolean;
+    flightAwareResolved?: boolean;
+  } = {},
+) {
   const hasActiveQuery = Boolean(callsign);
   const realtime = useAircraftTrackingRealtime(callsign, {
     enabled: hasActiveQuery,
@@ -46,6 +69,79 @@ export function useTrackedAircraft(callsign: unknown) {
   const retry = useCallback(() => {
     getAdsbaoRealtimeClient().connect();
   }, []);
+  const applyTrackedPayload = useCallback(
+    (
+      payloadInput: unknown,
+      {
+        source = "",
+        fetchedAt = "",
+      }: {
+        source?: string;
+        fetchedAt?: string;
+      } = {},
+    ) => {
+      const payload = normalizeTrackedPayload(payloadInput);
+      const matches = Array.isArray(payload.ac) ? payload.ac : [];
+      const nextTrackingState = payload.trackingState || null;
+      const nextSource =
+        typeof source === "string" && source
+          ? source
+          : typeof payload.source === "string"
+            ? payload.source
+            : "";
+      const signalState = getTrackedAircraftSignalState({
+        matchesLength: getActiveAdsbMatchesLength({
+          matchesLength: matches.length,
+          source: nextSource,
+        }),
+        previousMisses: missesRef.current,
+        flightAwareFallback: payload.flightAwareFallback,
+        trackingState: nextTrackingState,
+      });
+      const retainActiveTrackingState = shouldRetainActiveTrackingState({
+        previousTrackingState: trackingStateRef.current,
+        nextTrackingState,
+        matchesLength: matches.length,
+        lostSignal: signalState.lostSignal,
+      });
+      const committedTrackingState = retainActiveTrackingState
+        ? trackingStateRef.current
+        : nextTrackingState;
+      const committedFeedSource =
+        retainActiveTrackingState && !nextSource
+          ? feedSourceRef.current
+          : nextSource;
+
+      trackingStateRef.current = committedTrackingState;
+      feedSourceRef.current = committedFeedSource;
+      missesRef.current = signalState.misses;
+      setTrackingState(committedTrackingState);
+      setFlightAwareFallback(payload.flightAwareFallback || null);
+      setLostSignal(signalState.lostSignal);
+      setFeedSource(committedFeedSource);
+      setError(null);
+      setSettled(true);
+      setPollVersion((value) => value + 1);
+
+      if (matches.length === 0) return;
+
+      const parsedFetchedAt = Date.parse(fetchedAt);
+      const receiveTime = Number.isFinite(parsedFetchedAt)
+        ? parsedFetchedAt
+        : Date.now();
+      const normalized = normalizeAdsbAircraft(pickFreshest(matches), {
+        responseNow: payload.now,
+        receiveTime,
+      });
+      setAircraft({
+        ...normalized,
+        trackingState: committedTrackingState,
+      });
+      const positionDate = resolveLastSuccessfulPositionDate(normalized);
+      if (positionDate) setLastUpdated(positionDate);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!callsign) {
@@ -86,65 +182,92 @@ export function useTrackedAircraft(callsign: unknown) {
   useEffect(() => {
     const event = realtime.event;
     if (!callsign || !event || event.type !== "aircraft:update") return;
+    if (
+      flightAwareEnabled &&
+      flightAwareResolved &&
+      shouldHoldFlightAwarePosition(trackingStateRef.current)
+    ) {
+      return;
+    }
 
-    const payload = normalizeRealtimeTrackedPayload(event.data);
-    const matches = Array.isArray(payload.ac) ? payload.ac : [];
-    const nextTrackingState = payload.trackingState || null;
-    const signalState = getTrackedAircraftSignalState({
-      matchesLength: getActiveAdsbMatchesLength({
-        matchesLength: matches.length,
-        source: payload.source || event.source,
-      }),
-      previousMisses: missesRef.current,
-      flightAwareFallback: payload.flightAwareFallback,
-      trackingState: nextTrackingState,
+    applyTrackedPayload(event.data, {
+      source: event.source,
+      fetchedAt: event.fetchedAt,
     });
-    const retainActiveTrackingState = shouldRetainActiveTrackingState({
-      previousTrackingState: trackingStateRef.current,
-      nextTrackingState,
-      matchesLength: matches.length,
-      lostSignal: signalState.lostSignal,
-    });
-    const committedTrackingState = retainActiveTrackingState
-      ? trackingStateRef.current
-      : nextTrackingState;
-    const nextFeedSource =
-      typeof event.source === "string"
-        ? event.source
-        : typeof payload.source === "string"
-          ? payload.source
-          : "";
-    const committedFeedSource =
-      retainActiveTrackingState && !nextFeedSource
-        ? feedSourceRef.current
-        : nextFeedSource;
+  }, [
+    applyTrackedPayload,
+    callsign,
+    flightAwareEnabled,
+    flightAwareResolved,
+    realtime.event,
+  ]);
 
-    trackingStateRef.current = committedTrackingState;
-    feedSourceRef.current = committedFeedSource;
-    missesRef.current = signalState.misses;
-    setTrackingState(committedTrackingState);
-    setFlightAwareFallback(payload.flightAwareFallback || null);
-    setLostSignal(signalState.lostSignal);
-    setFeedSource(committedFeedSource);
-    setError(null);
-    setSettled(true);
-    setPollVersion((value) => value + 1);
+  useEffect(() => {
+    if (!callsign || !flightAwareResolved || !flightAwareEnabled) return undefined;
 
-    if (matches.length === 0) return;
+    const normalizedCallsign = String(callsign || "").trim().toUpperCase();
+    if (!normalizedCallsign) return undefined;
 
-    const fetchedAt = Date.parse(event.fetchedAt);
-    const receiveTime = Number.isFinite(fetchedAt) ? fetchedAt : Date.now();
-    const normalized = normalizeAdsbAircraft(pickFreshest(matches), {
-      responseNow: payload.now,
-      receiveTime,
-    });
-    setAircraft({
-      ...normalized,
-      trackingState: committedTrackingState,
-    });
-    const positionDate = resolveLastSuccessfulPositionDate(normalized);
-    if (positionDate) setLastUpdated(positionDate);
-  }, [callsign, realtime.event]);
+    let disposed = false;
+    let timer: number | null = null;
+    let controller: AbortController | null = null;
+
+    const poll = async () => {
+      controller?.abort();
+      controller = new AbortController();
+      try {
+        const response = await fetch(
+          `${AVIATION_PROXY_BASES.aircraftCallsign}/${encodeURIComponent(normalizedCallsign)}`,
+          {
+            cache: "no-store",
+            credentials: "same-origin",
+            signal: controller.signal,
+          },
+        );
+        if (!response.ok) {
+          throw new Error(`Aircraft callsign proxy HTTP ${response.status}`);
+        }
+        const payload = await response.json();
+        if (disposed) return;
+        applyTrackedPayload(payload, {
+          source:
+            response.headers.get("X-Data-Source") ||
+            (typeof payload?.source === "string" ? payload.source : ""),
+          fetchedAt: new Date().toISOString(),
+        });
+      } catch (error: any) {
+        if (disposed || error?.name === "AbortError") return;
+        setError(error);
+        setSettled(true);
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(
+            `[tracked-aircraft] FlightAware-aware refresh failed for ${normalizedCallsign}:`,
+            error,
+          );
+        }
+      } finally {
+        if (!disposed) {
+          timer = window.setTimeout(
+            poll,
+            AIRCRAFT_TRAFFIC_CONFIG.flightAwareTraceRefreshMs,
+          );
+        }
+      }
+    };
+
+    poll();
+
+    return () => {
+      disposed = true;
+      if (timer) window.clearTimeout(timer);
+      controller?.abort();
+    };
+  }, [
+    applyTrackedPayload,
+    callsign,
+    flightAwareEnabled,
+    flightAwareResolved,
+  ]);
 
   const waitingForRealtime =
     hasActiveQuery && (!settled || realtime.fallbackActive);


### PR DESCRIPTION
## Summary
- Poll FlightAware's trackpoll endpoint after loading the flight page so DAL58-style position updates are not stuck on the bootstrap payload.
- Reconnect the tracked-flight page to the authenticated aircraft callsign proxy when FlightAware access is enabled.
- Preserve FlightAware active positions from being overwritten by stale realtime ADS-B/ADS-C frames.

## Root Cause
The FlightAware fallback only parsed the initial `trackpollBootstrap` HTML payload, while the real FlightAware page refreshes positions through `/ajax/trackpoll.rvt`. The tracked-flight hook also moved to realtime-only `callsign:` updates, bypassing the authenticated FlightAware-aware callsign proxy.

## Validation
- `pnpm exec tsx src/features/aircraft/flightaware/flightAwareFallbackProvider.test.ts`
- `pnpm exec tsx src/features/aircraft/callsign/trackedAircraftCallsignFallback.test.ts`
- `pnpm exec tsx src/features/aircraft/tracking/trackedFlightPositionResolver.test.ts`
- `pnpm test`
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm build`
- `git diff --check`
- Live DAL58 provider smoke confirmed a request to `/ajax/trackpoll.rvt` and a newer FlightAware position timestamp.