### PR TITLE
Make New Relic logs URL-first

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.6.1",
+  "version": "2.6.2",
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/services/data-service/internal/metrics/metrics.go
+++ b/services/data-service/internal/metrics/metrics.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -272,6 +273,8 @@ func (m *Metrics) recordExternalRequestLog(input realtime.ExternalRequestMetricI
 	result := normalize(input.Result)
 	status = normalize(status)
 	class = normalize(class)
+	requestURL, queryParams := externalRequestURLParts(input.URL)
+	errorText := truncateExternalLogValue(strings.TrimSpace(input.Error))
 	durationSeconds := float64(input.DurationMS) / 1000
 	attributes := map[string]any{
 		"event.name":       "external_request_done",
@@ -279,6 +282,7 @@ func (m *Metrics) recordExternalRequestLog(input realtime.ExternalRequestMetricI
 		"endpoint":         endpoint,
 		"result":           result,
 		"status":           status,
+		"status_code":      status,
 		"status.class":     class,
 		"status_class":     class,
 		"duration.ms":      input.DurationMS,
@@ -286,23 +290,89 @@ func (m *Metrics) recordExternalRequestLog(input realtime.ExternalRequestMetricI
 		"duration.seconds": durationSeconds,
 		"duration_seconds": durationSeconds,
 	}
+	if requestURL != "" {
+		attributes["url"] = requestURL
+	}
+	if queryParams != "" {
+		attributes["query_params"] = queryParams
+	}
+	if errorText != "" {
+		attributes["error"] = errorText
+	}
 	m.logSink.RecordLog(
 		externalRequestLogLevel(result, class),
-		externalRequestLogMessage(provider, endpoint, result, status, class, input.DurationMS),
+		externalRequestLogMessage(status, requestURL, queryParams, errorText, input.DurationMS),
 		attributes,
 	)
 }
 
-func externalRequestLogMessage(provider, endpoint, result, status, class string, durationMS int64) string {
-	return fmt.Sprintf(
-		"external_request provider=%s endpoint=%s result=%s status=%s status_class=%s duration_ms=%d",
-		provider,
-		endpoint,
-		result,
-		status,
-		class,
-		durationMS,
-	)
+func externalRequestLogMessage(status, requestURL, queryParams, errorText string, durationMS int64) string {
+	if requestURL == "" {
+		requestURL = "unknown"
+	}
+	parts := []string{fmt.Sprintf("[%s]%s", normalize(status), requestURL)}
+	if queryParams != "" {
+		parts = append(parts, "params: "+queryParams)
+	}
+	if errorText != "" {
+		parts = append(parts, "error: "+errorText)
+	}
+	parts = append(parts, fmt.Sprintf("duration: %dms", durationMS))
+	return strings.Join(parts, ", ")
+}
+
+func externalRequestURLParts(rawURL string) (string, string) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return truncateExternalLogValue(rawURL), ""
+	}
+	query := sanitizedQuery(parsed.Query())
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return truncateExternalLogValue(parsed.String()), query
+}
+
+func sanitizedQuery(values url.Values) string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(values))
+	for _, key := range keys {
+		vals := values[key]
+		if sensitiveQueryKey(key) {
+			parts = append(parts, key+"=[redacted]")
+			continue
+		}
+		for _, value := range vals {
+			parts = append(parts, key+"="+value)
+		}
+	}
+	return truncateExternalLogValue(strings.Join(parts, "&"))
+}
+
+func sensitiveQueryKey(key string) bool {
+	key = strings.ToLower(key)
+	return strings.Contains(key, "key") ||
+		strings.Contains(key, "token") ||
+		strings.Contains(key, "secret") ||
+		strings.Contains(key, "password")
+}
+
+func truncateExternalLogValue(value string) string {
+	const maxLogValueBytes = 4094
+	if len(value) <= maxLogValueBytes {
+		return value
+	}
+	return value[:maxLogValueBytes]
 }
 
 func externalRequestLogLevel(result, class string) string {

--- a/services/data-service/internal/metrics/metrics_newrelic_test.go
+++ b/services/data-service/internal/metrics/metrics_newrelic_test.go
@@ -134,6 +134,8 @@ func TestMetricsRecordExternalRequestWritesStructuredLog(t *testing.T) {
 		Endpoint:   "positions",
 		Result:     "error",
 		Status:     503,
+		URL:        "https://api.adsb.lol/v2/aircraft?lat=42.3656&lon=-71.0096&api_key=secret",
+		Error:      "HTTP 503",
 		DurationMS: 2480,
 	})
 
