### PR TITLE
Add New Relic logs and observability IaC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,13 @@ dist-ssr
 .playwright-mcp
 *.lock
 
+# Terraform / OpenTofu local state
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+
 # clerk configuration (can include secrets)
 /.clerk/
 .claude/dev-server.log

--- a/README.md
+++ b/README.md
@@ -173,10 +173,12 @@ normally configure these variables:
 | `CLERK_SECRET_KEY` | Clerk server identity |
 | `NEXT_PUBLIC_ADSBAO_REALTIME_URL` | Optional WebSocket URL for the realtime ADS-B data service |
 | `ADSBAO_REALTIME_AUTH_SECRET` | Shared HMAC secret used by Vercel and the Railway data service to authorize FlightAware realtime subscriptions |
-| `NEW_RELIC_LICENSE_KEY` | Optional Railway data-service ingest key for New Relic Metric API reporting |
-| `NEW_RELIC_APP_NAME` | Optional New Relic app name for data-service metrics; defaults to `adsbao-data-service` |
+| `NEW_RELIC_LICENSE_KEY` | Optional Railway data-service ingest key for New Relic Metric API and Log API reporting |
+| `NEW_RELIC_APP_NAME` | Optional New Relic app name for data-service telemetry; defaults to `adsbao-data-service` |
 | `NEW_RELIC_METRICS_ENDPOINT` | Optional Metric API endpoint override for non-US New Relic accounts |
+| `NEW_RELIC_LOGS_ENDPOINT` | Optional Log API endpoint override for non-US New Relic accounts |
 | `METRICS_REPORT_INTERVAL_MS` | Optional dynamic metrics flush interval for the data-service; defaults to `30000` |
+| `LOGS_REPORT_INTERVAL_MS` | Optional backend log flush interval for the data-service; defaults to `5000` |
 | `NEXT_PUBLIC_SENTRY_DSN` | Optional browser Sentry events |
 | `SENTRY_DSN` | Optional server/edge Sentry events |
 | `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` | Optional production source-map upload |
@@ -246,8 +248,8 @@ route-handler-only helpers stay under `src/app/api/_shared`.
 The realtime backend is a separate Railway service deployed from
 `services/data-service`. The service includes `railway.json` config-as-code,
 uses the Dockerfile in the same directory, exposes `/health`,
-`/debug/channels`, and `/ws`, and pushes business metrics to New Relic when
-`NEW_RELIC_LICENSE_KEY` is configured.
+`/debug/channels`, and `/ws`, and pushes business metrics and backend logs to
+New Relic when `NEW_RELIC_LICENSE_KEY` is configured.
 
 Railway setup:
 
@@ -260,7 +262,9 @@ Railway setup:
 6. Set the same `ADSBAO_REALTIME_AUTH_SECRET` in Vercel and Railway when
    FlightAware realtime subscriptions are enabled.
 7. Set `NEW_RELIC_LICENSE_KEY` on the Railway data-service to enable business
-   metric ingest.
+   metric and backend log ingest.
+8. Apply `infra/newrelic` with a New Relic user API key and account ID to create
+   the ADSBao dashboard and NRQL alert policy.
 
 Railway handles production deployment through its GitHub integration. The
 service should be configured with root directory `services/data-service`,

--- a/docs/data-service-deployment.md
+++ b/docs/data-service-deployment.md
@@ -37,9 +37,13 @@ Stable metrics behavior:
 
 - Business metrics are pushed to New Relic through the Metric API when
   `NEW_RELIC_LICENSE_KEY` is present.
+- Backend logs emitted through the service logger are pushed to New Relic
+  through the Log API when `NEW_RELIC_LICENSE_KEY` is present.
 - Metric names use the `adsbao.*` namespace and low-cardinality attributes.
 - Do not add callsign, full channel name, user id, lat/lon, raw URL, token, or
   exact error text as New Relic metric attributes.
+- Log events include `service.name=adsbao-data-service`, `app.name`, `logtype`,
+  `environment`, `level`, `timestamp`, and `message`.
 - Railway built-in metrics remain the source for service CPU, memory, network,
   and volume usage.
 
@@ -70,11 +74,14 @@ Compatible env vars:
 - `AIRPORT_DIRECTORY_BASE_URL` defaults to `https://www.adsbao.dev` and is used
   as a fallback airport directory when FlightAware route pages omit embedded
   airport coordinates.
