### PR TITLE
Move FlightAware high-frequency polling to data service

### DIFF
--- a/services/data-service/src/channels/channelTypes.test.ts
+++ b/services/data-service/src/channels/channelTypes.test.ts
@@ -34,6 +34,15 @@ import {
     callsign: "AAL123",
     context: { type: "airport", icao: "KBOS" },
   });
+  assert.deepEqual(
+    buildChannelPollingTarget(channel.channel, { routeProvider: "flightaware" }),
+    {
+      kind: "route",
+      callsign: "AAL123",
+      context: { type: "airport", icao: "KBOS" },
+      provider: "flightaware",
+    },
+  );
 }
 
 {

--- a/services/data-service/src/channels/channelTypes.ts
+++ b/services/data-service/src/channels/channelTypes.ts
@@ -204,9 +204,24 @@ function parseRouteChannel(channel: string): PollingTarget {
   return { kind: "route", callsign };
 }
 
+function readBooleanParam(value: unknown) {
+  if (value === true) return true;
+  if (typeof value === "string") {
+    return /^(1|true|yes)$/i.test(value.trim());
+  }
+  return false;
+}
+
+function readRouteProviderParam(value: unknown) {
+  const provider = String(value || "").trim().toLowerCase();
+  if (provider === "flightaware") return "flightaware";
+  if (provider === "adsbdb") return "adsbdb";
+  return undefined;
+}
+
 export function buildChannelPollingTarget(
   input: string,
-  _params: SubscribeParams = {},
+  params: SubscribeParams = {},
 ): PollingTarget {
   const normalized = normalizeChannelName(input);
   if (normalized.ok !== true) throw new Error(normalized.error);
@@ -219,6 +234,7 @@ export function buildChannelPollingTarget(
     return {
       kind: "callsign",
       callsign: normalized.channel.slice("callsign:".length),
+      flightAwareFallback: readBooleanParam(params.flightAware),
     };
   }
 
@@ -230,7 +246,10 @@ export function buildChannelPollingTarget(
   }
 
   if (normalized.type === "route") {
-    return parseRouteChannel(normalized.channel);
+    const target = parseRouteChannel(normalized.channel);
+    if (target.kind !== "route") return target;
+    const provider = readRouteProviderParam(params.routeProvider);
+    return provider ? { ...target, provider } : target;
   }
 
   throw new Error(`${normalized.type} channel does not have an active polling target`);

--- a/services/data-service/src/polling/PollingScheduler.ts
+++ b/services/data-service/src/polling/PollingScheduler.ts
@@ -54,8 +54,14 @@ type PollingSchedulerOptions = {
 function buildChannelStateKey(
   channel: string,
   _type: RealtimeChannelType,
-  _target: PollingTarget,
+  target: PollingTarget,
 ) {
+  if (target.kind === "callsign" && target.flightAwareFallback === true) {
+    return `${channel}:mode:flightaware`;
+  }
+  if (target.kind === "route" && target.provider) {
+    return `${channel}:provider:${target.provider}`;
+  }
   return channel;
 }
 

--- a/services/data-service/src/sources/adsbClient.ts
+++ b/services/data-service/src/sources/adsbClient.ts
@@ -3,6 +3,8 @@ import type {
   FetchChannelInput,
   RealtimeEvent,
 } from "../types.js";
+import type { FlightAwareFallbackResult } from "./flightAwareFallback.js";
+import { getFlightAwareFallbackByCallsign } from "./flightAwareFallback.js";
 import { fetchWithProviderFallback } from "./providerFallback.js";
 
 const DEFAULT_TIMEOUT_MS = 2_800;
@@ -68,6 +70,9 @@ const ADSB_FI: Provider = {
 const POSITION_PROVIDER_CHAIN = Object.freeze([ADSB_LOL, AIRPLANES_LIVE, ADSB_FI]);
 const CALLSIGN_PROVIDER_CHAIN = Object.freeze([ADSB_LOL, AIRPLANES_LIVE, ADSB_FI]);
 const AIRCRAFT_PROVIDER_CHAIN = Object.freeze([ADSB_LOL, AIRPLANES_LIVE, ADSB_FI]);
+const FLIGHTAWARE_PROVIDER: Provider = {
+  id: "flightaware",
+};
 
 function isEmptyAircraftPayload(payload: Record<string, unknown>) {
   return !Array.isArray(payload.ac) || payload.ac.length === 0;
@@ -207,6 +212,137 @@ async function fetchCallsign(input: FetchChannelInput) {
   });
 }
 
+function toFiniteNumber(value: unknown) {
+  if (value == null || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function normalizeFlightAwareAircraft({
+  callsign,
+  fallback,
+}: {
+  callsign: string;
+  fallback: FlightAwareFallbackResult;
+}) {
+  const position = fallback.position || {};
+  const latitude = toFiniteNumber(position.lat);
+  const longitude = toFiniteNumber(position.lon);
+  if (latitude == null || longitude == null) return null;
+
+  const altitudeFt = toFiniteNumber(position.altitudeFt);
+  const groundSpeedKt = toFiniteNumber(position.groundSpeedKt);
+  const trackDeg = toFiniteNumber(position.trackDeg ?? position.headingDeg);
+  const normalizedCallsign = String(position.callsign || callsign || "")
+    .trim()
+    .toUpperCase();
+
+  return {
+    hex: String(position.hex || "").trim().toLowerCase() || undefined,
+    flight: normalizedCallsign ? `${normalizedCallsign.padEnd(8, " ")} ` : undefined,
+    callsign: normalizedCallsign || undefined,
+    lat: latitude,
+    lon: longitude,
+    alt_baro: altitudeFt ?? undefined,
+    gs: groundSpeedKt ?? undefined,
+    track: trackDeg ?? undefined,
+    seen: 0,
+    type: "flightaware",
+    flight_position_source: "flightaware",
+    flightAwareUrl: position.flightAwareUrl,
+    origin: position.origin,
+    destination: position.destination,
+    route: position.route,
+    status: position.status,
+    terminal: position.terminal,
+    quality: position.quality,
+  };
+}
+
+function getFlightAwareTrackingState(fallback: FlightAwareFallbackResult) {
+  const terminal =
+    fallback.position?.terminal === true ||
+    fallback.position?.quality?.terminal === true ||
+    fallback.metadata?.terminal === true;
+  if (terminal) {
+    return {
+      status: "flightaware_terminal",
+      source: "flightaware",
+      fetchedAt: fallback.fetchedAt,
+      sourceUpdatedAt: fallback.position?.quality?.sourceUpdatedAt,
+    };
+  }
+  if (fallback.ok && fallback.hasPosition === true) {
+    return {
+      status: "flightaware_active",
+      source: "flightaware",
+      fetchedAt: fallback.fetchedAt,
+      sourceUpdatedAt: fallback.position?.quality?.sourceUpdatedAt,
+    };
+  }
+  return {
+    status: "missing",
+    source: "flightaware",
+    fetchedAt: fallback.fetchedAt,
+    errorType: fallback.errorType,
+  };
+}
+
+function getFlightAwareAttemptStatus(fallback: FlightAwareFallbackResult) {
+  if (fallback.ok) return "200";
+  return String(fallback.upstreamStatus ?? fallback.errorType ?? "ERR");
+}
+
+async function fetchCallsignWithFlightAwareFallback(input: FetchChannelInput) {
+  if (input.target.kind !== "callsign") {
+    throw new Error("Expected callsign polling target");
+  }
+
+  const adsbResult = await fetchCallsign(input);
+  if (!isEmptyAircraftPayload(adsbResult.payload)) return adsbResult;
+
+  const fallback = await getFlightAwareFallbackByCallsign(input.target.callsign, {
+    metrics: input.metrics,
+  });
+  const attempts = [
+    ...adsbResult.attempts,
+    `flightaware:${getFlightAwareAttemptStatus(fallback)}`,
+  ];
+  const aircraft = normalizeFlightAwareAircraft({
+    callsign: input.target.callsign,
+    fallback,
+  });
+  const trackingState = getFlightAwareTrackingState(fallback);
+
+  if (!aircraft || fallback.ok !== true || fallback.hasPosition !== true) {
+    return {
+      ...adsbResult,
+      attempts,
+      payload: {
+        ...adsbResult.payload,
+        source: adsbResult.provider.id,
+        callsign: input.target.callsign,
+        flightAwareFallback: fallback,
+        trackingState,
+      },
+    };
+  }
+
+  return {
+    provider: FLIGHTAWARE_PROVIDER,
+    attempts,
+    payload: {
+      ac: [aircraft],
+      source: "flightaware",
+      callsign: input.target.callsign,
+      now: Date.now() / 1000,
+      fetchedAt: fallback.fetchedAt,
+      flightAwareFallback: fallback,
+      trackingState,
+    },
+  };
+}
+
 async function fetchAircraft(input: FetchChannelInput) {
   if (input.target.kind !== "aircraft") {
     throw new Error("Expected aircraft polling target");
@@ -258,6 +394,9 @@ export async function fetchAdsbChannel(input: FetchChannelInput): Promise<Realti
     return eventFromPayload(input, await fetchPositions(input));
   }
   if (input.target.kind === "callsign") {
+    if (input.target.flightAwareFallback === true) {
+      return eventFromPayload(input, await fetchCallsignWithFlightAwareFallback(input));
+    }
     return eventFromPayload(input, await fetchCallsign(input));
   }
   return eventFromPayload(input, await fetchAircraft(input));

--- a/services/data-service/src/sources/flightAwareFallback.ts
+++ b/services/data-service/src/sources/flightAwareFallback.ts
@@ -1,0 +1,686 @@
+import type { DataServiceMetricsSink } from "../types.js";
+
+const FLIGHTAWARE_FALLBACK_BASE = "https://www.flightaware.com/live/flight";
+const FLIGHTAWARE_TRACKPOLL_PATH = "/ajax/trackpoll.rvt";
+const FLIGHTAWARE_FALLBACK_CACHE_TTL_MS = 60_000;
+const FLIGHTAWARE_FALLBACK_TIMEOUT_MS = 7_000;
+const FLIGHTAWARE_FALLBACK_USER_AGENT =
+  "ADSBao data-service/1.0 (+https://adsbao.dev; flightaware/fallback)";
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+
+type FlightAwareRecord = Record<string, any>;
+type FlightAwareFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type FlightAwareFallbackResult = {
+  ok: boolean;
+  hasPosition: boolean;
+  errorType?: string;
+  message?: string;
+  upstreamStatus?: number;
+  fetchedAt?: string;
+  metadata?: FlightAwareRecord;
+  position?: FlightAwareRecord;
+};
+
+type FlightAwareFallbackCacheEntry = {
+  result: FlightAwareFallbackResult;
+  expiresAt: number;
+};
+
+type FlightAwareFallbackOptions = {
+  cacheStore?: Map<string, FlightAwareFallbackCacheEntry>;
+  env?: Record<string, string | undefined>;
+  fetchImpl?: FlightAwareFetch;
+  metrics?: DataServiceMetricsSink;
+  now?: () => number;
+  timeoutMs?: number;
+};
+
+const cache = new Map<string, FlightAwareFallbackCacheEntry>();
+const requestTimes: number[] = [];
+
+function cleanString(value: unknown) {
+  return String(value || "").trim();
+}
+
+function normalizeCallsign(value: unknown) {
+  const callsign = cleanString(value).toUpperCase().replace(/\s+/g, "");
+  return /^[A-Z][A-Z0-9]{2,7}$/.test(callsign) ? callsign : "";
+}
+
+function toNumber(value: unknown) {
+  if (value == null || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function htmlDecode(value: unknown) {
+  return cleanString(value)
+    .replaceAll("&amp;", "&")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">");
+}
+
+function escapeRegExp(value: unknown) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractMetaContent(html: unknown, key: string) {
+  const escaped = escapeRegExp(key);
+  const patterns = [
+    new RegExp(
+      `<meta\\b(?=[^>]*(?:name|property)=["']${escaped}["'])(?=[^>]*content=["']([^"']*)["'])[^>]*>`,
+      "i",
+    ),
+    new RegExp(
+      `<meta\\b(?=[^>]*content=["']([^"']*)["'])(?=[^>]*(?:name|property)=["']${escaped}["'])[^>]*>`,
+      "i",
+    ),
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(String(html || ""));
+    if (match?.[1]) return htmlDecode(match[1]);
+  }
+  return "";
+}
+
+function extractAssignedJson(html: unknown, name: string) {
+  const source = String(html || "");
+  const marker = `var ${name} =`;
+  const start = source.indexOf(marker);
+  if (start < 0) return null;
+  const objectStart = source.indexOf("{", start + marker.length);
+  if (objectStart < 0) return null;
+
+  let depth = 0;
+  let escaped = false;
+  let inString = false;
+  for (let index = objectStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(objectStart, index + 1);
+    }
+  }
+  return null;
+}
+
+function parseAssignedJson(html: unknown, name: string) {
+  const jsonText = extractAssignedJson(html, name);
+  if (!jsonText) return null;
+  try {
+    return JSON.parse(jsonText) as FlightAwareRecord;
+  } catch {
+    return null;
+  }
+}
+
+function extractTrackpollToken(html: unknown) {
+  const globals = parseAssignedJson(html, "trackpollGlobals");
+  return cleanString(globals?.TOKEN);
+}
+
+function readCoord(value: unknown) {
+  if (!Array.isArray(value) || value.length < 2) return null;
+  const lon = toNumber(value[0]);
+  const lat = toNumber(value[1]);
+  if (
+    lat == null ||
+    lon == null ||
+    lat < -90 ||
+    lat > 90 ||
+    lon < -180 ||
+    lon > 180
+  ) {
+    return null;
+  }
+  return { lat, lon };
+}
+
+function altitudeFt(value: unknown) {
+  const number = toNumber(value);
+  if (number == null) return undefined;
+  return Math.abs(number) < 1000 ? Math.round(number * 100) : Math.round(number);
+}
+
+function timestampIso(value: unknown) {
+  const number = toNumber(value);
+  if (number == null) return undefined;
+  const ms = number < 10_000_000_000 ? number * 1000 : number;
+  return new Date(ms).toISOString();
+}
+
+function errorResult(
+  errorType: string,
+  {
+    fetchedAt,
+    message = "",
+    upstreamStatus,
+  }: {
+    fetchedAt?: string;
+    message?: string;
+    upstreamStatus?: number;
+  } = {},
+): FlightAwareFallbackResult {
+  return {
+    ok: false,
+    hasPosition: false,
+    errorType,
+    message,
+    upstreamStatus,
+    fetchedAt: fetchedAt || new Date().toISOString(),
+  };
+}
+
+function cacheResult(
+  cacheStore: Map<string, FlightAwareFallbackCacheEntry>,
+  callsign: string,
+  result: FlightAwareFallbackResult,
+  nowMs: number,
+) {
+  cacheStore.set(callsign, {
+    result,
+    expiresAt: nowMs + FLIGHTAWARE_FALLBACK_CACHE_TTL_MS,
+  });
+}
+
+function selectBestFlight(flights: unknown) {
+  const list = Object.values((flights || {}) as Record<string, unknown>).filter(
+    (flight) => flight && typeof flight === "object",
+  ) as FlightAwareRecord[];
+  if (list.length === 0) return null;
+
+  return (
+    list
+      .map((flight, index) => {
+        const hasPosition =
+          Boolean(readCoord(flight.coord)) ||
+          (Array.isArray(flight.track) &&
+            flight.track.some((point: FlightAwareRecord) => readCoord(point?.coord)));
+        const hasEnded =
+          flight?.landingTimes?.actual != null ||
+          flight?.gateArrivalTimes?.actual != null ||
+          flight?.cancelled ||
+          flight?.resultUnknown;
+        const hasStarted =
+          flight?.takeoffTimes?.actual != null ||
+          flight?.gateDepartureTimes?.actual != null ||
+          hasPosition;
+        const timestamp = toNumber(flight.timestamp) || 0;
+        const score =
+          (hasPosition ? 10_000 : 0) +
+          (hasStarted ? 1_000 : 0) -
+          (hasEnded ? 2_000 : 0) -
+          (flight.historical ? 100 : 0) +
+          Math.min(timestamp / 1_000_000_000, 100);
+        return { flight, index, score };
+      })
+      .sort((a, b) => b.score - a.score || a.index - b.index)[0]?.flight || null
+  );
+}
+
+function selectPositionPoint(
+  flight: FlightAwareRecord | null | undefined,
+): FlightAwareRecord | null {
+  const topLevel = readCoord(flight?.coord);
+  if (topLevel) {
+    return {
+      ...topLevel,
+      alt: flight?.altitude,
+      gs: flight?.groundspeed,
+      heading: flight?.heading,
+      timestamp: flight?.timestamp,
+      type: flight?.updateType,
+    };
+  }
+
+  if (!Array.isArray(flight?.track)) return null;
+  return (
+    flight.track
+      .filter((point: FlightAwareRecord) => readCoord(point?.coord))
+      .map((point: FlightAwareRecord) => ({
+        ...point,
+        ...(readCoord(point.coord) as { lat: number; lon: number }),
+      }))
+      .sort(
+        (a: FlightAwareRecord, b: FlightAwareRecord) =>
+          (toNumber(b.timestamp) || 0) - (toNumber(a.timestamp) || 0),
+      )[0] || null
+  );
+}
+
+function normalizePositionKind({
+  flight,
+  point,
+}: {
+  flight?: FlightAwareRecord | null;
+  point?: FlightAwareRecord | null;
+}) {
+  const label = cleanString(flight?.updateType || point?.type);
+  if (/pred|tp/i.test(label)) return "predicted";
+  if (/interp/i.test(label)) return "interpolated";
+  if (/est|tentative/i.test(label)) return "estimated";
+  return "observed";
+}
+
+function isTerminalFlight(flight: FlightAwareRecord | null | undefined, status = "") {
+  if (!flight || typeof flight !== "object") return false;
+  if (
+    flight?.landingTimes?.actual != null ||
+    flight?.gateArrivalTimes?.actual != null ||
+    flight?.cancelled ||
+    flight?.resultUnknown
+  ) {
+    return true;
+  }
+  return /\b(arrived|landed|cancelled|canceled|diverted|result unknown)\b/i.test(
+    status,
+  );
+}
+
+function buildFlightAwareFallbackUrl(callsign: unknown) {
+  const normalized = normalizeCallsign(callsign);
+  if (!normalized) return "";
+  return `${FLIGHTAWARE_FALLBACK_BASE}/${encodeURIComponent(normalized)}`;
+}
+
+function buildFlightAwareTrackpollUrl(pageUrl: string, token: string) {
+  const url = new URL(FLIGHTAWARE_TRACKPOLL_PATH, FLIGHTAWARE_FALLBACK_BASE);
+  try {
+    const page = new URL(pageUrl);
+    page.searchParams.forEach((value, key) => {
+      url.searchParams.set(key, value);
+    });
+  } catch {
+    // Keep the plain trackpoll endpoint if the source URL is malformed.
+  }
+  url.searchParams.set("token", token);
+  url.searchParams.set("locale", "en_US");
+  url.searchParams.set("summary", "0");
+  return url.toString();
+}
+
+async function readResponseText(response: Response, maxBytes = MAX_RESPONSE_BYTES) {
+  const text = await response.text();
+  if (Buffer.byteLength(text, "utf8") > maxBytes) {
+    throw new Error("FlightAware response too large");
+  }
+  return text;
+}
+
+function buildMetadata({
+  callsign,
+  fetchedAt,
+  flight,
+  html,
+}: {
+  callsign: string;
+  fetchedAt: string;
+  flight: FlightAwareRecord;
+  html: unknown;
+}) {
+  const origin =
+    cleanString(flight?.origin?.icao) || cleanString(extractMetaContent(html, "origin"));
+  const destination =
+    cleanString(flight?.destination?.icao) ||
+    cleanString(extractMetaContent(html, "destination"));
+  const route = cleanString(flight?.flightPlan?.route);
+  const planSpeed = toNumber(flight?.flightPlan?.speed);
+  const planAltitude = altitudeFt(flight?.flightPlan?.altitude);
+  const sourceUpdatedAt = timestampIso(flight?.timestamp);
+  const status = cleanString(flight?.flightStatus) || undefined;
+  const terminal = isTerminalFlight(flight, status);
+
+  return {
+    callsign,
+    flightAwareUrl: buildFlightAwareFallbackUrl(callsign),
+    origin: origin || undefined,
+    destination: destination || undefined,
+    route: route || undefined,
+    altitudeFt: altitudeFt(flight?.altitude) ?? planAltitude,
+    groundSpeedKt: toNumber(flight?.groundspeed) ?? planSpeed ?? undefined,
+    trackDeg: toNumber(flight?.heading) ?? undefined,
+    status,
+    terminal,
+    sourceUpdatedAt,
+    fetchedAt,
+    notes: ["flightaware-public-page"],
+  };
+}
+
+function parseFlightAwarePayload({
+  callsign,
+  fetchedAt,
+  html = "",
+  payload,
+}: {
+  callsign?: unknown;
+  fetchedAt?: string;
+  html?: unknown;
+  payload?: FlightAwareRecord | null;
+} = {}): FlightAwareFallbackResult {
+  const normalizedCallsign = normalizeCallsign(callsign);
+  const fetched = fetchedAt || new Date().toISOString();
+  if (!normalizedCallsign) return errorResult("invalid_callsign", { fetchedAt: fetched });
+
+  const flight = selectBestFlight(payload?.flights);
+  if (!flight) {
+    return errorResult("parse_failed", {
+      fetchedAt: fetched,
+      message: "No flight entries found",
+    });
+  }
+
+  const metadata = buildMetadata({
+    callsign: normalizedCallsign,
+    fetchedAt: fetched,
+    flight,
+    html,
+  });
+  const point = selectPositionPoint(flight);
+  if (!point) {
+    return {
+      ok: true,
+      hasPosition: false,
+      fetchedAt: fetched,
+      metadata,
+    };
+  }
+
+  const kind = normalizePositionKind({ flight, point });
+  const sourceUpdatedAt = timestampIso(point.timestamp) || metadata.sourceUpdatedAt;
+  return {
+    ok: true,
+    hasPosition: true,
+    fetchedAt: fetched,
+    metadata,
+    position: {
+      lat: point.lat,
+      lon: point.lon,
+      flight_position_source: "flightaware",
+      altitudeFt: altitudeFt(point.alt),
+      groundSpeedKt: toNumber(point.gs) ?? metadata.groundSpeedKt,
+      trackDeg: toNumber(point.heading) ?? metadata.trackDeg,
+      headingDeg: toNumber(point.heading) ?? undefined,
+      callsign: normalizedCallsign,
+      hex: cleanString(flight?.hexid) || undefined,
+      flightAwareUrl: metadata.flightAwareUrl,
+      origin: metadata.origin,
+      destination: metadata.destination,
+      route: metadata.route,
+      status: metadata.status,
+      terminal: metadata.terminal,
+      quality: {
+        source: "flightaware",
+        flight_position_source: "flightaware",
+        kind,
+        isEstimated: kind !== "observed",
+        isPredicted: kind === "predicted",
+        isInterpolated: kind === "interpolated",
+        sourceLabel: "FlightAware",
+        sourceUpdatedAt,
+        fetchedAt: fetched,
+        confidence: kind === "observed" ? "medium" : "low",
+        status: metadata.status,
+        terminal: metadata.terminal,
+        notes: ["flightaware-public-page"],
+      },
+    },
+  };
+}
+
+function parseFlightAwareFallbackPage({
+  callsign,
+  fetchedAt,
+  html,
+}: {
+  callsign?: unknown;
+  fetchedAt?: string;
+  html?: unknown;
+}) {
+  const jsonText = extractAssignedJson(html, "trackpollBootstrap");
+  if (!jsonText) {
+    return errorResult("parse_failed", {
+      fetchedAt,
+      message: "trackpollBootstrap not found",
+    });
+  }
+  try {
+    return parseFlightAwarePayload({
+      callsign,
+      fetchedAt,
+      html,
+      payload: JSON.parse(jsonText) as FlightAwareRecord,
+    });
+  } catch (error) {
+    return errorResult("parse_failed", {
+      fetchedAt,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function parseFlightAwareTrackpollResponse({
+  callsign,
+  fetchedAt,
+  html,
+  text,
+}: {
+  callsign?: unknown;
+  fetchedAt?: string;
+  html?: unknown;
+  text?: unknown;
+}) {
+  try {
+    return parseFlightAwarePayload({
+      callsign,
+      fetchedAt,
+      html,
+      payload: JSON.parse(String(text || "")) as FlightAwareRecord,
+    });
+  } catch (error) {
+    return errorResult("parse_failed", {
+      fetchedAt,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function checkRateLimit(
+  nowMs: number,
+  { maxRequests = 20, windowMs = 60_000 } = {},
+) {
+  while (requestTimes.length && nowMs - requestTimes[0] > windowMs) {
+    requestTimes.shift();
+  }
+  if (requestTimes.length >= maxRequests) return false;
+  requestTimes.push(nowMs);
+  return true;
+}
+
+function isFlightAwareFallbackEnabled(env: Record<string, string | undefined>) {
+  return String(env.FLIGHTAWARE_FALLBACK_ENABLED || "true").toLowerCase() !== "false";
+}
+
+function recordExternalRequest({
+  durationMs,
+  metrics,
+  result,
+  status,
+}: {
+  durationMs: number;
+  metrics?: DataServiceMetricsSink;
+  result: "success" | "error";
+  status?: number | string | null;
+}) {
+  metrics?.recordExternalRequest({
+    provider: "flightaware",
+    endpoint: "callsign",
+    result,
+    status,
+    durationMs,
+  });
+}
+
+export async function getFlightAwareFallbackByCallsign(
+  callsign: unknown,
+  {
+    cacheStore = cache,
+    env = process.env,
+    fetchImpl = globalThis.fetch?.bind(globalThis),
+    metrics,
+    now = Date.now,
+    timeoutMs = FLIGHTAWARE_FALLBACK_TIMEOUT_MS,
+  }: FlightAwareFallbackOptions = {},
+): Promise<FlightAwareFallbackResult> {
+  const nowMs = now();
+  const fetchedAt = new Date(nowMs).toISOString();
+  if (!isFlightAwareFallbackEnabled(env)) {
+    return errorResult("feature_disabled", { fetchedAt });
+  }
+
+  const normalizedCallsign = normalizeCallsign(callsign);
+  const url = buildFlightAwareFallbackUrl(normalizedCallsign);
+  if (!normalizedCallsign || !url) return errorResult("invalid_callsign", { fetchedAt });
+  if (!fetchImpl) {
+    return errorResult("network_failed", {
+      fetchedAt,
+      message: "fetch unavailable",
+    });
+  }
+
+  const cached = cacheStore.get(normalizedCallsign);
+  if (cached && cached.expiresAt > nowMs) return cached.result;
+  if (!checkRateLimit(nowMs)) return errorResult("rate_limited", { fetchedAt });
+
+  const pageStartedAt = Date.now();
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: "text/html,application/xhtml+xml",
+        "User-Agent": FLIGHTAWARE_FALLBACK_USER_AGENT,
+      },
+      signal:
+        typeof AbortSignal !== "undefined" && AbortSignal.timeout
+          ? AbortSignal.timeout(timeoutMs)
+          : undefined,
+    });
+    recordExternalRequest({
+      durationMs: Date.now() - pageStartedAt,
+      metrics,
+      result: response.ok ? "success" : "error",
+      status: response.status,
+    });
+
+    if (response.status === 404) return errorResult("not_found", { fetchedAt });
+    if (response.status === 429) return errorResult("rate_limited", { fetchedAt });
+    if (response.status === 402) {
+      const result = errorResult("payment_required", {
+        fetchedAt,
+        message: "HTTP 402",
+        upstreamStatus: 402,
+      });
+      cacheResult(cacheStore, normalizedCallsign, result, nowMs);
+      return result;
+    }
+    if (!response.ok) {
+      return errorResult("network_failed", {
+        fetchedAt,
+        message: `HTTP ${response.status}`,
+        upstreamStatus: response.status,
+      });
+    }
+
+    const html = await readResponseText(response);
+    const trackpollToken = extractTrackpollToken(html);
+    if (trackpollToken) {
+      const trackpollStartedAt = Date.now();
+      try {
+        const trackpollResponse = await fetchImpl(
+          buildFlightAwareTrackpollUrl(url, trackpollToken),
+          {
+            headers: {
+              Accept: "application/json, text/javascript, */*; q=0.01",
+              Referer: url,
+              "User-Agent": FLIGHTAWARE_FALLBACK_USER_AGENT,
+              "X-Requested-With": "XMLHttpRequest",
+            },
+            signal:
+              typeof AbortSignal !== "undefined" && AbortSignal.timeout
+                ? AbortSignal.timeout(timeoutMs)
+                : undefined,
+          },
+        );
+        recordExternalRequest({
+          durationMs: Date.now() - trackpollStartedAt,
+          metrics,
+          result: trackpollResponse.ok ? "success" : "error",
+          status: trackpollResponse.status,
+        });
+        if (trackpollResponse.ok) {
+          const text = await readResponseText(trackpollResponse);
+          const trackpollResult = parseFlightAwareTrackpollResponse({
+            callsign: normalizedCallsign,
+            fetchedAt,
+            html,
+            text,
+          });
+          if (trackpollResult.ok) {
+            cacheResult(cacheStore, normalizedCallsign, trackpollResult, nowMs);
+            return trackpollResult;
+          }
+        }
+      } catch {
+        recordExternalRequest({
+          durationMs: Date.now() - trackpollStartedAt,
+          metrics,
+          result: "error",
+          status: "ERR",
+        });
+      }
+    }
+
+    const result = parseFlightAwareFallbackPage({
+      callsign: normalizedCallsign,
+      fetchedAt,
+      html,
+    });
+    cacheResult(cacheStore, normalizedCallsign, result, nowMs);
+    return result;
+  } catch (error) {
+    recordExternalRequest({
+      durationMs: Date.now() - pageStartedAt,
+      metrics,
+      result: "error",
+      status: "ERR",
+    });
+    const message = error instanceof Error ? error.message : String(error);
+    const isTimeout =
+      error instanceof Error &&
+      (error.name === "TimeoutError" || /timed out|aborted/i.test(message));
+    return errorResult(isTimeout ? "timeout" : "network_failed", {
+      fetchedAt,
+      message,
+    });
+  }
+}

--- a/services/data-service/src/sources/routeClient.test.ts
+++ b/services/data-service/src/sources/routeClient.test.ts
@@ -12,6 +12,16 @@ function jsonResponse(payload: unknown, status = 200) {
   } as Response;
 }
 
+function textResponse(body: string, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return body;
+    },
+  } as Response;
+}
+
 {
   const calls: string[] = [];
   const metrics = new DataServiceMetrics();
@@ -61,6 +71,60 @@ function jsonResponse(payload: unknown, status = 200) {
   assert.match(
     output,
     /adsbao_external_requests_total\{endpoint="route",provider="adsbdb",result="success",status="200",status_class="2xx"\} 1/,
+  );
+}
+
+{
+  const calls: string[] = [];
+  const metrics = new DataServiceMetrics();
+  const event = await fetchRouteChannel({
+    channel: "route:AAL1234:airport:KBOS",
+    channelType: "route",
+    metrics,
+    target: {
+      kind: "route",
+      callsign: "AAL1234",
+      context: { type: "airport", icao: "KBOS" },
+      provider: "flightaware",
+    },
+    params: { routeProvider: "flightaware" },
+    waitForTurn: async () => {},
+    fetchImpl: async (url: string) => {
+      calls.push(url);
+      return textResponse(`
+        <html>
+          <head>
+            <title>AA1234 (AAL1234) American Airlines Flight Tracking</title>
+            <meta name="origin" content="KBOS">
+            <meta name="destination" content="KLAX">
+            <meta name="airline" content="AAL">
+            <meta name="description" content="Track American Airlines (AA) #1234">
+          </head>
+          <body>
+            <script>
+              var trackpollBootstrap = {"flights":{"AAL1234":{
+                "origin":{"icao":"KBOS","iata":"BOS","coord":[-71.0096,42.3656],"friendlyName":"Boston Logan","friendlyLocation":"Boston, MA"},
+                "destination":{"icao":"KLAX","iata":"LAX","coord":[-118.4085,33.9416],"friendlyName":"Los Angeles Intl","friendlyLocation":"Los Angeles, CA"}
+              }}};
+            </script>
+          </body>
+        </html>
+      `);
+    },
+  });
+
+  assert.equal(calls[0], "https://www.flightaware.com/live/flight/AAL1234");
+  assert.equal(event.type, "route:update");
+  assert.equal(event.channel, "route:AAL1234:airport:KBOS");
+  assert.equal(event.source, "flightaware");
+  const data = event.data as any;
+  assert.equal(data.route.callsign, "AAL1234");
+  assert.equal(data.route.route.iata, "BOS-LAX");
+  assert.equal(data.route.source, "flightaware");
+  const output = metrics.render({ uptimeSec: 1, channels: [] });
+  assert.match(
+    output,
+    /adsbao_external_requests_total\{endpoint="route",provider="flightaware",result="success",status="200",status_class="2xx"\} 1/,
   );
 }
 

--- a/services/data-service/src/sources/routeClient.ts
+++ b/services/data-service/src/sources/routeClient.ts
@@ -1,10 +1,14 @@
 import type { FetchChannelInput, RealtimeEvent } from "../types.js";
 
 const ADSBDB_BASE = "https://api.adsbdb.com/v0";
+const FLIGHTAWARE_BASE = "https://www.flightaware.com/live/flight";
 const MAX_ROUTE_BYTES = 512 * 1024;
+const MAX_FLIGHTAWARE_ROUTE_BYTES = 2 * 1024 * 1024;
 const ROUTE_TIMEOUT_MS = 9_000;
 const ROUTE_QUEUE_INTERVAL_MS = 500;
 const USER_AGENT = "ADSBao data-service/1.0 (+https://adsbao.dev)";
+const FLIGHTAWARE_USER_AGENT =
+  "ADSBao data-service/1.0 (+https://adsbao.dev; flightaware/html)";
 
 type RouteFetchInput = FetchChannelInput & {
   fetchImpl?: typeof fetch;
@@ -21,6 +25,16 @@ const numberOrNull = (value: unknown) => {
   const next = Number(value);
   return Number.isFinite(next) ? next : null;
 };
+const inRange = (
+  value: number | null,
+  {
+    min,
+    max,
+  }: {
+    min: number;
+    max: number;
+  },
+) => value != null && Number.isFinite(value) && value >= min && value <= max;
 
 function normalizeAirport(raw: Record<string, unknown> | null | undefined) {
   if (!raw || typeof raw !== "object") return null;
@@ -73,6 +87,229 @@ function normalizeRoute(callsign: string, payload: any) {
   };
 }
 
+function htmlDecode(value: unknown) {
+  return clean(value)
+    .replaceAll("&amp;", "&")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">");
+}
+
+function escapeRegExp(value: unknown) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractMetaContent(html: unknown, key: string) {
+  const escaped = escapeRegExp(key);
+  const patterns = [
+    new RegExp(
+      `<meta\\b(?=[^>]*(?:name|property)=["']${escaped}["'])(?=[^>]*content=["']([^"']*)["'])[^>]*>`,
+      "i",
+    ),
+    new RegExp(
+      `<meta\\b(?=[^>]*content=["']([^"']*)["'])(?=[^>]*(?:name|property)=["']${escaped}["'])[^>]*>`,
+      "i",
+    ),
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(String(html || ""));
+    if (match?.[1]) return htmlDecode(match[1]);
+  }
+  return "";
+}
+
+function extractTitle(html: unknown) {
+  const match = /<title[^>]*>([^<]*)<\/title>/i.exec(String(html || ""));
+  return htmlDecode(match?.[1] || extractMetaContent(html, "title"));
+}
+
+function extractAirlineName({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  const titleMatch =
+    /\)\s+(.+?)\s+Flight Tracking(?:\s+and\s+History)?/i.exec(title);
+  if (titleMatch?.[1]) return clean(titleMatch[1]);
+
+  const descriptionMatch = /^Track\s+(.+?)\s+\([A-Z0-9]{2,3}\)\s+#/i.exec(
+    description,
+  );
+  return clean(descriptionMatch?.[1] || "");
+}
+
+function extractIataAndNumber({
+  callsign,
+  description,
+  title,
+}: {
+  callsign: string;
+  description: string;
+  title: string;
+}) {
+  const titleMatch = /^([A-Z0-9]{2})(\d{1,5}[A-Z]?)\s+\(/i.exec(title);
+  if (titleMatch) {
+    return {
+      airlineIata: upper(titleMatch[1]),
+      number: upper(titleMatch[2]),
+    };
+  }
+
+  const descriptionMatch = /\(([A-Z0-9]{2})\)\s+#(\d{1,5}[A-Z]?)/i.exec(
+    description,
+  );
+  if (descriptionMatch) {
+    return {
+      airlineIata: upper(descriptionMatch[1]),
+      number: upper(descriptionMatch[2]),
+    };
+  }
+
+  const callsignMatch = /^[A-Z]{2,3}(\d{1,5}[A-Z]?)$/.exec(callsign);
+  return {
+    airlineIata: "",
+    number: upper(callsignMatch?.[1] || ""),
+  };
+}
+
+function extractJsonString(block: string, key: string) {
+  const match = new RegExp(`"${escapeRegExp(key)}"\\s*:\\s*"([^"]*)"`, "i").exec(
+    block,
+  );
+  return htmlDecode(match?.[1] || "");
+}
+
+function normalizeFlightAwareAirport(airport: Record<string, unknown> | null) {
+  if (!airport) return null;
+  const lat = numberOrNull(airport.lat);
+  const lon = numberOrNull(airport.lon);
+  const icao = code(airport.icao || airport.ident || airport.code);
+  if (
+    !icao ||
+    !inRange(lat, { min: -90, max: 90 }) ||
+    !inRange(lon, { min: -180, max: 180 })
+  ) {
+    return null;
+  }
+  return {
+    icao,
+    iata: code(airport.iata, 3, 3),
+    name: clean(airport.name),
+    municipality: clean(airport.city || airport.municipality),
+    country: upper(airport.country),
+    lat,
+    lon,
+  };
+}
+
+function extractEmbeddedAirport(html: unknown, key: string, expectedIcao: string) {
+  const pattern = new RegExp(`"${escapeRegExp(key)}"\\s*:\\s*\\{`, "gi");
+  const source = String(html || "");
+  const normalizedExpectedIcao = code(expectedIcao);
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(source))) {
+    const block = source.slice(match.index, match.index + 1800);
+    const icao = code(extractJsonString(block, "icao"));
+    if (normalizedExpectedIcao && icao !== normalizedExpectedIcao) continue;
+
+    const coordMatch =
+      /"coord"\s*:\s*\[\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\]/i.exec(
+        block,
+      );
+    const lon = numberOrNull(coordMatch?.[1]);
+    const lat = numberOrNull(coordMatch?.[2]);
+    if (
+      !icao ||
+      !inRange(lat, { min: -90, max: 90 }) ||
+      !inRange(lon, { min: -180, max: 180 })
+    ) {
+      continue;
+    }
+
+    const friendlyLocation = extractJsonString(block, "friendlyLocation");
+    return {
+      icao,
+      iata: code(extractJsonString(block, "iata"), 3, 3),
+      name: extractJsonString(block, "friendlyName"),
+      municipality: clean(friendlyLocation.split(",")[0]),
+      country: "",
+      lat,
+      lon,
+    };
+  }
+  return null;
+}
+
+function buildFlightAwareCallsignRouteUrl(callsign: unknown) {
+  const normalized = upper(callsign);
+  if (!/^[A-Z][A-Z0-9]{2,7}$/.test(normalized)) return "";
+  return `${FLIGHTAWARE_BASE}/${encodeURIComponent(normalized)}`;
+}
+
+function buildFlightAwareAirlineLogoUrl(airlineIcao: unknown) {
+  const normalized = code(airlineIcao, 2, 3);
+  return normalized
+    ? `https://www.flightaware.com/images/airline_logos/90p/${normalized}.png`
+    : "";
+}
+
+function normalizeFlightAwareRoute(callsign: string, html: string) {
+  const normalizedCallsign = upper(callsign);
+  if (!/^[A-Z][A-Z0-9]{2,7}$/.test(normalizedCallsign)) return null;
+
+  const originIcao = code(extractMetaContent(html, "origin"));
+  const destinationIcao = code(extractMetaContent(html, "destination"));
+  const airlineIcao =
+    code(extractMetaContent(html, "airline"), 2, 3) || normalizedCallsign.slice(0, 3);
+  if (!originIcao || !destinationIcao || !airlineIcao) return null;
+
+  const title = extractTitle(html);
+  const description =
+    extractMetaContent(html, "twitter:description") ||
+    extractMetaContent(html, "og:description") ||
+    extractMetaContent(html, "description");
+  const { airlineIata, number } = extractIataAndNumber({
+    callsign: normalizedCallsign,
+    description,
+    title,
+  });
+  const origin = normalizeFlightAwareAirport(
+    extractEmbeddedAirport(html, "origin", originIcao),
+  );
+  const destination = normalizeFlightAwareAirport(
+    extractEmbeddedAirport(html, "destination", destinationIcao),
+  );
+  if (!origin || !destination) return null;
+
+  const routeIata = origin.iata && destination.iata ? `${origin.iata}-${destination.iata}` : "";
+  return {
+    callsign: normalizedCallsign,
+    callsignIcao: normalizedCallsign,
+    callsignIata: airlineIata && number ? `${airlineIata}${number}` : "",
+    number,
+    airline: {
+      icao: airlineIcao,
+      iata: airlineIata,
+      name: extractAirlineName({ title, description }),
+      callsign: "",
+      iconUrl: buildFlightAwareAirlineLogoUrl(airlineIcao),
+    },
+    origin,
+    destination,
+    route: {
+      icao: `${origin.icao}-${destination.icao}`,
+      iata: routeIata,
+    },
+    airports: [origin, destination],
+    source: "flightaware",
+    confidence: "scraped-reference",
+  };
+}
+
 let routeQueue = Promise.resolve();
 let lastRouteStartedAt = 0;
 
@@ -101,6 +338,74 @@ async function readJson(response: Response) {
   return JSON.parse(text);
 }
 
+async function readText(response: Response, maxBytes = MAX_FLIGHTAWARE_ROUTE_BYTES) {
+  const text = await response.text();
+  if (Buffer.byteLength(text, "utf8") > maxBytes) {
+    throw new Error("Route response too large");
+  }
+  return text;
+}
+
+async function fetchFlightAwareRouteChannel({
+  channel,
+  metrics,
+  target,
+  fetchImpl = fetch,
+  waitForTurn: waitForTurnImpl = waitForRouteTurn,
+}: RouteFetchInput): Promise<RealtimeEvent> {
+  if (target.kind !== "route") throw new Error("Expected route polling target");
+  await waitForTurnImpl();
+  const url = buildFlightAwareCallsignRouteUrl(target.callsign);
+  if (!url) throw new Error("Invalid FlightAware route callsign");
+  const startedAt = Date.now();
+  let status: number | string | null = null;
+  let route: ReturnType<typeof normalizeFlightAwareRoute> | null = null;
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: "text/html,application/xhtml+xml",
+        "User-Agent": FLIGHTAWARE_USER_AGENT,
+      },
+      signal: AbortSignal.timeout(ROUTE_TIMEOUT_MS),
+    });
+    status = response.status;
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`flightaware route HTTP ${response.status}`);
+    }
+    route =
+      response.status === 404
+        ? null
+        : normalizeFlightAwareRoute(target.callsign, await readText(response));
+    metrics?.recordExternalRequest({
+      provider: "flightaware",
+      endpoint: "route",
+      result: "success",
+      status,
+      durationMs: Date.now() - startedAt,
+    });
+  } catch (error) {
+    metrics?.recordExternalRequest({
+      provider: "flightaware",
+      endpoint: "route",
+      result: "error",
+      status: status ?? "ERR",
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
+  }
+  return {
+    type: "route:update",
+    channel,
+    source: "flightaware",
+    fetchedAt: new Date().toISOString(),
+    stale: false,
+    data: {
+      callsign: target.callsign,
+      route,
+    },
+  };
+}
+
 export async function fetchRouteChannel({
   channel,
   metrics,
@@ -109,6 +414,17 @@ export async function fetchRouteChannel({
   waitForTurn: waitForTurnImpl = waitForRouteTurn,
 }: RouteFetchInput): Promise<RealtimeEvent> {
   if (target.kind !== "route") throw new Error("Expected route polling target");
+  if (target.provider === "flightaware") {
+    return fetchFlightAwareRouteChannel({
+      channel,
+      channelType: "route",
+      metrics,
+      target,
+      params: {},
+      fetchImpl,
+      waitForTurn: waitForTurnImpl,
+    });
+  }
   await waitForTurnImpl();
   const url = `${ADSBDB_BASE}/callsign/${encodeURIComponent(target.callsign)}`;
   const startedAt = Date.now();

--- a/services/data-service/src/types.ts
+++ b/services/data-service/src/types.ts
@@ -32,6 +32,7 @@ export type PollingTarget =
   | {
       kind: "callsign";
       callsign: string;
+      flightAwareFallback?: boolean;
     }
   | {
       kind: "aircraft";
@@ -40,6 +41,7 @@ export type PollingTarget =
   | {
       kind: "route";
       callsign: string;
+      provider?: "adsbdb" | "flightaware";
       context?: {
         type: "airport";
         icao: string;

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.test.ts
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.test.ts
@@ -15,12 +15,12 @@ assert.equal(
 
 assert.equal(
   getTrackedFlightTraceRefreshKey({ lostSignal: true, pollVersion: 12 }),
-  "lost-signal:12",
+  "",
 );
 
 assert.equal(
-  getTrackedFlightTraceRefreshKey({ lostSignal: true, pollVersion: 13 }),
-  "lost-signal:13",
+  getTrackedFlightTraceRefreshKey({ lostSignal: true, pollVersion: 20 }),
+  "lost-signal:1",
 );
 
 assert.equal(
@@ -43,7 +43,16 @@ assert.equal(
     pollVersion: 21,
     visibilityRefreshVersion: 0,
   }),
-  "lost-signal:21",
+  "lost-signal:1",
+);
+
+assert.equal(
+  getTrackedFlightTraceRefreshKey({
+    lostSignal: true,
+    pollVersion: 40,
+    visibilityRefreshVersion: 0,
+  }),
+  "lost-signal:2",
 );
 
 assert.equal(

--- a/src/features/aircraft/tracking/lostSignalTrackingModel.ts
+++ b/src/features/aircraft/tracking/lostSignalTrackingModel.ts
@@ -39,10 +39,18 @@ export function hasTerminalFlightAwareFallback(fallback) {
 function getLostSignalTraceRefreshKey({
   lostSignal = false,
   pollVersion = 0,
+  pollMs = 3_000,
+  flightAwareTraceRefreshMs = 60_000,
 } = {}) {
   const version = Number(pollVersion);
   if (!lostSignal || !Number.isFinite(version) || version <= 0) return "";
-  return `lost-signal:${version}`;
+  const intervalMs = Math.max(1, Number(pollMs) || 1);
+  const refreshMs = Math.max(
+    intervalMs,
+    Number(flightAwareTraceRefreshMs) || intervalMs,
+  );
+  const bucket = Math.floor((version * intervalMs) / refreshMs);
+  return bucket > 0 ? `lost-signal:${bucket}` : "";
 }
 
 export function getTrackedFlightTraceRefreshKey({
@@ -64,7 +72,12 @@ export function getTrackedFlightTraceRefreshKey({
     flightAwareTraceRefreshMs,
   });
   if (flightAwareKey) return flightAwareKey;
-  return getLostSignalTraceRefreshKey({ lostSignal, pollVersion });
+  return getLostSignalTraceRefreshKey({
+    lostSignal,
+    pollVersion,
+    pollMs,
+    flightAwareTraceRefreshMs,
+  });
 }
 
 function getFlightAwareTraceRefreshKey({

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 
 import {
-  buildRouteProxyRequest,
   buildRouteCacheKey,
   buildRoutesByCallsign,
   getRouteLookupStats,
@@ -24,26 +23,11 @@ const route = {
   assert.equal(resolveRouteLookupEnabled(), true);
   assert.equal(
     resolveRouteLookupTransport({ routeProvider: "flightaware" }),
-    "proxy",
+    "realtime",
   );
   assert.equal(
     resolveRouteLookupTransport({ routeProvider: "adsbdb" }),
     "realtime",
-  );
-  assert.deepEqual(
-    buildRouteProxyRequest(" aal 1234 ", { routeProvider: "flightaware" }),
-    {
-      callsign: "AAL1234",
-      url: "/api/proxy/flight-routes/callsign/AAL1234?provider=flightaware",
-    },
-  );
-  assert.deepEqual(buildRouteProxyRequest("aal1234", {}), {
-    callsign: "AAL1234",
-    url: "/api/proxy/flight-routes/callsign/AAL1234",
-  });
-  assert.equal(
-    buildRouteProxyRequest("bad-call", { routeProvider: "flightaware" }),
-    null,
   );
 }
 

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.ts
@@ -66,7 +66,6 @@ type RoutesByCallsignOptions = {
 
 export const ROUTE_LOOKUP_TRANSPORT = Object.freeze({
   REALTIME: "realtime",
-  PROXY: "proxy",
 });
 
 const routeContextCode = (value: unknown) =>
@@ -119,9 +118,8 @@ function routeContextWithoutProvider(routeContext: RouteContext = {}) {
 }
 
 export function resolveRouteLookupTransport(routeContext: RouteContext = {}) {
-  return isFlightAwareRouteContext(routeContext)
-    ? ROUTE_LOOKUP_TRANSPORT.PROXY
-    : ROUTE_LOOKUP_TRANSPORT.REALTIME;
+  void routeContext;
+  return ROUTE_LOOKUP_TRANSPORT.REALTIME;
 }
 
 export function resolveRouteLookupEnabled({
@@ -130,25 +128,6 @@ export function resolveRouteLookupEnabled({
   featureFlagsResolved?: unknown;
 } = {}) {
   return featureFlagsResolved !== false;
-}
-
-export function buildRouteProxyRequest(
-  callsign: unknown,
-  routeContext: RouteContext = {},
-) {
-  const normalizedCallsign = normalizeCallsign(callsign);
-  if (!normalizedCallsign || !isLookupCallsign(normalizedCallsign)) return null;
-  const params = new URLSearchParams();
-  if (isFlightAwareRouteContext(routeContext)) {
-    params.set("provider", "flightaware");
-  }
-  const query = params.toString();
-  return {
-    callsign: normalizedCallsign,
-    url: `/api/proxy/flight-routes/callsign/${encodeURIComponent(normalizedCallsign)}${
-      query ? `?${query}` : ""
-    }`,
-  };
 }
 
 export function buildRouteCacheKey(callsign: unknown, routeContext: RouteContext = {}) {

--- a/src/hooks/useFlightRoutes.ts
+++ b/src/hooks/useFlightRoutes.ts
@@ -11,8 +11,6 @@ import type {
 } from "../features/aviation/flight-routes/flightRouteLookupModel";
 import {
   ROUTE_LOOKUP_TRANSPORT,
-  buildRouteCacheKey,
-  buildRouteProxyRequest,
   resolveRouteLookupTransport,
 } from "../features/aviation/flight-routes/flightRouteLookupModel";
 import { createRouteDisplayBatcher } from "../features/aviation/flight-routes/flightRouteDisplayBatchModel";
@@ -28,13 +26,14 @@ type RouteEventData = {
   route?: FlightRoute | null;
 };
 
-async function readRouteProxyResult(response: Response) {
-  if (!response.ok) {
-    throw new Error(`Route proxy HTTP ${response.status}`);
-  }
-  const text = await response.text();
-  if (!text) return null;
-  return JSON.parse(text) as FlightRoute | null;
+function routeSubscriptionKey({
+  channel,
+  params,
+}: {
+  channel: string;
+  params?: Record<string, unknown>;
+}) {
+  return `${channel}|${JSON.stringify(params || {})}`;
 }
 
 export function useFlightRoutes(
@@ -49,7 +48,6 @@ export function useFlightRoutes(
     null,
   );
   const routeUnsubscribersRef = useRef(new Map<string, () => void>());
-  const proxyControllersRef = useRef(new Map<string, AbortController>());
   const routeContext = useMemo(
     () => ({
       icao: routeContextInput?.icao,
@@ -74,7 +72,6 @@ export function useFlightRoutes(
   useEffect(() => {
     mountedRef.current = true;
     const routeUnsubscribers = routeUnsubscribersRef.current;
-    const proxyControllers = proxyControllersRef.current;
     routeDisplayBatcherRef.current = createRouteDisplayBatcher({
       publish: (routeVersion) => {
         if (!mountedRef.current) return;
@@ -88,8 +85,6 @@ export function useFlightRoutes(
       routeDisplayBatcherRef.current = null;
       for (const unsubscribe of routeUnsubscribers.values()) unsubscribe();
       routeUnsubscribers.clear();
-      for (const controller of proxyControllers.values()) controller.abort();
-      proxyControllers.clear();
     };
   }, []);
 
@@ -128,20 +123,25 @@ export function useFlightRoutes(
 
     const wanted = new Set(
       pendingCallsigns
-        .map((callsign) => buildRouteChannel(callsign, routeContext)?.channel || "")
+        .map((callsign) => {
+          const request = buildRouteChannel(callsign, routeContext);
+          return request ? routeSubscriptionKey(request) : "";
+        })
         .filter(Boolean),
     );
 
-    for (const [channel, unsubscribe] of routeUnsubscribersRef.current) {
-      if (!wanted.has(channel)) {
+    for (const [key, unsubscribe] of routeUnsubscribersRef.current) {
+      if (!wanted.has(key)) {
         unsubscribe();
-        routeUnsubscribersRef.current.delete(channel);
+        routeUnsubscribersRef.current.delete(key);
       }
     }
 
     for (const callsign of pendingCallsigns) {
       const request = buildRouteChannel(callsign, routeContext);
-      if (!request || routeUnsubscribersRef.current.has(request.channel)) continue;
+      if (!request) continue;
+      const key = routeSubscriptionKey(request);
+      if (routeUnsubscribersRef.current.has(key)) continue;
       const unsubscribe = client.subscribe({
         channel: request.channel,
         params: request.params,
@@ -157,65 +157,9 @@ export function useFlightRoutes(
           }
         },
       });
-      routeUnsubscribersRef.current.set(request.channel, unsubscribe);
+      routeUnsubscribersRef.current.set(key, unsubscribe);
     }
   }, [client, pendingCallsigns, routeContext, routeTransport]);
-
-  useEffect(() => {
-    const proxyControllers = proxyControllersRef.current;
-    if (routeTransport !== ROUTE_LOOKUP_TRANSPORT.PROXY) {
-      for (const controller of proxyControllers.values()) controller.abort();
-      proxyControllers.clear();
-      return;
-    }
-
-    const wanted = new Set<string>();
-    for (const callsign of pendingCallsigns) {
-      const request = buildRouteProxyRequest(callsign, routeContext);
-      if (!request) continue;
-      const key = buildRouteCacheKey(request.callsign, routeContext) || request.url;
-      wanted.add(key);
-      if (proxyControllers.has(key)) continue;
-
-      const controller = new AbortController();
-      proxyControllers.set(key, controller);
-      fetch(request.url, {
-        cache: "no-store",
-        credentials: "same-origin",
-        signal: controller.signal,
-      })
-        .then(readRouteProxyResult)
-        .then((route) => {
-          if (!mountedRef.current || controller.signal.aborted) return;
-          flightRouteScheduler.applyRouteResult(
-            request.callsign,
-            route || null,
-            routeContext,
-          );
-        })
-        .catch((error) => {
-          if (controller.signal.aborted) return;
-          if (process.env.NODE_ENV !== "production") {
-            console.warn(
-              `[flight-route-proxy] lookup failed for ${request.callsign}:`,
-              error,
-            );
-          }
-        })
-        .finally(() => {
-          if (proxyControllers.get(key) === controller) {
-            proxyControllers.delete(key);
-          }
-        });
-    }
-
-    for (const [key, controller] of proxyControllers) {
-      if (!wanted.has(key)) {
-        controller.abort();
-        proxyControllers.delete(key);
-      }
-    }
-  }, [pendingCallsigns, routeContext, routeTransport]);
 
   const routesByCallsign = useMemo(() => {
     version;

--- a/src/hooks/useRealtimeAircraftChannel.ts
+++ b/src/hooks/useRealtimeAircraftChannel.ts
@@ -115,11 +115,19 @@ export function useRealtimeAircraftChannel({
 
 export function useAircraftTrackingRealtime(
   callsign: unknown,
-  { enabled = true }: { enabled?: boolean } = {},
+  {
+    enabled = true,
+    flightAware = false,
+  }: { enabled?: boolean; flightAware?: boolean } = {},
 ) {
   const channel = useMemo(() => buildCallsignChannel(callsign), [callsign]);
+  const params = useMemo(
+    () => (flightAware ? { flightAware: true } : EMPTY_REALTIME_PARAMS),
+    [flightAware],
+  );
   return useRealtimeAircraftChannel({
     channel,
+    params,
     enabled,
   });
 }

--- a/src/hooks/useTrackedAircraft.ts
+++ b/src/hooks/useTrackedAircraft.ts
@@ -2,10 +2,6 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
-  AIRCRAFT_TRAFFIC_CONFIG,
-  AVIATION_PROXY_BASES,
-} from "../config/aviation";
-import {
   normalizeAdsbAircraft,
 } from "../features/aircraft/positions/aircraftPositionsModel";
 import { shouldShowAircraftLoadingOverlay } from "../features/aircraft/positions/aircraftLoadingOverlayModel";
@@ -33,12 +29,6 @@ function normalizeTrackedPayload(data: unknown) {
   return normalizeRealtimeTrackedPayload(data);
 }
 
-function shouldHoldFlightAwarePosition(trackingState: unknown) {
-  return (
-    String((trackingState as any)?.status || "").trim() === "flightaware_active"
-  );
-}
-
 export function useTrackedAircraft(
   callsign: unknown,
   {
@@ -52,6 +42,7 @@ export function useTrackedAircraft(
   const hasActiveQuery = Boolean(callsign);
   const realtime = useAircraftTrackingRealtime(callsign, {
     enabled: hasActiveQuery,
+    flightAware: flightAwareEnabled && flightAwareResolved,
   });
   const [aircraft, setAircraft] = useState<any>(null);
   const [feedSource, setFeedSource] = useState("");
@@ -193,13 +184,6 @@ export function useTrackedAircraft(
   useEffect(() => {
     const event = realtime.event;
     if (!callsign || !event || event.type !== "aircraft:update") return;
-    if (
-      flightAwareEnabled &&
-      flightAwareResolved &&
-      shouldHoldFlightAwarePosition(trackingStateRef.current)
-    ) {
-      return;
-    }
 
     applyTrackedPayload(event.data, {
       source: event.source,
@@ -208,79 +192,7 @@ export function useTrackedAircraft(
   }, [
     applyTrackedPayload,
     callsign,
-    flightAwareEnabled,
-    flightAwareResolved,
     realtime.event,
-  ]);
-
-  useEffect(() => {
-    if (!callsign || !flightAwareResolved || !flightAwareEnabled) return undefined;
-
-    const normalizedCallsign = String(callsign || "").trim().toUpperCase();
-    if (!normalizedCallsign) return undefined;
-
-    let disposed = false;
-    let timer: number | null = null;
-    let controller: AbortController | null = null;
-
-    const poll = async () => {
-      controller?.abort();
-      controller = new AbortController();
-      try {
-        const response = await fetch(
-          `${AVIATION_PROXY_BASES.aircraftCallsign}/${encodeURIComponent(normalizedCallsign)}`,
-          {
-            cache: "no-store",
-            credentials: "same-origin",
-            signal: controller.signal,
-          },
-        );
-        if (!response.ok) {
-          throw new Error(`Aircraft callsign proxy HTTP ${response.status}`);
-        }
-        const payload = await response.json();
-        if (disposed) return;
-        applyTrackedPayload(payload, {
-          source:
-            response.headers.get("X-Data-Source") ||
-            (typeof payload?.source === "string" ? payload.source : ""),
-          fetchedAt:
-            typeof payload?.fetchedAt === "string"
-              ? payload.fetchedAt
-              : response.headers.get("Date") || "",
-        });
-      } catch (error: any) {
-        if (disposed || error?.name === "AbortError") return;
-        setError(error);
-        setSettled(true);
-        if (process.env.NODE_ENV !== "production") {
-          console.warn(
-            `[tracked-aircraft] FlightAware-aware refresh failed for ${normalizedCallsign}:`,
-            error,
-          );
-        }
-      } finally {
-        if (!disposed) {
-          timer = window.setTimeout(
-            poll,
-            AIRCRAFT_TRAFFIC_CONFIG.flightAwareTraceRefreshMs,
-          );
-        }
-      }
-    };
-
-    poll();
-
-    return () => {
-      disposed = true;
-      if (timer) window.clearTimeout(timer);
-      controller?.abort();
-    };
-  }, [
-    applyTrackedPayload,
-    callsign,
-    flightAwareEnabled,
-    flightAwareResolved,
   ]);
 
   const waitingForRealtime =

--- a/src/lib/realtime/realtimeChannels.test.ts
+++ b/src/lib/realtime/realtimeChannels.test.ts
@@ -54,6 +54,16 @@ import {
     params: {},
   });
   assert.deepEqual(
+    buildRouteChannel(" aal123 ", {
+      icao: "kbos",
+      routeProvider: "flightaware",
+    }),
+    {
+      channel: "route:AAL123:airport:KBOS",
+      params: { routeProvider: "flightaware" },
+    },
+  );
+  assert.deepEqual(
     buildRouteChannel(" aal123 ", { lat: 42.3656, lon: -71.0096 }),
     {
       channel: "route:AAL123:center:42.4:-71",

--- a/src/lib/realtime/realtimeChannels.ts
+++ b/src/lib/realtime/realtimeChannels.ts
@@ -4,6 +4,7 @@ type RealtimeChannelRequest = {
     lat?: number;
     lon?: number;
     distNm?: number;
+    routeProvider?: string;
   };
 };
 
@@ -101,6 +102,11 @@ function normalizeRouteContext(routeContext: Record<string, unknown> = {}) {
   return `center:${formatNumber(roundToGrid(lat))}:${formatNumber(roundToGrid(lon))}`;
 }
 
+function normalizeRouteProvider(value: unknown) {
+  const provider = String(value || "").trim().toLowerCase();
+  return provider === "flightaware" || provider === "adsbdb" ? provider : "";
+}
+
 function normalizeTrafficChannel(value: string) {
   const [anchor, ...parts] = value.split(":");
   if (anchor === "center") {
@@ -135,7 +141,11 @@ export function buildRouteChannel(
   const normalized = normalizeCallsign(callsign);
   if (!normalized || !/^[A-Z][A-Z0-9]{2,7}$/.test(normalized)) return null;
   const context = normalizeRouteContext(routeContext);
-  return { channel: `route:${normalized}${context ? `:${context}` : ""}`, params: {} };
+  const routeProvider = normalizeRouteProvider(routeContext.routeProvider);
+  return {
+    channel: `route:${normalized}${context ? `:${context}` : ""}`,
+    params: routeProvider ? { routeProvider } : {},
+  };
 }
 
 export function normalizeRealtimeChannel(channel: unknown) {


### PR DESCRIPTION
## Summary
- move FlightAware-aware tracked-aircraft callsign refresh from browser -> Vercel proxy to browser -> Railway realtime WS -> data-service polling/fanout
- move FlightAware route lookup transport to realtime route channels with provider params so Railway handles provider fetches and queueing
- throttle lost-signal trace refresh keys to the existing FlightAware trace refresh window instead of changing every poll tick
- keep data-service metrics low-cardinality with provider/endpoint/status labels only

## Validation
- pnpm --dir services/data-service test
- pnpm --dir services/data-service build
- pnpm test
- pnpm build
- pnpm lint (passes with existing warnings in PlaneHunterStudio, VirtualNearbyList, useWeatherSlides)
- git diff --check
- static search: no hook/model hits for aircraft callsign proxy, flight-routes proxy transport, or flight-route-proxy
