### PR TITLE
[codex] Restore map status source label

### DIFF
--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -537,7 +537,7 @@ function AirportExplorerContent({
         >
           {!(isMobile && sidebarOpen) && (
             <ExplorerMapMenu
-              feedSource=""
+              feedSource={traffic.feedSource}
               feedStatus={traffic.feedStatus}
               lastUpdated={traffic.lastUpdated}
               routeProvider={traffic.routeProvider}

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -866,7 +866,7 @@ function FlightExplorerContent({ callsign }) {
         <div className="airport-map-stage relative min-w-0 flex-1 overflow-hidden bg-atc-bg">
           {!(isMobile && sidebarOpen) && (
             <ExplorerMapMenu
-              feedSource=""
+              feedSource={feedSource}
               feedStatus="live"
               lastUpdated={lastUpdated}
               routeProvider={routeProvider}


### PR DESCRIPTION
## Summary
- Restore the map-corner position source label on airport and flight tracking pages.
- Keep the timestamp path from #454: the time still comes from backend-provided aircraft position timestamps.

## Validation
- `pnpm lint` (existing warnings only)
- `pnpm build`
- Chrome local validation: `/airport/KBOS?locale=zh-CN` showed `ads-b08:41:46`.
- Chrome local validation: `/aircraft/ENY3807?locale=zh-CN` showed `ads-b08:41:58`.