### PR TITLE
Remove legacy database architecture fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ normally configure these variables:
 | Variable | Purpose |
 |---|---|
 | `NEXT_PUBLIC_SITE_URL` | Canonical site URL for metadata and absolute links |
-| `ADSBAO_DATABASE_URL` or `DATABASE_URL` | Server-side Postgres connection string for DAO reads/writes, imports, route feedback, feature flags, and map settings |
+| `ADSBAO_DATABASE_URL` | Server-side Postgres connection string for DAO reads/writes, imports, route feedback, feature flags, and map settings |
 | `PGSSLMODE` | Optional Postgres SSL mode. Set `disable` only for local non-SSL databases |
 | `PGPOOL_MAX` | Optional Postgres pool size cap for server route handlers and import scripts |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk browser identity |
@@ -207,7 +207,7 @@ Import OurAirports airport names with:
 pnpm import:airports
 ```
 
-The import scripts use `ADSBAO_DATABASE_URL`/`DATABASE_URL`; do not put database
+The import scripts use `ADSBAO_DATABASE_URL`; do not put database
 connection strings in `NEXT_PUBLIC_*` variables.
 
 ## Project Structure

--- a/database/README.md
+++ b/database/README.md
@@ -6,11 +6,8 @@ database URL through `NEXT_PUBLIC_*` variables.
 
 ## Environment
 
-Use one of:
-
 ```bash
 ADSBAO_DATABASE_URL=postgres://...
-DATABASE_URL=postgres://...
 ```
 
 Optional:
@@ -32,25 +29,4 @@ psql "$ADSBAO_DATABASE_URL" -f database/migrations/001_adsbao_postgres.sql
 pnpm import:airports
 pnpm import:facilities
 pnpm import:runways
-```
-
-## Supabase Export
-
-If preserving existing user flags, route feedback, or map settings from the old
-Supabase project, export only the app-owned tables and restore them into Railway
-Postgres after applying the schema. Do not restore Supabase roles, RLS policies,
-or platform schemas.
-
-Useful table list:
-
-```text
-airports
-airport_frequencies
-navaids
-runway_geometries
-flight_route_feedback_reports
-user_feature_flags
-user_map_settings
-openaip_airports
-openaip_cache
 ```

--- a/database/migrations/001_adsbao_postgres.sql
+++ b/database/migrations/001_adsbao_postgres.sql
@@ -1,6 +1,6 @@
 -- ADSBao Railway Postgres schema.
 --
--- This migration owns ADSBao persistence without Supabase Data API/RLS roles.
+-- This migration owns ADSBao persistence in Railway Postgres.
 -- Application code reaches these tables only from server-side DAO helpers.
 
 create extension if not exists pgcrypto;

--- a/scripts/feature-flags.ts
+++ b/scripts/feature-flags.ts
@@ -61,7 +61,7 @@ async function main() {
   });
   if (!repository) {
     throw new Error(
-      "Postgres feature flag repository is not configured. Check ADSBAO_DATABASE_URL or DATABASE_URL in .env.local.",
+      "Postgres feature flag repository is not configured. Check ADSBAO_DATABASE_URL in .env.local.",
     );
   }
 

--- a/scripts/postgresImport.ts
+++ b/scripts/postgresImport.ts
@@ -76,9 +76,7 @@ export async function bulkUpsertRows({
 export function createImportDatabaseFromEnv() {
   const queryClient = createPostgresQueryClientFromEnv();
   if (!queryClient) {
-    throw new Error(
-      "ADSBAO_DATABASE_URL or DATABASE_URL is required for database imports",
-    );
+    throw new Error("ADSBAO_DATABASE_URL is required for database imports");
   }
   return queryClient;
 }

--- a/src/app/api/dao/postgresClient.test.ts
+++ b/src/app/api/dao/postgresClient.test.ts
@@ -7,7 +7,6 @@ import { createPostgresQueryClientFromEnv } from "./postgresClient";
   const client = createPostgresQueryClientFromEnv({
     env: {
       ADSBAO_DATABASE_URL: "postgres://adsbao:secret@db.railway.internal:5432/railway",
-      DATABASE_URL: "postgres://ignored",
       PGPOOL_MAX: "3",
     },
     createPoolImpl: (options: Record<string, any>) => {
@@ -43,7 +42,7 @@ import { createPostgresQueryClientFromEnv } from "./postgresClient";
 {
   const client = createPostgresQueryClientFromEnv({
     env: {
-      DATABASE_URL: "postgres://adsbao:secret@localhost:5432/adsbao",
+      ADSBAO_DATABASE_URL: "postgres://adsbao:secret@localhost:5432/adsbao",
       PGSSLMODE: "disable",
     },
     createPoolImpl: (options: Record<string, any>) => ({
@@ -59,5 +58,24 @@ import { createPostgresQueryClientFromEnv } from "./postgresClient";
 }
 
 assert.equal(createPostgresQueryClientFromEnv({ env: {} }), null);
+
+assert.equal(
+  createPostgresQueryClientFromEnv({
+    env: {
+      DATABASE_URL: "postgres://legacy-generic-url",
+    },
+  }),
+  null,
+);
+
+assert.equal(
+  createPostgresQueryClientFromEnv({
+    env: {
+      POSTGRES_URL: "postgres://legacy-marketplace-url",
+      POSTGRES_PRISMA_URL: "postgres://legacy-prisma-url",
+    },
+  }),
+  null,
+);
 
 console.log("postgresClient.test.ts ok");

--- a/src/app/api/dao/postgresClient.ts
+++ b/src/app/api/dao/postgresClient.ts
@@ -27,11 +27,7 @@ type PoolLike = {
 type CreatePoolImpl = (options: Record<string, any>) => PoolLike;
 
 const databaseUrlFromEnv = (env: Record<string, string | undefined>) =>
-  env.ADSBAO_DATABASE_URL ||
-  env.DATABASE_URL ||
-  env.POSTGRES_URL ||
-  env.POSTGRES_PRISMA_URL ||
-  "";
+  env.ADSBAO_DATABASE_URL || "";
 
 const shouldDisableSsl = (
   connectionString: string,


### PR DESCRIPTION
## Summary
- restrict web/database scripts to `ADSBAO_DATABASE_URL` and stop accepting legacy `DATABASE_URL` / Vercel Postgres env fallbacks
- remove obsolete Supabase export migration notes from the database runbook
- clean database migration wording now that Railway Postgres is the canonical persistence layer
- removed stale low-level Postgres/Railway env vars from Vercel preview and production, leaving `ADSBAO_DATABASE_URL` as the database entrypoint

## Validation
- TDD: added failing coverage proving `DATABASE_URL`, `POSTGRES_URL`, and `POSTGRES_PRISMA_URL` are ignored, then removed the fallback behavior
- `pnpm test`
- `pnpm lint` (existing warnings only)
- `pnpm build`
- `go test ./...` in `services/data-service`
- `tofu init -backend=false && tofu validate && tofu fmt -check -diff` in `infra/newrelic`
- `git diff --check`
- repo scan: no Supabase/Grafana/Prometheus/Fly residues outside tests that assert old DB envs are ignored
- Vercel env scan: low-level Postgres/Railway vars removed from preview and production; `ADSBAO_DATABASE_URL` remains

## Notes
- Railway CLI token expired during the final resource recheck, so Railway service state was not re-queried in this PR. Previous cleanup had already removed Grafana/Prometheus services and volumes were pending deletion.
