### PR TITLE
[codex] Install CA certificates in data-service image

### DIFF
--- a/services/data-service/Dockerfile
+++ b/services/data-service/Dockerfile
@@ -8,6 +8,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/adsbao-
 FROM debian:bookworm-slim AS runner
 WORKDIR /app
 ENV PORT=8080
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /out/adsbao-data-service /app/adsbao-data-service
 EXPOSE 8080
 CMD ["/app/adsbao-data-service"]


### PR DESCRIPTION
## Summary

- Installs `ca-certificates` in the Go data-service runtime image.
- Fixes production provider HTTPS failures from the slim Debian runtime: `x509: certificate signed by unknown authority`.

## Validation

- `go test ./...` from `services/data-service`
- `go build ./cmd/adsbao-data-service` from `services/data-service`
- `pnpm build`
- Production evidence before fix: WebSocket subscribe worked but provider fetch returned `channel:error` with TLS CA verification failures for all ADS-B providers.

## Notes

Docker is not installed on the local machine, so container-level verification will be the Railway production deployment smoke after merge.
