### PR TITLE
Deduplicate FlightAware data-service helpers

### DIFF
--- a/services/data-service/src/sources/flightAwareFallback.ts
+++ b/services/data-service/src/sources/flightAwareFallback.ts
@@ -1,14 +1,23 @@
 import type { DataServiceMetricsSink } from "../types.js";
+import {
+  FLIGHTAWARE_LIVE_FLIGHT_BASE,
+  type FlightAwareRecord,
+  buildFlightAwareLiveFlightUrl as buildFlightAwareFallbackUrl,
+  cleanString,
+  extractAssignedJson,
+  extractMetaContent,
+  normalizeFlightAwareCallsign as normalizeCallsign,
+  parseAssignedJson,
+  readFlightAwareResponseText as readResponseText,
+  toNumber,
+} from "./flightAwareShared.js";
 
-const FLIGHTAWARE_FALLBACK_BASE = "https://www.flightaware.com/live/flight";
 const FLIGHTAWARE_TRACKPOLL_PATH = "/ajax/trackpoll.rvt";
 const FLIGHTAWARE_FALLBACK_CACHE_TTL_MS = 60_000;
 const FLIGHTAWARE_FALLBACK_TIMEOUT_MS = 7_000;
 const FLIGHTAWARE_FALLBACK_USER_AGENT =
   "ADSBao data-service/1.0 (+https://adsbao.dev; flightaware/fallback)";