@@ -141,7 +143,7 @@ func TestMetricsRecordExternalRequestWritesStructuredLog(t *testing.T) {
 		t.Fatalf("logs = %#v", logs.entries)
 	}
 	entry := logs.entries[0]
-	wantMessage := "external_request provider=adsb.lol endpoint=positions result=error status=503 status_class=5xx duration_ms=2480"
+	wantMessage := "[503]https://api.adsb.lol/v2/aircraft, params: api_key=[redacted]&lat=42.3656&lon=-71.0096, error: HTTP 503, duration: 2480ms"
 	if entry.level != "error" || entry.message != wantMessage {
 		t.Fatalf("entry = %#v", entry)
 	}
@@ -153,6 +155,9 @@ func TestMetricsRecordExternalRequestWritesStructuredLog(t *testing.T) {
 		"status":           "503",
 		"status.class":     "5xx",
 		"status_class":     "5xx",
+		"url":              "https://api.adsb.lol/v2/aircraft",
+		"query_params":     "api_key=[redacted]&lat=42.3656&lon=-71.0096",
+		"error":            "HTTP 503",
 		"duration.ms":      int64(2480),
 		"duration_ms":      int64(2480),
 		"duration.seconds": 2.48,

--- a/services/data-service/internal/providers/adsb/client.go
+++ b/services/data-service/internal/providers/adsb/client.go
@@ -341,48 +341,50 @@ func (c *Client) fetchProviderPayload(ctx context.Context, input realtime.FetchI
 	status := any(nil)
 	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL, nil)
 	if err != nil {
+		c.recordExternal(input, provider.ID, endpoint, "error", "ERR", requestURL, err.Error(), started)
 		return nil, providerError{message: err.Error(), status: "ERR"}
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", userAgent)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		c.recordExternal(input, provider.ID, endpoint, "error", "ERR", started)
+		c.recordExternal(input, provider.ID, endpoint, "error", "ERR", requestURL, err.Error(), started)
 		return nil, providerError{message: err.Error(), status: "ERR"}
 	}
 	defer resp.Body.Close()
 	status = resp.StatusCode
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		c.recordExternal(input, provider.ID, endpoint, "error", status, started)
+		message := fmt.Sprintf("HTTP %d", resp.StatusCode)
+		c.recordExternal(input, provider.ID, endpoint, "error", status, requestURL, message, started)
 		return nil, providerError{message: fmt.Sprintf("HTTP %d", resp.StatusCode), status: status}
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, c.maxBytes+1))
 	if err != nil {
-		c.recordExternal(input, provider.ID, endpoint, "error", "ERR", started)
+		c.recordExternal(input, provider.ID, endpoint, "error", "ERR", requestURL, err.Error(), started)
 		return nil, providerError{message: err.Error(), status: "ERR"}
 	}
 	if int64(len(body)) > c.maxBytes {
-		c.recordExternal(input, provider.ID, endpoint, "error", "SIZE", started)
+		c.recordExternal(input, provider.ID, endpoint, "error", "SIZE", requestURL, "ADS-B response too large", started)
 		return nil, providerError{message: "ADS-B response too large", status: "SIZE"}
 	}
 	var payload map[string]any
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	if err := decoder.Decode(&payload); err != nil {
-		c.recordExternal(input, provider.ID, endpoint, "error", "PARSE", started)
+		c.recordExternal(input, provider.ID, endpoint, "error", "PARSE", requestURL, "Invalid ADS-B JSON", started)
 		return nil, providerError{message: "Invalid ADS-B JSON", status: "PARSE"}
 	}
 	if provider.Normalize != nil {
 		payload = provider.Normalize(payload)
 	}
 	if _, ok := payload["ac"].([]any); !ok {
-		c.recordExternal(input, provider.ID, endpoint, "error", "SHAPE", started)
+		c.recordExternal(input, provider.ID, endpoint, "error", "SHAPE", requestURL, "Invalid aircraft payload", started)
 		return nil, providerError{message: "Invalid aircraft payload", status: "SHAPE"}
 	}
