### PR TITLE
[codex] Fix flight map status label

### DIFF
--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -11,6 +11,7 @@ export default function ExplorerMapMenu({
   lastUpdated = null,
   loadingStatus = "",
   realtimeStatus = "",
+  sourceLabel = "",
   traceViewItems = [],
   userLocationActive = false,
   userLocationAudioActive = false,
@@ -110,6 +111,7 @@ export default function ExplorerMapMenu({
         lastUpdated={lastUpdated}
         loadingStatus={loadingStatus}
         realtimeStatus={realtimeStatus}
+        sourceLabel={sourceLabel}
         wakeLockActive={wakeLockState.active}
       />
     </div>

--- a/src/components/explorer/MobileMapSourceStatus.tsx
+++ b/src/components/explorer/MobileMapSourceStatus.tsx
@@ -7,6 +7,7 @@ export default function MobileMapSourceStatus({
   lastUpdated = null,
   loadingStatus = "",
   realtimeStatus = "",
+  sourceLabel = "",
   wakeLockActive = false,
 }) {
   const status = buildMapSourceStatusDisplay({ feedSource });
@@ -14,7 +15,7 @@ export default function MobileMapSourceStatus({
 
   return (
     <MapSourceStatusDisplay
-      feedSource={status.feedSource}
+      feedSource={sourceLabel || status.feedSource}
       feedStatus={feedStatus}
       updatedLabel={updatedLabel}
       loadingStatus={loadingStatus}

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -32,7 +32,10 @@ import {
 import { resolveFocusedFlightAwareRouteArcPath } from "@/features/aviation/flight-routes/flightRouteArcModel";
 import { resolveRouteLookupEnabled } from "@/features/aviation/flight-routes/flightRouteLookupModel";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled";
-import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel";
+import {
+  getMapPositionSourceBadge,
+  resolveRouteProvider,
+} from "@/features/aviation/sourceDisplayModel";
 import { mergeTrackedAircraftIntoNearby } from "@/features/airport/explorer/airportExplorerModel";
 import { AIRCRAFT_TRAFFIC_CONFIG } from "@/config/aviation";
 import {
@@ -562,6 +565,11 @@ function FlightExplorerContent({ callsign }) {
       trackedAircraftForDisplay
     );
   }, [aircraft, trackedAircraftForDisplay]);
+  const mapPositionSourceBadge = getMapPositionSourceBadge({
+    positionQuality: trackedAircraftForDisplay?.positionQuality,
+    trackingState,
+    lastUpdated,
+  });
   const routeEndpointCandidates = useMemo(
     () =>
       buildRouteEndpointCandidates({
@@ -868,10 +876,11 @@ function FlightExplorerContent({ callsign }) {
             <ExplorerMapMenu
               feedSource={feedSource}
               feedStatus="live"
-              lastUpdated={lastUpdated}
+              lastUpdated={null}
               routeProvider={routeProvider}
               loadingStatus={sourceLoadingStatus}
               realtimeStatus={realtimeStatus}
+              sourceLabel={mapPositionSourceBadge}
               {...toolbarContextProps}
             />
           )}

--- a/src/features/aviation/sourceDisplayModel.test.ts
+++ b/src/features/aviation/sourceDisplayModel.test.ts
@@ -4,6 +4,7 @@ import {
   ROUTE_PROVIDER,
   buildMapSourceStatusDisplay,
   getAircraftPositionSourceBadge,
+  getMapPositionSourceBadge,
   resolveFlightPositionSource,
 } from "./sourceDisplayModel";
 
@@ -49,6 +50,40 @@ assert.equal(
 assert.equal(
   getAircraftPositionSourceBadge({ source: "unknown", kind: "stale" }),
   "Stale",
+);
+assert.equal(
+  getAircraftPositionSourceBadge({
+    source: "airplanes_live",
+    flight_position_source: "estimated",
+    kind: "stale",
+    isStale: true,
+  }),
+  "Stale",
+);
+assert.equal(
+  getMapPositionSourceBadge({
+    positionQuality: { source: "airplanes_live", kind: "observed" },
+    lastUpdated: new Date("2026-06-14T04:00:00.000Z"),
+    now: Date.parse("2026-06-14T04:02:00.000Z"),
+  }),
+  "Stale",
+);
+assert.equal(
+  getMapPositionSourceBadge({
+    positionQuality: { source: "airplanes_live", kind: "observed" },
+    trackingState: { status: "stale" },
+    lastUpdated: new Date("2026-06-14T04:01:50.000Z"),
+    now: Date.parse("2026-06-14T04:02:00.000Z"),
+  }),
+  "Stale",
+);
+assert.equal(
+  getMapPositionSourceBadge({
+    positionQuality: { source: "airplanes_live", kind: "observed" },
+    lastUpdated: new Date("2026-06-14T04:01:50.000Z"),
+    now: Date.parse("2026-06-14T04:02:00.000Z"),
+  }),
+  "ads-b",
 );
 
 assert.equal(resolveFlightPositionSource({ flight_position_source: "MLAT" }), "mlat");

--- a/src/features/aviation/sourceDisplayModel.ts
+++ b/src/features/aviation/sourceDisplayModel.ts
@@ -41,8 +41,31 @@ const AIRCRAFT_POSITION_SOURCE_LABELS = Object.freeze({
   unknown: "",
 });
 
+const STALE_POSITION_AGE_MS = 90 * 1000;
+
+type MapPositionSourceBadgeOptions = {
+  positionQuality?: Record<string, any> | null;
+  trackingState?: Record<string, any> | null;
+  lastUpdated?: unknown;
+  now?: number;
+};
+
 function normalizeKey(value) {
   return String(value || "").trim().toLowerCase();
+}
+
+function parseTimestampMs(value: unknown) {
+  if (value == null || value === "") return null;
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+  const number = Number(value);
+  if (Number.isFinite(number)) {
+    return number < 10_000_000_000 ? Math.round(number * 1000) : Math.round(number);
+  }
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function getDataSourceDisplayName(source) {
@@ -102,6 +125,29 @@ export function getAircraftPositionSourceBadge(quality: Record<string, any> = {}
   if (source === "flightaware") return sourceLabel;
   if (kind === "stale") return "Stale";
   return sourceLabel;
+}
+
+export function getMapPositionSourceBadge({
+  positionQuality = {},
+  trackingState = null,
+  lastUpdated = null,
+  now = Date.now(),
+}: MapPositionSourceBadgeOptions = {}) {
+  const normalizedPositionQuality = positionQuality || {};
+  const trackingStatus = normalizeKey(trackingState?.status);
+  const qualityKind = normalizeKey(normalizedPositionQuality.kind);
+  if (trackingStatus === "stale" || qualityKind === "stale") return "Stale";
+
+  const lastUpdatedMs = parseTimestampMs(lastUpdated);
+  if (
+    lastUpdatedMs != null &&
+    Number.isFinite(now) &&
+    now - lastUpdatedMs > STALE_POSITION_AGE_MS
+  ) {
+    return "Stale";
+  }
+
+  return getAircraftPositionSourceBadge(normalizedPositionQuality);
 }
 
 export function buildMapSourceStatusDisplay({


### PR DESCRIPTION
## Summary
- Replace the flight map corner timestamp with a derived position status label.
- Show `Stale` when tracking state or position age indicates stale data, while preserving source labels for fresh data.
- Add focused source display model coverage for stale and fresh status cases.

## Validation
- `pnpm exec tsx src/features/aviation/sourceDisplayModel.test.ts`
- `pnpm lint` (existing warnings only)
- `pnpm build`
- Chrome local validation on `/aircraft/DAL58`: map status reads `Stale` and no longer contains `00:18:29`.

## Notes
- Left unrelated local dirty files out of this PR: `src/hooks/useTrackedAircraft.ts` and untracked `trackedAircraftStatusModel*` files.