-- `NEW_RELIC_LICENSE_KEY` enables New Relic Metric API reporting.
+- `NEW_RELIC_LICENSE_KEY` enables New Relic Metric API and Log API reporting.
 - `NEW_RELIC_APP_NAME` defaults to `adsbao-data-service`.
 - `NEW_RELIC_METRICS_ENDPOINT` defaults to
   `https://metric-api.newrelic.com/metric/v1`.
+- `NEW_RELIC_LOGS_ENDPOINT` defaults to
+  `https://log-api.newrelic.com/log/v1`.
 - `METRICS_REPORT_INTERVAL_MS` defaults to `30000`.
+- `LOGS_REPORT_INTERVAL_MS` defaults to `5000`.
 
 Optional Go-only debug env:
 
@@ -149,6 +156,7 @@ Check New Relic metrics for:
 - Poll duration
 - Active channels and subscriptions
 - Stale channels and consecutive failures
+- Backend log volume and error logs
 
 Useful NRQL starting points:
 
@@ -156,14 +164,16 @@ Useful NRQL starting points:
 FROM Metric SELECT sum(adsbao.ws.subscribe) FACET channel_type, result TIMESERIES
 FROM Metric SELECT sum(adsbao.external_requests) FACET provider, status_class TIMESERIES
 FROM Metric SELECT average(adsbao.active_channels.current) FACET channel_type TIMESERIES
