### PR TITLE
[codex] Reduce provider error rate

### DIFF
--- a/services/data-service/internal/providers/adsb/client.go
+++ b/services/data-service/internal/providers/adsb/client.go
@@ -9,16 +9,19 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/adsbao/adsbao/services/data-service/internal/realtime"
 )
 
 const (
-	defaultTimeout = 2800 * time.Millisecond
-	maxBodyBytes   = 2 * 1024 * 1024
-	userAgent      = "ADSBao data-service/1.0 (+https://adsbao.dev)"
+	defaultTimeout          = 2800 * time.Millisecond
+	defaultProviderCooldown = time.Minute
+	maxBodyBytes            = 2 * 1024 * 1024
+	userAgent               = "ADSBao data-service/1.0 (+https://adsbao.dev)"
 )
 
 type URLBuilder func(string) string
@@ -38,6 +41,8 @@ type Options struct {
 	Providers           []Provider
 	Timeout             time.Duration
 	MaxBytes            int64
+	ProviderCooldown    time.Duration
+	Now                 func() time.Time
 	FlightAwareFallback func(context.Context, string, realtime.MetricsSink) (FallbackResult, error)
 }
 
@@ -46,7 +51,11 @@ type Client struct {
 	providers           []Provider
 	timeout             time.Duration
 	maxBytes            int64
+	providerCooldown    time.Duration
+	now                 func() time.Time
 	flightAwareFallback func(context.Context, string, realtime.MetricsSink) (FallbackResult, error)
+	mu                  sync.Mutex
+	cooldowns           map[string]time.Time
 }
 
 type FallbackResult struct {
@@ -86,6 +95,14 @@ func NewClient(options Options) *Client {
 	if maxBytes <= 0 {
 		maxBytes = maxBodyBytes
 	}
+	providerCooldown := options.ProviderCooldown
+	if providerCooldown <= 0 {
+		providerCooldown = defaultProviderCooldown
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
 	httpClient := options.HTTPClient
 	if httpClient == nil {
 		httpClient = &http.Client{}
@@ -95,7 +112,10 @@ func NewClient(options Options) *Client {
 		providers:           providers,
 		timeout:             timeout,
 		maxBytes:            maxBytes,
+		providerCooldown:    providerCooldown,
+		now:                 now,
 		flightAwareFallback: options.FlightAwareFallback,
+		cooldowns:           map[string]time.Time{},
 	}
 }
 
@@ -225,6 +245,10 @@ func (c *Client) fetchWithFallback(ctx context.Context, input realtime.FetchInpu
 	var lastRetryable *providerResult
 	var failures []error
 	for _, provider := range c.providers {
+		if c.providerInCooldown(provider.ID, endpoint) {
+			attempts = append(attempts, provider.ID+":cooldown")
+			continue
+		}
 		requestURL, ok := buildURL(provider)
 		if !ok {
 			continue
@@ -238,8 +262,10 @@ func (c *Client) fetchWithFallback(ctx context.Context, input realtime.FetchInpu
 			}
 			attempts = append(attempts, provider.ID+":"+status)
 			failures = append(failures, err)
+			c.recordProviderFailure(provider.ID, endpoint, err)
 			continue
 		}
+		c.recordProviderSuccess(provider.ID, endpoint)
 		attempts = append(attempts, provider.ID+":200")
 		result := providerResult{provider: provider, payload: payload, attempts: append([]string{}, attempts...)}
 		if retryEmpty && isEmptyAircraftPayload(payload) {
@@ -253,6 +279,59 @@ func (c *Client) fetchWithFallback(ctx context.Context, input realtime.FetchInpu
 		return *lastRetryable, nil
 	}
 	return providerResult{}, fmt.Errorf("all ADS-B providers failed: %v", failures)
+}
+
+func (c *Client) providerInCooldown(providerID, endpoint string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := providerCooldownKey(providerID, endpoint)
+	expiresAt, ok := c.cooldowns[key]
+	if !ok {
+		return false
+	}
+	if c.now().Before(expiresAt) {
+		return true
+	}
+	delete(c.cooldowns, key)
+	return false
+}
+
+func (c *Client) recordProviderFailure(providerID, endpoint string, err error) {
+	if !shouldCooldownProviderError(err) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cooldowns[providerCooldownKey(providerID, endpoint)] = c.now().Add(c.providerCooldown)
+}
+
+func (c *Client) recordProviderSuccess(providerID, endpoint string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.cooldowns, providerCooldownKey(providerID, endpoint))
+}
+
+func providerCooldownKey(providerID, endpoint string) string {
+	return strings.ToLower(strings.TrimSpace(providerID)) + "|" + strings.ToLower(strings.TrimSpace(endpoint))
+}
+
+func shouldCooldownProviderError(err error) bool {
+	var providerErr providerError
+	if !errors.As(err, &providerErr) {
+		return true
+	}
+	statusText := strings.TrimSpace(fmt.Sprint(providerErr.status))
+	if statusText == "" {
+		return true
+	}
+	if statusText == "ERR" || statusText == "PARSE" || statusText == "SHAPE" || statusText == "SIZE" {
+		return true
+	}
+	statusCode, parseErr := strconv.Atoi(statusText)
+	if parseErr != nil {
+		return true
+	}
+	return statusCode == http.StatusTooManyRequests || statusCode >= 500
 }
 
 func (c *Client) fetchProviderPayload(ctx context.Context, input realtime.FetchInput, provider Provider, endpoint, requestURL string) (map[string]any, error) {

--- a/services/data-service/internal/providers/adsb/client_test.go
+++ b/services/data-service/internal/providers/adsb/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/adsbao/adsbao/services/data-service/internal/realtime"
 )
@@ -103,5 +104,76 @@ func TestCallsignCanUseFlightAwareFallbackAfterEmptyADSB(t *testing.T) {
 	aircraft := ac[0].(map[string]any)
 	if aircraft["flight_position_source"] != "flightaware" || aircraft["lat"] != 49.05 {
 		t.Fatalf("aircraft = %#v", aircraft)
+	}
+}
+
+func TestPositionProviderCooldownSkipsRecentlyFailingProvider(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	var adsbLolRequests int
+	var airplanesRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/adsb-lol/"):
+			adsbLolRequests++
+			if adsbLolRequests == 1 {
+				http.Error(w, "limited", http.StatusTooManyRequests)
+				return
+			}
+			_, _ = w.Write([]byte(`{"ac":[{"hex":"a1","flight":"AAL100  ","lat":42.1,"lon":-71.1}]}`))
+		case strings.Contains(r.URL.Path, "/airplanes/"):
+			airplanesRequests++
+			_, _ = w.Write([]byte(`{"ac":[{"hex":"b2","flight":"DAL200  ","lat":42.2,"lon":-71.2}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Options{
+		Providers: []Provider{
+			{ID: "adsb.lol", PositionURL: func(lat, lon float64, distNM int) string { return server.URL + "/adsb-lol/positions" }},
+			{ID: "airplanes.live", PositionURL: func(lat, lon float64, distNM int) string { return server.URL + "/airplanes/positions" }},
+		},
+		ProviderCooldown: time.Minute,
+		Now:              func() time.Time { return now },
+	})
+	input := realtime.FetchInput{
+		Channel:     "traffic:center:42.4:-71:40",
+		ChannelType: realtime.ChannelTraffic,
+		Target: realtime.PollingTarget{
+			Kind:   "positions",
+			Lat:    42.4,
+			Lon:    -71,
+			DistNM: 40,
+		},
+	}
+
+	first, err := client.Fetch(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first Fetch returned error: %v", err)
+	}
+	if first.Source != "airplanes.live" || adsbLolRequests != 1 || airplanesRequests != 1 {
+		t.Fatalf("first source=%q adsb=%d airplanes=%d", first.Source, adsbLolRequests, airplanesRequests)
+	}
+
+	second, err := client.Fetch(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second Fetch returned error: %v", err)
+	}
+	if second.Source != "airplanes.live" || adsbLolRequests != 1 || airplanesRequests != 2 {
+		t.Fatalf("cooldown source=%q adsb=%d airplanes=%d", second.Source, adsbLolRequests, airplanesRequests)
+	}
+	secondAttempts := second.Data.(map[string]any)["attempts"].([]string)
+	if len(secondAttempts) != 2 || secondAttempts[0] != "adsb.lol:cooldown" || secondAttempts[1] != "airplanes.live:200" {
+		t.Fatalf("cooldown attempts = %#v", secondAttempts)
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	third, err := client.Fetch(context.Background(), input)
+	if err != nil {
+		t.Fatalf("third Fetch returned error: %v", err)
+	}
+	if third.Source != "adsb.lol" || adsbLolRequests != 2 || airplanesRequests != 2 {
+		t.Fatalf("recovery source=%q adsb=%d airplanes=%d", third.Source, adsbLolRequests, airplanesRequests)
 	}
 }

--- a/services/data-service/internal/providers/route/client.go
+++ b/services/data-service/internal/providers/route/client.go
@@ -26,6 +26,7 @@ const (
 	defaultTimeout           = 9 * time.Second
 	defaultMaxBytes          = 2 * 1024 * 1024
 	defaultQueueInterval     = 500 * time.Millisecond
+	defaultFlightAwareSlots  = 3
 	userAgent                = "ADSBao data-service/1.0 (+https://adsbao.dev)"
 	flightAwareRouteUA       = "ADSBao data-service/1.0 (+https://adsbao.dev; flightaware/html)"
 	flightAwareLogoURLFormat = "https://www.flightaware.com/images/airline_logos/90p/%s.png"
@@ -39,6 +40,7 @@ type Options struct {
 	Timeout                 time.Duration
 	MaxBytes                int64
 	QueueInterval           time.Duration
+	FlightAwareConcurrency  int
 	DisableQueue            bool
 }
 
@@ -50,6 +52,7 @@ type Client struct {
 	timeout                 time.Duration
 	maxBytes                int64
 	queueInterval           time.Duration
+	flightAwareSlots        chan struct{}
 	mu                      sync.Mutex
 	lastStarted             time.Time
 }
@@ -83,6 +86,10 @@ func NewClient(options Options) *Client {
 	if queueInterval == 0 && !options.DisableQueue {
 		queueInterval = defaultQueueInterval
 	}
+	flightAwareConcurrency := options.FlightAwareConcurrency
+	if flightAwareConcurrency <= 0 {
+		flightAwareConcurrency = defaultFlightAwareSlots
+	}
 	return &Client{
 		httpClient:              httpClient,
 		adsbdbBaseURL:           adsbdbBase,
@@ -91,6 +98,7 @@ func NewClient(options Options) *Client {
 		timeout:                 timeout,
 		maxBytes:                maxBytes,
 		queueInterval:           queueInterval,
+		flightAwareSlots:        make(chan struct{}, flightAwareConcurrency),
 	}
 }
 
@@ -142,9 +150,11 @@ func (c *Client) fetchADSBDB(ctx context.Context, input realtime.FetchInput) (re
 }
 
 func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput) (realtime.Event, error) {
-	if err := c.waitForTurn(ctx); err != nil {
+	release, err := c.acquireFlightAwareSlot(ctx)
+	if err != nil {
 		return realtime.Event{}, err
 	}
+	defer release()
 	requestURL := c.flightAwareURL(input.Target.Callsign)
 	if requestURL == "" {
 		return realtime.Event{}, errors.New("Invalid FlightAware route callsign")
@@ -174,6 +184,18 @@ func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput
 	}
 	c.recordExternal(input, "flightaware", "success", status, started)
 	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, c.normalizeFlightAwareRoute(ctx, input, string(body))), nil
+}
+
+func (c *Client) acquireFlightAwareSlot(ctx context.Context) (func(), error) {
+	if c.flightAwareSlots == nil {
+		return func() {}, nil
+	}
+	select {
+	case c.flightAwareSlots <- struct{}{}:
+		return func() { <-c.flightAwareSlots }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (c *Client) do(ctx context.Context, requestURL, accept, ua string) (*http.Response, context.CancelFunc, error) {
@@ -266,9 +288,94 @@ func routeEvent(channel, source, callsign string, route map[string]any) realtime
 		Stale:     false,
 		Data: map[string]any{
 			"callsign": callsign,
-			"route":    route,
+			"route":    compactRoutePayload(route),
 		},
 	}
+}
+
+func compactRoutePayload(route map[string]any) map[string]any {
+	if route == nil {
+		return nil
+	}
+	origin := compactAirportPayload(asMap(route["origin"]))
+	destination := compactAirportPayload(asMap(route["destination"]))
+	if origin == nil || destination == nil {
+		return nil
+	}
+	airlineRaw := asMap(route["airline"])
+	out := map[string]any{
+		"origin":      origin,
+		"destination": destination,
+	}
+	if callsign := firstNonEmpty(upper(route["callsign"]), upper(route["callsignIcao"]), upper(route["callsign_icao"])); callsign != "" {
+		out["callsign"] = callsign
+	}
+	if callsignICAO := firstNonEmpty(upper(route["callsignIcao"]), upper(route["callsign_icao"]), upper(route["callsign"])); callsignICAO != "" {
+		out["callsignIcao"] = callsignICAO
+	}
+	if callsignIata := firstNonEmpty(upper(route["callsignIata"]), upper(route["callsign_iata"])); callsignIata != "" {
+		out["callsignIata"] = callsignIata
+	}
+	if airlineICAO := firstNonEmpty(code(route["airlineIcao"], 2, 3), code(airlineRaw["icao"], 2, 3)); airlineICAO != "" {
+		out["airlineIcao"] = airlineICAO
+	}
+	if airlineIATA := firstNonEmpty(code(route["airlineIata"], 2, 2), code(airlineRaw["iata"], 2, 2)); airlineIATA != "" {
+		out["airlineIata"] = airlineIATA
+	}
+	if routeCodes := compactRouteCodes(asMap(route["route"])); routeCodes != nil {
+		out["route"] = routeCodes
+	}
+	if source := clean(route["source"]); source != "" {
+		out["source"] = source
+	}
+	if confidence := clean(route["confidence"]); confidence != "" {
+		out["confidence"] = confidence
+	}
+	for _, key := range []string{"temporary", "displaySuffix", "expiresAt", "feedbackReason"} {
+		if value, ok := route[key]; ok && value != nil {
+			if text, ok := value.(string); ok && strings.TrimSpace(text) == "" {
+				continue
+			}
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func compactAirportPayload(airport map[string]any) map[string]any {
+	if airport == nil {
+		return nil
+	}
+	icao := code(firstNonEmpty(airport["icao"], airport["icao_code"]), 3, 4)
+	iata := code(firstNonEmpty(airport["iata"], airport["iata_code"]), 3, 3)
+	lat, latOK := number(firstNonEmpty(airport["lat"], airport["latitude"]))
+	lon, lonOK := number(firstNonEmpty(airport["lon"], airport["longitude"]))
+	if icao == "" || !latOK || !lonOK {
+		return nil
+	}
+	out := map[string]any{
+		"icao": icao,
+		"lat":  lat,
+		"lon":  lon,
+	}
+	if iata != "" {
+		out["iata"] = iata
+	}
+	return out
+}
+
+func compactRouteCodes(route map[string]any) map[string]any {
+	out := map[string]any{}
+	if icao := upper(route["icao"]); icao != "" {
+		out["icao"] = icao
+	}
+	if iata := upper(route["iata"]); iata != "" {
+		out["iata"] = iata
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func normalizeADSBDBRoute(callsign string, payload map[string]any) map[string]any {

--- a/services/data-service/internal/providers/route/client_test.go
+++ b/services/data-service/internal/providers/route/client_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -194,5 +196,158 @@ func TestFlightAwareRouteAllowsLargeHTMLPage(t *testing.T) {
 	routeCodes := route["route"].(map[string]any)
 	if routeCodes["icao"] != "KBOS-KJFK" {
 		t.Fatalf("route = %#v", route)
+	}
+}
+
+func TestFlightAwareRouteRequestsStartInParallel(t *testing.T) {
+	started := make(chan string, 3)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAll := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	var active atomic.Int64
+	var maxActive atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := active.Add(1)
+		for {
+			peak := maxActive.Load()
+			if current <= peak || maxActive.CompareAndSwap(peak, current) {
+				break
+			}
+		}
+		started <- r.URL.Path
+		defer active.Add(-1)
+		<-release
+		_, _ = w.Write([]byte(`
+			<html>
+				<head>
+					<title>AA1234 (AAL1234) American Airlines Flight Tracking</title>
+					<meta name="origin" content="KBOS">
+					<meta name="destination" content="KLAX">
+					<meta name="airline" content="AAL">
+					<meta name="description" content="Track American Airlines (AA) #1234">
+				</head>
+				<body>
+					<script>
+						var trackpollBootstrap = {"flights":{"AAL1234":{
+							"origin":{"icao":"KBOS","iata":"BOS","coord":[-71.0096,42.3656],"friendlyName":"Boston Logan","friendlyLocation":"Boston, MA"},
+							"destination":{"icao":"KLAX","iata":"LAX","coord":[-118.4085,33.9416],"friendlyName":"Los Angeles Intl","friendlyLocation":"Los Angeles, CA"}
+						}}};
+					</script>
+				</body>
+			</html>
+		`))
+	}))
+	defer func() {
+		releaseAll()
+		server.Close()
+	}()
+
+	client := NewClient(Options{
+		FlightAwareBase: server.URL + "/live/flight",
+		QueueInterval:   150 * time.Millisecond,
+	})
+	var wg sync.WaitGroup
+	for _, callsign := range []string{"AAL1234", "AAL1235"} {
+		wg.Add(1)
+		go func(callsign string) {
+			defer wg.Done()
+			_, _ = client.Fetch(context.Background(), realtime.FetchInput{
+				Channel:     "route:" + callsign + ":airport:KBOS",
+				ChannelType: realtime.ChannelRoute,
+				Target: realtime.PollingTarget{
+					Kind:          "route",
+					Callsign:      callsign,
+					RouteProvider: "flightaware",
+					RouteContext:  &realtime.RouteContext{Type: "airport", ICAO: "KBOS"},
+				},
+			})
+		}(callsign)
+	}
+
+	waitStartedPath(t, started, 250*time.Millisecond)
+	waitStartedPath(t, started, 75*time.Millisecond)
+	if maxActive.Load() < 2 {
+		t.Fatalf("FlightAware route fetches did not overlap; max active = %d", maxActive.Load())
+	}
+	releaseAll()
+	wg.Wait()
+}
+
+func TestRouteEventCompactsRealtimeRoutePayload(t *testing.T) {
+	event := routeEvent("route:AAL1234:airport:KBOS", "flightaware", "AAL1234", map[string]any{
+		"callsign":     "AAL1234",
+		"callsignIcao": "AAL1234",
+		"callsignIata": "AA1234",
+		"number":       "1234",
+		"airline": map[string]any{
+			"icao":     "AAL",
+			"iata":     "AA",
+			"name":     "American Airlines",
+			"callsign": "",
+			"iconUrl":  "https://www.flightaware.com/images/airline_logos/90p/AAL.png",
+		},
+		"origin": map[string]any{
+			"icao":         "KBOS",
+			"iata":         "BOS",
+			"name":         "Boston Logan",
+			"municipality": "Boston",
+			"country":      "US",
+			"lat":          42.3656,
+			"lon":          -71.0096,
+		},
+		"destination": map[string]any{
+			"icao":         "KLAX",
+			"iata":         "LAX",
+			"name":         "Los Angeles Intl",
+			"municipality": "Los Angeles",
+			"country":      "US",
+			"lat":          33.9416,
+			"lon":          -118.4085,
+		},
+		"route":      map[string]any{"icao": "KBOS-KLAX", "iata": "BOS-LAX"},
+		"airports":   []any{map[string]any{"icao": "KBOS"}, map[string]any{"icao": "KLAX"}},
+		"source":     "flightaware",
+		"confidence": "scraped-reference",
+	})
+	data := event.Data.(map[string]any)
+	route := data["route"].(map[string]any)
+
+	if _, ok := route["airports"]; ok {
+		t.Fatalf("compact route should omit airports duplication: %#v", route)
+	}
+	if _, ok := route["airline"]; ok {
+		t.Fatalf("compact route should omit nested airline object: %#v", route)
+	}
+	if route["airlineIcao"] != "AAL" {
+		t.Fatalf("airlineIcao = %#v", route["airlineIcao"])
+	}
+	origin := route["origin"].(map[string]any)
+	destination := route["destination"].(map[string]any)
+	for _, airport := range []map[string]any{origin, destination} {
+		for _, key := range []string{"name", "municipality", "country"} {
+			if _, ok := airport[key]; ok {
+				t.Fatalf("compact airport should omit %s: %#v", key, airport)
+			}
+		}
+	}
+	if origin["icao"] != "KBOS" || origin["iata"] != "BOS" || origin["lat"] != 42.3656 || origin["lon"] != -71.0096 {
+		t.Fatalf("origin = %#v", origin)
+	}
+	if destination["icao"] != "KLAX" || destination["iata"] != "LAX" || destination["lat"] != 33.9416 || destination["lon"] != -118.4085 {
+		t.Fatalf("destination = %#v", destination)
+	}
+}
+
+func waitStartedPath(t *testing.T, started <-chan string, timeout time.Duration) string {
+	t.Helper()
+	select {
+	case path := <-started:
+		return path
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for parallel FlightAware route request to start")
+		return ""
 	}
 }

--- a/src/app/api/proxy/flight-routes/callsign/[callsign]/route.ts
+++ b/src/app/api/proxy/flight-routes/callsign/[callsign]/route.ts
@@ -9,6 +9,7 @@ import { normalizeRouteCallsign } from "@/features/aviation/flight-routes/flight
 import {
   ROUTE_MISS_STATUS,
   buildRouteCacheHeaders,
+  compactFlightRoutePayload,
 } from "@/features/aviation/flight-routes/flightRoutes.models";
 import { resolveFlightRoute } from "@/features/aviation/flight-routes/flightRoutes.mechanism";
 
@@ -45,10 +46,11 @@ export async function GET(request, { params }) {
       .trim()
       .toLowerCase();
     const providerSpecificRequest = requestedProvider === "flightaware";
-    const body = await resolveFlightRoute({
+    const resolvedRoute = await resolveFlightRoute({
       callsign,
       requestedProvider,
     });
+    const body = compactFlightRoutePayload(resolvedRoute);
 
     return logProxyRouteResponse({
       request,

--- a/src/features/aviation/aviationServiceModel.test.ts
+++ b/src/features/aviation/aviationServiceModel.test.ts
@@ -49,6 +49,33 @@ import { normalizeLocalWeather } from "../weather/localWeatherNormalizer";
 }
 
 {
+  const route = normalizeFlightRoute({
+    callsign: " aal1234 ",
+    callsignIata: "aa1234",
+    airlineIcao: "aal",
+    airlineIata: "aa",
+    origin: {
+      icao: "kbos",
+      iata: "bos",
+      lat: 42.3656,
+      lon: -71.0096,
+    },
+    destination: {
+      icao: "klax",
+      iata: "lax",
+      lat: 33.9416,
+      lon: -118.4085,
+    },
+    source: "flightaware",
+  });
+
+  assert.equal(route.callsignIata, "AA1234");
+  assert.equal(route.airlineIcao, "AAL");
+  assert.equal(route.airlineIata, "AA");
+  assert.equal(route.source, "flightaware");
+}
+
+{
   const weather = normalizeLocalWeather({
     timezone: "America/New_York",
     current: {

--- a/src/features/aviation/flight-routes/flightRouteLookupModel.ts
+++ b/src/features/aviation/flight-routes/flightRouteLookupModel.ts
@@ -24,12 +24,20 @@ export type AircraftRouteCandidate = {
 type RouteAirportCode = {
   icao?: string;
   iata?: string;
+  lat?: number;
+  lon?: number;
 };
 
 export type FlightRoute = {
   callsign?: unknown;
   callsignIcao?: unknown;
   callsignIata?: unknown;
+  airlineIcao?: unknown;
+  airlineIata?: unknown;
+  airline?: {
+    icao?: unknown;
+    iata?: unknown;
+  } | null;
   origin?: RouteAirportCode | null;
   destination?: RouteAirportCode | null;
   route?: {

--- a/src/features/aviation/flight-routes/flightRouteNormalizer.ts
+++ b/src/features/aviation/flight-routes/flightRouteNormalizer.ts
@@ -32,17 +32,24 @@ export const normalizeFlightRoute = (payload) => {
     .toUpperCase();
   if (!callsign) return null;
   const number = String(route.number || "").trim();
-  const airlineIata = String(route.airline?.iata || "")
+  const airlineIata = String(route.airlineIata || route.airline?.iata || "")
     .trim()
     .toUpperCase();
-  const airlineIcao = String(route.airline?.icao || "")
+  const airlineIcao = String(route.airlineIcao || route.airline?.icao || "")
+    .trim()
+    .toUpperCase();
+  const callsignIata = String(
+    route.callsignIata ||
+      route.callsign_iata ||
+      (airlineIata && number ? `${airlineIata}${number}` : ""),
+  )
     .trim()
     .toUpperCase();
 
   return {
     callsign,
     callsignIcao: callsign,
-    callsignIata: airlineIata && number ? `${airlineIata}${number}` : "",
+    callsignIata,
     airlineName: String(route.airline?.name || "").trim(),
     airlineIcao,
     airlineIata,

--- a/src/features/aviation/flight-routes/flightRoutes.models.test.ts
+++ b/src/features/aviation/flight-routes/flightRoutes.models.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
-import { buildRouteCacheHeaders } from "./flightRoutes.models";
+import {
+  buildRouteCacheHeaders,
+  compactFlightRoutePayload,
+} from "./flightRoutes.models";
 
 assert.deepEqual(
   buildRouteCacheHeaders(
@@ -16,5 +19,55 @@ assert.equal(
   ],
   "public, max-age=0, s-maxage=3600, stale-while-revalidate=600",
 );
+
+{
+  const compact = compactFlightRoutePayload({
+    callsign: "AAL1234",
+    callsignIcao: "AAL1234",
+    callsignIata: "AA1234",
+    number: "1234",
+    airline: {
+      icao: "AAL",
+      iata: "AA",
+      name: "American Airlines",
+      iconUrl: "https://www.flightaware.com/images/airline_logos/90p/AAL.png",
+    },
+    origin: {
+      icao: "KBOS",
+      iata: "BOS",
+      name: "Boston Logan",
+      municipality: "Boston",
+      country: "US",
+      lat: 42.3656,
+      lon: -71.0096,
+    },
+    destination: {
+      icao: "KLAX",
+      iata: "LAX",
+      name: "Los Angeles Intl",
+      municipality: "Los Angeles",
+      country: "US",
+      lat: 33.9416,
+      lon: -118.4085,
+    },
+    route: { icao: "KBOS-KLAX", iata: "BOS-LAX" },
+    airports: [{ icao: "KBOS" }, { icao: "KLAX" }],
+    source: "flightaware",
+    confidence: "scraped-reference",
+  });
+
+  assert.deepEqual(compact, {
+    callsign: "AAL1234",
+    callsignIcao: "AAL1234",
+    callsignIata: "AA1234",
+    airlineIcao: "AAL",
+    airlineIata: "AA",
+    origin: { icao: "KBOS", iata: "BOS", lat: 42.3656, lon: -71.0096 },
+    destination: { icao: "KLAX", iata: "LAX", lat: 33.9416, lon: -118.4085 },
+    route: { icao: "KBOS-KLAX", iata: "BOS-LAX" },
+    source: "flightaware",
+    confidence: "scraped-reference",
+  });
+}
 
 console.log("flightRoutes.models.test.ts ok");

--- a/src/features/aviation/flight-routes/flightRoutes.models.ts
+++ b/src/features/aviation/flight-routes/flightRoutes.models.ts
@@ -29,3 +29,70 @@ export function buildRouteCacheHeaders(body, { bypassSharedCache = false } = {})
     "Vercel-CDN-Cache-Control": sharedValue,
   };
 }
+
+const cleanString = (value) => String(value || "").trim();
+const cleanUpper = (value) => cleanString(value).toUpperCase();
+
+function compactAirportPayload(airport) {
+  if (!airport || typeof airport !== "object") return null;
+  const icao = cleanUpper(airport.icao || airport.icao_code);
+  const iata = cleanUpper(airport.iata || airport.iata_code);
+  const lat = Number(airport.lat ?? airport.latitude);
+  const lon = Number(airport.lon ?? airport.longitude);
+  if (!icao || !Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  return {
+    icao,
+    ...(iata ? { iata } : {}),
+    lat,
+    lon,
+  };
+}
+
+function compactRouteCodes(route) {
+  if (!route || typeof route !== "object") return null;
+  const icao = cleanUpper(route.icao);
+  const iata = cleanUpper(route.iata);
+  if (!icao && !iata) return null;
+  return {
+    ...(icao ? { icao } : {}),
+    ...(iata ? { iata } : {}),
+  };
+}
+
+export function compactFlightRoutePayload(payload) {
+  const route = payload && typeof payload === "object" ? payload : null;
+  if (!route) return null;
+
+  const origin = compactAirportPayload(route.origin);
+  const destination = compactAirportPayload(route.destination);
+  if (!origin || !destination) return null;
+
+  const airline = route.airline && typeof route.airline === "object" ? route.airline : {};
+  const compact: Record<string, any> = {
+    callsign: cleanUpper(route.callsign || route.callsign_icao),
+    callsignIcao: cleanUpper(
+      route.callsignIcao || route.callsign_icao || route.callsign,
+    ),
+    origin,
+    destination,
+    source: cleanString(route.source),
+    confidence: cleanString(route.confidence),
+  };
+  const callsignIata = cleanUpper(route.callsignIata || route.callsign_iata);
+  const airlineIcao = cleanUpper(route.airlineIcao || airline.icao);
+  const airlineIata = cleanUpper(route.airlineIata || airline.iata);
+  const routeCodes = compactRouteCodes(route.route);
+
+  if (callsignIata) compact.callsignIata = callsignIata;
+  if (/^[A-Z0-9]{2,3}$/.test(airlineIcao)) compact.airlineIcao = airlineIcao;
+  if (/^[A-Z0-9]{2}$/.test(airlineIata)) compact.airlineIata = airlineIata;
+  if (routeCodes) compact.route = routeCodes;
+
+  for (const key of ["temporary", "displaySuffix", "expiresAt", "feedbackReason"]) {
+    if (route[key] !== undefined && route[key] !== null && route[key] !== "") {
+      compact[key] = route[key];
+    }
+  }
+
+  return compact;
+}


### PR DESCRIPTION
## Summary
- Add a short ADS-B provider cooldown so retryable upstream failures skip the failing provider briefly instead of hitting it every poll.
- Allow FlightAware route lookups to run with bounded parallelism instead of the old serialized queue.
- Compact route payloads across the data-service realtime route event and Next route proxy while preserving the fields the frontend needs.

## Root Cause
Grafana's steady error rate was coming from `adsbao_external_requests_total{provider="adsb.lol", endpoint="positions", result="error"}`. Production was trying `adsb.lol` first for every traffic poll, seeing `ERR`/429 on Railway, then succeeding through `airplanes.live`; users still got traffic, but the fallback path created continuous provider error metrics and extra upstream calls.

## Validation
- `go test ./internal/providers/adsb`
- `go test ./...` in `services/data-service`
- `go test -race ./...` in `services/data-service`
- `go vet ./...` in `services/data-service`
- `go build ./cmd/adsbao-data-service` in `services/data-service`
- `pnpm test`
- `pnpm lint` (existing warnings only)
- `pnpm build`
- `curl http://localhost:3000` returned 200