### PR TITLE
Improve New Relic log readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/services/data-service/internal/metrics/metrics.go
+++ b/services/data-service/internal/metrics/metrics.go
@@ -267,18 +267,42 @@ func (m *Metrics) recordExternalRequestLog(input realtime.ExternalRequestMetricI
 	if m.logSink == nil {
 		return
 	}
+	provider := normalize(input.Provider)
+	endpoint := normalize(input.Endpoint)
+	result := normalize(input.Result)
+	status = normalize(status)
+	class = normalize(class)
 	durationSeconds := float64(input.DurationMS) / 1000
 	attributes := map[string]any{
 		"event.name":       "external_request_done",
-		"provider":         normalize(input.Provider),
-		"endpoint":         normalize(input.Endpoint),
-		"result":           normalize(input.Result),
-		"status":           normalize(status),
-		"status.class":     normalize(class),
+		"provider":         provider,
+		"endpoint":         endpoint,
+		"result":           result,
+		"status":           status,
+		"status.class":     class,
+		"status_class":     class,
 		"duration.ms":      input.DurationMS,
+		"duration_ms":      input.DurationMS,
 		"duration.seconds": durationSeconds,
+		"duration_seconds": durationSeconds,
 	}
-	m.logSink.RecordLog(externalRequestLogLevel(input.Result, class), "external_request_done", attributes)
+	m.logSink.RecordLog(
+		externalRequestLogLevel(result, class),
+		externalRequestLogMessage(provider, endpoint, result, status, class, input.DurationMS),
+		attributes,
+	)
+}
+
+func externalRequestLogMessage(provider, endpoint, result, status, class string, durationMS int64) string {
+	return fmt.Sprintf(
+		"external_request provider=%s endpoint=%s result=%s status=%s status_class=%s duration_ms=%d",
+		provider,
+		endpoint,
+		result,
+		status,
+		class,
+		durationMS,
+	)
 }
 
 func externalRequestLogLevel(result, class string) string {

--- a/services/data-service/internal/metrics/metrics_newrelic_test.go
+++ b/services/data-service/internal/metrics/metrics_newrelic_test.go
@@ -141,7 +141,8 @@ func TestMetricsRecordExternalRequestWritesStructuredLog(t *testing.T) {
 		t.Fatalf("logs = %#v", logs.entries)
 	}
 	entry := logs.entries[0]
-	if entry.level != "error" || entry.message != "external_request_done" {
+	wantMessage := "external_request provider=adsb.lol endpoint=positions result=error status=503 status_class=5xx duration_ms=2480"
+	if entry.level != "error" || entry.message != wantMessage {
 		t.Fatalf("entry = %#v", entry)
 	}
 	want := map[string]any{
@@ -151,8 +152,11 @@ func TestMetricsRecordExternalRequestWritesStructuredLog(t *testing.T) {
 		"result":           "error",
 		"status":           "503",
 		"status.class":     "5xx",
+		"status_class":     "5xx",
 		"duration.ms":      int64(2480),
+		"duration_ms":      int64(2480),
 		"duration.seconds": 2.48,
+		"duration_seconds": 2.48,
 	}
 	for key, value := range want {
 		if entry.attributes[key] != value {

--- a/src/app/api/_shared/apiProxySecurity.test.ts
+++ b/src/app/api/_shared/apiProxySecurity.test.ts
@@ -208,9 +208,14 @@ assert.deepEqual(
 
   const logPayload = logIngest.body[0];
   assert.equal(logPayload.common.attributes["service.name"], "adsbao-web");
-  assert.equal(logPayload.logs[0].message, "proxy_route_done");
+  assert.equal(
+    logPayload.logs[0].message,
+    "proxy_route route=/api/proxy/aircraft/positions source=adsb.lol result=error status=503 status_class=5xx duration_ms=245 attempts=adsb.lol:503;airplanes.live:429",
+  );
   assert.equal(logPayload.logs[0].level, "error");
   assert.equal(logPayload.logs[0].attributes.route, "/api/proxy/aircraft/positions");
   assert.equal(logPayload.logs[0].attributes["request.id"], "iad1::proxy");
   assert.equal(logPayload.logs[0].attributes["duration.ms"], 245);
+  assert.equal(logPayload.logs[0].attributes.duration_ms, 245);
+  assert.equal(logPayload.logs[0].attributes.status_class, "5xx");
 }

--- a/src/app/api/_shared/apiProxySecurity.ts
+++ b/src/app/api/_shared/apiProxySecurity.ts
@@ -395,13 +395,9 @@ async function recordNewRelicProxyObservation(
           logs: [
             {
               timestamp: payload.timestamp,
-              message: payload.msg,
+              message: proxyLogMessage(payload),
               level: payload.level,
-              attributes: {
-                ...attributes,
-                "request.id": payload.requestId || "unknown",
-                "duration.ms": payload.ms,
-              },
+              attributes: proxyLogAttributes(payload, attributes),
             },
           ],
         },
@@ -432,7 +428,38 @@ function proxyTelemetryAttributes(payload: ProxyObservation) {
     result: payload.result,
     status: String(payload.status || "unknown"),
     "status.class": payload.statusClass,
+    status_class: payload.statusClass,
   };
+}
+
+function proxyLogMessage(payload: ProxyObservation) {
+  return [
+    "proxy_route",
+    `route=${payload.route || "unknown"}`,
+    `source=${payload.source || "unknown"}`,
+    `result=${payload.result}`,
+    `status=${payload.status || "unknown"}`,
+    `status_class=${payload.statusClass}`,
+    `duration_ms=${payload.ms ?? "unknown"}`,
+    `attempts=${payload.attempts || "none"}`,
+  ].join(" ");
+}
+
+function proxyLogAttributes(
+  payload: ProxyObservation,
+  attributes: ReturnType<typeof proxyTelemetryAttributes>,
+) {
+  const out: Record<string, unknown> = {
+    ...attributes,
+    "request.id": payload.requestId || "unknown",
+  };
+  if (payload.ms != null) {
+    out["duration.ms"] = payload.ms;
+    out["duration.seconds"] = payload.ms / 1000;
+    out.duration_ms = payload.ms;
+    out.duration_seconds = payload.ms / 1000;
+  }
+  return out;
 }
 
 function proxyMetrics(

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -7,6 +7,18 @@
 
 export const CHANGELOG = [
   {
+    version: "v2.6.1",
+    kind: "patch",
+    title: "Readable observability logs",
+    summary:
+      "New Relic logs now expose provider, route, status, result, and latency directly in the message column.",
+    highlights: [
+      "Expanded data-service external request logs with readable provider, endpoint, result, status class, and duration details",
+      "Expanded Vercel proxy logs with route, source, attempt chain, status class, and duration details",
+      "Added snake_case New Relic fields so Logs and NRQL views can show latency and status columns without dotted-field friction",
+    ],
+  },
+  {
     version: "v2.6.0",
     kind: "feat",
     title: "New Relic observability",


### PR DESCRIPTION
## Summary
- Make data-service external request log messages readable in New Relic's message column
- Make Vercel proxy log messages include route, source, result, status class, duration, and provider attempts
- Add snake_case New Relic attributes for easier Logs/NRQL columns and bump ADSBao to v2.6.1

## Validation
- go test ./... (services/data-service)
- pnpm test
- pnpm lint (0 errors, existing warnings only)
- pnpm build
- git diff --check