+FROM Log SELECT timestamp, level, message WHERE service.name = 'adsbao-data-service' LIMIT 100
 ```
 
 The dynamic channel gauges should emit zero-valued series for idle aircraft,
 callsign, route, and traffic channel types so charts remain visible when no
 clients are connected.
 
-Also watch Railway memory/CPU/network, provider request rate in New Relic, and
-Vercel aircraft proxy invocations after each production deploy.
+Apply `infra/newrelic` to create the ADSBao dashboard and NRQL alert policy in
+New Relic. Also watch Railway memory/CPU/network, provider request rate in New
+Relic, and Vercel aircraft proxy invocations after each production deploy.
 
 ## Rollback
 

--- a/infra/newrelic/.gitignore
+++ b/infra/newrelic/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.*
+*.tfvars
+*.tfvars.json

--- a/infra/newrelic/README.md
+++ b/infra/newrelic/README.md
@@ -1,0 +1,31 @@
+# ADSBao New Relic Observability
+
+This Terraform module creates the ADSBao data-service dashboard and NRQL alert
+conditions in New Relic.
+
+It does not store secrets. Provide credentials through environment variables:
+
+```bash
+export TF_VAR_new_relic_account_id="<account-id>"
+export TF_VAR_new_relic_api_key="<user-api-key>"
+```
+
+Then run with Terraform or OpenTofu:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+The data-service itself still uses `NEW_RELIC_LICENSE_KEY` on Railway for Metric
+API and Log API ingest. The user API key above is only for managing dashboards
+and alerts through Terraform.
+
+Useful New Relic queries after deploy:
+
+```sql
+FROM Metric SELECT sum(adsbao.ws.subscribe) WHERE service.name = 'adsbao-data-service' FACET channel_type, result TIMESERIES
+FROM Metric SELECT sum(adsbao.external_requests) WHERE service.name = 'adsbao-data-service' FACET provider, status_class TIMESERIES
+FROM Log SELECT timestamp, level, message WHERE service.name = 'adsbao-data-service' LIMIT 100
+```

--- a/infra/newrelic/alerts.tf
+++ b/infra/newrelic/alerts.tf
@@ -1,0 +1,76 @@
+resource "newrelic_alert_policy" "adsbao_data_service" {
+  name                = "ADSBao Data Service"
+  incident_preference = "PER_CONDITION"
+}
+
+resource "newrelic_nrql_alert_condition" "external_provider_error_ratio" {
+  account_id                   = var.new_relic_account_id
+  policy_id                    = newrelic_alert_policy.adsbao_data_service.id
+  type                         = "static"
+  name                         = "External provider error ratio"
+  description                  = "Provider contact errors are elevated for ADSBao data-service."
+  enabled                      = true
+  violation_time_limit_seconds = 3600
+  aggregation_window           = 60
+  aggregation_method           = "event_flow"
+  aggregation_delay            = 120
+
+  nrql {
+    query = "FROM Metric SELECT percentage(sum(adsbao.external_requests), WHERE result != 'success' OR status_class = '5xx') WHERE service.name = 'adsbao-data-service'"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = var.external_error_ratio_critical
+    threshold_duration    = 300
+    threshold_occurrences = "all"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "stale_channels" {
+  account_id                   = var.new_relic_account_id
+  policy_id                    = newrelic_alert_policy.adsbao_data_service.id
+  type                         = "static"
+  name                         = "Stale realtime channels"
+  description                  = "Realtime polling channels are stale."
+  enabled                      = true
+  violation_time_limit_seconds = 3600
+  aggregation_window           = 60
+  aggregation_method           = "event_flow"
+  aggregation_delay            = 120
+
+  nrql {
+    query = "FROM Metric SELECT sum(adsbao.stale_channels.current) WHERE service.name = 'adsbao-data-service'"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = var.stale_channel_critical
+    threshold_duration    = 600
+    threshold_occurrences = "all"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "backend_error_logs" {
+  account_id                   = var.new_relic_account_id
+  policy_id                    = newrelic_alert_policy.adsbao_data_service.id
+  type                         = "static"
+  name                         = "Backend error logs"
+  description                  = "ADSBao data-service is emitting error logs."
+  enabled                      = true
+  violation_time_limit_seconds = 3600
+  aggregation_window           = 60
+  aggregation_method           = "event_flow"
+  aggregation_delay            = 120
+
+  nrql {
+    query = "FROM Log SELECT count(*) WHERE service.name = 'adsbao-data-service' AND level = 'error'"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = var.log_error_rate_critical
+    threshold_duration    = 300
+    threshold_occurrences = "all"
+  }
+}

--- a/infra/newrelic/dashboard.tf
+++ b/infra/newrelic/dashboard.tf
@@ -1,0 +1,221 @@
+locals {
+  metric_filter = "WHERE service.name = 'adsbao-data-service'"
+  log_filter    = "WHERE service.name = 'adsbao-data-service'"
+}
+
+resource "newrelic_one_dashboard" "adsbao_data_service" {
+  name        = "ADSBao Data Service"
+  permissions = var.dashboard_permissions
+
+  page {
+    name = "Realtime"
+
+    widget_billboard {
+      title  = "Active WebSocket connections"
+      row    = 1
+      column = 1
+      width  = 3
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT latest(adsbao.ws.connections.current) ${local.metric_filter}"
+      }
+    }
+
+    widget_billboard {
+      title  = "Active subscriptions"
+      row    = 1
+      column = 4
+      width  = 3
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT sum(adsbao.subscriptions.current) ${local.metric_filter}"
+      }
+    }
+
+    widget_billboard {
+      title  = "Stale channels"
+      row    = 1
+      column = 7
+      width  = 3
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT sum(adsbao.stale_channels.current) ${local.metric_filter}"
+      }
+    }
+
+    widget_billboard {
+      title  = "Service uptime"
+      row    = 1
+      column = 10
+      width  = 3
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT latest(adsbao.uptime.seconds) ${local.metric_filter}"
+      }
+    }
+
+    widget_line {
+      title  = "Subscribe and unsubscribe rate"
+      row    = 4
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT sum(adsbao.ws.subscribe), sum(adsbao.ws.unsubscribe) ${local.metric_filter} FACET channel_type, result TIMESERIES"
+      }
+    }
+
+    widget_line {
+      title  = "WebSocket message rate"
+      row    = 4
+      column = 7
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT sum(adsbao.ws.messages) ${local.metric_filter} FACET direction, type, result TIMESERIES"
+      }
+    }
+
+    widget_line {
+      title  = "Active channels"
+      row    = 7
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT average(adsbao.active_channels.current) ${local.metric_filter} FACET channel_type TIMESERIES"
+      }
+    }
+
+    widget_line {
+      title  = "Channel failures"
+      row    = 7
+      column = 7
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT average(adsbao.channel_consecutive_failures.current) ${local.metric_filter} FACET channel_type TIMESERIES"
+      }
+    }
+  }
+
+  page {
+    name = "Providers"
+
+    widget_line {
+      title  = "External provider request rate"
+      row    = 1
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT sum(adsbao.external_requests) ${local.metric_filter} FACET provider, endpoint, status_class TIMESERIES"
+      }
+    }
+
+    widget_line {
+      title  = "External provider latency"
+      row    = 1
+      column = 7
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT average(adsbao.external_request.duration.seconds), percentile(adsbao.external_request.duration.seconds, 95) ${local.metric_filter} FACET provider, endpoint TIMESERIES"
+      }
+    }
+
+    widget_line {
+      title  = "Polling request rate"
+      row    = 4
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT sum(adsbao.poll.requests) ${local.metric_filter} FACET channel_type, source, result TIMESERIES"
+      }
+    }
+
+    widget_line {
+      title  = "Polling duration"
+      row    = 4
+      column = 7
+      width  = 6
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Metric SELECT average(adsbao.poll.duration.seconds), percentile(adsbao.poll.duration.seconds, 95) ${local.metric_filter} FACET channel_type, source TIMESERIES"
+      }
+    }
+  }
+
+  page {
+    name = "Logs"
+
+    widget_billboard {
+      title  = "Error logs in last 30 minutes"
+      row    = 1
+      column = 1
+      width  = 4
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Log SELECT count(*) ${local.log_filter} AND level = 'error' SINCE 30 minutes ago"
+      }
+    }
+
+    widget_line {
+      title  = "Log volume by level"
+      row    = 1
+      column = 5
+      width  = 8
+      height = 3
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Log SELECT count(*) ${local.log_filter} FACET level TIMESERIES"
+      }
+    }
+
+    widget_table {
+      title  = "Latest backend logs"
+      row    = 4
+      column = 1
+      width  = 12
+      height = 6
+
+      nrql_query {
+        account_id = var.new_relic_account_id
+        query      = "FROM Log SELECT timestamp, level, message ${local.log_filter} LIMIT 100"
+      }
+
+      initial_sorting {
+        direction = "desc"
+        name      = "timestamp"
+      }
+    }
+  }
+}

--- a/infra/newrelic/outputs.tf
+++ b/infra/newrelic/outputs.tf
@@ -1,0 +1,9 @@
+output "dashboard_guid" {
+  description = "New Relic dashboard GUID."
+  value       = newrelic_one_dashboard.adsbao_data_service.guid
+}
+
+output "alert_policy_id" {
+  description = "New Relic alert policy ID."
+  value       = newrelic_alert_policy.adsbao_data_service.id
+}

--- a/infra/newrelic/provider.tf
+++ b/infra/newrelic/provider.tf
@@ -1,0 +1,5 @@
+provider "newrelic" {
+  account_id = var.new_relic_account_id
+  api_key    = var.new_relic_api_key
+  region     = var.new_relic_region
+}

--- a/infra/newrelic/variables.tf
+++ b/infra/newrelic/variables.tf
@@ -1,0 +1,45 @@
+variable "new_relic_account_id" {
+  description = "New Relic account ID that receives ADSBao telemetry."
+  type        = number
+}
+
+variable "new_relic_api_key" {
+  description = "New Relic user API key for managing dashboards and alerts."
+  type        = string
+  sensitive   = true
+}
+
+variable "new_relic_region" {
+  description = "New Relic account region."
+  type        = string
+  default     = "US"
+
+  validation {
+    condition     = contains(["US", "EU"], var.new_relic_region)
+    error_message = "new_relic_region must be US or EU."
+  }
+}
+
+variable "dashboard_permissions" {
+  description = "New Relic dashboard permissions."
+  type        = string
+  default     = "public_read_only"
+}
+
+variable "external_error_ratio_critical" {
+  description = "Critical alert threshold for external provider error ratio."
+  type        = number
+  default     = 25
+}
+
+variable "stale_channel_critical" {
+  description = "Critical alert threshold for stale realtime channels."
+  type        = number
+  default     = 0
+}
+
+variable "log_error_rate_critical" {
+  description = "Critical alert threshold for data-service error logs per 5 minutes."
+  type        = number
+  default     = 3
+}

--- a/infra/newrelic/versions.tf
+++ b/infra/newrelic/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "3.93.0"
+    }
+  }
+}

--- a/services/data-service/README.md
+++ b/services/data-service/README.md
@@ -2,7 +2,7 @@
 
 Go implementation of the Railway realtime data-service. It owns long-running
 ADS-B polling, WebSocket fanout, provider fallback, health/debug endpoints, and
-New Relic Metric API reporting for ADSBao realtime surfaces.
+New Relic telemetry reporting for ADSBao realtime surfaces.
 
 ## Local Run
 
@@ -44,18 +44,22 @@ Optional Go profiling endpoints are available under `/debug/pprof/` only when
   Defaults to `https://www.adsbao.dev`.
 - `ENABLE_PPROF`
 - `NEW_RELIC_LICENSE_KEY` — New Relic ingest license key. When unset, metrics