-	c.recordExternal(input, provider.ID, endpoint, "success", status, started)
+	c.recordExternal(input, provider.ID, endpoint, "success", status, requestURL, "", started)
 	return payload, nil
 }
 
-func (c *Client) recordExternal(input realtime.FetchInput, provider, endpoint, result string, status any, started time.Time) {
+func (c *Client) recordExternal(input realtime.FetchInput, provider, endpoint, result string, status any, requestURL, errorText string, started time.Time) {
 	if input.Metrics == nil {
 		return
 	}
@@ -391,6 +393,8 @@ func (c *Client) recordExternal(input realtime.FetchInput, provider, endpoint, r
 		Endpoint:   endpoint,
 		Result:     result,
 		Status:     status,
+		URL:        requestURL,
+		Error:      errorText,
 		DurationMS: time.Since(started).Milliseconds(),
 	})
 }

--- a/services/data-service/internal/providers/adsb/client_test.go
+++ b/services/data-service/internal/providers/adsb/client_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/adsbao/adsbao/services/data-service/internal/realtime"
 )
 
+type recordingMetricsSink struct {
+	external []realtime.ExternalRequestMetricInput
+}
+
+func (s *recordingMetricsSink) RecordExternalRequest(input realtime.ExternalRequestMetricInput) {
+	s.external = append(s.external, input)
+}
+
 func TestCallsignProviderFallbackRetriesEmptyPayload(t *testing.T) {
 	var requested []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -104,6 +112,47 @@ func TestCallsignCanUseFlightAwareFallbackAfterEmptyADSB(t *testing.T) {
 	aircraft := ac[0].(map[string]any)
 	if aircraft["flight_position_source"] != "flightaware" || aircraft["lat"] != 49.05 {
 		t.Fatalf("aircraft = %#v", aircraft)
+	}
+}
+
+func TestPositionProviderMetricsIncludeRequestURLAndError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	metrics := &recordingMetricsSink{}
+	client := NewClient(Options{
+		Providers: []Provider{
+			{ID: "adsb.lol", PositionURL: func(lat, lon float64, distNM int) string {
+				return server.URL + "/adsb-lol/positions?lat=42.4&lon=-71&dist=40"
+			}},
+		},
+	})
+
+	_, err := client.Fetch(context.Background(), realtime.FetchInput{
+		Channel:     "traffic:center:42.4:-71:40",
+		ChannelType: realtime.ChannelTraffic,
+		Metrics:     metrics,
+		Target: realtime.PollingTarget{
+			Kind:   "positions",
+			Lat:    42.4,
+			Lon:    -71,
+			DistNM: 40,
+		},
+	})
+	if err == nil {
+		t.Fatal("Fetch returned nil error")
+	}
+	if len(metrics.external) != 1 {
+		t.Fatalf("external metrics = %#v", metrics.external)
+	}
+	entry := metrics.external[0]
+	if entry.URL != server.URL+"/adsb-lol/positions?lat=42.4&lon=-71&dist=40" ||
+		entry.Error != "HTTP 429" ||
+		entry.Status != http.StatusTooManyRequests ||
+		entry.DurationMS < 0 {
+		t.Fatalf("external metric = %#v", entry)
 	}
 }
 

