### PR TITLE
[codex] Show backend aircraft position times

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -537,7 +537,7 @@ function AirportExplorerContent({
         >
           {!(isMobile && sidebarOpen) && (
             <ExplorerMapMenu
-              feedSource={traffic.feedSource}
+              feedSource=""
               feedStatus={traffic.feedStatus}
               lastUpdated={traffic.lastUpdated}
               routeProvider={traffic.routeProvider}

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -11,7 +11,6 @@ export default function ExplorerMapMenu({
   lastUpdated = null,
   loadingStatus = "",
   realtimeStatus = "",
-  sourceLabel = "",
   traceViewItems = [],
   userLocationActive = false,
   userLocationAudioActive = false,
@@ -111,7 +110,6 @@ export default function ExplorerMapMenu({
         lastUpdated={lastUpdated}
         loadingStatus={loadingStatus}
         realtimeStatus={realtimeStatus}
-        sourceLabel={sourceLabel}
         wakeLockActive={wakeLockState.active}
       />
     </div>

--- a/src/components/explorer/MobileMapSourceStatus.tsx
+++ b/src/components/explorer/MobileMapSourceStatus.tsx
@@ -7,7 +7,6 @@ export default function MobileMapSourceStatus({
   lastUpdated = null,
   loadingStatus = "",
   realtimeStatus = "",
-  sourceLabel = "",
   wakeLockActive = false,
 }) {
   const status = buildMapSourceStatusDisplay({ feedSource });
@@ -15,7 +14,7 @@ export default function MobileMapSourceStatus({
 
   return (
     <MapSourceStatusDisplay
-      feedSource={sourceLabel || status.feedSource}
+      feedSource={status.feedSource}
       feedStatus={feedStatus}
       updatedLabel={updatedLabel}
       loadingStatus={loadingStatus}

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -32,10 +32,7 @@ import {
 import { resolveFocusedFlightAwareRouteArcPath } from "@/features/aviation/flight-routes/flightRouteArcModel";
 import { resolveRouteLookupEnabled } from "@/features/aviation/flight-routes/flightRouteLookupModel";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled";
-import {
-  getMapPositionSourceBadge,
-  resolveRouteProvider,
-} from "@/features/aviation/sourceDisplayModel";
+import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel";
 import { mergeTrackedAircraftIntoNearby } from "@/features/airport/explorer/airportExplorerModel";
 import { AIRCRAFT_TRAFFIC_CONFIG } from "@/config/aviation";
 import {
@@ -565,11 +562,6 @@ function FlightExplorerContent({ callsign }) {
       trackedAircraftForDisplay
     );
   }, [aircraft, trackedAircraftForDisplay]);
-  const mapPositionSourceBadge = getMapPositionSourceBadge({
-    positionQuality: trackedAircraftForDisplay?.positionQuality,
-    trackingState,
-    lastUpdated,
-  });
   const routeEndpointCandidates = useMemo(
     () =>
       buildRouteEndpointCandidates({
@@ -874,13 +866,12 @@ function FlightExplorerContent({ callsign }) {
         <div className="airport-map-stage relative min-w-0 flex-1 overflow-hidden bg-atc-bg">
           {!(isMobile && sidebarOpen) && (
             <ExplorerMapMenu
-              feedSource={feedSource}
+              feedSource=""
               feedStatus="live"
               lastUpdated={lastUpdated}
               routeProvider={routeProvider}
               loadingStatus={sourceLoadingStatus}
               realtimeStatus={realtimeStatus}
-              sourceLabel={mapPositionSourceBadge}
               {...toolbarContextProps}
             />
           )}

--- a/src/features/aircraft/positions/aircraftPositions.mechanism.test.ts
+++ b/src/features/aircraft/positions/aircraftPositions.mechanism.test.ts
@@ -11,7 +11,7 @@ globalThis.fetch = async (url) => {
     return new Response(
       JSON.stringify({
         now: 1779678000,
-        aircraft: [{ hex: "a360b7", flight: "JBU396  " }],
+        aircraft: [{ hex: "a360b7", flight: "JBU396  ", seen_pos: 5.2 }],
         resultCount: 1,
       }),
       {
@@ -42,7 +42,27 @@ try {
   );
   if (result.source === "adsb.fi") {
     assert.deepEqual((result.payload as unknown as { ac: unknown[] }).ac, [
-      { hex: "a360b7", flight: "JBU396  " },
+      {
+        hex: "a360b7",
+        flight: "JBU396  ",
+        seen_pos: 5.2,
+        source: "adsb.fi",
+        positionQuality: {
+          source: "adsb_fi",
+          flight_position_source: "adsb",
+          kind: "observed",
+          isEstimated: false,
+          isPredicted: false,
+          isInterpolated: false,
+          isStale: false,
+          sourceLabel: "adsb.fi",
+          sourceUpdatedAt: new Date(1779678000 * 1000 - 5200).toISOString(),
+          fetchedAt: new Date(1779678000 * 1000).toISOString(),
+          ageSeconds: 5,
+          confidence: "high",
+          notes: undefined,
+        },
+      },
     ]);
   }
 } finally {

--- a/src/features/aircraft/positions/aircraftPositions.mechanism.ts
+++ b/src/features/aircraft/positions/aircraftPositions.mechanism.ts
@@ -4,6 +4,9 @@ import {
   createAdaptiveProviderSelector,
   raceProviders,
 } from "../../aviation/providerHealth";
+import {
+  annotateAdsbPosition,
+} from "../tracking/trackedFlightPositionResolver";
 
 import {
   AIRCRAFT_POSITIONS_MAX_BYTES,
@@ -17,6 +20,12 @@ import {
 const selector = createAdaptiveProviderSelector();
 
 type AircraftPositionsRecord = Record<string, any>;
+
+function payloadNowMs(payload: AircraftPositionsRecord) {
+  const now = Number(payload?.now);
+  if (!Number.isFinite(now)) return Date.now();
+  return now < 10_000_000_000 ? Math.round(now * 1000) : Math.round(now);
+}
 
 async function fetchProviderPayload(provider: AircraftPositionsRecord, { latitude, longitude, distanceNm }: AircraftPositionsRecord) {
   const url = provider.buildPositionUrl({
@@ -71,11 +80,24 @@ async function fetchProviderPayload(provider: AircraftPositionsRecord, { latitud
   return normalizedPayload;
 }
 
-const successResult = (provider: AircraftPositionsRecord, payload: AircraftPositionsRecord, attempts: string[]) => ({
-  payload: { ...payload, source: provider.id },
-  source: provider.id,
-  attempts,
-});
+const successResult = (
+  provider: AircraftPositionsRecord,
+  payload: AircraftPositionsRecord,
+  attempts: string[],
+) => {
+  const now = payloadNowMs(payload);
+  return {
+    payload: {
+      ...payload,
+      ac: (payload.ac || []).map((aircraft) =>
+        annotateAdsbPosition(aircraft, { source: provider.id, now }),
+      ),
+      source: provider.id,
+    },
+    source: provider.id,
+    attempts,
+  };
+};
 
 export const fetchAircraftPositions = async ({
   latitude,

--- a/src/features/aircraft/tracking/trackedAircraftStatusModel.test.ts
+++ b/src/features/aircraft/tracking/trackedAircraftStatusModel.test.ts
@@ -17,7 +17,7 @@ import { resolveTrackedAircraftStatusUpdatedDate } from "./trackedAircraftStatus
     trackingState: { status: "flightaware_active" },
   });
 
-  assert.equal(result?.toISOString(), "2026-06-14T04:26:20.000Z");
+  assert.equal(result?.toISOString(), "2026-06-14T04:25:16.000Z");
 }
 
 {
@@ -35,7 +35,7 @@ import { resolveTrackedAircraftStatusUpdatedDate } from "./trackedAircraftStatus
     trackingState: { status: "adsb_live" },
   });
 
-  assert.equal(result?.toISOString(), "2026-06-14T04:22:00.000Z");
+  assert.equal(result?.toISOString(), "2026-06-14T04:20:12.000Z");
 }
 
 {
@@ -51,7 +51,7 @@ import { resolveTrackedAircraftStatusUpdatedDate } from "./trackedAircraftStatus
     feedSource: "flightaware",
   });
 
-  assert.equal(result?.toISOString(), "2026-06-14T04:27:20.000Z");
+  assert.equal(result?.toISOString(), "2026-06-14T04:25:16.000Z");
 }
 
 {
@@ -66,6 +66,19 @@ import { resolveTrackedAircraftStatusUpdatedDate } from "./trackedAircraftStatus
   });
 
   assert.equal(result?.toISOString(), "2026-06-14T04:20:12.000Z");
+}
+
+{
+  const result = resolveTrackedAircraftStatusUpdatedDate({
+    aircraft: {
+      positionQuality: {
+        fetchedAt: "2026-06-14T04:27:20.000Z",
+      },
+    },
+    fetchedAt: "2026-06-14T04:28:20.000Z",
+  });
+
+  assert.equal(result?.toISOString(), "2026-06-14T04:28:20.000Z");
 }
 
 console.log("trackedAircraftStatusModel.test.ts ok");

--- a/src/features/aircraft/tracking/trackedAircraftStatusModel.ts
+++ b/src/features/aircraft/tracking/trackedAircraftStatusModel.ts
@@ -22,9 +22,14 @@ export function resolveTrackedAircraftStatusUpdatedDate({
   feedSource?: unknown;
   trackingState?: TrackingRecord | null;
 } = {}) {
+  const positionDate = aircraft
+    ? resolveLastSuccessfulPositionDate(aircraft)
+    : null;
+  if (positionDate) return positionDate;
+
   const fetchedDate =
     parseDate(fetchedAt) || parseDate(aircraft?.positionQuality?.fetchedAt);
   if (fetchedDate) return fetchedDate;
 
-  return aircraft ? resolveLastSuccessfulPositionDate(aircraft) : null;
+  return null;
 }

--- a/src/features/aircraft/tracking/trackedFlightPositionResolver.test.ts
+++ b/src/features/aircraft/tracking/trackedFlightPositionResolver.test.ts
@@ -49,6 +49,10 @@ const flightAware = {
   assert.equal(resolved.source, "adsb.lol");
   assert.equal(resolved.position.lat, 42.1);
   assert.equal(resolved.position.positionQuality.source, "adsb_lol");
+  assert.equal(
+    resolved.position.positionQuality.sourceUpdatedAt,
+    "2026-05-25T02:59:48.000Z",
+  );
   assert.equal(flightAwareCalls, 0);
 }
 
@@ -106,6 +110,10 @@ const flightAware = {
   assert.equal(resolved.source, "airplanes.live");
   assert.equal(resolved.position.positionQuality.kind, "oceanic");
   assert.equal(resolved.position.positionQuality.flight_position_source, "adsc");
+  assert.equal(
+    resolved.position.positionQuality.sourceUpdatedAt,
+    "2026-05-25T02:50:00.000Z",
+  );
   assert.equal(resolved.trackingState.status, "oceanic_adsc");
   assert.equal(resolved.trackingState.active, true);
   assert.equal(flightAwareCalls, 0);
@@ -165,7 +173,32 @@ const flightAware = {
 
   assert.equal(resolved.source, "airplanes.live");
   assert.equal(resolved.position.positionQuality.kind, "stale");
+  assert.equal(
+    resolved.position.positionQuality.sourceUpdatedAt,
+    "2026-05-25T02:40:00.000Z",
+  );
   assert.equal(resolved.trackingState.status, "stale");
+}
+
+{
+  const resolved = await resolveTrackedFlightPosition({
+    adsbLolPosition: null,
+    airplanesLivePosition: null,
+    localProjection: {
+      lat: 40,
+      lon: -70,
+      callsign: "AAL100",
+    },
+    callsign: "AAL100",
+    featureEnabled: false,
+    now,
+  });
+
+  assert.equal(resolved.source, "local_projection");
+  assert.equal(
+    resolved.position.positionQuality.sourceUpdatedAt,
+    "2026-05-25T03:00:00.000Z",
+  );
 }
 
 {
@@ -207,6 +240,10 @@ const flightAware = {
   assert.equal(resolved.source, "last_known");
   assert.equal(resolved.position.lat, 40);
   assert.equal(resolved.position.positionQuality.kind, "stale");
+  assert.equal(
+    resolved.position.positionQuality.sourceUpdatedAt,
+    "2026-05-25T02:55:00.000Z",
+  );
   assert.equal(resolved.trackingState.status, "missing");
   assert.equal(flightAwareCalls, 1);
 }

--- a/src/features/aircraft/tracking/trackedFlightPositionResolver.ts
+++ b/src/features/aircraft/tracking/trackedFlightPositionResolver.ts
@@ -33,6 +33,10 @@ const toNumber = (value: unknown) => {
 };
 
 const isoFromNow = (now = Date.now()) => new Date(now || Date.now()).toISOString();
+const isoFromAge = (now: number, ageSeconds: number | null) =>
+  ageSeconds != null && Number.isFinite(ageSeconds)
+    ? new Date(now - ageSeconds * 1000).toISOString()
+    : undefined;
 
 function buildTrackingState(status: string, overrides: TrackingRecord = {}) {
   return {
@@ -121,6 +125,7 @@ export function annotateAdsbPosition(
       source,
       kind: isStale ? "stale" : "observed",
       fetchedAt: isoFromNow(now),
+      sourceUpdatedAt: isoFromAge(now, ageSeconds),
       ageSeconds: Number.isFinite(ageSeconds) ? Math.round(ageSeconds) : undefined,
       sourceLabel: source,
       confidence: isStale ? "low" : "high",
@@ -180,6 +185,7 @@ function annotateOceanicAdscPosition(
       kind: "oceanic",
       flightPositionSource: "adsc",
       fetchedAt: isoFromNow(now),
+      sourceUpdatedAt: isoFromAge(now, ageSeconds),
       ageSeconds: ageSeconds == null ? undefined : Math.round(ageSeconds),
       sourceLabel: candidate.source,
       confidence: "medium",
@@ -311,6 +317,7 @@ export async function resolveTrackedFlightPosition({
             source: "local_projection",
             kind: "interpolated",
             fetchedAt: isoFromNow(now),
+            sourceUpdatedAt: isoFromNow(now),
             confidence: "low",
           }),
       },
@@ -327,6 +334,10 @@ export async function resolveTrackedFlightPosition({
     const staleStatus = stale
       ? TRACKED_FLIGHT_STATUS.STALE
       : TRACKED_FLIGHT_STATUS.MISSING;
+    const fallbackAgeSeconds = getAdsbPositionAgeSeconds(fallbackPosition, now);
+    const roundedFallbackAgeSeconds = Number.isFinite(fallbackAgeSeconds)
+      ? Math.round(fallbackAgeSeconds)
+      : undefined;
     return {
       source: stale?.source || "last_known",
       position: {
@@ -335,7 +346,8 @@ export async function resolveTrackedFlightPosition({
           source: stale?.source || fallbackPosition.source || "unknown",
           kind: "stale",
           fetchedAt: isoFromNow(now),
-          ageSeconds: Math.round(getAdsbPositionAgeSeconds(fallbackPosition, now)),
+          sourceUpdatedAt: isoFromAge(now, fallbackAgeSeconds),
+          ageSeconds: roundedFallbackAgeSeconds,
           confidence: "low",
         }),
       },

--- a/src/features/aviation/sourceDisplayModel.test.ts
+++ b/src/features/aviation/sourceDisplayModel.test.ts
@@ -4,7 +4,6 @@ import {
   ROUTE_PROVIDER,
   buildMapSourceStatusDisplay,
   getAircraftPositionSourceBadge,
-  getMapPositionSourceBadge,
   resolveFlightPositionSource,
 } from "./sourceDisplayModel";
 
@@ -59,31 +58,6 @@ assert.equal(
     isStale: true,
   }),
   "Stale",
-);
-assert.equal(
-  getMapPositionSourceBadge({
-    positionQuality: { source: "airplanes_live", kind: "observed" },
-    lastUpdated: new Date("2026-06-14T04:00:00.000Z"),
-    now: Date.parse("2026-06-14T04:02:00.000Z"),
-  }),
-  "Stale",
-);
-assert.equal(
-  getMapPositionSourceBadge({
-    positionQuality: { source: "airplanes_live", kind: "observed" },
-    trackingState: { status: "stale" },
-    lastUpdated: new Date("2026-06-14T04:01:50.000Z"),
-    now: Date.parse("2026-06-14T04:02:00.000Z"),
-  }),
-  "Stale",
-);
-assert.equal(
-  getMapPositionSourceBadge({
-    positionQuality: { source: "airplanes_live", kind: "observed" },
-    lastUpdated: new Date("2026-06-14T04:01:50.000Z"),
-    now: Date.parse("2026-06-14T04:02:00.000Z"),
-  }),
-  "ads-b",
 );
 
 assert.equal(resolveFlightPositionSource({ flight_position_source: "MLAT" }), "mlat");

--- a/src/features/aviation/sourceDisplayModel.ts
+++ b/src/features/aviation/sourceDisplayModel.ts
@@ -41,31 +41,8 @@ const AIRCRAFT_POSITION_SOURCE_LABELS = Object.freeze({
   unknown: "",
 });
 
-const STALE_POSITION_AGE_MS = 90 * 1000;
-
-type MapPositionSourceBadgeOptions = {
-  positionQuality?: Record<string, any> | null;
-  trackingState?: Record<string, any> | null;
-  lastUpdated?: unknown;
-  now?: number;
-};
-
 function normalizeKey(value) {
   return String(value || "").trim().toLowerCase();
-}
-
-function parseTimestampMs(value: unknown) {
-  if (value == null || value === "") return null;
-  if (value instanceof Date) {
-    const timestamp = value.getTime();
-    return Number.isFinite(timestamp) ? timestamp : null;
-  }
-  const number = Number(value);
-  if (Number.isFinite(number)) {
-    return number < 10_000_000_000 ? Math.round(number * 1000) : Math.round(number);
-  }
-  const parsed = Date.parse(String(value));
-  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function getDataSourceDisplayName(source) {
@@ -125,29 +102,6 @@ export function getAircraftPositionSourceBadge(quality: Record<string, any> = {}
   if (source === "flightaware") return sourceLabel;
   if (kind === "stale") return "Stale";
   return sourceLabel;
-}
-
-export function getMapPositionSourceBadge({
-  positionQuality = {},
-  trackingState = null,
-  lastUpdated = null,
-  now = Date.now(),
-}: MapPositionSourceBadgeOptions = {}) {
-  const normalizedPositionQuality = positionQuality || {};
-  const trackingStatus = normalizeKey(trackingState?.status);
-  const qualityKind = normalizeKey(normalizedPositionQuality.kind);
-  if (trackingStatus === "stale" || qualityKind === "stale") return "Stale";
-
-  const lastUpdatedMs = parseTimestampMs(lastUpdated);
-  if (
-    lastUpdatedMs != null &&
-    Number.isFinite(now) &&
-    now - lastUpdatedMs > STALE_POSITION_AGE_MS
-  ) {
-    return "Stale";
-  }
-
-  return getAircraftPositionSourceBadge(normalizedPositionQuality);
 }
 
 export function buildMapSourceStatusDisplay({

--- a/src/hooks/useAircraftPositions.ts
+++ b/src/hooks/useAircraftPositions.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AIRCRAFT_TRAFFIC_CONFIG } from "../config/aviation";
 import {
   normalizeAircraftSnapshot,
+  resolveLastSuccessfulPositionDate,
 } from "../features/aircraft/positions/aircraftPositionsModel";
 import { shouldShowAircraftLoadingOverlay } from "../features/aircraft/positions/aircraftLoadingOverlayModel";
 import { createAircraftTraceTracker } from "../features/aircraft/trace/aircraftTraceModel";
@@ -108,9 +109,7 @@ export function useAircraftPositions(
           ? payload.source
           : "",
     );
-    const statusUpdatedDate = Number.isFinite(fetchedAt)
-      ? new Date(fetchedAt)
-      : null;
+    const statusUpdatedDate = resolveLastSuccessfulPositionDate(snapshot);
     if (statusUpdatedDate) {
       setLastUpdated((prev) =>
         prev && prev.getTime() === statusUpdatedDate.getTime()


### PR DESCRIPTION
## Summary
- Add backend `positionQuality.sourceUpdatedAt` timestamps to aircraft position payloads across airport traffic and tracking fallbacks.
- Make map-corner status text display only the backend-provided aircraft position time, without source/status labels.
- Remove the frontend source/status badge fallback that inferred `ads-b` or `Stale` in the map corner.

## Validation
- `pnpm test`
- `pnpm lint` (existing warnings only)
- `pnpm build`
- Chrome local validation: `/airport/KBOS?locale=zh-CN` status showed only a clock time, no source label.
- Chrome local validation: `/aircraft/AAL2951?locale=zh-CN` status showed only a clock time, no source label.