-  reporting is disabled.
+  and backend log reporting are disabled.
 - `NEW_RELIC_APP_NAME` — New Relic app name. Defaults to `adsbao-data-service`.
 - `NEW_RELIC_METRICS_ENDPOINT` — Metric API endpoint. Defaults to the US
   endpoint `https://metric-api.newrelic.com/metric/v1`.
+- `NEW_RELIC_LOGS_ENDPOINT` — Log API endpoint. Defaults to the US endpoint
+  `https://log-api.newrelic.com/log/v1`.
 - `METRICS_REPORT_INTERVAL_MS` — periodic dynamic gauge flush interval.
   Defaults to `30000`.
+- `LOGS_REPORT_INTERVAL_MS` — periodic backend log flush interval. Defaults to
+  `5000`.
 
 ## Railway Deployment
 
 Deploy this service from the repository root directory `services/data-service`
 using `services/data-service/railway.json`. Validate `/health`, direct
 WebSocket subscribe/ping behavior, Railway resource metrics, and New Relic
-business metrics after each production deploy.
+business metrics and backend logs after each production deploy.
 
 See the repository deployment runbook at `docs/data-service-deployment.md`.

--- a/services/data-service/cmd/adsbao-data-service/main.go
+++ b/services/data-service/cmd/adsbao-data-service/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/adsbao/adsbao/services/data-service/internal/config"
 	"github.com/adsbao/adsbao/services/data-service/internal/httpapi"
 	"github.com/adsbao/adsbao/services/data-service/internal/metrics"
