### PR TITLE
[codex] Fix FlightAware route body cancellation

### DIFF
--- a/services/data-service/internal/providers/flightaware/fallback.go
+++ b/services/data-service/internal/providers/flightaware/fallback.go
@@ -130,11 +130,12 @@ func (c *FallbackClient) ByCallsign(ctx context.Context, callsign any, metrics r
 	}
 
 	started := time.Now()
-	resp, err := c.do(ctx, pageURL, "text/html,application/xhtml+xml", "", metrics, started)
+	resp, cancel, err := c.do(ctx, pageURL, "text/html,application/xhtml+xml", "", metrics, started)
 	if err != nil {
 		record(metrics, "error", "ERR", started)
 		return errorResult(timeoutOrNetwork(err), fetchedAt, err.Error(), nil), nil
 	}
+	defer cancel()
 	defer resp.Body.Close()
 	record(metrics, resultForStatus(resp.StatusCode), resp.StatusCode, started)
 	if resp.StatusCode == http.StatusNotFound {
@@ -170,11 +171,12 @@ func (c *FallbackClient) ByCallsign(ctx context.Context, callsign any, metrics r
 func (c *FallbackClient) tryTrackpoll(ctx context.Context, callsign, fetchedAt, pageURL, token, htmlText string, metrics realtime.MetricsSink) (adsb.FallbackResult, bool) {
 	trackURL := buildTrackpollURL(pageURL, token)
 	started := time.Now()
-	resp, err := c.do(ctx, trackURL, "application/json, text/javascript, */*; q=0.01", pageURL, metrics, started)
+	resp, cancel, err := c.do(ctx, trackURL, "application/json, text/javascript, */*; q=0.01", pageURL, metrics, started)
 	if err != nil {
 		record(metrics, "error", "ERR", started)
 		return adsb.FallbackResult{}, false
 	}
+	defer cancel()
 	defer resp.Body.Close()
 	record(metrics, resultForStatus(resp.StatusCode), resp.StatusCode, started)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -188,12 +190,12 @@ func (c *FallbackClient) tryTrackpoll(ctx context.Context, callsign, fetchedAt, 
 	return result, result.OK
 }
 
-func (c *FallbackClient) do(ctx context.Context, requestURL, accept, referer string, _ realtime.MetricsSink, _ time.Time) (*http.Response, error) {
+func (c *FallbackClient) do(ctx context.Context, requestURL, accept, referer string, _ realtime.MetricsSink, _ time.Time) (*http.Response, context.CancelFunc, error) {
 	requestCtx, cancel := context.WithTimeout(ctx, c.timeout)
-	defer cancel()
 	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL, nil)
 	if err != nil {
-		return nil, err
+		cancel()
+		return nil, nil, err
 	}
 	req.Header.Set("Accept", accept)
 	req.Header.Set("User-Agent", userAgentFallback)
@@ -201,7 +203,12 @@ func (c *FallbackClient) do(ctx context.Context, requestURL, accept, referer str
 		req.Header.Set("Referer", referer)
 		req.Header.Set("X-Requested-With", "XMLHttpRequest")
 	}
-	return c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	return resp, cancel, nil
 }
 
 func (c *FallbackClient) pageURL(callsign string) string {

--- a/services/data-service/internal/providers/flightaware/fallback_test.go
+++ b/services/data-service/internal/providers/flightaware/fallback_test.go
@@ -15,6 +15,10 @@ func TestFallbackParsesBootstrapPositionAndCaches(t *testing.T) {
 		if r.URL.Path != "/live/flight/DAL58" {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+			time.Sleep(20 * time.Millisecond)
+		}
 		_, _ = w.Write([]byte(`
 			<html>
 				<head>

--- a/services/data-service/internal/providers/route/client.go
+++ b/services/data-service/internal/providers/route/client.go
@@ -103,11 +103,12 @@ func (c *Client) fetchADSBDB(ctx context.Context, input realtime.FetchInput) (re
 	requestURL := c.adsbdbBaseURL + "/callsign/" + url.PathEscape(input.Target.Callsign)
 	started := time.Now()
 	status := any(nil)
-	resp, err := c.do(ctx, requestURL, "application/json", userAgent)
+	resp, cancel, err := c.do(ctx, requestURL, "application/json", userAgent)
 	if err != nil {
 		c.recordExternal(input, "adsbdb", "error", "ERR", started)
 		return realtime.Event{}, err
 	}
+	defer cancel()
 	defer resp.Body.Close()
 	status = resp.StatusCode
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -142,11 +143,12 @@ func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput
 	}
 	started := time.Now()
 	status := any(nil)
-	resp, err := c.do(ctx, requestURL, "text/html,application/xhtml+xml", flightAwareRouteUA)
+	resp, cancel, err := c.do(ctx, requestURL, "text/html,application/xhtml+xml", flightAwareRouteUA)
 	if err != nil {
 		c.recordExternal(input, "flightaware", "error", "ERR", started)
 		return realtime.Event{}, err
 	}
+	defer cancel()
 	defer resp.Body.Close()
 	status = resp.StatusCode
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -166,16 +168,21 @@ func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput
 	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, normalizeFlightAwareRoute(input.Target.Callsign, string(body))), nil
 }
 
-func (c *Client) do(ctx context.Context, requestURL, accept, ua string) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, requestURL, accept, ua string) (*http.Response, context.CancelFunc, error) {
 	requestCtx, cancel := context.WithTimeout(ctx, c.timeout)
-	defer cancel()
 	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL, nil)
 	if err != nil {
-		return nil, err
+		cancel()
+		return nil, nil, err
 	}
 	req.Header.Set("Accept", accept)
 	req.Header.Set("User-Agent", ua)
-	return c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	return resp, cancel, nil
 }
 
 func (c *Client) readBody(resp *http.Response) ([]byte, error) {

--- a/services/data-service/internal/providers/route/client_test.go
+++ b/services/data-service/internal/providers/route/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/adsbao/adsbao/services/data-service/internal/realtime"
 )
@@ -42,6 +43,10 @@ func TestFlightAwareRouteNormalizesScrapedRoute(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/live/flight/AAL1234" {
 			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+			time.Sleep(20 * time.Millisecond)
 		}
 		_, _ = w.Write([]byte(`
 			<html>


### PR DESCRIPTION
## Summary
- Keep FlightAware route and fallback request contexts alive until response bodies are closed.
- Add streamed-response tests that reproduce the prior context cancellation failure.

## Root Cause
The Go FlightAware HTTP helpers returned `*http.Response` while deferring `cancel()` inside the helper. That canceled the request context before callers read streamed response bodies, so logged-in FlightAware route subscriptions could emit `channel:error` with `context canceled`.

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- Local WS smoke: `route:DAL176:airport:KBOS` with `{ "routeProvider": "flightaware" }` returned `route:update` from `flightaware`.