--- a/services/data-service/internal/providers/flightaware/fallback.go
+++ b/services/data-service/internal/providers/flightaware/fallback.go
@@ -132,12 +132,12 @@ func (c *FallbackClient) ByCallsign(ctx context.Context, callsign any, metrics r
 	started := time.Now()
 	resp, cancel, err := c.do(ctx, pageURL, "text/html,application/xhtml+xml", "", metrics, started)
 	if err != nil {
-		record(metrics, "error", "ERR", started)
+		record(metrics, "error", "ERR", pageURL, err.Error(), started)
 		return errorResult(timeoutOrNetwork(err), fetchedAt, err.Error(), nil), nil
 	}
 	defer cancel()
 	defer resp.Body.Close()
-	record(metrics, resultForStatus(resp.StatusCode), resp.StatusCode, started)
+	record(metrics, resultForStatus(resp.StatusCode), resp.StatusCode, pageURL, statusError(resp.StatusCode), started)
 	if resp.StatusCode == http.StatusNotFound {
 		return errorResult("not_found", fetchedAt, "", nil), nil
 	}
@@ -173,12 +173,12 @@ func (c *FallbackClient) tryTrackpoll(ctx context.Context, callsign, fetchedAt, 
 	started := time.Now()
 	resp, cancel, err := c.do(ctx, trackURL, "application/json, text/javascript, */*; q=0.01", pageURL, metrics, started)
 	if err != nil {
-		record(metrics, "error", "ERR", started)
+		record(metrics, "error", "ERR", trackURL, err.Error(), started)
 		return adsb.FallbackResult{}, false
 	}
 	defer cancel()
 	defer resp.Body.Close()
-	record(metrics, resultForStatus(resp.StatusCode), resp.StatusCode, started)
+	record(metrics, resultForStatus(resp.StatusCode), resp.StatusCode, trackURL, statusError(resp.StatusCode), started)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return adsb.FallbackResult{}, false
 	}
@@ -620,12 +620,12 @@ func readBody(reader io.Reader, limit int64) ([]byte, error) {
 	return body, nil
 }
 
-func record(metrics realtime.MetricsSink, result string, status any, started time.Time) {
+func record(metrics realtime.MetricsSink, result string, status any, requestURL, errorText string, started time.Time) {
 	if metrics == nil {
 		return
 	}
 	metrics.RecordExternalRequest(realtime.ExternalRequestMetricInput{
-		Provider: "flightaware", Endpoint: "callsign", Result: result, Status: status, DurationMS: time.Since(started).Milliseconds(),
+		Provider: "flightaware", Endpoint: "callsign", Result: result, Status: status, URL: requestURL, Error: errorText, DurationMS: time.Since(started).Milliseconds(),
 	})
 }
 
@@ -634,6 +634,13 @@ func resultForStatus(status int) string {
 		return "success"
 	}
 	return "error"
+}
+
+func statusError(status int) string {
+	if status >= 200 && status < 300 {
+		return ""
+	}
+	return fmt.Sprintf("HTTP %d", status)
 }
 
 func timeoutOrNetwork(err error) string {

--- a/services/data-service/internal/providers/route/client.go
+++ b/services/data-service/internal/providers/route/client.go
@@ -121,7 +121,7 @@ func (c *Client) fetchADSBDB(ctx context.Context, input realtime.FetchInput) (re
 	status := any(nil)
 	resp, cancel, err := c.do(ctx, requestURL, "application/json", userAgent)
 	if err != nil {
-		c.recordExternal(input, "adsbdb", "error", "ERR", started)
+		c.recordExternal(input, "adsbdb", "error", "ERR", requestURL, err.Error(), started)
 		return realtime.Event{}, err
 	}
 	defer cancel()
@@ -129,23 +129,24 @@ func (c *Client) fetchADSBDB(ctx context.Context, input realtime.FetchInput) (re
 	status = resp.StatusCode
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp.StatusCode != http.StatusNotFound {
-			c.recordExternal(input, "adsbdb", "error", status, started)
+			message := fmt.Sprintf("HTTP %d", resp.StatusCode)
+			c.recordExternal(input, "adsbdb", "error", status, requestURL, message, started)
 			return realtime.Event{}, fmt.Errorf("adsbdb route HTTP %d", resp.StatusCode)
 		}
-		c.recordExternal(input, "adsbdb", "success", status, started)
+		c.recordExternal(input, "adsbdb", "success", status, requestURL, "", started)
 		return routeEvent(input.Channel, "adsbdb", input.Target.Callsign, nil), nil
 	}
 	body, err := c.readBody(resp)
 	if err != nil {
-		c.recordExternal(input, "adsbdb", "error", "ERR", started)
+		c.recordExternal(input, "adsbdb", "error", "ERR", requestURL, err.Error(), started)
 		return realtime.Event{}, err
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
-		c.recordExternal(input, "adsbdb", "error", "PARSE", started)
+		c.recordExternal(input, "adsbdb", "error", "PARSE", requestURL, "Invalid ADSBDB JSON", started)
 		return realtime.Event{}, err
 	}
-	c.recordExternal(input, "adsbdb", "success", status, started)
+	c.recordExternal(input, "adsbdb", "success", status, requestURL, "", started)
 	return routeEvent(input.Channel, "adsbdb", input.Target.Callsign, normalizeADSBDBRoute(input.Target.Callsign, payload)), nil
 }
 
@@ -163,7 +164,7 @@ func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput
 	status := any(nil)
 	resp, cancel, err := c.do(ctx, requestURL, "text/html,application/xhtml+xml", flightAwareRouteUA)
 	if err != nil {
-		c.recordExternal(input, "flightaware", "error", "ERR", started)
+		c.recordExternal(input, "flightaware", "error", "ERR", requestURL, err.Error(), started)
 		return realtime.Event{}, err
 	}
 	defer cancel()
@@ -171,18 +172,19 @@ func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput
 	status = resp.StatusCode
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp.StatusCode != http.StatusNotFound {
-			c.recordExternal(input, "flightaware", "error", status, started)
+			message := fmt.Sprintf("HTTP %d", resp.StatusCode)
+			c.recordExternal(input, "flightaware", "error", status, requestURL, message, started)
 			return realtime.Event{}, fmt.Errorf("flightaware route HTTP %d", resp.StatusCode)
 		}
-		c.recordExternal(input, "flightaware", "success", status, started)
+		c.recordExternal(input, "flightaware", "success", status, requestURL, "", started)
 		return routeEvent(input.Channel, "flightaware", input.Target.Callsign, nil), nil
 	}
 	body, err := c.readBody(resp)
 	if err != nil {
-		c.recordExternal(input, "flightaware", "error", "ERR", started)
+		c.recordExternal(input, "flightaware", "error", "ERR", requestURL, err.Error(), started)
 		return realtime.Event{}, err
 	}
-	c.recordExternal(input, "flightaware", "success", status, started)
+	c.recordExternal(input, "flightaware", "success", status, requestURL, "", started)
 	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, c.normalizeFlightAwareRoute(ctx, input, string(body))), nil
 }
 