+	"github.com/adsbao/adsbao/services/data-service/internal/observability"
 	"github.com/adsbao/adsbao/services/data-service/internal/providers/adsb"
 	"github.com/adsbao/adsbao/services/data-service/internal/providers/flightaware"
 	"github.com/adsbao/adsbao/services/data-service/internal/providers/route"
@@ -24,6 +25,16 @@ import (
 
 func main() {
 	cfg := config.FromEnv(os.Getenv)
+	logForwarder := observability.NewRelicLogForwarder(observability.NewRelicLogOptions{
+		LicenseKey:  cfg.NewRelicLicenseKey,
+		Endpoint:    cfg.NewRelicLogsEndpoint,
+		AppName:     cfg.NewRelicAppName,
+		Environment: stringValue(os.Getenv("RAILWAY_ENVIRONMENT_NAME"), "production"),
+		Source:      os.Stdout,
+	})
+	log.SetFlags(0)
+	log.SetOutput(logForwarder)
+
 	started := time.Now()
 	metricSink := metrics.NewRelicSink(metrics.NewRelicOptions{
 		LicenseKey: cfg.NewRelicLicenseKey,
@@ -79,14 +90,21 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	go reportMetrics(ctx, registry, started, cfg.MetricsReportInterval, polling.DebugChannels)
+	go logForwarder.Run(ctx, cfg.LogsReportInterval)
+	serverErr := make(chan error, 1)
 	go func() {
 		log.Printf("adsbao-data-service listening on :%d", cfg.Port)
 		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("server failed: %v", err)
+			serverErr <- err
 		}
 	}()
 
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case err := <-serverErr:
+		log.Printf("server failed: %v", err)
+		stop()
+	}
 	polling.Dispose()
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -96,6 +114,9 @@ func main() {
 	}
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Printf("graceful shutdown failed: %v", err)
+	}
+	if err := logForwarder.Shutdown(shutdownCtx); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "logs shutdown failed: %v\n", err)
 	}
 }
 
@@ -116,4 +137,11 @@ func reportMetrics(ctx context.Context, registry *metrics.Metrics, started time.
 			}
 		}
 	}
+}
+
+func stringValue(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
 }

