### PR TITLE
Harden realtime data service migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ normally configure these variables:
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk browser identity |
 | `CLERK_SECRET_KEY` | Clerk server identity |
 | `NEXT_PUBLIC_ADSBAO_REALTIME_URL` | Optional WebSocket URL for the realtime ADS-B data service |
+| `ADSBAO_REALTIME_AUTH_SECRET` | Shared HMAC secret used by Vercel and the Railway data service to authorize FlightAware realtime subscriptions |
 | `NEXT_PUBLIC_SENTRY_DSN` | Optional browser Sentry events |
 | `SENTRY_DSN` | Optional server/edge Sentry events |
 | `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` | Optional production source-map upload |
@@ -252,6 +253,8 @@ Railway setup:
 4. Generate a public Railway domain for the service.
 5. Set Vercel `NEXT_PUBLIC_ADSBAO_REALTIME_URL` to
    `wss://<railway-domain>/ws` for production and preview.
+6. Set the same `ADSBAO_REALTIME_AUTH_SECRET` in Vercel and Railway when
+   FlightAware realtime subscriptions are enabled.
 
 Railway handles production deployment through its GitHub integration. The
 service should be configured with root directory `services/data-service`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ are active:
 
 | Product anchor | Traffic channel | Route channel |
 |---|---|---|
-| Airport page | `traffic:airport:{icao}:{lat}:{lon}:{distNm}` | `route:{callsign}:airport:{icao}` |
+| Airport page | `traffic:center:{lat}:{lon}:{distNm}` | `route:{callsign}:airport:{icao}` |
 | Here / user location | `traffic:center:{lat}:{lon}:{distNm}` | `route:{callsign}:center:{lat}:{lon}` |
 | Tracking page | `traffic:center:{aircraftLat}:{aircraftLon}:{distNm}` | `route:{callsign}:center:{aircraftLat}:{aircraftLon}` |
 
@@ -52,6 +52,13 @@ share the same loop instead of creating one-off subscriptions. `route:*` remains
 separate from `traffic:*` because route lookup cadence and cache lifetime are
 much slower than ADS-B positions, and because the route display context changes
 with the current center for here/tracking flows.
+
+FlightAware-backed realtime modes are privileged. The browser first asks
+Vercel `/api/realtime/auth` for a short-lived provider grant after the normal
+Clerk feature-flag check, then sends that grant with `flightAware` or
+`routeProvider=flightaware` subscription params. The Go service verifies the
+HMAC grant with `ADSBAO_REALTIME_AUTH_SECRET` before it starts any FlightAware
+polling loop, and strips the token before params reach the scheduler.
 
 The frontend discovers it through `NEXT_PUBLIC_ADSBAO_REALTIME_URL`. Realtime
 surfaces do not start their own external-provider polling when the WebSocket is

--- a/docs/data-service-deployment.md
+++ b/docs/data-service-deployment.md
@@ -64,6 +64,11 @@ Compatible env vars:
 - `MAX_SOCKET_SUBSCRIPTIONS`
 - `ALLOWED_WS_ORIGINS`
 - `FLIGHTAWARE_FALLBACK_ENABLED`
+- `ADSBAO_REALTIME_AUTH_SECRET` must match the Vercel environment value so
+  `/api/realtime/auth` grants can authorize FlightAware realtime subscriptions.
+- `AIRPORT_DIRECTORY_BASE_URL` defaults to `https://www.adsbao.dev` and is used
+  as a fallback airport directory when FlightAware route pages omit embedded
+  airport coordinates.
 
 Optional Go-only debug env:
 
@@ -140,6 +145,10 @@ Check Grafana panels for:
 - Poll duration
 - Active channels and subscriptions
 - Stale channels and consecutive failures
+
+The dynamic channel gauges should emit zero-valued series for idle aircraft,
+callsign, route, and traffic channel types so panels remain visible when no
+clients are connected.
 
 Also watch Railway memory, CPU, provider request rate, and Vercel aircraft
 proxy invocations after each production deploy.

--- a/services/data-service/.dockerignore
+++ b/services/data-service/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.next
+dist
+node_modules
+coverage
+*.log
+adsbao-data-service

--- a/services/data-service/README.md
+++ b/services/data-service/README.md
@@ -37,6 +37,12 @@ Optional Go profiling endpoints are available under `/debug/pprof/` only when
 - `MAX_SOCKET_SUBSCRIPTIONS`
 - `ALLOWED_WS_ORIGINS`
 - `FLIGHTAWARE_FALLBACK_ENABLED`
+- `ADSBAO_REALTIME_AUTH_SECRET` — shared HMAC secret used by Vercel
+  `/api/realtime/auth` and the data-service to authorize FlightAware realtime
+  subscriptions.
+- `AIRPORT_DIRECTORY_BASE_URL` — ADSBao web origin used as the fallback airport
+  directory for FlightAware route pages that omit embedded airport coordinates.
+  Defaults to `https://www.adsbao.dev`.
 - `ENABLE_PPROF`
 
 ## Railway Deployment

--- a/services/data-service/cmd/adsbao-data-service/main.go
+++ b/services/data-service/cmd/adsbao-data-service/main.go
@@ -36,7 +36,9 @@ func main() {
 			return flightAwareFallback.ByCallsign(ctx, callsign, sink)
 		},
 	})