@@ -266,7 +268,7 @@ func (c *Client) airportDirectoryURL(ident string) string {
 	return c.airportDirectoryBaseURL + "/api/airport/" + url.PathEscape(normalized)
 }
 
-func (c *Client) recordExternal(input realtime.FetchInput, provider, result string, status any, started time.Time) {
+func (c *Client) recordExternal(input realtime.FetchInput, provider, result string, status any, requestURL, errorText string, started time.Time) {
 	if input.Metrics == nil {
 		return
 	}
@@ -275,6 +277,8 @@ func (c *Client) recordExternal(input realtime.FetchInput, provider, result stri
 		Endpoint:   "route",
 		Result:     result,
 		Status:     status,
+		URL:        requestURL,
+		Error:      errorText,
 		DurationMS: time.Since(started).Milliseconds(),
 	})
 }
@@ -503,34 +507,34 @@ func (c *Client) fetchDirectoryAirport(ctx context.Context, input realtime.Fetch
 	started := time.Now()
 	resp, cancel, err := c.do(ctx, requestURL, "application/json", userAgent)
 	if err != nil {
-		c.recordAirportDirectory(input, "error", "ERR", started)
+		c.recordAirportDirectory(input, "error", "ERR", requestURL, err.Error(), started)
 		return nil
 	}
 	defer cancel()
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		c.recordAirportDirectory(input, "success", resp.StatusCode, started)
+		c.recordAirportDirectory(input, "success", resp.StatusCode, requestURL, "", started)
 		return nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		c.recordAirportDirectory(input, "error", resp.StatusCode, started)
+		c.recordAirportDirectory(input, "error", resp.StatusCode, requestURL, fmt.Sprintf("HTTP %d", resp.StatusCode), started)
 		return nil
 	}
 	body, err := c.readBody(resp)
 	if err != nil {
-		c.recordAirportDirectory(input, "error", "ERR", started)
+		c.recordAirportDirectory(input, "error", "ERR", requestURL, err.Error(), started)
 		return nil
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
-		c.recordAirportDirectory(input, "error", "PARSE", started)
+		c.recordAirportDirectory(input, "error", "PARSE", requestURL, "Invalid airport directory JSON", started)
 		return nil
 	}