--- a/services/data-service/internal/config/config.go
+++ b/services/data-service/internal/config/config.go
@@ -21,7 +21,9 @@ type Config struct {
 	NewRelicLicenseKey         string
 	NewRelicAppName            string
 	NewRelicMetricsEndpoint    string
+	NewRelicLogsEndpoint       string
 	MetricsReportInterval      time.Duration
+	LogsReportInterval         time.Duration
 }
 
 type LookupFunc func(string) string
@@ -42,7 +44,9 @@ func FromEnv(lookup LookupFunc) Config {
 		NewRelicLicenseKey:         strings.TrimSpace(lookup("NEW_RELIC_LICENSE_KEY")),
 		NewRelicAppName:            stringValue(lookup("NEW_RELIC_APP_NAME"), "adsbao-data-service"),
 		NewRelicMetricsEndpoint:    stringValue(lookup("NEW_RELIC_METRICS_ENDPOINT"), "https://metric-api.newrelic.com/metric/v1"),
+		NewRelicLogsEndpoint:       stringValue(lookup("NEW_RELIC_LOGS_ENDPOINT"), "https://log-api.newrelic.com/log/v1"),
 		MetricsReportInterval:      durationMS(lookup("METRICS_REPORT_INTERVAL_MS"), 30*time.Second),
+		LogsReportInterval:         durationMS(lookup("LOGS_REPORT_INTERVAL_MS"), 5*time.Second),
 	}
 }
 

--- a/services/data-service/internal/config/config_test.go
+++ b/services/data-service/internal/config/config_test.go
@@ -21,7 +21,9 @@ func TestFromEnvParsesCompatibleDataServiceVariables(t *testing.T) {
 		"NEW_RELIC_LICENSE_KEY":        "new-relic-secret",
 		"NEW_RELIC_APP_NAME":           "adsbao-prod",
 		"NEW_RELIC_METRICS_ENDPOINT":   "https://metric-api.example.test/metric/v1",
+		"NEW_RELIC_LOGS_ENDPOINT":      "https://log-api.example.test/log/v1",
 		"METRICS_REPORT_INTERVAL_MS":   "45000",
+		"LOGS_REPORT_INTERVAL_MS":      "2000",
 	}
 
 	cfg := FromEnv(func(key string) string { return env[key] })