-const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 
-type FlightAwareRecord = Record<string, any>;
 type FlightAwareFetch = (
   input: string | URL | Request,
   init?: RequestInit,
@@ -41,99 +50,6 @@ type FlightAwareFallbackOptions = {
 
 const cache = new Map<string, FlightAwareFallbackCacheEntry>();
 const requestTimes: number[] = [];
-
-function cleanString(value: unknown) {
-  return String(value || "").trim();
-}
-
-function normalizeCallsign(value: unknown) {
-  const callsign = cleanString(value).toUpperCase().replace(/\s+/g, "");
-  return /^[A-Z][A-Z0-9]{2,7}$/.test(callsign) ? callsign : "";
-}
-
-function toNumber(value: unknown) {
-  if (value == null || value === "") return null;
-  const number = Number(value);
-  return Number.isFinite(number) ? number : null;
-}
-
-function htmlDecode(value: unknown) {
-  return cleanString(value)
-    .replaceAll("&amp;", "&")
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#39;", "'")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">");
-}
-
-function escapeRegExp(value: unknown) {
-  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function extractMetaContent(html: unknown, key: string) {
-  const escaped = escapeRegExp(key);
-  const patterns = [
-    new RegExp(
-      `<meta\\b(?=[^>]*(?:name|property)=["']${escaped}["'])(?=[^>]*content=["']([^"']*)["'])[^>]*>`,
-      "i",
-    ),
-    new RegExp(
-      `<meta\\b(?=[^>]*content=["']([^"']*)["'])(?=[^>]*(?:name|property)=["']${escaped}["'])[^>]*>`,
-      "i",
-    ),
-  ];
-  for (const pattern of patterns) {
-    const match = pattern.exec(String(html || ""));
-    if (match?.[1]) return htmlDecode(match[1]);
-  }
-  return "";
-}
-
-function extractAssignedJson(html: unknown, name: string) {
-  const source = String(html || "");
-  const marker = `var ${name} =`;
-  const start = source.indexOf(marker);
-  if (start < 0) return null;
-  const objectStart = source.indexOf("{", start + marker.length);
-  if (objectStart < 0) return null;
-
-  let depth = 0;
-  let escaped = false;
-  let inString = false;
-  for (let index = objectStart; index < source.length; index += 1) {
-    const char = source[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      continue;
-    }
-    if (char === "{") depth += 1;
-    if (char === "}") {
-      depth -= 1;
-      if (depth === 0) return source.slice(objectStart, index + 1);
-    }
-  }
-  return null;
-}
-
-function parseAssignedJson(html: unknown, name: string) {
-  const jsonText = extractAssignedJson(html, name);
-  if (!jsonText) return null;
-  try {
-    return JSON.parse(jsonText) as FlightAwareRecord;
-  } catch {
-    return null;
-  }
-}
 
 function extractTrackpollToken(html: unknown) {
   const globals = parseAssignedJson(html, "trackpollGlobals");
@@ -298,14 +214,8 @@ function isTerminalFlight(flight: FlightAwareRecord | null | undefined, status =
   );
 }
 
-function buildFlightAwareFallbackUrl(callsign: unknown) {
-  const normalized = normalizeCallsign(callsign);
-  if (!normalized) return "";
-  return `${FLIGHTAWARE_FALLBACK_BASE}/${encodeURIComponent(normalized)}`;
-}
-
 function buildFlightAwareTrackpollUrl(pageUrl: string, token: string) {
-  const url = new URL(FLIGHTAWARE_TRACKPOLL_PATH, FLIGHTAWARE_FALLBACK_BASE);
+  const url = new URL(FLIGHTAWARE_TRACKPOLL_PATH, FLIGHTAWARE_LIVE_FLIGHT_BASE);
   try {
     const page = new URL(pageUrl);
     page.searchParams.forEach((value, key) => {
@@ -318,14 +228,6 @@ function buildFlightAwareTrackpollUrl(pageUrl: string, token: string) {
   url.searchParams.set("locale", "en_US");
   url.searchParams.set("summary", "0");
   return url.toString();
-}
-
-async function readResponseText(response: Response, maxBytes = MAX_RESPONSE_BYTES) {
-  const text = await response.text();
-  if (Buffer.byteLength(text, "utf8") > maxBytes) {
-    throw new Error("FlightAware response too large");
-  }
-  return text;
 }
 
 function buildMetadata({

--- a/services/data-service/src/sources/flightAwareShared.ts
+++ b/services/data-service/src/sources/flightAwareShared.ts
@@ -1,0 +1,115 @@
+export const FLIGHTAWARE_LIVE_FLIGHT_BASE =
+  "https://www.flightaware.com/live/flight";
+export const MAX_FLIGHTAWARE_HTML_BYTES = 2 * 1024 * 1024;
+
+export type FlightAwareRecord = Record<string, any>;
+
+export function cleanString(value: unknown) {
+  return String(value || "").trim();
+}
+
+export function normalizeFlightAwareCallsign(value: unknown) {
+  const callsign = cleanString(value).toUpperCase().replace(/\s+/g, "");
+  return /^[A-Z][A-Z0-9]{2,7}$/.test(callsign) ? callsign : "";
+}
+
+export function toNumber(value: unknown) {
+  if (value == null || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+export function htmlDecode(value: unknown) {
+  return cleanString(value)
+    .replaceAll("&amp;", "&")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">");
+}
+
+export function escapeRegExp(value: unknown) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function extractMetaContent(html: unknown, key: string) {
+  const escaped = escapeRegExp(key);
+  const patterns = [
+    new RegExp(
+      `<meta\\b(?=[^>]*(?:name|property)=["']${escaped}["'])(?=[^>]*content=["']([^"']*)["'])[^>]*>`,
+      "i",
+    ),
+    new RegExp(
+      `<meta\\b(?=[^>]*content=["']([^"']*)["'])(?=[^>]*(?:name|property)=["']${escaped}["'])[^>]*>`,
+      "i",
+    ),
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(String(html || ""));
+    if (match?.[1]) return htmlDecode(match[1]);
+  }
+  return "";
+}
+
+export function extractAssignedJson(html: unknown, name: string) {
+  const source = String(html || "");
+  const marker = `var ${name} =`;
+  const start = source.indexOf(marker);
+  if (start < 0) return null;
+  const objectStart = source.indexOf("{", start + marker.length);
+  if (objectStart < 0) return null;
+
+  let depth = 0;
+  let escaped = false;
+  let inString = false;
+  for (let index = objectStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(objectStart, index + 1);
+    }
+  }
+  return null;
+}
+
+export function parseAssignedJson<T = FlightAwareRecord>(html: unknown, name: string) {
+  const jsonText = extractAssignedJson(html, name);
+  if (!jsonText) return null;
+  try {
+    return JSON.parse(jsonText) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function buildFlightAwareLiveFlightUrl(callsign: unknown) {
+  const normalized = normalizeFlightAwareCallsign(callsign);
+  if (!normalized) return "";
+  return `${FLIGHTAWARE_LIVE_FLIGHT_BASE}/${encodeURIComponent(normalized)}`;
+}
+
+export async function readFlightAwareResponseText(
+  response: Response,
+  maxBytes = MAX_FLIGHTAWARE_HTML_BYTES,
+) {
+  const text = await response.text();
+  if (Buffer.byteLength(text, "utf8") > maxBytes) {
+    throw new Error("FlightAware response too large");
+  }
+  return text;
+}

--- a/services/data-service/src/sources/routeClient.ts
+++ b/services/data-service/src/sources/routeClient.ts
@@ -1,9 +1,16 @@
 import type { FetchChannelInput, RealtimeEvent } from "../types.js";
+import {
+  buildFlightAwareLiveFlightUrl,
+  cleanString as clean,
+  escapeRegExp,
+  extractMetaContent,
+  htmlDecode,
+  readFlightAwareResponseText,
+  toNumber as numberOrNull,
+} from "./flightAwareShared.js";
 
 const ADSBDB_BASE = "https://api.adsbdb.com/v0";
-const FLIGHTAWARE_BASE = "https://www.flightaware.com/live/flight";
 const MAX_ROUTE_BYTES = 512 * 1024;
-const MAX_FLIGHTAWARE_ROUTE_BYTES = 2 * 1024 * 1024;
 const ROUTE_TIMEOUT_MS = 9_000;
 const ROUTE_QUEUE_INTERVAL_MS = 500;
 const USER_AGENT = "ADSBao data-service/1.0 (+https://adsbao.dev)";
@@ -15,15 +22,10 @@ type RouteFetchInput = FetchChannelInput & {
   waitForTurn?: () => Promise<void>;
 };
 
-const clean = (value: unknown) => String(value || "").trim();
 const upper = (value: unknown) => clean(value).toUpperCase();
 const code = (value: unknown, min = 3, max = 4) => {
   const next = upper(value);
   return new RegExp(`^[A-Z0-9]{${min},${max}}$`).test(next) ? next : "";
-};
-const numberOrNull = (value: unknown) => {
-  const next = Number(value);
-  return Number.isFinite(next) ? next : null;
 };
 const inRange = (
   value: number | null,
@@ -85,38 +87,6 @@ function normalizeRoute(callsign: string, payload: any) {
     source: "adsbdb",
     confidence: "reference-data",
   };
-}
-
-function htmlDecode(value: unknown) {
-  return clean(value)
-    .replaceAll("&amp;", "&")
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#39;", "'")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">");
-}
-
-function escapeRegExp(value: unknown) {
-  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function extractMetaContent(html: unknown, key: string) {
-  const escaped = escapeRegExp(key);
-  const patterns = [
-    new RegExp(
-      `<meta\\b(?=[^>]*(?:name|property)=["']${escaped}["'])(?=[^>]*content=["']([^"']*)["'])[^>]*>`,
-      "i",
-    ),
-    new RegExp(
-      `<meta\\b(?=[^>]*content=["']([^"']*)["'])(?=[^>]*(?:name|property)=["']${escaped}["'])[^>]*>`,
-      "i",
-    ),
-  ];
-  for (const pattern of patterns) {
-    const match = pattern.exec(String(html || ""));
-    if (match?.[1]) return htmlDecode(match[1]);
-  }
-  return "";
 }
 
 function extractTitle(html: unknown) {
@@ -244,12 +214,6 @@ function extractEmbeddedAirport(html: unknown, key: string, expectedIcao: string
   return null;
 }
 
-function buildFlightAwareCallsignRouteUrl(callsign: unknown) {
-  const normalized = upper(callsign);
-  if (!/^[A-Z][A-Z0-9]{2,7}$/.test(normalized)) return "";
-  return `${FLIGHTAWARE_BASE}/${encodeURIComponent(normalized)}`;
-}
-
 function buildFlightAwareAirlineLogoUrl(airlineIcao: unknown) {
   const normalized = code(airlineIcao, 2, 3);
   return normalized
@@ -338,14 +302,6 @@ async function readJson(response: Response) {
   return JSON.parse(text);
 }
 
-async function readText(response: Response, maxBytes = MAX_FLIGHTAWARE_ROUTE_BYTES) {
-  const text = await response.text();
-  if (Buffer.byteLength(text, "utf8") > maxBytes) {
-    throw new Error("Route response too large");
-  }
-  return text;
-}
-
 async function fetchFlightAwareRouteChannel({
   channel,
   metrics,
@@ -355,7 +311,7 @@ async function fetchFlightAwareRouteChannel({
 }: RouteFetchInput): Promise<RealtimeEvent> {
   if (target.kind !== "route") throw new Error("Expected route polling target");
   await waitForTurnImpl();
-  const url = buildFlightAwareCallsignRouteUrl(target.callsign);
+  const url = buildFlightAwareLiveFlightUrl(target.callsign);
   if (!url) throw new Error("Invalid FlightAware route callsign");
   const startedAt = Date.now();
   let status: number | string | null = null;
@@ -375,7 +331,10 @@ async function fetchFlightAwareRouteChannel({
     route =
       response.status === 404
         ? null
-        : normalizeFlightAwareRoute(target.callsign, await readText(response));
+        : normalizeFlightAwareRoute(
+            target.callsign,
+            await readFlightAwareResponseText(response),
+          );
     metrics?.recordExternalRequest({
       provider: "flightaware",
       endpoint: "route",


### PR DESCRIPTION
## Summary
- extract shared FlightAware HTML/callsign/url/response helpers for data-service sources
- remove duplicated helper implementations from callsign fallback and route clients
- keep provider-specific caching, trackpoll, route parsing, and metrics behavior unchanged

## Validation
- pnpm --dir services/data-service build
- pnpm --dir services/data-service test
- pnpm test
- pnpm lint (passes with existing warnings in PlaneHunterStudio, VirtualNearbyList, useWeatherSlides)
- git diff --check