-	c.recordAirportDirectory(input, "success", resp.StatusCode, started)
+	c.recordAirportDirectory(input, "success", resp.StatusCode, requestURL, "", started)
 	return asMap(payload["airport"])
 }
 
-func (c *Client) recordAirportDirectory(input realtime.FetchInput, result string, status any, started time.Time) {
+func (c *Client) recordAirportDirectory(input realtime.FetchInput, result string, status any, requestURL, errorText string, started time.Time) {
 	if input.Metrics == nil {
 		return
 	}
@@ -539,6 +543,8 @@ func (c *Client) recordAirportDirectory(input realtime.FetchInput, result string
 		Endpoint:   "airport",
 		Result:     result,
 		Status:     status,
+		URL:        requestURL,
+		Error:      errorText,
 		DurationMS: time.Since(started).Milliseconds(),
 	})
 }

--- a/services/data-service/internal/realtime/types.go
+++ b/services/data-service/internal/realtime/types.go
@@ -76,6 +76,8 @@ type ExternalRequestMetricInput struct {
 	Endpoint   string
 	Result     string
 	Status     any
+	URL        string
+	Error      string
 	DurationMS int64
 }
 

--- a/src/app/api/_shared/apiProxySecurity.test.ts
+++ b/src/app/api/_shared/apiProxySecurity.test.ts
@@ -124,8 +124,11 @@ assert.deepEqual(
     level: "info",
     msg: "proxy_route_done",
     route: "/api/proxy/aircraft/positions",
+    url: "/api/proxy/aircraft/positions/1/2/3",
+    queryParams: null,
     requestId: "iad1::abc",
     status: 200,
+    error: null,
     ms: 28,
     source: "adsb.lol",
     attempts: "adsb.lol:200",
@@ -159,7 +162,7 @@ assert.deepEqual(
   });
   assert.equal(
     await logProxyRouteResponse({
-      request: new Request("https://adsbao.test/api/proxy/aircraft/positions/1/2/3", {
+      request: new Request("https://adsbao.test/api/proxy/aircraft/positions/1/2/3?provider=adsb.lol", {
         headers: { "x-vercel-id": "iad1::proxy" },
       }),
       route: "/api/proxy/aircraft/positions",
@@ -202,6 +205,7 @@ assert.deepEqual(
   assert.equal(metricPayload.metrics[0].attributes.route, "/api/proxy/aircraft/positions");
   assert.equal(metricPayload.metrics[0].attributes.source, "adsb.lol");
   assert.equal(metricPayload.metrics[0].attributes.status, "503");
+  assert.equal(metricPayload.metrics[0].attributes.status_code, "503");
   assert.equal(metricPayload.metrics[0].attributes["status.class"], "5xx");
   assert.equal(metricPayload.metrics[0].attributes.result, "error");
   assert.equal(metricPayload.metrics[1].value.sum, 0.245);
@@ -210,10 +214,13 @@ assert.deepEqual(
   assert.equal(logPayload.common.attributes["service.name"], "adsbao-web");
   assert.equal(
     logPayload.logs[0].message,
-    "proxy_route route=/api/proxy/aircraft/positions source=adsb.lol result=error status=503 status_class=5xx duration_ms=245 attempts=adsb.lol:503;airplanes.live:429",
+    "[503]/api/proxy/aircraft/positions/1/2/3, params: provider=adsb.lol, error: status=503, duration: 245ms",
   );
   assert.equal(logPayload.logs[0].level, "error");
   assert.equal(logPayload.logs[0].attributes.route, "/api/proxy/aircraft/positions");
+  assert.equal(logPayload.logs[0].attributes.url, "/api/proxy/aircraft/positions/1/2/3");
+  assert.equal(logPayload.logs[0].attributes.query_params, "provider=adsb.lol");
+  assert.equal(logPayload.logs[0].attributes.error, "status=503");
   assert.equal(logPayload.logs[0].attributes["request.id"], "iad1::proxy");
   assert.equal(logPayload.logs[0].attributes["duration.ms"], 245);
   assert.equal(logPayload.logs[0].attributes.duration_ms, 245);

--- a/src/app/api/_shared/apiProxySecurity.ts
+++ b/src/app/api/_shared/apiProxySecurity.ts
@@ -55,10 +55,13 @@ type ProxyObservation = {
   level: "info" | "warn" | "error";
   msg: "proxy_route_done";
   route: string;
+  url: string;
+  queryParams: string | null;
   requestId: string | null;
   status: number;
   statusClass: string;
   result: "success" | "error";
+  error: string | null;
   ms: number | null;
   source: string | null;
   attempts: string | null;
@@ -299,14 +302,18 @@ export async function logProxyRouteResponse({
   const status = Number(response?.status) || 0;
   const statusClass = status > 0 ? `${Math.floor(status / 100)}xx` : "unknown";
   const result = status > 0 && status < 400 ? "success" : "error";
+  const target = proxyRequestTarget(request, route);
   const payload: ProxyObservation = {
     level: status >= 500 || status === 0 ? "error" : status >= 400 ? "warn" : "info",
     msg: "proxy_route_done",
     route: String(route || ""),
+    url: target.url,
+    queryParams: target.queryParams,
     requestId: request?.headers?.get?.("x-vercel-id") || null,
     status,
     statusClass,
     result,
+    error: result === "error" ? `status=${status || "unknown"}` : null,
     ms:
       Number.isFinite(startedAt) && Number.isFinite(finishedAt)
         ? Math.max(0, Math.round(finishedAt - startedAt))
@@ -331,8 +338,11 @@ function toProxyConsolePayload(payload: ProxyObservation) {
     level: payload.level,
     msg: payload.msg,
     route: payload.route,
+    url: payload.url,
+    queryParams: payload.queryParams,
     requestId: payload.requestId,
     status: payload.status,
+    error: payload.error,
     ms: payload.ms,
     source: payload.source,
     attempts: payload.attempts,
@@ -427,22 +437,22 @@ function proxyTelemetryAttributes(payload: ProxyObservation) {
     attempts: payload.attempts || "none",
     result: payload.result,
     status: String(payload.status || "unknown"),
+    status_code: String(payload.status || "unknown"),
     "status.class": payload.statusClass,
     status_class: payload.statusClass,
   };
 }
 
 function proxyLogMessage(payload: ProxyObservation) {
-  return [
-    "proxy_route",
-    `route=${payload.route || "unknown"}`,
-    `source=${payload.source || "unknown"}`,
-    `result=${payload.result}`,
-    `status=${payload.status || "unknown"}`,
-    `status_class=${payload.statusClass}`,
-    `duration_ms=${payload.ms ?? "unknown"}`,
-    `attempts=${payload.attempts || "none"}`,
-  ].join(" ");
+  const parts = [`[${payload.status || "unknown"}]${payload.url || "unknown"}`];
+  if (payload.queryParams) {
+    parts.push(`params: ${payload.queryParams}`);
+  }
+  if (payload.error) {
+    parts.push(`error: ${payload.error}`);
+  }
+  parts.push(`duration: ${payload.ms ?? "unknown"}ms`);
+  return parts.join(", ");
 }
 
 function proxyLogAttributes(
@@ -451,8 +461,15 @@ function proxyLogAttributes(
 ) {
   const out: Record<string, unknown> = {
     ...attributes,
+    url: payload.url || "unknown",
     "request.id": payload.requestId || "unknown",
   };
+  if (payload.queryParams) {
+    out.query_params = payload.queryParams;
+  }
+  if (payload.error) {
+    out.error = payload.error;
+  }
   if (payload.ms != null) {
     out["duration.ms"] = payload.ms;
     out["duration.seconds"] = payload.ms / 1000;
@@ -460,6 +477,40 @@ function proxyLogAttributes(
     out.duration_seconds = payload.ms / 1000;
   }
   return out;
+}
+
+function proxyRequestTarget(request?: Request, route?: string) {
+  const fallback = String(route || "unknown");
+  if (!request?.url) {
+    return { url: fallback, queryParams: null };
+  }
+  try {
+    const parsed = new URL(request.url);
+    return {
+      url: parsed.pathname || fallback,
+      queryParams: sanitizedQueryParams(parsed.searchParams),
+    };
+  } catch {
+    return { url: fallback, queryParams: null };
+  }
+}
+
+function sanitizedQueryParams(params: URLSearchParams) {
+  const parts: string[] = [];
+  params.forEach((value, key) => {
+    parts.push(`${key}=${isSensitiveQueryKey(key) ? "[redacted]" : value}`);
+  });
+  return parts.length > 0 ? parts.join("&") : null;
+}
+
+function isSensitiveQueryKey(key: string) {
+  const normalized = key.toLowerCase();
+  return (
+    normalized.includes("key") ||
+    normalized.includes("token") ||
+    normalized.includes("secret") ||
+    normalized.includes("password")
+  );
 }
 
 function proxyMetrics(

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -7,6 +7,18 @@
 
 export const CHANGELOG = [
   {
+    version: "v2.6.2",
+    kind: "patch",
+    title: "URL-first provider logs",
+    summary:
+      "New Relic log messages now show the called URL, query parameters, error, and duration in one compact line.",
+    highlights: [
+      "Changed data-service external request logs to use status-prefixed provider URLs with optional query params and error details",
+      "Changed Vercel proxy logs to show the requested API path, query params, status error, and duration",
+      "Kept provider, source, route, status class, and duration fields queryable as structured New Relic attributes",
+    ],
+  },
+  {
     version: "v2.6.1",
     kind: "patch",
     title: "Readable observability logs",


### PR DESCRIPTION
## Summary
- Change data-service external request log messages to `[status]url, params: ..., error: ..., duration: ...ms`
- Pass actual provider request URLs and error text from ADS-B, route, airport fallback, and FlightAware fallback providers into New Relic logs
- Change Vercel proxy log messages to show requested API path, query params, status error, and duration; keep structured attributes queryable
- Bump ADSBao to v2.6.2 and update changelog

## Validation
- go test ./... (services/data-service)
- pnpm test
- pnpm lint (0 errors, existing warnings only)
- pnpm build
- git diff --check