@@ -49,7 +51,9 @@ func TestFromEnvParsesCompatibleDataServiceVariables(t *testing.T) {
 	if cfg.NewRelicLicenseKey != "new-relic-secret" ||
 		cfg.NewRelicAppName != "adsbao-prod" ||
 		cfg.NewRelicMetricsEndpoint != "https://metric-api.example.test/metric/v1" ||
-		cfg.MetricsReportInterval != 45*time.Second {
+		cfg.NewRelicLogsEndpoint != "https://log-api.example.test/log/v1" ||
+		cfg.MetricsReportInterval != 45*time.Second ||
+		cfg.LogsReportInterval != 2*time.Second {
 		t.Fatalf("new relic config = %#v", cfg)
 	}
 }
@@ -69,7 +73,9 @@ func TestFromEnvDefaultsMatchProductionService(t *testing.T) {
 		cfg.NewRelicLicenseKey != "" ||
 		cfg.NewRelicAppName != "adsbao-data-service" ||
 		cfg.NewRelicMetricsEndpoint != "https://metric-api.newrelic.com/metric/v1" ||
-		cfg.MetricsReportInterval != 30*time.Second {
+		cfg.NewRelicLogsEndpoint != "https://log-api.newrelic.com/log/v1" ||
+		cfg.MetricsReportInterval != 30*time.Second ||
+		cfg.LogsReportInterval != 5*time.Second {
 		t.Fatalf("defaults = %#v", cfg)
 	}
 }

--- a/services/data-service/internal/observability/logs.go
+++ b/services/data-service/internal/observability/logs.go
@@ -1,0 +1,225 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultNewRelicLogsEndpoint = "https://log-api.newrelic.com/log/v1"
+
+type NewRelicLogOptions struct {
+	LicenseKey  string
+	Endpoint    string
+	AppName     string
+	Environment string
+	Source      io.Writer
+	HTTPClient  *http.Client
+	Now         func() time.Time
+	MaxBatch    int
+}
+
+type LogForwarder struct {
+	mu          sync.Mutex
+	entries     []newRelicLogEntry
+	licenseKey  string
+	endpoint    string
+	appName     string
+	environment string
+	source      io.Writer
+	client      *http.Client
+	now         func() time.Time
+	maxBatch    int
+}
+
+func NewRelicLogForwarder(options NewRelicLogOptions) *LogForwarder {
+	endpoint := strings.TrimSpace(options.Endpoint)
+	if endpoint == "" {
+		endpoint = defaultNewRelicLogsEndpoint
+	}
+	appName := strings.TrimSpace(options.AppName)
+	if appName == "" {
+		appName = "adsbao-data-service"
+	}
+	environment := strings.TrimSpace(options.Environment)
+	if environment == "" {
+		environment = "production"
+	}
+	client := options.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	maxBatch := options.MaxBatch
+	if maxBatch <= 0 {
+		maxBatch = 100
+	}
+	return &LogForwarder{
+		licenseKey:  strings.TrimSpace(options.LicenseKey),
+		endpoint:    endpoint,
+		appName:     appName,
+		environment: environment,
+		source:      options.Source,
+		client:      client,
+		now:         now,
+		maxBatch:    maxBatch,
+	}
+}
+
+func (f *LogForwarder) Write(p []byte) (int, error) {
+	if f.source != nil {
+		_, _ = f.source.Write(p)
+	}
+	message := strings.TrimSpace(string(p))
+	if message == "" || f.licenseKey == "" {
+		return len(p), nil
+	}
+	f.enqueue(newRelicLogEntry{
+		Timestamp: f.now().UnixMilli(),
+		Message:   truncateLogValue(message),
+		Level:     inferLogLevel(message),
+	})
+	return len(p), nil
+}
+
+func (f *LogForwarder) Run(ctx context.Context, interval time.Duration) {
+	if f.licenseKey == "" {
+		return
+	}
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := f.Flush(ctx); err != nil && f.source != nil {
+				_, _ = fmt.Fprintf(f.source, "new relic logs flush failed: %v\n", err)
+			}
+		}
+	}
+}
+
+func (f *LogForwarder) Flush(ctx context.Context) error {
+	entries := f.drain()
+	if len(entries) == 0 || f.licenseKey == "" {
+		return nil
+	}
+	body, err := json.Marshal([]newRelicLogPayload{{
+		Common: newRelicLogCommon{
+			Attributes: map[string]string{
+				"app.name":     f.appName,
+				"service.name": "adsbao-data-service",
+				"environment":  f.environment,
+				"logtype":      "adsbao-data-service",
+			},
+		},
+		Logs: entries,
+	}})
+	if err != nil {
+		f.requeue(entries)
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, f.endpoint, bytes.NewReader(body))
+	if err != nil {
+		f.requeue(entries)
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Api-Key", f.licenseKey)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		f.requeue(entries)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		f.requeue(entries)
+		return fmt.Errorf("new relic logs status %d: %s", resp.StatusCode, strings.TrimSpace(string(responseBody)))
+	}
+	return nil
+}
+
+func (f *LogForwarder) Shutdown(ctx context.Context) error {
+	return f.Flush(ctx)
+}
+
+func (f *LogForwarder) enqueue(entry newRelicLogEntry) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.entries) >= f.maxBatch {
+		copy(f.entries, f.entries[1:])
+		f.entries[len(f.entries)-1] = entry
+		return
+	}
+	f.entries = append(f.entries, entry)
+}
+
+func (f *LogForwarder) drain() []newRelicLogEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	entries := f.entries
+	f.entries = nil
+	return entries
+}
+
+func (f *LogForwarder) requeue(entries []newRelicLogEntry) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	combined := append(entries, f.entries...)
+	if len(combined) > f.maxBatch {
+		combined = combined[len(combined)-f.maxBatch:]
+	}
+	f.entries = combined
+}
+
+type newRelicLogPayload struct {
+	Common newRelicLogCommon  `json:"common"`
+	Logs   []newRelicLogEntry `json:"logs"`
+}
+
+type newRelicLogCommon struct {
+	Attributes map[string]string `json:"attributes"`
+}
+
+type newRelicLogEntry struct {
+	Timestamp int64  `json:"timestamp"`
+	Message   string `json:"message"`
+	Level     string `json:"level"`
+}
+
+func inferLogLevel(message string) string {
+	lower := strings.ToLower(message)
+	switch {
+	case strings.Contains(lower, "fatal"),
+		strings.Contains(lower, "panic"),
+		strings.Contains(lower, "failed"),
+		strings.Contains(lower, "error"):
+		return "error"
+	case strings.Contains(lower, "warn"):
+		return "warn"
+	default:
+		return "info"
+	}
+}
+
+func truncateLogValue(value string) string {
+	const maxLogValueBytes = 4094
+	if len(value) <= maxLogValueBytes {
+		return value
+	}
+	return value[:maxLogValueBytes]
+}