-	routeClient := route.NewClient(route.Options{})
+	routeClient := route.NewClient(route.Options{
+		AirportDirectoryBaseURL: cfg.AirportDirectoryBaseURL,
+	})
 	polling := scheduler.New(scheduler.Options{
 		Fetch: func(input realtime.FetchInput) (realtime.Event, error) {
 			if input.ChannelType == realtime.ChannelRoute {
@@ -55,6 +57,7 @@ func main() {
 		registry,
 		cfg.AllowedWSOrigins,
 		ws.WithMaxSubscriptions(cfg.MaxSocketSubscriptions),
+		ws.WithRealtimeAuthSecret(cfg.RealtimeAuthSecret),
 	)
 	handler := httpapi.New(httpapi.ServerOptions{
 		Metrics:       registry,

--- a/services/data-service/internal/config/config.go
+++ b/services/data-service/internal/config/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	MaxSocketSubscriptions     int
 	AllowedWSOrigins           []string
 	FlightAwareFallbackEnabled bool
+	RealtimeAuthSecret         string
+	AirportDirectoryBaseURL    string
 	EnablePprof                bool
 }
 
@@ -30,6 +32,8 @@ func FromEnv(lookup LookupFunc) Config {
 		MaxSocketSubscriptions:     intValue(lookup("MAX_SOCKET_SUBSCRIPTIONS"), 96),
 		AllowedWSOrigins:           csv(lookup("ALLOWED_WS_ORIGINS")),
 		FlightAwareFallbackEnabled: !falseString(lookup("FLIGHTAWARE_FALLBACK_ENABLED")),
+		RealtimeAuthSecret:         strings.TrimSpace(lookup("ADSBAO_REALTIME_AUTH_SECRET")),
+		AirportDirectoryBaseURL:    stringValue(lookup("AIRPORT_DIRECTORY_BASE_URL"), "https://www.adsbao.dev"),
 		EnablePprof:                trueString(lookup("ENABLE_PPROF")),
 	}
 }
@@ -56,6 +60,14 @@ func durationMS(raw string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return time.Duration(value) * time.Millisecond
+}
+
+func stringValue(raw, fallback string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return fallback
+	}
+	return value
 }
 
 func csv(raw string) []string {

--- a/services/data-service/internal/config/config_test.go
+++ b/services/data-service/internal/config/config_test.go
@@ -15,6 +15,8 @@ func TestFromEnvParsesCompatibleDataServiceVariables(t *testing.T) {
 		"MAX_SOCKET_SUBSCRIPTIONS":     "7",
 		"ALLOWED_WS_ORIGINS":           "https://staging.example, https://preview.example",
 		"FLIGHTAWARE_FALLBACK_ENABLED": "false",
+		"ADSBAO_REALTIME_AUTH_SECRET":  "shared-secret",
+		"AIRPORT_DIRECTORY_BASE_URL":   "https://www.adsbao.dev",
 		"ENABLE_PPROF":                 "true",
 	}
 
@@ -37,6 +39,9 @@ func TestFromEnvParsesCompatibleDataServiceVariables(t *testing.T) {
 	if cfg.FlightAwareFallbackEnabled || !cfg.EnablePprof {
 		t.Fatalf("booleans = fallback:%v pprof:%v", cfg.FlightAwareFallbackEnabled, cfg.EnablePprof)
 	}
+	if cfg.RealtimeAuthSecret != "shared-secret" || cfg.AirportDirectoryBaseURL != "https://www.adsbao.dev" {
+		t.Fatalf("urls/secrets = %#v", cfg)
+	}
 }
 
 func TestFromEnvDefaultsMatchProductionService(t *testing.T) {
@@ -48,6 +53,8 @@ func TestFromEnvDefaultsMatchProductionService(t *testing.T) {
 		cfg.MaxSocketSubscriptions != 96 ||
 		cfg.PollJitterRatio != 0.1 ||
 		!cfg.FlightAwareFallbackEnabled ||
+		cfg.RealtimeAuthSecret != "" ||
+		cfg.AirportDirectoryBaseURL != "https://www.adsbao.dev" ||
 		cfg.EnablePprof {
 		t.Fatalf("defaults = %#v", cfg)
 	}

--- a/services/data-service/internal/metrics/metrics.go
+++ b/services/data-service/internal/metrics/metrics.go
@@ -18,6 +18,12 @@ import (
 
 var durationBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
 var messageByteBuckets = []float64{128, 512, 1024, 4 * 1024, 16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024}
+var dynamicChannelTypes = []string{
+	string(realtime.ChannelAircraft),
+	string(realtime.ChannelCallsign),
+	string(realtime.ChannelRoute),
+	string(realtime.ChannelTraffic),
+}
 
 type Metrics struct {
 	mu       sync.Mutex
@@ -173,6 +179,14 @@ func (m *Metrics) UpdateDynamic(uptimeSec float64, channels []realtime.DebugChan
 	m.channelPollIntervalSecond.Reset()
 	m.staleChannelsCurrent.Reset()
 
+	for _, typ := range dynamicChannelTypes {
+		m.activeChannelsCurrent.WithLabelValues(typ).Set(0)
+		m.subscriptionsCurrent.WithLabelValues(typ).Set(0)
+		m.channelFailuresCurrent.WithLabelValues(typ).Set(0)
+		m.channelPollIntervalSecond.WithLabelValues(typ).Set(0)
+		m.staleChannelsCurrent.WithLabelValues(typ).Set(0)
+	}
+
 	type aggregate struct {
 		active      int
 		subscribers int
@@ -203,9 +217,7 @@ func (m *Metrics) UpdateDynamic(uptimeSec float64, channels []realtime.DebugChan
 		m.subscriptionsCurrent.WithLabelValues(typ).Set(float64(item.subscribers))
 		m.channelFailuresCurrent.WithLabelValues(typ).Set(float64(item.failures))
 		m.channelPollIntervalSecond.WithLabelValues(typ).Set(float64(item.maxInterval) / 1000)
-		if item.stale > 0 {
-			m.staleChannelsCurrent.WithLabelValues(typ).Set(float64(item.stale))
-		}
+		m.staleChannelsCurrent.WithLabelValues(typ).Set(float64(item.stale))
 	}
 }
 

--- a/services/data-service/internal/metrics/metrics_test.go
+++ b/services/data-service/internal/metrics/metrics_test.go
@@ -65,3 +65,26 @@ func TestMetricsPreserveNamesAndLowCardinalityLabels(t *testing.T) {
 		t.Fatalf("metrics output contains high-cardinality channel name:\n%s", out)
 	}
 }
+
+func TestMetricsExposeZeroSeriesForIdleChannelTypes(t *testing.T) {
+	m := New()
+	out, err := m.Render(10, nil)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	for _, channelType := range []string{"aircraft", "callsign", "route", "traffic"} {
+		required := []string{
+			`adsbao_active_channels_current{channel_type="` + channelType + `"} 0`,
+			`adsbao_subscriptions_current{channel_type="` + channelType + `"} 0`,
+			`adsbao_channel_consecutive_failures_current{channel_type="` + channelType + `"} 0`,
+			`adsbao_channel_poll_interval_seconds{channel_type="` + channelType + `"} 0`,
+			`adsbao_stale_channels_current{channel_type="` + channelType + `"} 0`,
+		}
+		for _, needle := range required {
+			if !strings.Contains(out, needle) {
+				t.Fatalf("metrics output missing %q\n%s", needle, out)
+			}
+		}
+	}
+}

--- a/services/data-service/internal/providers/route/client.go
+++ b/services/data-service/internal/providers/route/client.go
@@ -22,6 +22,7 @@ import (
 const (
 	defaultADSBDBBaseURL     = "https://api.adsbdb.com/v0"
 	defaultFlightAwareBase   = "https://www.flightaware.com/live/flight"
+	defaultAirportDirectory  = "https://www.adsbao.dev"
 	defaultTimeout           = 9 * time.Second
 	defaultMaxBytes          = 2 * 1024 * 1024
 	defaultQueueInterval     = 500 * time.Millisecond
@@ -31,24 +32,26 @@ const (
 )
 
 type Options struct {
-	HTTPClient      *http.Client
-	ADSBDBBaseURL   string
-	FlightAwareBase string
-	Timeout         time.Duration
-	MaxBytes        int64
-	QueueInterval   time.Duration
-	DisableQueue    bool
+	HTTPClient              *http.Client
+	ADSBDBBaseURL           string
+	FlightAwareBase         string
+	AirportDirectoryBaseURL string
+	Timeout                 time.Duration
+	MaxBytes                int64
+	QueueInterval           time.Duration
+	DisableQueue            bool
 }
 
 type Client struct {
-	httpClient      *http.Client
-	adsbdbBaseURL   string
-	flightAwareBase string
-	timeout         time.Duration
-	maxBytes        int64
-	queueInterval   time.Duration
-	mu              sync.Mutex
-	lastStarted     time.Time
+	httpClient              *http.Client
+	adsbdbBaseURL           string
+	flightAwareBase         string
+	airportDirectoryBaseURL string
+	timeout                 time.Duration
+	maxBytes                int64
+	queueInterval           time.Duration
+	mu                      sync.Mutex
+	lastStarted             time.Time
 }
 
 func NewClient(options Options) *Client {
@@ -64,6 +67,10 @@ func NewClient(options Options) *Client {
 	if flightAwareBase == "" {
 		flightAwareBase = defaultFlightAwareBase
 	}
+	airportDirectoryBaseURL := strings.TrimRight(options.AirportDirectoryBaseURL, "/")
+	if airportDirectoryBaseURL == "" {
+		airportDirectoryBaseURL = defaultAirportDirectory
+	}
 	timeout := options.Timeout
 	if timeout <= 0 {
 		timeout = defaultTimeout
@@ -77,12 +84,13 @@ func NewClient(options Options) *Client {
 		queueInterval = defaultQueueInterval
 	}
 	return &Client{
-		httpClient:      httpClient,
-		adsbdbBaseURL:   adsbdbBase,
-		flightAwareBase: flightAwareBase,
-		timeout:         timeout,
-		maxBytes:        maxBytes,
-		queueInterval:   queueInterval,
+		httpClient:              httpClient,
+		adsbdbBaseURL:           adsbdbBase,
+		flightAwareBase:         flightAwareBase,
+		airportDirectoryBaseURL: airportDirectoryBaseURL,
+		timeout:                 timeout,
+		maxBytes:                maxBytes,
+		queueInterval:           queueInterval,
 	}
 }
 
@@ -165,7 +173,7 @@ func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput
 		return realtime.Event{}, err
 	}
 	c.recordExternal(input, "flightaware", "success", status, started)
-	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, normalizeFlightAwareRoute(input.Target.Callsign, string(body))), nil
+	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, c.normalizeFlightAwareRoute(ctx, input, string(body))), nil
 }
 
 func (c *Client) do(ctx context.Context, requestURL, accept, ua string) (*http.Response, context.CancelFunc, error) {
@@ -226,6 +234,14 @@ func (c *Client) flightAwareURL(callsign string) string {
 		return ""
 	}
 	return c.flightAwareBase + "/" + url.PathEscape(normalized)
+}
+
+func (c *Client) airportDirectoryURL(ident string) string {
+	normalized := code(ident, 3, 4)
+	if normalized == "" || c.airportDirectoryBaseURL == "" {
+		return ""
+	}
+	return c.airportDirectoryBaseURL + "/api/airport/" + url.PathEscape(normalized)
 }
 
 func (c *Client) recordExternal(input realtime.FetchInput, provider, result string, status any, started time.Time) {
@@ -300,7 +316,17 @@ func normalizeADSBDBRoute(callsign string, payload map[string]any) map[string]an
 	}
 }
 
+func (c *Client) normalizeFlightAwareRoute(ctx context.Context, input realtime.FetchInput, source string) map[string]any {
+	return normalizeFlightAwareRouteWithResolver(input.Target.Callsign, source, func(ident string) map[string]any {
+		return c.fetchDirectoryAirport(ctx, input, ident)
+	})
+}
+
 func normalizeFlightAwareRoute(callsign, source string) map[string]any {
+	return normalizeFlightAwareRouteWithResolver(callsign, source, nil)
+}
+
+func normalizeFlightAwareRouteWithResolver(callsign, source string, resolveAirport func(string) map[string]any) map[string]any {
 	normalizedCallsign := upper(callsign)
 	if !regexp.MustCompile(`^[A-Z][A-Z0-9]{2,7}$`).MatchString(normalizedCallsign) {
 		return nil
@@ -319,6 +345,14 @@ func normalizeFlightAwareRoute(callsign, source string) map[string]any {
 	airlineIATA, number := extractIATAAndNumber(normalizedCallsign, description, title)
 	origin := normalizeFlightAwareAirport(extractEmbeddedAirport(source, "origin", originICAO))
 	destination := normalizeFlightAwareAirport(extractEmbeddedAirport(source, "destination", destICAO))
+	if resolveAirport != nil {
+		if origin == nil {
+			origin = normalizeAirport(resolveAirport(originICAO))
+		}
+		if destination == nil {
+			destination = normalizeAirport(resolveAirport(destICAO))
+		}
+	}
 	if origin == nil || destination == nil {
 		return nil
 	}
@@ -354,6 +388,54 @@ func normalizeFlightAwareRoute(callsign, source string) map[string]any {
 	}
 }
 
+func (c *Client) fetchDirectoryAirport(ctx context.Context, input realtime.FetchInput, ident string) map[string]any {
+	requestURL := c.airportDirectoryURL(ident)
+	if requestURL == "" {
+		return nil
+	}
+	started := time.Now()
+	resp, cancel, err := c.do(ctx, requestURL, "application/json", userAgent)
+	if err != nil {
+		c.recordAirportDirectory(input, "error", "ERR", started)
+		return nil
+	}
+	defer cancel()
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		c.recordAirportDirectory(input, "success", resp.StatusCode, started)
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		c.recordAirportDirectory(input, "error", resp.StatusCode, started)
+		return nil
+	}
+	body, err := c.readBody(resp)
+	if err != nil {
+		c.recordAirportDirectory(input, "error", "ERR", started)
+		return nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		c.recordAirportDirectory(input, "error", "PARSE", started)
+		return nil
+	}
+	c.recordAirportDirectory(input, "success", resp.StatusCode, started)
+	return asMap(payload["airport"])
+}
+
+func (c *Client) recordAirportDirectory(input realtime.FetchInput, result string, status any, started time.Time) {
+	if input.Metrics == nil {
+		return
+	}
+	input.Metrics.RecordExternalRequest(realtime.ExternalRequestMetricInput{
+		Provider:   "adsbao-web",
+		Endpoint:   "airport",
+		Result:     result,
+		Status:     status,
+		DurationMS: time.Since(started).Milliseconds(),
+	})
+}
+
 func normalizeAirport(raw map[string]any) map[string]any {
 	if raw == nil {
 		return nil
@@ -369,7 +451,7 @@ func normalizeAirport(raw map[string]any) map[string]any {
 		"icao":         icao,
 		"iata":         iata,
 		"name":         clean(raw["name"]),
-		"municipality": clean(raw["municipality"]),
+		"municipality": clean(firstNonEmpty(raw["municipality"], raw["city"])),
 		"country":      upper(firstNonEmpty(raw["country_iso_name"], raw["country"])),
 		"lat":          lat,
 		"lon":          lon,

--- a/services/data-service/internal/providers/route/client_test.go
+++ b/services/data-service/internal/providers/route/client_test.go
@@ -96,6 +96,57 @@ func TestFlightAwareRouteNormalizesScrapedRoute(t *testing.T) {
 	}
 }
 
+func TestFlightAwareRouteUsesAirportDirectoryFallbackWhenPageOmitsEmbeddedAirports(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/live/flight/AAL1234":
+			_, _ = w.Write([]byte(`
+				<html>
+					<head>
+						<title>AA1234 (AAL1234) American Airlines Flight Tracking</title>
+						<meta name="origin" content="KBOS">
+						<meta name="destination" content="KLAX">
+						<meta name="airline" content="AAL">
+						<meta name="description" content="Track American Airlines (AA) #1234">
+					</head>
+				</html>
+			`))
+		case "/api/airport/KBOS":
+			_, _ = w.Write([]byte(`{"airport":{"icao":"KBOS","iata":"BOS","name":"Boston Logan","city":"Boston","country":"US","lat":42.3656,"lon":-71.0096}}`))
+		case "/api/airport/KLAX":
+			_, _ = w.Write([]byte(`{"airport":{"icao":"KLAX","iata":"LAX","name":"Los Angeles Intl","city":"Los Angeles","country":"US","lat":33.9416,"lon":-118.4085}}`))
+		default:
+			t.Fatalf("unexpected path = %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Options{
+		FlightAwareBase:         server.URL + "/live/flight",
+		AirportDirectoryBaseURL: server.URL,
+		QueueInterval:           0,
+	})
+	event, err := client.Fetch(context.Background(), realtime.FetchInput{
+		Channel:     "route:AAL1234:airport:KBOS",
+		ChannelType: realtime.ChannelRoute,
+		Target: realtime.PollingTarget{
+			Kind:          "route",
+			Callsign:      "AAL1234",
+			RouteProvider: "flightaware",
+			RouteContext:  &realtime.RouteContext{Type: "airport", ICAO: "KBOS"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	data := event.Data.(map[string]any)
+	route := data["route"].(map[string]any)
+	routeCodes := route["route"].(map[string]any)
+	if routeCodes["iata"] != "BOS-LAX" || routeCodes["icao"] != "KBOS-KLAX" {
+		t.Fatalf("route = %#v", route)
+	}
+}
+
 func TestFlightAwareRouteAllowsLargeHTMLPage(t *testing.T) {
 	padding := strings.Repeat(" ", 600*1024)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/services/data-service/internal/ws/auth.go
+++ b/services/data-service/internal/ws/auth.go
@@ -1,0 +1,46 @@
+package ws
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+const realtimeAuthTokenParam = "realtimeAuthToken"
+
+type providerGrant struct {
+	Provider string `json:"provider"`
+	Exp      int64  `json:"exp"`
+}
+
+func verifyProviderGrant(token, provider, secret string, now time.Time) bool {
+	token = strings.TrimSpace(token)
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	secret = strings.TrimSpace(secret)
+	if token == "" || provider == "" || secret == "" {
+		return false
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(parts[0]))
+	expected := mac.Sum(nil)
+	got, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil || !hmac.Equal(got, expected) {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	var grant providerGrant
+	if err := json.Unmarshal(payload, &grant); err != nil {
+		return false
+	}
+	return strings.ToLower(grant.Provider) == provider && grant.Exp > now.Unix()
+}

--- a/services/data-service/internal/ws/ws.go
+++ b/services/data-service/internal/ws/ws.go
@@ -27,12 +27,20 @@ type Scheduler interface {
 	Subscribe(channel string, params realtime.SubscribeParams, send func(realtime.Event)) (func(), error)
 }
 
+type realtimeConn interface {
+	Read(context.Context) (websocket.MessageType, []byte, error)
+	Write(context.Context, websocket.MessageType, []byte) error
+	Close(websocket.StatusCode, string) error
+}
+
 type Handler struct {
 	scheduler                 Scheduler
 	metrics                   *metrics.Metrics
 	path                      string
 	allowedOrigins            []string
 	maxSubscriptionsPerSocket int
+	realtimeAuthSecret        string
+	writeTimeout              time.Duration
 }
 
 type Option func(*Handler)
@@ -45,6 +53,14 @@ func WithMaxSubscriptions(max int) Option {
 	return func(h *Handler) { h.maxSubscriptionsPerSocket = max }
 }
 
+func WithRealtimeAuthSecret(secret string) Option {
+	return func(h *Handler) { h.realtimeAuthSecret = strings.TrimSpace(secret) }
+}
+
+func WithWriteTimeout(timeout time.Duration) Option {
+	return func(h *Handler) { h.writeTimeout = timeout }
+}
+
 func NewHandler(scheduler Scheduler, metrics *metrics.Metrics, allowedOrigins []string, opts ...Option) *Handler {
 	h := &Handler{
 		scheduler:                 scheduler,
@@ -52,6 +68,7 @@ func NewHandler(scheduler Scheduler, metrics *metrics.Metrics, allowedOrigins []
 		path:                      "/ws",
 		allowedOrigins:            allowedOrigins,
 		maxSubscriptionsPerSocket: 96,
+		writeTimeout:              5 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -103,6 +120,8 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		scheduler:     h.scheduler,
 		maxSubs:       h.maxSubscriptionsPerSocket,
 		openedAt:      time.Now(),
+		authSecret:    h.realtimeAuthSecret,
+		writeTimeout:  h.writeTimeout,
 		subscriptions: map[string]func(){},
 	}
 	client.run(r.Context())
@@ -115,11 +134,13 @@ func (h *Handler) recordUpgrade(reason, result string) {
 }
 
 type clientConn struct {
-	conn          *websocket.Conn
+	conn          realtimeConn
 	metrics       *metrics.Metrics
 	scheduler     Scheduler
 	maxSubs       int
 	openedAt      time.Time
+	authSecret    string
+	writeTimeout  time.Duration
 	writeMu       sync.Mutex
 	subscriptions map[string]func()
 }
@@ -190,7 +211,7 @@ func (c *clientConn) handleMessage(ctx context.Context, msg clientMessage) {
 	case "ping":
 		c.sendRaw(ctx, map[string]any{"type": "pong", "now": time.Now().UTC().Format(time.RFC3339Nano)})
 	case "unsubscribe":
-		c.unsubscribe(ctx, msg.Channel)
+		c.unsubscribe(ctx, msg.Channel, msg.Params)
 	case "subscribe":
 		c.subscribe(ctx, msg)
 	default:
@@ -207,7 +228,16 @@ func (c *clientConn) subscribe(ctx context.Context, msg clientMessage) {
 		c.sendRaw(ctx, map[string]any{"type": "subscribe:error", "channel": msg.Channel, "error": err.Error()})
 		return
 	}
-	if _, exists := c.subscriptions[normalized.Channel]; exists {
+	params, authorized := c.authorizeParams(msg.Params)
+	if !authorized {
+		if c.metrics != nil {
+			c.metrics.RecordWSSubscribe(normalized.Type, "unauthorized")
+		}
+		c.sendRaw(ctx, map[string]any{"type": "subscribe:error", "channel": normalized.Channel, "error": "FlightAware realtime access requires authorization"})
+		return
+	}
+	key := subscriptionKey(normalized.Channel, params)
+	if _, exists := c.subscriptions[key]; exists {
 		if c.metrics != nil {
 			c.metrics.RecordWSSubscribe(normalized.Type, "duplicate")
 		}
@@ -221,7 +251,7 @@ func (c *clientConn) subscribe(ctx context.Context, msg clientMessage) {
 		c.sendRaw(ctx, map[string]any{"type": "subscribe:error", "channel": normalized.Channel, "error": "Socket subscription limit reached"})
 		return
 	}
-	unsubscribe, err := c.scheduler.Subscribe(normalized.Channel, msg.Params, func(event realtime.Event) {
+	unsubscribe, err := c.scheduler.Subscribe(normalized.Channel, params, func(event realtime.Event) {
 		c.send(context.Background(), event)
 	})
 	if err != nil {
@@ -231,14 +261,14 @@ func (c *clientConn) subscribe(ctx context.Context, msg clientMessage) {
 		c.sendRaw(ctx, map[string]any{"type": "subscribe:error", "channel": normalized.Channel, "error": err.Error()})
 		return
 	}
-	c.subscriptions[normalized.Channel] = unsubscribe
+	c.subscriptions[key] = unsubscribe
 	if c.metrics != nil {
 		c.metrics.RecordWSSubscribe(normalized.Type, "ok")
 	}
 	c.sendRaw(ctx, map[string]any{"type": "subscribed:ready", "channel": normalized.Channel})
 }
 
-func (c *clientConn) unsubscribe(ctx context.Context, channel string) {
+func (c *clientConn) unsubscribe(ctx context.Context, channel string, params realtime.SubscribeParams) {
 	normalized, err := channels.NormalizeName(channel)
 	if err != nil {
 		if c.metrics != nil {
@@ -246,15 +276,29 @@ func (c *clientConn) unsubscribe(ctx context.Context, channel string) {
 		}
 		return
 	}
-	unsubscribe := c.subscriptions[normalized.Channel]
-	if unsubscribe == nil {
+	key := ""
+	if len(params) > 0 {
+		if candidate := subscriptionKey(normalized.Channel, params); c.subscriptions[candidate] != nil {
+			key = candidate
+		}
+	}
+	if key == "" {
+		for itemKey := range c.subscriptions {
+			if itemKey == normalized.Channel || strings.HasPrefix(itemKey, normalized.Channel+":") {
+				key = itemKey
+				break
+			}
+		}
+	}
+	unsubscribe := c.subscriptions[key]
+	if key == "" || unsubscribe == nil {
 		if c.metrics != nil {
 			c.metrics.RecordWSUnsubscribe(normalized.Type, "invalid")
 		}
 		return
 	}
 	unsubscribe()
-	delete(c.subscriptions, normalized.Channel)
+	delete(c.subscriptions, key)
 	if c.metrics != nil {
 		c.metrics.RecordWSUnsubscribe(normalized.Type, "ok")
 	}
@@ -271,14 +315,69 @@ func (c *clientConn) sendRaw(ctx context.Context, payload any) {
 		return
 	}
 	typ := payloadType(payload)
+	writeCtx := ctx
+	cancel := func() {}
+	if c.writeTimeout > 0 {
+		writeCtx, cancel = context.WithTimeout(ctx, c.writeTimeout)
+	}
+	defer cancel()
 	c.writeMu.Lock()
-	err = c.conn.Write(ctx, websocket.MessageText, data)
+	err = c.conn.Write(writeCtx, websocket.MessageText, data)
 	c.writeMu.Unlock()
 	result := "ok"
 	if err != nil {
 		result = "error"
+		_ = c.conn.Close(websocket.StatusPolicyViolation, "write failed")
 	}
 	c.recordMessage("outbound", typ, result, len(data))
+}
+
+func (c *clientConn) authorizeParams(params realtime.SubscribeParams) (realtime.SubscribeParams, bool) {
+	copied := copyParams(params)
+	if !requiresFlightAwareGrant(copied) {
+		delete(copied, realtimeAuthTokenParam)
+		return copied, true
+	}
+	token, _ := copied[realtimeAuthTokenParam].(string)
+	if !verifyProviderGrant(token, "flightaware", c.authSecret, time.Now()) {
+		return nil, false
+	}
+	delete(copied, realtimeAuthTokenParam)
+	return copied, true
+}
+
+func copyParams(params realtime.SubscribeParams) realtime.SubscribeParams {
+	if len(params) == 0 {
+		return realtime.SubscribeParams{}
+	}
+	copied := make(realtime.SubscribeParams, len(params))
+	for key, value := range params {
+		copied[key] = value
+	}
+	return copied
+}
+
+func requiresFlightAwareGrant(params realtime.SubscribeParams) bool {
+	return readBoolParam(params["flightAware"]) || strings.EqualFold(strings.TrimSpace(fmt.Sprint(params["routeProvider"])), "flightaware")
+}
+
+func readBoolParam(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
+}
+
+func subscriptionKey(channel string, params realtime.SubscribeParams) string {
+	target, err := channels.PollingTarget(channel, params)
+	if err != nil {
+		return channel
+	}
+	return channels.SchedulerKey(channel, target)
 }
 
 func (c *clientConn) recordMessage(direction, typ, result string, bytes int) {

--- a/services/data-service/internal/ws/ws_test.go
+++ b/services/data-service/internal/ws/ws_test.go
@@ -2,10 +2,14 @@ package ws
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,10 +19,21 @@ import (
 )
 
 type fakeScheduler struct {
-	send func(realtime.Event)
+	mu           sync.Mutex
+	send         func(realtime.Event)
+	calls        []fakeSchedulerCall
+	unsubscribes []fakeSchedulerCall
+}
+
+type fakeSchedulerCall struct {
+	channel string
+	params  realtime.SubscribeParams
 }
 
 func (f *fakeScheduler) Subscribe(channel string, params realtime.SubscribeParams, send func(realtime.Event)) (func(), error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, fakeSchedulerCall{channel: channel, params: params})
+	f.mu.Unlock()
 	f.send = send
 	send(realtime.Event{
 		Type:      "aircraft:update",
@@ -27,7 +42,141 @@ func (f *fakeScheduler) Subscribe(channel string, params realtime.SubscribeParam
 		FetchedAt: time.Unix(0, 0).UTC().Format(time.RFC3339),
 		Data:      map[string]any{"ac": []any{}},
 	})
-	return func() {}, nil
+	return func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.unsubscribes = append(f.unsubscribes, fakeSchedulerCall{channel: channel, params: params})
+	}, nil
+}
+
+func (f *fakeScheduler) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func (f *fakeScheduler) snapshotCalls() []fakeSchedulerCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]fakeSchedulerCall(nil), f.calls...)
+}
+
+func (f *fakeScheduler) snapshotUnsubscribes() []fakeSchedulerCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]fakeSchedulerCall(nil), f.unsubscribes...)
+}
+
+func TestFlightAwareSubscribeRequiresProviderGrant(t *testing.T) {
+	scheduler := &fakeScheduler{}
+	handler := NewHandler(scheduler, metrics.New(), nil, WithRealtimeAuthSecret("test-secret"))
+	server := httptest.NewServer(http.HandlerFunc(handler.Handle))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	conn, _, err := websocket.Dial(ctx, url, nil)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer conn.CloseNow()
+	_ = readJSON(t, ctx, conn)
+
+	writeJSON(t, ctx, conn, map[string]any{
+		"type":    "subscribe",
+		"channel": "route:DAL58",
+		"params":  map[string]any{"routeProvider": "flightaware"},
+	})
+	if msg := readJSON(t, ctx, conn); msg["type"] != "subscribe:error" {
+		t.Fatalf("unauthorized subscribe = %#v", msg)
+	}
+	if scheduler.callCount() != 0 {
+		t.Fatalf("unauthorized subscribe reached scheduler: %#v", scheduler.snapshotCalls())
+	}
+
+	token := signTestProviderGrant(t, "flightaware", "test-secret", time.Now().Add(time.Minute))
+	writeJSON(t, ctx, conn, map[string]any{
+		"type":    "subscribe",
+		"channel": "route:DAL58",
+		"params": map[string]any{
+			"routeProvider":      "flightaware",
+			"realtimeAuthToken":  token,
+			"irrelevantMetadata": "kept",
+		},
+	})
+	receivedReady := false
+	for !receivedReady {
+		msg := readJSON(t, ctx, conn)
+		if msg["type"] == "subscribed:ready" {
+			receivedReady = true
+		}
+	}
+	calls := scheduler.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("scheduler calls = %#v", calls)
+	}
+	params := calls[0].params
+	if params["routeProvider"] != "flightaware" || params["realtimeAuthToken"] != nil {
+		t.Fatalf("authorized params = %#v", params)
+	}
+}
+
+func TestSubscriptionKeyIncludesParamSensitiveModes(t *testing.T) {
+	scheduler := &fakeScheduler{}
+	handler := NewHandler(scheduler, metrics.New(), nil, WithRealtimeAuthSecret("test-secret"))
+	server := httptest.NewServer(http.HandlerFunc(handler.Handle))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	conn, _, err := websocket.Dial(ctx, url, nil)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer conn.CloseNow()
+	_ = readJSON(t, ctx, conn)
+
+	writeJSON(t, ctx, conn, map[string]any{
+		"type":    "subscribe",
+		"channel": "route:DAL58",
+		"params":  map[string]any{"routeProvider": "adsbdb"},
+	})
+	token := signTestProviderGrant(t, "flightaware", "test-secret", time.Now().Add(time.Minute))
+	writeJSON(t, ctx, conn, map[string]any{
+		"type":    "subscribe",
+		"channel": "route:DAL58",
+		"params": map[string]any{
+			"routeProvider":     "flightaware",
+			"realtimeAuthToken": token,
+		},
+	})
+
+	for scheduler.callCount() < 2 {
+		_ = readJSON(t, ctx, conn)
+	}
+	calls := scheduler.snapshotCalls()
+	if calls[0].params["routeProvider"] != "adsbdb" ||
+		calls[1].params["routeProvider"] != "flightaware" {
+		t.Fatalf("scheduler calls = %#v", calls)
+	}
+
+	writeJSON(t, ctx, conn, map[string]any{
+		"type":    "unsubscribe",
+		"channel": "route:DAL58",
+		"params":  map[string]any{"routeProvider": "flightaware"},
+	})
+	receivedRemoved := false
+	for !receivedRemoved {
+		if msg := readJSON(t, ctx, conn); msg["type"] == "subscribed:removed" {
+			receivedRemoved = true
+		}
+	}
+	unsubscribes := scheduler.snapshotUnsubscribes()
+	if len(unsubscribes) != 1 || unsubscribes[0].params["routeProvider"] != "flightaware" {
+		t.Fatalf("unsubscribes = %#v", unsubscribes)
+	}
 }
 
 func TestAllowedOriginRules(t *testing.T) {
@@ -47,6 +196,22 @@ func TestAllowedOriginRules(t *testing.T) {
 	if !IsAllowedOrigin("https://staging.example", []string{"https://staging.example"}) {
 		t.Fatal("extra allowed origin should be accepted")
 	}
+}
+
+func signTestProviderGrant(t *testing.T, provider, secret string, expiresAt time.Time) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"provider": provider,
+		"exp":      expiresAt.Unix(),
+	})
+	if err != nil {
+		t.Fatalf("Marshal grant returned error: %v", err)
+	}
+	payloadSegment := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payloadSegment))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return payloadSegment + "." + signature
 }
 
 func TestWebSocketProtocolReadySubscribePingUnsubscribe(t *testing.T) {

--- a/src/app/api/realtime/auth/route.ts
+++ b/src/app/api/realtime/auth/route.ts
@@ -1,0 +1,55 @@
+import { currentUser } from "@clerk/nextjs/server";
+
+import { isFlightAwareEnabledForUser } from "@/features/app-shell/feature-flags/userFeatureFlags.server";
+import { signRealtimeProviderGrant } from "@/lib/realtime/realtimeAuthToken";
+
+const REALTIME_GRANT_TTL_SECONDS = 5 * 60;
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const provider = url.searchParams.get("provider") || "";
+  if (provider.toLowerCase() !== "flightaware") {
+    return Response.json(
+      { error: "Unsupported realtime provider" },
+      { status: 400, headers: noStoreHeaders() },
+    );
+  }
+
+  const secret = process.env.ADSBAO_REALTIME_AUTH_SECRET || "";
+  if (!secret) {
+    return Response.json(
+      { error: "Realtime auth is not configured" },
+      { status: 503, headers: noStoreHeaders() },
+    );
+  }
+
+  const user = await currentUser();
+  const allowed = await isFlightAwareEnabledForUser({ user });
+  if (!allowed) {
+    return Response.json(
+      { error: "FlightAware realtime access is not enabled" },
+      { status: 403, headers: noStoreHeaders() },
+    );
+  }
+
+  const expiresAt = Math.floor(Date.now() / 1000) + REALTIME_GRANT_TTL_SECONDS;
+  const token = signRealtimeProviderGrant({
+    provider: "flightaware",
+    secret,
+    expiresAt,
+  });
+
+  return Response.json(
+    { provider: "flightaware", token, expiresAt },
+    { headers: noStoreHeaders() },
+  );
+}
+
+function noStoreHeaders() {
+  return {
+    "Cache-Control": "no-store",
+  };
+}

--- a/src/lib/realtime/adsbaoRealtimeClient.test.ts
+++ b/src/lib/realtime/adsbaoRealtimeClient.test.ts
@@ -190,4 +190,105 @@ function createTimerHost() {
   assert.equal(timers.timeoutCount, 0);
 }
 
+{
+  FakeSocket.instances = [];
+  const timers = createTimerHost();
+  const tokenProviders: string[] = [];
+  const client = new AdsbaoRealtimeClient("ws://example.test/ws", {
+    WebSocketCtor: FakeSocket as any,
+    timerHost: timers.host as any,
+    heartbeatIntervalMs: 0,
+    authTokenFetcher: async (provider) => {
+      tokenProviders.push(provider);
+      return "signed-flightaware-grant";
+    },
+  });
+
+  client.subscribe({
+    channel: "route:DAL58",
+    params: { routeProvider: "adsbdb" },
+    listener: () => {},
+  });
+  const unsubscribeFlightAware = client.subscribe({
+    channel: "route:DAL58",
+    params: { routeProvider: "flightaware" },
+    listener: () => {},
+  });
+  const socket = FakeSocket.instances[0];
+  socket.open();
+  for (let i = 0; i < 4 && socket.sent.length < 2; i += 1) {
+    await Promise.resolve();
+  }
+
+  assert.deepEqual(socket.sent.map((payload) => JSON.parse(payload)), [
+    {
+      type: "subscribe",
+      channel: "route:DAL58",
+      params: { routeProvider: "adsbdb" },
+    },
+    {
+      type: "subscribe",
+      channel: "route:DAL58",
+      params: {
+        routeProvider: "flightaware",
+        realtimeAuthToken: "signed-flightaware-grant",
+      },
+    },
+  ]);
+  assert.deepEqual(tokenProviders, ["flightaware"]);
+
+  unsubscribeFlightAware();
+  assert.deepEqual(JSON.parse(socket.sent.at(-1) || "{}"), {
+    type: "unsubscribe",
+    channel: "route:DAL58",
+    params: { routeProvider: "flightaware" },
+  });
+}
+
+{
+  FakeSocket.instances = [];
+  const timers = createTimerHost();
+  const received: string[] = [];
+  const client = new AdsbaoRealtimeClient("ws://example.test/ws", {
+    WebSocketCtor: FakeSocket as any,
+    timerHost: timers.host as any,
+    heartbeatIntervalMs: 0,
+    authTokenFetcher: async () => "signed-flightaware-grant",
+  });
+
+  client.subscribe({
+    channel: "route:DAL58",
+    params: { routeProvider: "adsbdb" },
+    listener: () => received.push("adsbdb"),
+  });
+  client.subscribe({
+    channel: "route:DAL58",
+    params: { routeProvider: "flightaware" },
+    listener: () => received.push("flightaware"),
+  });
+  const socket = FakeSocket.instances[0];
+  socket.open();
+  for (let i = 0; i < 4 && socket.sent.length < 2; i += 1) {
+    await Promise.resolve();
+  }
+
+  socket.message({
+    type: "route:update",
+    channel: "route:DAL58",
+    source: "adsbdb",
+    fetchedAt: new Date().toISOString(),
+    stale: false,
+    data: {},
+  });
+  socket.message({
+    type: "route:update",
+    channel: "route:DAL58",
+    source: "flightaware",
+    fetchedAt: new Date().toISOString(),
+    stale: false,
+    data: {},
+  });
+  assert.deepEqual(received, ["adsbdb", "flightaware"]);
+}
+
 console.log("adsbaoRealtimeClient.test.ts ok");

--- a/src/lib/realtime/adsbaoRealtimeClient.ts
+++ b/src/lib/realtime/adsbaoRealtimeClient.ts
@@ -58,6 +58,7 @@ type AdsbaoRealtimeClientOptions = {
   reconnectMaxDelayMs?: number;
   heartbeatIntervalMs?: number;
   heartbeatTimeoutMs?: number;
+  authTokenFetcher?: RealtimeAuthTokenFetcher | null;
 };
 
 declare global {
@@ -65,6 +66,8 @@ declare global {
     __adsbaoRealtimeDebug?: Record<string, unknown>;
   }
 }
+
+type RealtimeAuthTokenFetcher = (provider: string) => Promise<string>;
 
 function resolveRealtimeUrl() {
   if (typeof document !== "undefined") {
@@ -101,6 +104,43 @@ function resolveDocumentHost(): RealtimeDocumentHost | null {
   return typeof document !== "undefined" ? document : null;
 }
 
+async function fetchRealtimeAuthToken(provider: string) {
+  const response = await fetch(
+    `/api/realtime/auth?provider=${encodeURIComponent(provider)}`,
+    {
+      cache: "no-store",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Realtime auth failed (${response.status})`);
+  }
+  const payload = await response.json();
+  const token = String(payload?.token || "");
+  if (!token) throw new Error("Realtime auth response omitted token");
+  return token;
+}
+
+function realtimeSubscriptionKey(channel: string, params?: Record<string, unknown>) {
+  return `${channel}|${JSON.stringify(params || {})}`;
+}
+
+function flightAwareProviderFromParams(params?: Record<string, unknown>) {
+  if (!params) return "";
+  const routeProvider = String(params.routeProvider || "").trim().toLowerCase();
+  if (routeProvider === "flightaware") return "flightaware";
+  if (params.flightAware === true || String(params.flightAware || "").toLowerCase() === "true") {
+    return "flightaware";
+  }
+  return "";
+}
+
+function routeProviderFromParams(params?: Record<string, unknown>) {
+  const provider = String(params?.routeProvider || "").trim().toLowerCase();
+  return provider === "flightaware" || provider === "adsbdb" ? provider : "";
+}
+
 export class AdsbaoRealtimeClient {
   private readonly url: string;
   private readonly WebSocketCtor: RealtimeSocketConstructor | null;
@@ -110,6 +150,7 @@ export class AdsbaoRealtimeClient {
   private readonly reconnectMaxDelayMs: number;
   private readonly heartbeatIntervalMs: number;
   private readonly heartbeatTimeoutMs: number;
+  private readonly authTokenFetcher: RealtimeAuthTokenFetcher | null;
   private socket: RealtimeSocket | null = null;
   private connectionState: ConnectionState;
   private reconnectTimer: number | null = null;
@@ -139,6 +180,10 @@ export class AdsbaoRealtimeClient {
     this.reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? 30_000;
     this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? 25_000;
     this.heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? 10_000;
+    this.authTokenFetcher =
+      options.authTokenFetcher === undefined
+        ? fetchRealtimeAuthToken
+        : options.authTokenFetcher;
     this.connectionState = url ? "closed" : "disabled";
     this.installLifecycleReconnectHandlers();
     this.syncDebug({
@@ -220,7 +265,7 @@ export class AdsbaoRealtimeClient {
     listener,
   }: RealtimeSubscription): () => void {
     if (!channel) return () => {};
-    const key = channel;
+    const key = realtimeSubscriptionKey(channel, params);
     const existing = this.subscriptions.get(key);
     if (existing) {
       existing.listeners.add(listener);
@@ -239,11 +284,7 @@ export class AdsbaoRealtimeClient {
     });
     this.connect();
     if (!existing) {
-      this.send({
-        type: "subscribe",
-        channel,
-        params,
-      });
+      this.sendSubscribe({ channel, params });
     }
     return () => {
       const current = this.subscriptions.get(key);
@@ -256,7 +297,7 @@ export class AdsbaoRealtimeClient {
           lastUnsubscribeChannel: channel,
           subscriptionCount: this.subscriptions.size,
         });
-        this.send({ type: "unsubscribe", channel });
+        this.send({ type: "unsubscribe", channel, params: current.params });
         if (this.subscriptions.size === 0) {
           this.disconnect();
         }
@@ -283,11 +324,7 @@ export class AdsbaoRealtimeClient {
   }
 
   private send(payload: unknown) {
-    if (
-      !this.socket ||
-      !this.WebSocketCtor ||
-      this.socket.readyState !== this.WebSocketCtor.OPEN
-    ) {
+    if (!this.canSend()) {
       return;
     }
     this.socket.send(JSON.stringify(payload));
@@ -295,12 +332,68 @@ export class AdsbaoRealtimeClient {
 
   private resubscribeAll() {
     for (const subscription of this.subscriptions.values()) {
+      this.sendSubscribe(subscription);
+    }
+  }
+
+  private sendSubscribe(subscription: Pick<StoredRealtimeSubscription, "channel" | "params">) {
+    if (!this.canSend()) return;
+    const provider = flightAwareProviderFromParams(subscription.params);
+    if (!provider) {
       this.send({
         type: "subscribe",
         channel: subscription.channel,
         params: subscription.params,
       });
+      return;
     }
+    void this.sendAuthenticatedSubscribe(subscription, provider);
+  }
+
+  private async sendAuthenticatedSubscribe(
+    subscription: Pick<StoredRealtimeSubscription, "channel" | "params">,
+    provider: string,
+  ) {
+    const params = await this.withAuthParams(subscription.params, provider);
+    if (!this.hasActiveSubscription(subscription.channel, subscription.params)) return;
+    this.send({
+      type: "subscribe",
+      channel: subscription.channel,
+      params,
+    });
+  }
+
+  private async withAuthParams(params: Record<string, unknown> | undefined, provider: string) {
+    try {
+      if (!this.authTokenFetcher) {
+        throw new Error("Realtime auth token fetcher is not configured");
+      }
+      const token = await this.authTokenFetcher(provider);
+      return {
+        ...(params || {}),
+        realtimeAuthToken: token,
+      };
+    } catch (error) {
+      this.syncDebug({
+        lastAuthErrorAt: new Date().toISOString(),
+        lastAuthProvider: provider,
+        lastAuthError:
+          error instanceof Error ? error.message : String(error || "unknown"),
+      });
+      return params;
+    }
+  }
+
+  private hasActiveSubscription(channel: string, params?: Record<string, unknown>) {
+    return this.subscriptions.has(realtimeSubscriptionKey(channel, params));
+  }
+
+  private canSend() {
+    return Boolean(
+      this.socket &&
+        this.WebSocketCtor &&
+        this.socket.readyState === this.WebSocketCtor.OPEN,
+    );
   }
 
   private scheduleReconnect() {
@@ -345,8 +438,21 @@ export class AdsbaoRealtimeClient {
     });
 
     for (const listener of this.listeners) listener(event);
-    const subscription = this.subscriptions.get(event.channel);
-    for (const listener of subscription?.listeners || []) listener(event);
+    for (const subscription of this.subscriptions.values()) {
+      if (!this.subscriptionMatchesEvent(subscription, event)) continue;
+      for (const listener of subscription.listeners) listener(event);
+    }
+  }
+
+  private subscriptionMatchesEvent(
+    subscription: StoredRealtimeSubscription,
+    event: AdsbaoRealtimeEvent,
+  ) {
+    if (subscription.channel !== event.channel) return false;
+    if (event.type !== "route:update") return true;
+    const provider = routeProviderFromParams(subscription.params);
+    if (!provider || !event.source) return true;
+    return provider === String(event.source).trim().toLowerCase();
   }
 
   private syncDebug(next: Record<string, unknown>) {

--- a/src/lib/realtime/realtimeAuthToken.test.ts
+++ b/src/lib/realtime/realtimeAuthToken.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+
+import { signRealtimeProviderGrant } from "./realtimeAuthToken";
+
+function decodeBase64Url(segment: string) {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+}
+
+{
+  const token = signRealtimeProviderGrant({
+    provider: "flightaware",
+    secret: "test-secret",
+    expiresAt: 1_800,
+  });
+  const [payloadSegment, signatureSegment] = token.split(".");
+  assert.ok(payloadSegment);
+  assert.ok(signatureSegment);
+  assert.deepEqual(decodeBase64Url(payloadSegment), {
+    provider: "flightaware",
+    exp: 1_800,
+  });
+
+  const expectedSignature = createHmac("sha256", "test-secret")
+    .update(payloadSegment)
+    .digest("base64url");
+  assert.equal(signatureSegment, expectedSignature);
+}
+
+assert.throws(
+  () =>
+    signRealtimeProviderGrant({
+      provider: "adsbdb",
+      secret: "test-secret",
+      expiresAt: 1_800,
+    }),
+  /Unsupported realtime provider/,
+);
+
+assert.throws(
+  () =>
+    signRealtimeProviderGrant({
+      provider: "flightaware",
+      secret: "",
+      expiresAt: 1_800,
+    }),
+  /Realtime auth secret is not configured/,
+);
+
+console.log("realtimeAuthToken.test.ts ok");

--- a/src/lib/realtime/realtimeAuthToken.ts
+++ b/src/lib/realtime/realtimeAuthToken.ts
@@ -1,0 +1,37 @@
+import { createHmac } from "node:crypto";
+
+const SUPPORTED_REALTIME_PROVIDERS = new Set(["flightaware"]);
+
+export function signRealtimeProviderGrant({
+  provider,
+  secret,
+  expiresAt,
+}: {
+  provider: unknown;
+  secret: unknown;
+  expiresAt: unknown;
+}) {
+  const normalizedProvider = String(provider || "").trim().toLowerCase();
+  const normalizedSecret = String(secret || "").trim();
+  const exp = Number(expiresAt);
+  if (!SUPPORTED_REALTIME_PROVIDERS.has(normalizedProvider)) {
+    throw new Error("Unsupported realtime provider");
+  }
+  if (!normalizedSecret) {
+    throw new Error("Realtime auth secret is not configured");
+  }
+  if (!Number.isFinite(exp) || exp <= 0) {
+    throw new Error("Realtime auth expiry is invalid");
+  }
+
+  const payloadSegment = Buffer.from(
+    JSON.stringify({
+      provider: normalizedProvider,
+      exp: Math.floor(exp),
+    }),
+  ).toString("base64url");
+  const signatureSegment = createHmac("sha256", normalizedSecret)
+    .update(payloadSegment)
+    .digest("base64url");
+  return `${payloadSegment}.${signatureSegment}`;
+}


### PR DESCRIPTION
## Summary
- require signed realtime provider grants before Go data-service accepts FlightAware realtime subscriptions
- add WS write timeouts, param-sensitive subscription keys, and FlightAware route airport-directory fallback
- keep Grafana dynamic gauges visible at zero and document Railway/Vercel env requirements

## Required deploy config
- Set the same `ADSBAO_REALTIME_AUTH_SECRET` value in Vercel and the Railway data-service before relying on FlightAware realtime subscriptions.

## Validation
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./cmd/adsbao-data-service`
- `pnpm exec tsx src/lib/realtime/adsbaoRealtimeClient.test.ts`
- `pnpm exec tsx src/lib/realtime/realtimeAuthToken.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
