### PR TITLE
[codex] Use backend status timestamps

### DIFF
--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -876,7 +876,7 @@ function FlightExplorerContent({ callsign }) {
             <ExplorerMapMenu
               feedSource={feedSource}
               feedStatus="live"
-              lastUpdated={null}
+              lastUpdated={lastUpdated}
               routeProvider={routeProvider}
               loadingStatus={sourceLoadingStatus}
               realtimeStatus={realtimeStatus}

--- a/src/features/aircraft/callsign/aircraftCallsign.mechanism.ts
+++ b/src/features/aircraft/callsign/aircraftCallsign.mechanism.ts
@@ -97,6 +97,10 @@ async function fetchAllCallsignProviders({ callsign }: AircraftCallsignRecord) {
     .filter(Boolean);
 }
 
+function statusFetchedAt(now: unknown) {
+  return new Date(Number(now) || Date.now()).toISOString();
+}
+
 function annotatePayload(payload: AircraftCallsignRecord, { source, now, fallback, trackingState }: AircraftCallsignRecord) {
   return {
     ...payload,
@@ -104,6 +108,7 @@ function annotatePayload(payload: AircraftCallsignRecord, { source, now, fallbac
       annotateAdsbPosition(aircraft, { source, now }),
     ),
     source,
+    fetchedAt: statusFetchedAt(now),
     flightAwareFallback: sanitizeFallbackForClient(fallback),
     trackingState,
   };
@@ -116,6 +121,7 @@ function payloadForResolvedPosition({ resolved, callsign, fallback, now }: Aircr
       ac: [],
       source: "",
       now: now / 1000,
+      fetchedAt: statusFetchedAt(now),
       flightAwareFallback: clientFallback,
       trackingState: resolved.trackingState,
     };
@@ -126,6 +132,7 @@ function payloadForResolvedPosition({ resolved, callsign, fallback, now }: Aircr
       ac: [resolved.position],
       source: "flightaware",
       now: now / 1000,
+      fetchedAt: statusFetchedAt(now),
       flightAwareFallback: clientFallback,
       trackingState: resolved.trackingState,
     };
@@ -135,6 +142,7 @@ function payloadForResolvedPosition({ resolved, callsign, fallback, now }: Aircr
     ac: [resolved.position],
     source: resolved.source || "",
     now: now / 1000,
+    fetchedAt: statusFetchedAt(now),
     flightAwareFallback: clientFallback,
     callsign,
     trackingState: resolved.trackingState,

--- a/src/features/aircraft/callsign/trackedAircraftCallsignFallback.test.ts
+++ b/src/features/aircraft/callsign/trackedAircraftCallsignFallback.test.ts
@@ -39,6 +39,7 @@ const staleAircraft = {
   const result = await fetchTrackedAircraftByCallsign({
     callsign: "AAL100",
     featureEnabled: true,
+    now: Date.parse("2026-06-14T04:22:00.000Z"),
     fetchPrimaryProviders: async () => [
       providerPayload(ADSB_LOL_ID, [freshAircraft]),
       providerPayload(AIRPLANES_LIVE_ID, []),
@@ -50,6 +51,7 @@ const staleAircraft = {
   });
 
   assert.equal(result.source, ADSB_LOL_ID);
+  assert.equal(result.payload.fetchedAt, "2026-06-14T04:22:00.000Z");
   assert.equal(result.payload.ac[0].lat, 42.1);
   assert.equal(result.payload.ac[0].positionQuality.source, "adsb_lol");
   assert.equal(flightAwareCalls, 0);

--- a/src/features/aircraft/tracking/trackedAircraftStatusModel.test.ts
+++ b/src/features/aircraft/tracking/trackedAircraftStatusModel.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+
+import { resolveTrackedAircraftStatusUpdatedDate } from "./trackedAircraftStatusModel";
+
+{
+  const result = resolveTrackedAircraftStatusUpdatedDate({
+    aircraft: {
+      positionTime: "2026-06-14T04:20:00.000Z",
+      positionQuality: {
+        source: "flightaware",
+        sourceUpdatedAt: "2026-06-14T04:25:16.000Z",
+        fetchedAt: "2026-06-14T04:25:20.000Z",
+      },
+    },
+    fetchedAt: "2026-06-14T04:26:20.000Z",
+    feedSource: "flightaware",
+    trackingState: { status: "flightaware_active" },
+  });
+
+  assert.equal(result?.toISOString(), "2026-06-14T04:26:20.000Z");
+}
+
+{
+  const result = resolveTrackedAircraftStatusUpdatedDate({
+    aircraft: {
+      positionTime: "2026-06-14T04:20:00.000Z",
+      positionQuality: {
+        source: "adsb_lol",
+        sourceUpdatedAt: "2026-06-14T04:20:12.000Z",
+        fetchedAt: "2026-06-14T04:21:00.000Z",
+      },
+    },
+    fetchedAt: "2026-06-14T04:22:00.000Z",
+    feedSource: "adsb.lol",
+    trackingState: { status: "adsb_live" },
+  });
+
+  assert.equal(result?.toISOString(), "2026-06-14T04:22:00.000Z");
+}
+
+{
+  const result = resolveTrackedAircraftStatusUpdatedDate({
+    aircraft: {
+      positionTime: "2026-06-14T04:20:00.000Z",
+      positionQuality: {
+        source: "flightaware",
+        sourceUpdatedAt: "2026-06-14T04:25:16.000Z",
+        fetchedAt: "2026-06-14T04:27:20.000Z",
+      },
+    },
+    feedSource: "flightaware",
+  });
+
+  assert.equal(result?.toISOString(), "2026-06-14T04:27:20.000Z");
+}
+
+{
+  const result = resolveTrackedAircraftStatusUpdatedDate({
+    aircraft: {
+      positionTime: "2026-06-14T04:20:00.000Z",
+      positionQuality: {
+        source: "adsb_lol",
+        sourceUpdatedAt: "2026-06-14T04:20:12.000Z",
+      },
+    },
+  });
+
+  assert.equal(result?.toISOString(), "2026-06-14T04:20:12.000Z");
+}
+
+console.log("trackedAircraftStatusModel.test.ts ok");

--- a/src/features/aircraft/tracking/trackedAircraftStatusModel.ts
+++ b/src/features/aircraft/tracking/trackedAircraftStatusModel.ts
@@ -1,0 +1,30 @@
+import { resolveLastSuccessfulPositionDate } from "../positions/aircraftPositionsModel";
+
+type TrackingRecord = Record<string, any>;
+
+function parseDate(value: unknown) {
+  if (value == null || value === "") return null;
+  const number = Number(value);
+  const timestamp = Number.isFinite(number)
+    ? number < 10_000_000_000
+      ? Math.round(number * 1000)
+      : Math.round(number)
+    : Date.parse(String(value));
+  return Number.isFinite(timestamp) ? new Date(timestamp) : null;
+}
+
+export function resolveTrackedAircraftStatusUpdatedDate({
+  aircraft = null,
+  fetchedAt = "",
+}: {
+  aircraft?: TrackingRecord | null;
+  fetchedAt?: unknown;
+  feedSource?: unknown;
+  trackingState?: TrackingRecord | null;
+} = {}) {
+  const fetchedDate =
+    parseDate(fetchedAt) || parseDate(aircraft?.positionQuality?.fetchedAt);
+  if (fetchedDate) return fetchedDate;
+
+  return aircraft ? resolveLastSuccessfulPositionDate(aircraft) : null;
+}

--- a/src/hooks/useAircraftPositions.ts
+++ b/src/hooks/useAircraftPositions.ts
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AIRCRAFT_TRAFFIC_CONFIG } from "../config/aviation";
 import {
   normalizeAircraftSnapshot,
-  resolveLastSuccessfulPositionDate,
 } from "../features/aircraft/positions/aircraftPositionsModel";
 import { shouldShowAircraftLoadingOverlay } from "../features/aircraft/positions/aircraftLoadingOverlayModel";
 import { createAircraftTraceTracker } from "../features/aircraft/trace/aircraftTraceModel";
@@ -109,10 +108,14 @@ export function useAircraftPositions(
           ? payload.source
           : "",
     );
-    const positionDate = resolveLastSuccessfulPositionDate(nextAircraft);
-    if (positionDate) {
+    const statusUpdatedDate = Number.isFinite(fetchedAt)
+      ? new Date(fetchedAt)
+      : null;
+    if (statusUpdatedDate) {
       setLastUpdated((prev) =>
-        prev && prev.getTime() === positionDate.getTime() ? prev : positionDate,
+        prev && prev.getTime() === statusUpdatedDate.getTime()
+          ? prev
+          : statusUpdatedDate,
       );
     }
     setSettled(true);

--- a/src/hooks/useTrackedAircraft.ts
+++ b/src/hooks/useTrackedAircraft.ts
@@ -7,9 +7,9 @@ import {
 } from "../config/aviation";
 import {
   normalizeAdsbAircraft,
-  resolveLastSuccessfulPositionDate,
 } from "../features/aircraft/positions/aircraftPositionsModel";
 import { shouldShowAircraftLoadingOverlay } from "../features/aircraft/positions/aircraftLoadingOverlayModel";
+import { resolveTrackedAircraftStatusUpdatedDate } from "../features/aircraft/tracking/trackedAircraftStatusModel";
 import {
   getActiveAdsbMatchesLength,
   getTrackedAircraftSignalState,
@@ -137,8 +137,19 @@ export function useTrackedAircraft(
         ...normalized,
         trackingState: committedTrackingState,
       });
-      const positionDate = resolveLastSuccessfulPositionDate(normalized);
-      if (positionDate) setLastUpdated(positionDate);
+      const statusUpdatedDate = resolveTrackedAircraftStatusUpdatedDate({
+        aircraft: normalized,
+        fetchedAt,
+        feedSource: committedFeedSource,
+        trackingState: committedTrackingState,
+      });
+      if (statusUpdatedDate) {
+        setLastUpdated((prev) =>
+          prev && prev.getTime() === statusUpdatedDate.getTime()
+            ? prev
+            : statusUpdatedDate,
+        );
+      }
     },
     [],
   );
@@ -233,7 +244,10 @@ export function useTrackedAircraft(
           source:
             response.headers.get("X-Data-Source") ||
             (typeof payload?.source === "string" ? payload.source : ""),
-          fetchedAt: new Date().toISOString(),
+          fetchedAt:
+            typeof payload?.fetchedAt === "string"
+              ? payload.fetchedAt
+              : response.headers.get("Date") || "",
         });
       } catch (error: any) {
         if (disposed || error?.name === "AbortError") return;


### PR DESCRIPTION
## Summary
- Add a shared tracked-aircraft status timestamp resolver that prefers backend-provided `fetchedAt`.
- Include `fetchedAt` in callsign proxy payloads so HTTP fallback matches realtime event semantics.
- Use backend status timestamps for tracked aircraft and nearby traffic map status labels while preserving position timestamps for movement/trace data.

## Validation
- `pnpm exec tsx src/features/aircraft/tracking/trackedAircraftStatusModel.test.ts`
- `pnpm exec tsx src/features/aircraft/callsign/trackedAircraftCallsignFallback.test.ts`
- `pnpm exec tsx src/features/aviation/sourceDisplayModel.test.ts`
- `pnpm lint` (existing warnings only)
- `pnpm build`