### PR TITLE
Track applied New Relic resources in IaC

### DIFF
--- a/infra/newrelic/imports.tf
+++ b/infra/newrelic/imports.tf
@@ -1,0 +1,28 @@
+# Production resources already applied in New Relic account 8173845.
+# These imports keep a fresh local state from creating duplicate dashboards or
+# alert conditions when applying this repo from a new machine.
+
+import {
+  to = newrelic_one_dashboard.adsbao_data_service
+  id = "ODE3Mzg0NXxWSVp8REFTSEJPQVJEfGRhOjEyNzIwODc3"
+}
+
+import {
+  to = newrelic_alert_policy.adsbao_data_service
+  id = "7626534"
+}
+
+import {
+  to = newrelic_nrql_alert_condition.external_provider_error_ratio
+  id = "7626534:62050808"
+}
+
+import {
+  to = newrelic_nrql_alert_condition.stale_channels
+  id = "7626534:62050806"
+}
+
+import {
+  to = newrelic_nrql_alert_condition.backend_error_logs
+  id = "7626534:62050807"
+}

--- a/infra/newrelic/outputs.tf
+++ b/infra/newrelic/outputs.tf
@@ -3,6 +3,11 @@ output "dashboard_guid" {
   value       = newrelic_one_dashboard.adsbao_data_service.guid
 }
 
+output "dashboard_permalink" {
+  description = "New Relic dashboard permalink."
+  value       = newrelic_one_dashboard.adsbao_data_service.permalink
+}
+
 output "alert_policy_id" {
   description = "New Relic alert policy ID."
   value       = newrelic_alert_policy.adsbao_data_service.id


### PR DESCRIPTION
## Summary
- add Terraform import blocks for the New Relic dashboard, alert policy, and NRQL alert conditions already applied in account 8173845
- expose the New Relic dashboard permalink as an IaC output

## Validation
- `tofu fmt -check -diff`
- fresh-state `tofu plan` showed 5 imports, 0 adds, 0 changes, 0 destroys
- fresh-state `tofu apply` imported the 5 resources with 0 added/changed/destroyed
- follow-up `tofu plan -detailed-exitcode` returned no changes
- `tofu validate`
- NerdGraph confirmed the dashboard entity exists and ADSBao metrics/logs are present in account 8173845