--- a/services/data-service/internal/observability/logs_newrelic_test.go
+++ b/services/data-service/internal/observability/logs_newrelic_test.go
@@ -1,0 +1,107 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewRelicLogForwarderWritesSourceAndPostsStructuredLogs(t *testing.T) {
+	var source bytes.Buffer
+	var gotAPIKey string
+	var gotPayload []newRelicLogPayload
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("Api-Key")
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("content type = %s", r.Header.Get("Content-Type"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	forwarder := NewRelicLogForwarder(NewRelicLogOptions{
+		LicenseKey:  "test-license",
+		Endpoint:    server.URL,
+		AppName:     "adsbao-test",
+		Environment: "production",
+		Source:      &source,
+		Now: func() time.Time {
+			return time.UnixMilli(1710000000123)
+		},
+	})
+
+	if _, err := forwarder.Write([]byte("metrics flush failed: boom\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := forwarder.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	if source.String() != "metrics flush failed: boom\n" {
+		t.Fatalf("source output = %q", source.String())
+	}
+	if gotAPIKey != "test-license" {
+		t.Fatalf("api key = %q", gotAPIKey)
+	}
+	if len(gotPayload) != 1 || len(gotPayload[0].Logs) != 1 {
+		t.Fatalf("payload = %#v", gotPayload)
+	}
+	attrs := gotPayload[0].Common.Attributes
+	if attrs["app.name"] != "adsbao-test" ||
+		attrs["service.name"] != "adsbao-data-service" ||
+		attrs["environment"] != "production" ||
+		attrs["logtype"] != "adsbao-data-service" {
+		t.Fatalf("common attrs = %#v", attrs)
+	}
+	log := gotPayload[0].Logs[0]
+	if log.Timestamp != 1710000000123 ||
+		log.Message != "metrics flush failed: boom" ||
+		log.Level != "error" {
+		t.Fatalf("log = %#v", log)
+	}
+}
+
+func TestNewRelicLogForwarderRequeuesOnFailedFlush(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			http.Error(w, "retry later", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	forwarder := NewRelicLogForwarder(NewRelicLogOptions{
+		LicenseKey: "test-license",
+		Endpoint:   server.URL,
+		AppName:    "adsbao-test",
+		Source:     &bytes.Buffer{},
+	})
+
+	if _, err := forwarder.Write([]byte("server failed: listen tcp\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	err := forwarder.Flush(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "new relic logs status 503") {
+		t.Fatalf("first flush error = %v", err)
+	}
+	if err := forwarder.Flush(context.Background()); err != nil {
+		t.Fatalf("second flush: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d", attempts)
+	}
+}


### PR DESCRIPTION
## Summary
- forward data-service backend logs to New Relic Log API using the existing Railway license key
- add Terraform/OpenTofu IaC for ADSBao New Relic dashboard and NRQL alert policy
- document New Relic metric/log env vars and the IaC apply path

## Validation
- `go test ./internal/config ./internal/observability`
- `go test ./...` in `services/data-service`
- `go vet ./...` in `services/data-service`
- `go build ./cmd/adsbao-data-service` in `services/data-service`
- `go test -race ./...` in `services/data-service`
- `tofu init -backend=false && tofu validate && tofu fmt -check -diff` in `infra/newrelic`
- New Relic Log API smoke returned HTTP 202
- `pnpm test`
- `pnpm lint` (existing warnings only)
- `pnpm build`
- `git diff --check`

## Notes
- The New Relic dashboard/alert IaC is validated but not applied from Codex because this environment does not have a New Relic user API key or account ID. The existing Railway license key is sufficient for ingest only.
