### PR TITLE
v2.7.1 — FAA-accurate, zoom-performant runway/taxiway lighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.7.0",
+  "version": "2.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/api/webapi/airport_surface.go
+++ b/services/data-service/internal/api/webapi/airport_surface.go
@@ -16,10 +16,11 @@ import (
 const (
 	defaultOverpassBaseURL             = "https://overpass-api.de/api/interpreter"
 	defaultAirportSurfaceCacheTTL      = 6 * time.Hour
-	airportSurfaceRequestTimeout       = 6 * time.Second
+	airportSurfaceRequestTimeout       = 18 * time.Second
 	airportSurfaceBBoxPaddingMeters    = 1800
 	airportSurfaceFallbackRadiusMeters = 4500
-	maxAirportSurfaceFeatures          = 500
+	maxAirportSurfaceFeatures          = 1400
+	maxAirportSurfaceBuildings         = 600
 )
 
 type airportSurfaceBBox struct {
@@ -185,12 +186,25 @@ func buildAirportSurfaceOverpassQuery(bbox airportSurfaceBBox) string {
 		formatBBoxCoordinate(bbox.east),
 	}, ",")
 
-	return fmt.Sprintf(`[out:json][timeout:8];
+	// Buildings are constrained to INSIDE the airport's aerodrome polygon (via
+	// map_to_area) so we color only on-field structures, not the surrounding
+	// city. Aeroway pavement still uses the bbox so runways/taxiways render even
+	// when an airport has no mapped aerodrome area.
+	return fmt.Sprintf(`[out:json][timeout:20];
+(
+  way["aeroway"="aerodrome"](%s);
+  relation["aeroway"="aerodrome"](%s);
+)->.aerodrome;
+.aerodrome map_to_area->.apt;
 (
   way["aeroway"~"^(runway|taxiway|taxilane|apron)$"](%s);
   relation["aeroway"~"^(runway|taxiway|taxilane|apron)$"](%s);
+  way["aeroway"="terminal"](%s);
+  relation["aeroway"="terminal"](%s);
+  way["building"](area.apt);
+  relation["building"](area.apt);
 );
-out tags geom;`, formatted, formatted)
+out tags geom;`, formatted, formatted, formatted, formatted, formatted, formatted)
 }
 
 func formatBBoxCoordinate(value float64) string {
@@ -205,12 +219,22 @@ func buildAirportSurfaceMapFromOverpass(airport string, payload map[string]any) 
 
 	features := []map[string]any{}
 	counts := map[string]int{}
+	buildingCount := 0
 	for _, element := range asRecords(payload["elements"]) {
 		feature := airportSurfaceFeature(element)
 		if feature == nil {
 			continue
 		}
 		kind := stringValue(valueAt(feature, "properties", "kind"))
+		// Cap buildings independently so a building-dense airport can never
+		// starve the aeroway pavement (runways/taxiways/aprons) it shares the
+		// overall budget with.
+		if kind == "building" {
+			if buildingCount >= maxAirportSurfaceBuildings {
+				continue
+			}
+			buildingCount++
+		}
 		counts[kind]++
 		features = append(features, feature)
 		if len(features) >= maxAirportSurfaceFeatures {
@@ -244,6 +268,18 @@ func buildAirportSurfaceMapFromOverpass(airport string, payload map[string]any) 
 func airportSurfaceFeature(element map[string]any) map[string]any {
 	tags := asRecord(element["tags"])
 	kind := strings.ToLower(stringValue(tags["aeroway"]))
+	// `stringValue` yields "<nil>" for a missing tag — normalize to empty.
+	if kind == "<nil>" {
+		kind = ""
+	}
+	// Buildings carry no aeroway tag; aeroway=terminal is already a building.
+	// Classify them so the frontend can color terminals distinctly from other
+	// airport buildings.
+	if kind == "" {
+		if _, ok := tags["building"]; ok {
+			kind = "building"
+		}
+	}
 	if !isAirportSurfaceKind(kind) {
 		return nil
 	}
@@ -283,7 +319,7 @@ func airportSurfaceFeature(element map[string]any) map[string]any {
 
 func isAirportSurfaceKind(kind string) bool {
 	switch kind {
-	case "runway", "taxiway", "taxilane", "apron":
+	case "runway", "taxiway", "taxilane", "apron", "terminal", "building":
 		return true
 	default:
 		return false
@@ -306,7 +342,9 @@ func shouldRenderAirportSurfaceAsPolygon(kind string, coordinates []any) bool {
 	if len(coordinates) < 4 {
 		return false
 	}
-	if kind != "apron" && kind != "runway" {
+	switch kind {
+	case "apron", "runway", "terminal", "building":
+	default:
 		return false
 	}
 	first := coordinates[0].([]any)
@@ -315,16 +353,22 @@ func shouldRenderAirportSurfaceAsPolygon(kind string, coordinates []any) bool {
 }
 
 func airportSurfaceKindRank(kind string) int {
+	// Lower ranks render first (underneath). Buildings/terminals sit below the
+	// pavement; runways sit on top.
 	switch kind {
-	case "apron":
+	case "building":
 		return 0
-	case "taxilane":
+	case "terminal":
 		return 1
-	case "taxiway":
+	case "apron":
 		return 2
-	case "runway":
+	case "taxilane":
 		return 3
-	default:
+	case "taxiway":
 		return 4
+	case "runway":
+		return 5
+	default:
+		return 6
 	}
 }

--- a/services/data-service/internal/api/webapi/airport_surface_test.go
+++ b/services/data-service/internal/api/webapi/airport_surface_test.go
@@ -39,9 +39,12 @@ func TestBuildAirportSurfaceOverpassQuery(t *testing.T) {
 		east:  -70.986,
 	})
 
-	if !strings.Contains(query, `[out:json][timeout:8];`) ||
+	if !strings.Contains(query, `[out:json][timeout:20];`) ||
 		!strings.Contains(query, `way["aeroway"~"^(runway|taxiway|taxilane|apron)$"](42.344000,-71.031000,42.385000,-70.986000);`) ||
 		!strings.Contains(query, `relation["aeroway"~"^(runway|taxiway|taxilane|apron)$"](42.344000,-71.031000,42.385000,-70.986000);`) ||
+		!strings.Contains(query, `way["aeroway"="terminal"](42.344000,-71.031000,42.385000,-70.986000);`) ||
+		!strings.Contains(query, `map_to_area->.apt;`) ||
+		!strings.Contains(query, `way["building"](area.apt);`) ||
 		!strings.Contains(query, `out tags geom;`) {
 		t.Fatalf("unexpected query:\n%s", query)
 	}
@@ -76,6 +79,19 @@ func TestBuildAirportSurfaceMapFromOverpass(t *testing.T) {
 				"tags":     map[string]any{"aeroway": "helipad"},
 				"geometry": []any{map[string]any{"lat": 42.36, "lon": -71.01}},
 			},
+			// A building with no aeroway tag must be classified as "building"
+			// (guards the missing-tag "<nil>" normalization).
+			map[string]any{
+				"type": "way",
+				"id":   104,
+				"tags": map[string]any{"building": "yes", "name": "Terminal A"},
+				"geometry": []any{
+					map[string]any{"lat": 42.365, "lon": -71.015},
+					map[string]any{"lat": 42.365, "lon": -71.013},
+					map[string]any{"lat": 42.366, "lon": -71.013},
+					map[string]any{"lat": 42.365, "lon": -71.015},
+				},
+			},
 		},
 	}
 
@@ -87,19 +103,24 @@ func TestBuildAirportSurfaceMapFromOverpass(t *testing.T) {
 		t.Fatalf("unexpected surface map metadata: %#v", surfaceMap)
 	}
 	features := surfaceMap["features"].(map[string]any)["features"].([]map[string]any)
-	if len(features) != 2 {
+	if len(features) != 3 {
 		t.Fatalf("features = %#v", features)
 	}
-	if valueAt(features[0], "properties", "kind") != "apron" ||
+	// Buildings rank first (drawn underneath), then apron, then taxiway.
+	if valueAt(features[0], "properties", "kind") != "building" ||
 		valueAt(features[0], "geometry", "type") != "Polygon" {
-		t.Fatalf("expected apron polygon first, got %#v", features[0])
+		t.Fatalf("expected building polygon first, got %#v", features[0])
 	}
-	if valueAt(features[1], "properties", "kind") != "taxiway" ||
-		valueAt(features[1], "geometry", "type") != "LineString" {
-		t.Fatalf("expected taxiway line second, got %#v", features[1])
+	if valueAt(features[1], "properties", "kind") != "apron" ||
+		valueAt(features[1], "geometry", "type") != "Polygon" {
+		t.Fatalf("expected apron polygon second, got %#v", features[1])
+	}
+	if valueAt(features[2], "properties", "kind") != "taxiway" ||
+		valueAt(features[2], "geometry", "type") != "LineString" {
+		t.Fatalf("expected taxiway line third, got %#v", features[2])
 	}
 	counts := surfaceMap["counts"].(map[string]int)
-	if counts["apron"] != 1 || counts["taxiway"] != 1 {
+	if counts["apron"] != 1 || counts["taxiway"] != 1 || counts["building"] != 1 {
 		t.Fatalf("counts = %#v", counts)
 	}
 }

--- a/src/components/map/AirportSurfaceLayer.tsx
+++ b/src/components/map/AirportSurfaceLayer.tsx
@@ -27,12 +27,20 @@ const shouldRenderAirportSurfaceFeature = (
   feature: Record<string, any>,
 ) => {
   const kind = String(feature?.properties?.kind || "");
-  return kind === "runway" || kind === "taxiway" || kind === "taxilane";
+  return (
+    kind === "runway" ||
+    kind === "taxiway" ||
+    kind === "taxilane" ||
+    kind === "apron" ||
+    kind === "terminal" ||
+    kind === "building"
+  );
 };
 
 const airportSurfaceStyle = (
   feature: Record<string, any>,
   theme: string,
+  lightsActive: boolean,
 ) => {
   const kind = String(feature?.properties?.kind || "");
   const geometryType = String(feature?.geometry?.type || "");
@@ -40,6 +48,11 @@ const airportSurfaceStyle = (
   const isLight = theme === "light";
 
   if (kind === "runway") {
+    // When FAA lights are rendered (mid/near band), the thick runway stroke
+    // fills the narrow runway into a solid "bar" that competes with the lights.
+    // Thin and dim it so the lights define the runway; keep the full stroke at
+    // far zoom, where it is the only runway indicator.
+    const baseWeight = isLight ? (polygon ? 1.8 : 2.4) : polygon ? 5.6 : 6.2;
     return {
       className: airportSurfaceClassName(kind),
       color: "var(--airport-surface-runway-stroke)",
@@ -48,11 +61,28 @@ const airportSurfaceStyle = (
       fillOpacity: 0,
       lineCap: "round",
       lineJoin: "round",
-      opacity: isLight ? 0.28 : 0.68,
+      opacity: lightsActive ? (isLight ? 0.16 : 0.34) : isLight ? 0.28 : 0.68,
       stroke: true,
-      weight: isLight
-        ? polygon ? 1.8 : 2.4
-        : polygon ? 5.6 : 6.2,
+      weight: lightsActive ? (isLight ? 1.2 : 2.2) : baseWeight,
+    };
+  }
+
+  // Filled airport structures. Terminals get a distinct accent; other
+  // buildings a muted fill; aprons a subtle pavement tone. Colors resolve from
+  // theme tokens so both light and dark stay in the design system.
+  if (kind === "terminal" || kind === "building" || kind === "apron") {
+    const variant = kind === "apron" ? "apron" : kind === "terminal" ? "terminal" : "building";
+    return {
+      className: airportSurfaceClassName(kind),
+      color: `var(--airport-surface-${variant}-stroke)`,
+      fill: true,
+      fillColor: `var(--airport-surface-${variant}-fill)`,
+      fillOpacity: isLight ? 0.42 : 0.5,
+      lineCap: "round",
+      lineJoin: "round",
+      opacity: isLight ? 0.5 : 0.6,
+      stroke: true,
+      weight: isLight ? 0.7 : 0.8,
     };
   }
 
@@ -93,6 +123,8 @@ export default function AirportSurfaceLayer({
     () => buildRenderableAirportSurfaceFeatureCollection(surfaceMap, runwayMap),
     [runwayMap, surfaceMap],
   );
+  const lightingBand = useMemo(() => runwayLightingLodForZoom(zoom), [zoom]);
+  const lightsActive = lightingBand !== "far";
 
   useEffect(() => {
     if (!map || !surfaceFeatures?.features?.length) return undefined;
@@ -110,7 +142,7 @@ export default function AirportSurfaceLayer({
         return shouldRenderAirportSurfaceFeature(feature as Record<string, any>);
       },
       style(feature) {
-        return airportSurfaceStyle(feature as Record<string, any>, theme);
+        return airportSurfaceStyle(feature as Record<string, any>, theme, lightsActive);
       },
     } as any);
 
@@ -126,12 +158,11 @@ export default function AirportSurfaceLayer({
       renderer.remove();
       layerRef.current = null;
     };
-  }, [map, surfaceFeatures, theme, zoom]);
+  }, [map, surfaceFeatures, theme, zoom, lightsActive]);
 
   // Taxiway lights (green centerline + blue edge) on a shared canvas. Near band
   // only — taxiway lights are dense and low-value when zoomed out. Rebuilds only
   // on band crossing / airport / theme change, not on every fractional zoom.
-  const lightingBand = useMemo(() => runwayLightingLodForZoom(zoom), [zoom]);
   useEffect(() => {
     if (!map || !surfaceFeatures?.features?.length) return undefined;
     if (lightingBand !== "near") return undefined;

--- a/src/components/map/AirportSurfaceLayer.tsx
+++ b/src/components/map/AirportSurfaceLayer.tsx
@@ -6,6 +6,9 @@ import { AIRPORT_MAP_ZOOM } from "../../config/aviation";
 import { AIRPORT_MAP_PANES } from "../../config/airportMap";
 import { ensureAirportMapPane } from "../../features/airport/map/mapPane";
 import { buildRenderableAirportSurfaceFeatureCollection } from "../../features/airport/map/runwayAnnotationModel";
+import { buildTaxiwayLightCollection } from "../../features/airport/map/runwayLightingModel";
+import { runwayLightingLodForZoom } from "../../features/airport/map/airportMapZoomFeatures";
+import { buildRunwayLightCanvasLayer } from "../../features/airport/map/runwayLightCanvas";
 import {
   safeAddToMap,
   safeRemoveFromMap,
@@ -124,6 +127,27 @@ export default function AirportSurfaceLayer({
       layerRef.current = null;
     };
   }, [map, surfaceFeatures, theme, zoom]);
+
+  // Taxiway lights (green centerline + blue edge) on a shared canvas. Near band
+  // only — taxiway lights are dense and low-value when zoomed out. Rebuilds only
+  // on band crossing / airport / theme change, not on every fractional zoom.
+  const lightingBand = useMemo(() => runwayLightingLodForZoom(zoom), [zoom]);
+  useEffect(() => {
+    if (!map || !surfaceFeatures?.features?.length) return undefined;
+    if (lightingBand !== "near") return undefined;
+
+    const lights = buildTaxiwayLightCollection(surfaceFeatures, { band: lightingBand });
+    if (!lights.features.length) return undefined;
+
+    const { layer, renderer } = buildRunwayLightCanvasLayer({ data: lights, map });
+    renderer.addTo(map);
+    layer.addTo(map);
+
+    return () => {
+      layer.remove();
+      renderer.remove();
+    };
+  }, [map, surfaceFeatures, lightingBand, theme]);
 
   return null;
 }

--- a/src/components/map/RunwayAnnotationLayer.tsx
+++ b/src/components/map/RunwayAnnotationLayer.tsx
@@ -15,8 +15,13 @@ import {
   buildRunwayCenterlineCollection,
   buildRunwayEndLabels,
   buildRunwayMapFromSurfaceMap,
-  buildRunwayLightCollection,
 } from "../../features/airport/map/runwayAnnotationModel";
+import { buildRunwayFaaLightCollection } from "../../features/airport/map/runwayLightingModel";
+import { runwayLightingLodForZoom } from "../../features/airport/map/airportMapZoomFeatures";
+import {
+  buildRunwayLightCanvasLayer,
+  startReilFlashTimer,
+} from "../../features/airport/map/runwayLightCanvas";
 
 const escapeHtml = (value: unknown) =>
   String(value).replace(/[&<>"']/g, (character) => {
@@ -51,11 +56,6 @@ const isWideAirportZoom = (zoom: unknown) => {
   return Number.isFinite(numericZoom) && numericZoom <= AIRPORT_MAP_ZOOM.approach;
 };
 
-const shouldShowRunwayLightsForZoom = (zoom: unknown) => {
-  const numericZoom = Number(zoom);
-  return !Number.isFinite(numericZoom) || numericZoom >= AIRPORT_MAP_ZOOM.airport;
-};
-
 const runwayLabelIcon = (ident: string, theme: string) =>
   L.divIcon({
     className: `runway-end-label runway-end-label--${theme}`,
@@ -63,14 +63,6 @@ const runwayLabelIcon = (ident: string, theme: string) =>
     iconSize: [34, 18],
     iconAnchor: [17, 22],
   });
-
-const runwayLightRadius = (feature: Record<string, any>) => {
-  const kind = String(feature?.properties?.kind || "");
-  if (kind === "centerline") return 0.82;
-  const progress = Number(feature?.properties?.progress);
-  if (progress === 0 || progress === 1) return 1.55;
-  return 1.12;
-};
 
 const isLeafletLayer = (layer: unknown): layer is L.Layer =>
   Boolean(
@@ -126,30 +118,6 @@ const buildApproachLayer = ({ kind, data, map, theme }: Record<string, any>) => 
   return { layer, beamLayer: layer, beamRenderer };
 };
 
-const buildRunwayLightLayer = ({ data }: Record<string, any>) =>
-  L.geoJSON(data as any, {
-    interactive: false,
-    pointToLayer(feature, latlng) {
-      const kind = String(feature?.properties?.kind || "");
-      const isCenterline = kind === "centerline";
-      const fillColor = isCenterline
-        ? "var(--runway-light-core)"
-        : "var(--runway-light)";
-      return L.circleMarker(latlng, {
-        bubblingMouseEvents: false,
-        className: "runway-light-dot",
-        color: "var(--runway-light-core)",
-        fill: true,
-        fillColor,
-        fillOpacity: isCenterline ? 0.68 : 0.86,
-        opacity: isCenterline ? 0.62 : 0.88,
-        radius: runwayLightRadius(feature as Record<string, any>),
-        stroke: true,
-        weight: 0.45,
-      });
-    },
-  } as any);
-
 export default function RunwayAnnotationLayer({
   runwayMap,
   surfaceMap = null,
@@ -166,13 +134,19 @@ export default function RunwayAnnotationLayer({
     () => buildRunwayMapFromSurfaceMap(surfaceMap, runwayMap),
     [runwayMap, surfaceMap],
   );
+  const annotationRunwayMap = useMemo(
+    () => surfaceRunwayMap || runwayMap,
+    [surfaceRunwayMap, runwayMap],
+  );
+  // Level-of-detail band for point lights. Derived from zoom but only changes
+  // at the breakpoints, so the canvas light effect rebuilds on band crossings
+  // (far→mid→near) — not on every fractional zoomend.
+  const lightingBand = useMemo(() => runwayLightingLodForZoom(zoom), [zoom]);
 
   useEffect(() => {
-    const annotationRunwayMap = surfaceRunwayMap || runwayMap;
     if (!map || !annotationRunwayMap?.runways?.length) return undefined;
 
     const compactZoom = Boolean(compact) || isWideAirportZoom(zoom);
-    const showRunwayLights = shouldShowRunwayLightsForZoom(zoom);
     const sublayers: L.Layer[] = [];
     if (showCenterlines) {
       const centerlines = buildRunwayCenterlineCollection(annotationRunwayMap);
@@ -194,7 +168,10 @@ export default function RunwayAnnotationLayer({
     let beamLayer = null;
     let beamRenderer = null;
 
-    if (showBeams && !compactZoom) {
+    // Approach beams render at ALL zoom levels, including the farthest, where
+    // they are the only lighting cue (point lights are hidden at the `far`
+    // band). The beam profile already widens/lengthens at approach zoom.
+    if (showBeams) {
       const visualization = buildRunwayApproachVisualization(annotationRunwayMap, {
         zoom,
         theme,
@@ -208,14 +185,6 @@ export default function RunwayAnnotationLayer({
       if (isLeafletLayer(built.layer)) sublayers.unshift(built.layer);
       beamLayer = isLeafletLayer(built.beamLayer) ? built.beamLayer : null;
       beamRenderer = built.beamRenderer;
-    }
-
-    if (!compactZoom && theme !== "light" && showRunwayLights) {
-      const runwayLights = buildRunwayLightCollection(annotationRunwayMap);
-      if (runwayLights.features.length) {
-        const lightLayer = buildRunwayLightLayer({ data: runwayLights });
-        if (isLeafletLayer(lightLayer)) sublayers.push(lightLayer);
-      }
     }
 
     if (!compactZoom && showBadges) {
@@ -264,8 +233,7 @@ export default function RunwayAnnotationLayer({
     };
   }, [
     map,
-    runwayMap,
-    surfaceRunwayMap,
+    annotationRunwayMap,
     theme,
     zoom,
     compact,
@@ -273,6 +241,34 @@ export default function RunwayAnnotationLayer({
     showBadges,
     showCenterlines,
   ]);
+
+  // FAA point lights on a single shared canvas. Separate effect so it rebuilds
+  // only when the LOD band crosses a breakpoint (far→mid→near), the airport, or
+  // the theme changes — not on every fractional zoom. Within a band, Leaflet
+  // reprojects the canvas on zoom without a rebuild.
+  useEffect(() => {
+    if (!map || !annotationRunwayMap?.runways?.length) return undefined;
+    if (lightingBand === "far") return undefined;
+
+    const lights = buildRunwayFaaLightCollection(annotationRunwayMap, {
+      band: lightingBand,
+    });
+    if (!lights.features.length) return undefined;
+
+    const { layer, renderer, reilMarkers } = buildRunwayLightCanvasLayer({
+      data: lights,
+      map,
+    });
+    renderer.addTo(map);
+    layer.addTo(map);
+    const stopReilFlash = startReilFlashTimer(reilMarkers);
+
+    return () => {
+      stopReilFlash();
+      layer.remove();
+      renderer.remove();
+    };
+  }, [map, annotationRunwayMap, lightingBand, theme]);
 
   return null;
 }

--- a/src/config/airportMap.ts
+++ b/src/config/airportMap.ts
@@ -89,6 +89,51 @@ export const RUNWAY_APPROACH_BEAM_CONFIG = {
   ],
 };
 
+// FAA AIM Ch.2 §3 lighting geometry. Spacing/zone distances are in feet
+// (FAA spec units); the model converts to meters. Colors are NOT here — the
+// renderer maps each light's semantic color role to a CSS variable so themes
+// stay the source of truth (see --atc-runway-light-* in style.css).
+export const RUNWAY_FAA_LIGHTING_CONFIG = {
+  // Longitudinal spacing along the runway. NOTE: these are intentionally WIDER
+  // than the real FAA spacing (edge 200ft, centerline 50ft). At the map's max
+  // usable zoom, true spacing packs the dots into a solid line; widening the
+  // gaps keeps individual lights legible. Color ZONES below stay distance-exact
+  // (in feet), so the FAA color pattern is preserved regardless of spacing.
+  edgeSpacingFt: 400,
+  centerlineSpacingFt: 200,
+  // Symmetric color zones, measured from the nearer threshold.
+  edgeCautionFt: 2000, // edge turns amber within last 2000ft (or half, whichever less)
+  centerlineRedFt: 1000, // centerline all-red within last 1000ft
+  centerlineAltFt: 3000, // centerline alternates red/white from 3000ft to 1000ft remaining
+  // Touchdown zone lights: from `tdzStartFt` past the (displaced) threshold,
+  // extending up to `tdzLengthFt` or the runway midpoint, whichever is less.
+  tdzStartFt: 100,
+  tdzLengthFt: 3000,
+  tdzBarSpacingFt: 300, // widened for legibility (real ~100ft)
+  tdzBarHalfCount: 2, // lights per side of a single TDZ bar
+  // Threshold / runway-end bar: number of lights across the runway width.
+  endBarLightCount: 5,
+  // REIL: a pair of synchronized flashing strobes flanking each threshold.
+  reilOffsetFt: 40, // lateral offset outboard of the runway edge
+  // Taxiway lights (OSM geometry; width is estimated since OSM rarely has it).
+  // Also widened from real spacing (centerline 50ft, edge 200ft) for legibility.
+  taxiwayCenterlineSpacingFt: 200,
+  taxiwayEdgeSpacingFt: 400,
+  taxiwayDefaultHalfWidthFt: 38, // ~11.5m assumed half-width for blue edge offset
+  // Per-band decimation: keep mid-zoom point counts sane.
+  midCenterlineDecimation: 2, // render every Nth centerline light at mid band
+  // Canvas point radius (screen px) per color role bucket.
+  radius: {
+    edge: 1.55,
+    centerline: 0.95,
+    tdz: 0.95,
+    endBar: 1.3,
+    reil: 1.6,
+    approach: 1.15,
+    taxiway: 0.85,
+  },
+} as const;
+
 export const RUNWAY_ANNOTATION_STYLE_CONFIG = {
   lineStyles: {
     dark: {

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -52,6 +52,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         en: "Light spacing is widened from the exact FAA values so individual lights stay legible at the map's maximum zoom, while the color zones remain distance-accurate; lights render in both light and dark themes",
         zh: "灯光间距在 FAA 实际值基础上适当放大，使单个灯光在最大缩放下仍可分辨，同时配色分区仍按真实距离精确呈现；明暗主题下均可显示",
       },
+      {
+        en: "Airport buildings are now colored: terminals get an accent fill, other on-field buildings and aprons a muted fill. Buildings are pulled from OpenStreetMap constrained to inside the aerodrome boundary, and the thick runway surface stroke is thinned when lights are shown so it no longer reads as a solid bar",
+        zh: "机场建筑现在带有配色：航站楼使用强调色填充，场内其他建筑与停机坪使用低饱和填充。建筑数据取自 OpenStreetMap 并限定在机场边界内；显示灯光时跑道地面描边会变细，不再呈现为实心色条",
+      },
     ],
   },
   {

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.7.1",
+    kind: "feat",
+    title: {
+      en: "FAA-accurate runway & taxiway lighting",
+      zh: "符合 FAA 的跑道与滑行道灯光",
+    },
+    summary: {
+      en: "Runway and taxiway lights now follow FAA color conventions and scale by zoom for performance.",
+      zh: "跑道与滑行道灯光改为遵循 FAA 配色规范，并按缩放级别分层渲染以保证性能。",
+    },
+    highlights: [
+      {
+        en: "Synthesized FAA color zones: white/amber runway edges, white→red-white→red centerline, green threshold + red end bars, touchdown-zone lights, flashing REIL, plus blue taxiway edges and green taxiway centerline",
+        zh: "合成 FAA 配色分区：白/琥珀色跑道边灯、白→红白→红的中线灯、绿色入口与红色端灯、接地区灯、闪烁 REIL，以及蓝色滑行道边灯与绿色滑行道中线灯",
+      },
+      {
+        en: "Zoom level-of-detail: farthest zoom shows only approach beams, mid adds edge/threshold lights, near shows full detail — all point lights moved to a single canvas to stay smooth at busy fields",
+        zh: "按缩放分级渲染：最远缩放只显示进近光束，中景加入边灯/入口灯，近景显示完整细节；所有点光源统一改用 canvas 渲染，繁忙机场也能保持流畅",
+      },
+      {
+        en: "Light spacing is widened from the exact FAA values so individual lights stay legible at the map's maximum zoom, while the color zones remain distance-accurate; lights render in both light and dark themes",
+        zh: "灯光间距在 FAA 实际值基础上适当放大，使单个灯光在最大缩放下仍可分辨，同时配色分区仍按真实距离精确呈现；明暗主题下均可显示",
+      },
+    ],
+  },
+  {
     version: "v2.7.0",
     kind: "feat",
     title: {

--- a/src/features/airport/map/airportMapZoomFeatures.ts
+++ b/src/features/airport/map/airportMapZoomFeatures.ts
@@ -77,3 +77,27 @@ export const shouldShowCandidateWatchingSpotCountForZoom = (zoom: unknown) =>
 
 export const shouldShowCandidateWatchingSpotDetailsForZoom = (zoom: unknown) =>
   airportMapZoomFeaturesFor(zoom).showCandidateWatchingSpotDetails;
+
+// Level-of-detail band for runway/taxiway point lights. Keyed to the same
+// zoom breakpoints as the rest of the airport map:
+//   far  (<= approach)  → no point lights, approach beams only
+//   mid  (airport..<detail) → edge + threshold/end + ALS dots, coarse centerline
+//   near (>= detail)    → full FAA density (50ft centerline, TDZL, REIL, taxiway)
+export type RunwayLightingLodBand = "far" | "mid" | "near";
+
+const LOD_BAND_RANK: Record<RunwayLightingLodBand, number> = {
+  far: 0,
+  mid: 1,
+  near: 2,
+};
+
+export const runwayLightingLodBandRank = (band: RunwayLightingLodBand) =>
+  LOD_BAND_RANK[band] ?? 0;
+
+export const runwayLightingLodForZoom = (zoom: unknown): RunwayLightingLodBand => {
+  const numericZoom = Number(zoom);
+  if (!Number.isFinite(numericZoom)) return "near";
+  if (numericZoom <= ZOOM_APPROACH) return "far";
+  if (numericZoom >= ZOOM_DETAIL) return "near";
+  return "mid";
+};

--- a/src/features/airport/map/runwayAnnotationModel.ts
+++ b/src/features/airport/map/runwayAnnotationModel.ts
@@ -4,7 +4,7 @@ import { shouldShowRunwayEndLabelsForZoom } from "./airportMapZoomFeatures";
 
 const METERS_PER_DEGREE_LATITUDE = 111_320;
 const STATUTE_MILE_METERS = 1_609.344;
-const FEET_TO_METERS = 0.3048;
+export const FEET_TO_METERS = 0.3048;
 const RUNWAY_LIGHT_SPACING_METERS = 170;
 const RUNWAY_CENTERLINE_LIGHT_SPACING_METERS = 260;
 const RUNWAY_APPROACH_LIGHT_SPACING_METERS = 180;
@@ -25,7 +25,7 @@ const INVALID_SURFACE_RUNWAY_IDS = new Set([
 const shouldShowRunwayEndLabels = shouldShowRunwayEndLabelsForZoom;
 
 type RunwayAnnotationRecord = Record<string, any>;
-type Coordinate2D = [number, number];
+export type Coordinate2D = [number, number];
 type SurfaceRunwaySegment = {
   feature: RunwayAnnotationRecord;
   coordinates: Coordinate2D[];
@@ -59,7 +59,7 @@ type CanonicalSurfaceRunwayFeature = RunwayAnnotationRecord & {
 const metersPerDegreeLongitude = (latitude: number) =>
   METERS_PER_DEGREE_LATITUDE * Math.cos((latitude * Math.PI) / 180);
 
-const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+export const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 const interpolate = (from: number, to: number, progress: number) => from + (to - from) * progress;
 
@@ -103,7 +103,7 @@ const normalizedRunwayMapById = (runwayMap: RunwayAnnotationRecord) => {
   return byId;
 };
 
-const metersBetweenCoordinates = (left: Coordinate2D, right: Coordinate2D) => {
+export const metersBetweenCoordinates = (left: Coordinate2D, right: Coordinate2D) => {
   const lonMeters = metersPerDegreeLongitude((left[1] + right[1]) / 2);
   const dx = (right[0] - left[0]) * lonMeters;
   const dy = (right[1] - left[1]) * METERS_PER_DEGREE_LATITUDE;
@@ -506,7 +506,7 @@ const scaleRunwayBeamProfile = (profile: RunwayAnnotationRecord, distanceScale =
   nearWidth: profile.nearWidth * distanceScale,
 });
 
-const runwayEndVector = (end: RunwayAnnotationRecord, oppositeEnd: RunwayAnnotationRecord) => {
+export const runwayEndVector = (end: RunwayAnnotationRecord, oppositeEnd: RunwayAnnotationRecord) => {
   const lonMeters = metersPerDegreeLongitude(end.lat);
   const dx = (end.lon - oppositeEnd.lon) * lonMeters;
   const dy = (end.lat - oppositeEnd.lat) * METERS_PER_DEGREE_LATITUDE;
@@ -532,12 +532,12 @@ const offsetPoint = ({ end, vector, distance, halfWidth, side }: RunwayAnnotatio
   ];
 };
 
-const coordinateFromVectorMeters = ({ end, vector, distance }: RunwayAnnotationRecord) => [
+export const coordinateFromVectorMeters = ({ end, vector, distance }: RunwayAnnotationRecord) => [
   end.lon + (vector.x * distance) / vector.lonMeters,
   end.lat + (vector.y * distance) / METERS_PER_DEGREE_LATITUDE,
 ];
 
-const lineCoordinateAtProgress = (
+export const lineCoordinateAtProgress = (
   start: Coordinate2D,
   end: Coordinate2D,
   progress: number,
@@ -546,7 +546,7 @@ const lineCoordinateAtProgress = (
   start[1] + (end[1] - start[1]) * progress,
 ] as Coordinate2D;
 
-const runwayVectorFromCoordinates = (start: Coordinate2D, end: Coordinate2D) => {
+export const runwayVectorFromCoordinates = (start: Coordinate2D, end: Coordinate2D) => {
   const lonMeters = metersPerDegreeLongitude((start[1] + end[1]) / 2);
   const dx = (end[0] - start[0]) * lonMeters;
   const dy = (end[1] - start[1]) * METERS_PER_DEGREE_LATITUDE;
@@ -561,7 +561,7 @@ const runwayVectorFromCoordinates = (start: Coordinate2D, end: Coordinate2D) => 
   };
 };
 
-const offsetCoordinate = (
+export const offsetCoordinate = (
   coordinate: Coordinate2D,
   vector: RunwayAnnotationRecord,
   lateralDistanceMeters: number,
@@ -574,7 +574,7 @@ const offsetCoordinate = (
   ] as Coordinate2D;
 };
 
-const runwayWidthMeters = (runway: RunwayAnnotationRecord) => {
+export const runwayWidthMeters = (runway: RunwayAnnotationRecord) => {
   const widthMeters = Number(runway?.widthFt) * FEET_TO_METERS;
   if (!Number.isFinite(widthMeters) || widthMeters <= 0) {
     return DEFAULT_RUNWAY_WIDTH_METERS;

--- a/src/features/airport/map/runwayLightCanvas.ts
+++ b/src/features/airport/map/runwayLightCanvas.ts
@@ -1,0 +1,114 @@
+// Shared Leaflet canvas rendering for synthesized airport lights.
+//
+// FAA-accurate density (50ft centerline + TDZL + taxiway) produces thousands of
+// points; rendering them as SVG circleMarkers would create thousands of DOM
+// nodes and rebuild on every zoom. A single `L.canvas()` renderer collapses all
+// of them to ONE <canvas>. Used by both RunwayAnnotationLayer and
+// AirportSurfaceLayer (taxiway lights).
+//
+// Canvas cannot read CSS variables, so light colors are resolved from the FAA
+// color tokens (--atc-runway-light-*) into concrete values ONCE per build via
+// getComputedStyle. Tokens remain the source of truth; this is the one place
+// they are read into JS. Re-resolved whenever the layer rebuilds (theme change).
+
+import L from "leaflet";
+import { runwayLightRadius, type LightColorRole } from "./runwayLightingModel";
+
+const FALLBACK_LIGHT_COLORS: Record<LightColorRole, string> = {
+  white: "#fff2c0",
+  amber: "#ffd36a",
+  red: "#ff5a52",
+  green: "#54e08a",
+  blue: "#5aa6ff",
+};
+
+const resolveLightColors = (map: any): Record<LightColorRole, string> => {
+  try {
+    const styles = getComputedStyle(map.getContainer());
+    const read = (name: string, fallback: string) =>
+      styles.getPropertyValue(name).trim() || fallback;
+    return {
+      white: read("--atc-runway-light-white", FALLBACK_LIGHT_COLORS.white),
+      amber: read("--atc-runway-light-amber", FALLBACK_LIGHT_COLORS.amber),
+      red: read("--atc-runway-light-red", FALLBACK_LIGHT_COLORS.red),
+      green: read("--atc-runway-light-green", FALLBACK_LIGHT_COLORS.green),
+      blue: read("--atc-runway-light-blue", FALLBACK_LIGHT_COLORS.blue),
+    };
+  } catch {
+    return FALLBACK_LIGHT_COLORS;
+  }
+};
+
+const REIL_ON_OPACITY = 0.95;
+
+// Build a single canvas layer for a FeatureCollection of light points. Returns
+// the geoJSON layer, the canvas renderer (add/remove on the map alongside it),
+// and the subset of flashing REIL markers for the flash timer.
+export const buildRunwayLightCanvasLayer = ({
+  data,
+  map,
+}: {
+  data: Record<string, any>;
+  map: any;
+}) => {
+  const renderer = L.canvas({ padding: 0.5 });
+  const colors = resolveLightColors(map);
+  const reilMarkers: any[] = [];
+
+  const layer = L.geoJSON(data as any, {
+    interactive: false,
+    pointToLayer(feature: any, latlng: any) {
+      const props = feature?.properties || {};
+      const colorRole = (props.color || "white") as LightColorRole;
+      const color = colors[colorRole] || colors.white;
+      const marker = L.circleMarker(latlng, {
+        renderer,
+        interactive: false,
+        bubblingMouseEvents: false,
+        color,
+        fill: true,
+        fillColor: color,
+        fillOpacity: 0.92,
+        opacity: 0.65,
+        radius: faaLightRadiusFor(props.role),
+        stroke: false,
+        weight: 0,
+      } as any);
+      if (props.flashing) reilMarkers.push(marker);
+      return marker;
+    },
+  } as any);
+
+  return { layer, renderer, reilMarkers };
+};
+
+const faaLightRadiusFor = (role: unknown) =>
+  runwayLightRadius((role as any) || "centerline");
+
+// Synchronized REIL flash (~1.5 Hz) driven by one shared timer. Honors
+// prefers-reduced-motion by leaving the strobes steady-on (no timer). Returns a
+// cleanup function.
+export const startReilFlashTimer = (reilMarkers: any[]): (() => void) => {
+  if (!reilMarkers.length) return () => {};
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  if (prefersReducedMotion) return () => {};
+
+  let on = true;
+  const timer = window.setInterval(() => {
+    on = !on;
+    const fillOpacity = on ? REIL_ON_OPACITY : 0;
+    const opacity = on ? REIL_ON_OPACITY : 0;
+    reilMarkers.forEach((marker) => {
+      try {
+        marker.setStyle({ fillOpacity, opacity });
+      } catch {
+        // marker removed mid-cycle — ignore
+      }
+    });
+  }, 640);
+
+  return () => window.clearInterval(timer);
+};

--- a/src/features/airport/map/runwayLightingModel.test.ts
+++ b/src/features/airport/map/runwayLightingModel.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+
+import {
+  buildRunwayFaaLightCollection,
+  buildTaxiwayLightCollection,
+  runwayLightRadius,
+} from "./runwayLightingModel";
+import { runwayLightingLodForZoom } from "./airportMapZoomFeatures";
+import { RUNWAY_FAA_LIGHTING_CONFIG } from "../../../config/airportMap";
+import {
+  ZOOM_AIRPORT,
+  ZOOM_APPROACH,
+  ZOOM_DETAIL,
+} from "../../../utils/airportMapDisplay";
+
+const FEET_TO_METERS = 0.3048;
+const expectedCenterlineGapM = RUNWAY_FAA_LIGHTING_CONFIG.centerlineSpacingFt * FEET_TO_METERS;
+
+const metersBetween = ([leftLon, leftLat], [rightLon, rightLat]) => {
+  const metersPerDegreeLatitude = 111_320;
+  const metersPerDegreeLongitude =
+    metersPerDegreeLatitude * Math.cos((leftLat * Math.PI) / 180);
+  const dx = (rightLon - leftLon) * metersPerDegreeLongitude;
+  const dy = (rightLat - leftLat) * metersPerDegreeLatitude;
+  return Math.hypot(dx, dy);
+};
+
+// KBOS 04R/22L — a long runway (~8500ft from these endpoints) so the symmetric
+// color zones (white middle, red/amber ends) are all present.
+const runwayMap = {
+  airport: "KBOS",
+  source: "OurAirports",
+  cycle: "260514",
+  runways: [
+    {
+      id: "04R/22L",
+      lengthFt: 10083,
+      widthFt: 150,
+      lighted: true,
+      ends: [
+        { ident: "04R", lat: 42.35404, lon: -71.010352, displacedThresholdFt: 0 },
+        { ident: "22L", lat: 42.377344, lon: -70.999076, displacedThresholdFt: 0 },
+      ],
+      centerline: {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [-71.010352, 42.35404],
+            [-70.999076, 42.377344],
+          ],
+        },
+        properties: { id: "04R/22L" },
+      },
+    },
+  ],
+};
+
+// --- LOD bands keyed to the airport-map zoom breakpoints.
+assert.equal(runwayLightingLodForZoom(ZOOM_APPROACH), "far");
+assert.equal(runwayLightingLodForZoom(ZOOM_AIRPORT), "mid");
+assert.equal(runwayLightingLodForZoom(ZOOM_AIRPORT + 1), "mid");
+assert.equal(runwayLightingLodForZoom(ZOOM_DETAIL), "near");
+assert.equal(runwayLightingLodForZoom(ZOOM_DETAIL + 2), "near");
+
+// --- Far band renders no point lights (approach beams handled separately).
+assert.equal(buildRunwayFaaLightCollection(runwayMap, { band: "far" }).features.length, 0);
+
+// --- Near band produces a full light set.
+const near = buildRunwayFaaLightCollection(runwayMap, { band: "near" });
+assert.ok(near.features.length > 100, "near band should produce many lights");
+
+const byRole = (collection, predicate) =>
+  collection.features.filter((feature) => predicate(String(feature.properties.role)));
+
+const centerlineFeatures = byRole(
+  near,
+  (role) => role.startsWith("centerline"),
+);
+
+// Centerline spacing ≈ 50ft (15.24m): consecutive in-order points are evenly
+// spaced. Validates the arc-length walk, not chord interpolation.
+const centerlineGaps = centerlineFeatures
+  .slice(1)
+  .map((feature, index) =>
+    metersBetween(
+      centerlineFeatures[index].geometry.coordinates,
+      feature.geometry.coordinates,
+    ),
+  );
+const avgGap = centerlineGaps.reduce((sum, gap) => sum + gap, 0) / centerlineGaps.length;
+assert.ok(
+  avgGap > expectedCenterlineGapM * 0.9 && avgGap < expectedCenterlineGapM * 1.1,
+  `centerline avg gap ${avgGap} should be ≈${expectedCenterlineGapM}m`,
+);
+
+// --- Symmetric color transitions: ends red, middle white.
+assert.equal(
+  centerlineFeatures[0].properties.color,
+  "red",
+  "centerline light at the threshold should be red (last 1000ft)",
+);
+assert.equal(
+  centerlineFeatures.at(-1).properties.color,
+  "red",
+  "centerline light at the far threshold should also be red",
+);
+const midCenterline = centerlineFeatures[Math.floor(centerlineFeatures.length / 2)];
+assert.equal(
+  midCenterline.properties.color,
+  "white",
+  "centerline light in the middle should be white",
+);
+
+// Edge lights: amber within the caution zone at the ends, white in the middle.
+const edgeFeatures = byRole(near, (role) => role.startsWith("edge"));
+assert.equal(edgeFeatures[0].properties.color, "amber", "edge light at the end should be amber");
+const edgeWhite = edgeFeatures.filter((feature) => feature.properties.color === "white");
+const edgeAmber = edgeFeatures.filter((feature) => feature.properties.color === "amber");
+assert.ok(edgeWhite.length > 0 && edgeAmber.length > 0, "edge should have both white and amber");
+
+// Threshold (green) + end (red) bars exist at both ends.
+const greenBars = byRole(near, (role) => role === "threshold");
+const redBars = byRole(near, (role) => role === "end");
+assert.equal(greenBars.length, 10, "two green threshold bars of 5 lights each");
+assert.equal(redBars.length, 10, "two red end bars of 5 lights each");
+assert.ok(greenBars.every((f) => f.properties.color === "green"));
+assert.ok(redBars.every((f) => f.properties.color === "red"));
+
+// REIL flashing strobes only at the near band.
+const reil = byRole(near, (role) => role === "reil");
+assert.equal(reil.length, 4, "two REIL strobes per end");
+assert.ok(reil.every((f) => f.properties.flashing === true && f.properties.color === "white"));
+
+// --- Mid band: lights present, but no TDZL/REIL and a decimated centerline.
+const mid = buildRunwayFaaLightCollection(runwayMap, { band: "mid" });
+assert.equal(byRole(mid, (role) => role === "reil").length, 0, "no REIL at mid band");
+assert.equal(byRole(mid, (role) => role === "tdz").length, 0, "no TDZL at mid band");
+const midCenterlineCount = byRole(mid, (role) => role.startsWith("centerline")).length;
+assert.ok(
+  midCenterlineCount > 0 && midCenterlineCount < centerlineFeatures.length,
+  "mid band centerline should be decimated",
+);
+
+// --- `lighted` gating: false suppresses, undefined (OSM) renders.
+const unlit = { ...runwayMap, runways: [{ ...runwayMap.runways[0], lighted: false }] };
+assert.equal(buildRunwayFaaLightCollection(unlit, { band: "near" }).features.length, 0);
+const unknownLit = { ...runwayMap, runways: [{ ...runwayMap.runways[0], lighted: undefined }] };
+assert.ok(
+  buildRunwayFaaLightCollection(unknownLit, { band: "near" }).features.length > 0,
+  "unknown lighting is treated as lighted",
+);
+
+// --- Arc-length walk handles multi-vertex (bent) centerlines evenly.
+const bent = {
+  airport: "TEST",
+  runways: [
+    {
+      id: "01/19",
+      lengthFt: 6000,
+      widthFt: 100,
+      ends: [
+        { ident: "01", lat: 40.0, lon: -75.0 },
+        { ident: "19", lat: 40.02, lon: -74.99 },
+      ],
+      centerline: {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [-75.0, 40.0],
+            [-74.995, 40.01],
+            [-74.99, 40.02],
+          ],
+        },
+        properties: { id: "01/19" },
+      },
+    },
+  ],
+};
+const bentCenterline = byRole(
+  buildRunwayFaaLightCollection(bent, { band: "near" }),
+  (role) => role.startsWith("centerline"),
+);
+const bentGaps = bentCenterline
+  .slice(1)
+  .map((feature, index) =>
+    metersBetween(
+      bentCenterline[index].geometry.coordinates,
+      feature.geometry.coordinates,
+    ),
+  );
+assert.ok(
+  bentGaps.every(
+    (gap) => gap > expectedCenterlineGapM * 0.8 && gap < expectedCenterlineGapM * 1.2,
+  ),
+  `bent-centerline gaps stay near ${expectedCenterlineGapM}m (arc-length walk)`,
+);
+
+// --- Taxiway lights: near band only, green centerline + blue edge.
+const surface = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: { kind: "taxiway" },
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-71.01, 42.36],
+          [-71.0, 42.365],
+        ],
+      },
+    },
+  ],
+};
+assert.equal(
+  buildTaxiwayLightCollection(surface, { band: "far" }).features.length,
+  0,
+  "no taxiway lights at far band",
+);
+assert.equal(
+  buildTaxiwayLightCollection(surface, { band: "mid" }).features.length,
+  0,
+  "no taxiway lights at mid band",
+);
+const taxiwayNear = buildTaxiwayLightCollection(surface, { band: "near" });
+assert.ok(
+  taxiwayNear.features.some((f) => f.properties.color === "green"),
+  "taxiway has green centerline",
+);
+assert.ok(
+  taxiwayNear.features.some((f) => f.properties.color === "blue"),
+  "taxiway has blue edge",
+);
+
+// --- Radius lookup returns a finite size per role.
+const radiusRoles = ["edge", "centerline", "tdz", "reil", "approach", "taxiway-centerline"] as const;
+for (const role of radiusRoles) {
+  assert.ok(Number.isFinite(runwayLightRadius(role)), `radius for ${role}`);
+}
+
+console.log("runwayLightingModel.test.ts ok");

--- a/src/features/airport/map/runwayLightingModel.ts
+++ b/src/features/airport/map/runwayLightingModel.ts
@@ -1,0 +1,438 @@
+// FAA AIM Ch.2 §3 runway/taxiway lighting, synthesized from geometry.
+//
+// OSM lighting tags (navigationaid=*) are too sparse for global coverage, so
+// we derive FAA-correct COLOR + SPACING from the runway geometry we have
+// (endpoints, length, width, displaced thresholds, `lighted`). Output is plain
+// GeoJSON point features tagged with a semantic color ROLE — the Leaflet layer
+// maps each role to a CSS variable so themes stay the source of truth. All math
+// reuses the shared helpers exported from runwayAnnotationModel.ts.
+
+import { RUNWAY_FAA_LIGHTING_CONFIG } from "../../../config/airportMap";
+import {
+  runwayLightingLodBandRank,
+  type RunwayLightingLodBand,
+} from "./airportMapZoomFeatures";
+import {
+  FEET_TO_METERS,
+  clamp,
+  type Coordinate2D,
+  metersBetweenCoordinates,
+  lineCoordinateAtProgress,
+  runwayVectorFromCoordinates,
+  offsetCoordinate,
+  runwayWidthMeters,
+  runwayEndVector,
+  coordinateFromVectorMeters,
+} from "./runwayAnnotationModel";
+
+type LightRecord = Record<string, any>;
+
+export type { RunwayLightingLodBand } from "./airportMapZoomFeatures";
+
+export type LightColorRole = "white" | "amber" | "red" | "green" | "blue";
+
+export type LightRole =
+  | "edge"
+  | "edge-caution"
+  | "centerline"
+  | "centerline-alt"
+  | "centerline-red"
+  | "threshold"
+  | "end"
+  | "tdz"
+  | "reil"
+  | "approach"
+  | "taxiway-edge"
+  | "taxiway-centerline";
+
+const C = RUNWAY_FAA_LIGHTING_CONFIG;
+const ftToM = (feet: number) => feet * FEET_TO_METERS;
+
+const ROLE_RADIUS_BUCKET: Record<LightRole, keyof typeof C.radius> = {
+  edge: "edge",
+  "edge-caution": "edge",
+  centerline: "centerline",
+  "centerline-alt": "centerline",
+  "centerline-red": "centerline",
+  threshold: "endBar",
+  end: "endBar",
+  tdz: "tdz",
+  reil: "reil",
+  approach: "approach",
+  "taxiway-edge": "taxiway",
+  "taxiway-centerline": "taxiway",
+};
+
+// Screen-pixel radius for a light role (consumed by the canvas renderer and
+// asserted indirectly via role in tests — never hardcode at call sites).
+export const runwayLightRadius = (role: LightRole): number =>
+  C.radius[ROLE_RADIUS_BUCKET[role]] ?? C.radius.centerline;
+
+const isFiniteCoordinate = (value: unknown): value is Coordinate2D =>
+  Array.isArray(value) &&
+  Number.isFinite(value[0]) &&
+  Number.isFinite(value[1]);
+
+type PolylineSample = {
+  coordinate: Coordinate2D;
+  vector: LightRecord;
+  distanceMeters: number;
+  index: number;
+};
+
+// Walk a polyline by cumulative arc length and emit evenly-spaced samples
+// (including both endpoints) with the local direction vector at each sample.
+// Arc-length walking — not chord interpolation — keeps multi-vertex OSM
+// runways/taxiways correctly spaced.
+const sampleAlongPolyline = (
+  coordinates: Coordinate2D[],
+  spacingMeters: number,
+): { samples: PolylineSample[]; totalMeters: number } => {
+  const clean = coordinates.filter(isFiniteCoordinate);
+  if (clean.length < 2 || spacingMeters <= 0) {
+    return { samples: [], totalMeters: 0 };
+  }
+
+  const segments: { a: Coordinate2D; b: Coordinate2D; start: number; length: number }[] = [];
+  let total = 0;
+  for (let i = 1; i < clean.length; i += 1) {
+    const length = metersBetweenCoordinates(clean[i - 1], clean[i]);
+    if (length <= 0) continue;
+    segments.push({ a: clean[i - 1], b: clean[i], start: total, length });
+    total += length;
+  }
+  if (total <= 0 || segments.length === 0) return { samples: [], totalMeters: 0 };
+
+  const count = Math.max(1, Math.round(total / spacingMeters));
+  const step = total / count;
+  const samples: PolylineSample[] = [];
+  let segIndex = 0;
+  for (let k = 0; k <= count; k += 1) {
+    const distance = Math.min(k * step, total);
+    while (
+      segIndex < segments.length - 1 &&
+      distance > segments[segIndex].start + segments[segIndex].length
+    ) {
+      segIndex += 1;
+    }
+    const segment = segments[segIndex];
+    const fraction = segment.length > 0 ? (distance - segment.start) / segment.length : 0;
+    const coordinate = lineCoordinateAtProgress(segment.a, segment.b, clamp(fraction, 0, 1));
+    const vector = runwayVectorFromCoordinates(segment.a, segment.b);
+    if (!vector) continue;
+    samples.push({ coordinate, vector, distanceMeters: distance, index: k });
+  }
+  return { samples, totalMeters: total };
+};
+
+const feature = (coordinate: Coordinate2D, properties: LightRecord): LightRecord => ({
+  type: "Feature",
+  geometry: { type: "Point", coordinates: coordinate },
+  properties,
+});
+
+// Centerline color by distance from the NEARER threshold (symmetric / chart
+// depiction): red in the last 1000ft, alternating red/white 1000–3000ft,
+// white in the middle.
+const centerlineColorRole = (
+  remainingFt: number,
+  index: number,
+): { role: LightRole; color: LightColorRole } => {
+  if (remainingFt <= C.centerlineRedFt) {
+    return { role: "centerline-red", color: "red" };
+  }
+  if (remainingFt <= C.centerlineAltFt) {
+    return index % 2 === 0
+      ? { role: "centerline-alt", color: "red" }
+      : { role: "centerline", color: "white" };
+  }
+  return { role: "centerline", color: "white" };
+};
+
+const runwayEnds = (runway: LightRecord) =>
+  (runway?.ends || []).filter(
+    (end: LightRecord) => Number.isFinite(end?.lat) && Number.isFinite(end?.lon),
+  );
+
+const runwayLightFeatures = (
+  runway: LightRecord,
+  { includeNear, decimateCenterline }: { includeNear: boolean; decimateCenterline: boolean },
+): LightRecord[] => {
+  const coordinates = (runway?.centerline?.geometry?.coordinates || []) as Coordinate2D[];
+  if (coordinates.filter(isFiniteCoordinate).length < 2) return [];
+
+  const halfWidthMeters = runwayWidthMeters(runway) / 2;
+  const features: LightRecord[] = [];
+
+  // --- Edge lights (200ft): white, amber within the caution zone of each end.
+  const edge = sampleAlongPolyline(coordinates, ftToM(C.edgeSpacingFt));
+  const totalMeters = edge.totalMeters;
+  const lengthFt =
+    Number.isFinite(runway?.lengthFt) && runway.lengthFt > 0
+      ? Number(runway.lengthFt)
+      : totalMeters / FEET_TO_METERS;
+  const cautionFt = Math.min(C.edgeCautionFt, lengthFt / 2);
+
+  for (const sample of edge.samples) {
+    const remainingMeters = Math.min(sample.distanceMeters, totalMeters - sample.distanceMeters);
+    const remainingFt = remainingMeters / FEET_TO_METERS;
+    const caution = remainingFt <= cautionFt;
+    for (const side of [-1, 1]) {
+      features.push(
+        feature(offsetCoordinate(sample.coordinate, sample.vector, halfWidthMeters * side), {
+          role: caution ? "edge-caution" : "edge",
+          color: caution ? "amber" : "white",
+          runwayId: runway.id,
+          side: side < 0 ? "left" : "right",
+          lightIndex: sample.index,
+          progress: totalMeters > 0 ? sample.distanceMeters / totalMeters : 0,
+          minBand: "mid",
+        }),
+      );
+    }
+  }
+
+  // --- Centerline lights (50ft): symmetric red / red-white / white.
+  const centerline = sampleAlongPolyline(coordinates, ftToM(C.centerlineSpacingFt));
+  centerline.samples.forEach((sample) => {
+    if (decimateCenterline && sample.index % C.midCenterlineDecimation !== 0) {
+      return;
+    }
+    const remainingMeters = Math.min(
+      sample.distanceMeters,
+      centerline.totalMeters - sample.distanceMeters,
+    );
+    const remainingFt = remainingMeters / FEET_TO_METERS;
+    const { role, color } = centerlineColorRole(remainingFt, sample.index);
+    features.push(
+      feature(sample.coordinate, {
+        role,
+        color,
+        runwayId: runway.id,
+        side: "center",
+        lightIndex: sample.index,
+        progress:
+          centerline.totalMeters > 0 ? sample.distanceMeters / centerline.totalMeters : 0,
+        minBand: "mid",
+      }),
+    );
+  });
+
+  // --- Per-end systems: threshold (green) + end (red) bars, ALS dots,
+  //     and (near band only) TDZL + REIL.
+  const ends = runwayEnds(runway);
+  if (ends.length >= 2) {
+    ends.forEach((end: LightRecord, endIndex: number) => {
+      const opposite = ends[endIndex === 0 ? 1 : 0];
+      const vectorOut = runwayEndVector(end, opposite); // points outward (toward approach)
+      if (!vectorOut) return;
+      const displacedMeters = Math.max(0, Number(end.displacedThresholdFt || 0) * FEET_TO_METERS);
+      const thresholdCoord = coordinateFromVectorMeters({
+        end,
+        vector: vectorOut,
+        distance: -displacedMeters,
+      }) as Coordinate2D;
+      const thresholdEnd = { lon: thresholdCoord[0], lat: thresholdCoord[1] };
+
+      const barLight = (
+        center: Coordinate2D,
+        i: number,
+        n: number,
+        role: LightRole,
+        color: LightColorRole,
+      ) => {
+        const lateral = (i / Math.max(1, n - 1) - 0.5) * halfWidthMeters * 2;
+        return feature(offsetCoordinate(center, vectorOut, lateral), {
+          role,
+          color,
+          runwayId: runway.id,
+          runwayEnd: end.ident,
+          side: "center",
+          lightIndex: i,
+          minBand: "mid",
+        });
+      };
+
+      // Green threshold bar at the (displaced) threshold; red end bar just
+      // inboard so both colors read on a top-down map.
+      for (let i = 0; i < C.endBarLightCount; i += 1) {
+        features.push(barLight(thresholdCoord, i, C.endBarLightCount, "threshold", "green"));
+      }
+      const endBarCoord = coordinateFromVectorMeters({
+        end: thresholdEnd,
+        vector: vectorOut,
+        distance: -ftToM(40),
+      }) as Coordinate2D;
+      for (let i = 0; i < C.endBarLightCount; i += 1) {
+        features.push(barLight(endBarCoord, i, C.endBarLightCount, "end", "red"));
+      }
+
+      // ALS approach centerline dots, extending outward from the threshold.
+      const approachLengthMeters = ftToM(2400);
+      const approachCount = clamp(
+        Math.round(approachLengthMeters / ftToM(C.edgeSpacingFt)),
+        4,
+        40,
+      );
+      const approachStep = approachLengthMeters / approachCount;
+      for (let k = 1; k <= approachCount; k += 1) {
+        features.push(
+          feature(
+            coordinateFromVectorMeters({
+              end: thresholdEnd,
+              vector: vectorOut,
+              distance: k * approachStep,
+            }) as Coordinate2D,
+            {
+              role: "approach",
+              color: "white",
+              runwayId: runway.id,
+              runwayEnd: end.ident,
+              side: "center",
+              lightIndex: k,
+              minBand: "mid",
+            },
+          ),
+        );
+      }
+
+      if (!includeNear) return;
+
+      // TDZL: two rows of white barrettes, tdzStartFt..min(tdzLengthFt, len/2).
+      const maxTdzFt = Math.min(C.tdzLengthFt, lengthFt / 2);
+      for (let d = C.tdzStartFt; d <= maxTdzFt; d += C.tdzBarSpacingFt) {
+        const barCenter = coordinateFromVectorMeters({
+          end: thresholdEnd,
+          vector: vectorOut,
+          distance: -ftToM(d),
+        }) as Coordinate2D;
+        for (const sideSign of [-1, 1]) {
+          for (let k = 1; k <= C.tdzBarHalfCount; k += 1) {
+            const lateral = sideSign * halfWidthMeters * 0.12 * k;
+            features.push(
+              feature(offsetCoordinate(barCenter, vectorOut, lateral), {
+                role: "tdz",
+                color: "white",
+                runwayId: runway.id,
+                runwayEnd: end.ident,
+                side: sideSign < 0 ? "left" : "right",
+                minBand: "near",
+              }),
+            );
+          }
+        }
+      }
+
+      // REIL: synchronized flashing white strobes flanking the threshold.
+      for (const sideSign of [-1, 1]) {
+        const lateral = sideSign * (halfWidthMeters + ftToM(C.reilOffsetFt));
+        features.push(
+          feature(offsetCoordinate(thresholdCoord, vectorOut, lateral), {
+            role: "reil",
+            color: "white",
+            runwayId: runway.id,
+            runwayEnd: end.ident,
+            side: sideSign < 0 ? "left" : "right",
+            flashing: true,
+            minBand: "near",
+          }),
+        );
+      }
+    });
+  }
+
+  return features;
+};
+
+const emptyCollection = (runwayMap: LightRecord): LightRecord => ({
+  type: "FeatureCollection",
+  properties: {
+    airport: runwayMap?.airport || "",
+    source: runwayMap?.source || "Runway geometry",
+    cycle: runwayMap?.cycle || "",
+  },
+  features: [],
+});
+
+// FAA runway lights for the given LOD band. `far` → no point lights (approach
+// beams are rendered separately and survive the farthest zoom). `mid` → edge +
+// threshold/end + ALS dots with a decimated centerline. `near` → full density
+// including TDZL + REIL. Runways with `lighted === false` are skipped; unknown
+// (`undefined`, e.g. OSM-derived) is treated as lighted.
+export function buildRunwayFaaLightCollection(
+  runwayMap: LightRecord,
+  { band = "near" as RunwayLightingLodBand }: { band?: RunwayLightingLodBand } = {},
+): LightRecord {
+  if (band === "far") return emptyCollection(runwayMap);
+  const includeNear = runwayLightingLodBandRank(band) >= runwayLightingLodBandRank("near");
+  const decimateCenterline = band === "mid";
+
+  const features = (runwayMap?.runways || [])
+    .filter((runway: LightRecord) => runway?.lighted !== false)
+    .flatMap((runway: LightRecord) =>
+      runwayLightFeatures(runway, { includeNear, decimateCenterline }),
+    );
+
+  return {
+    ...emptyCollection(runwayMap),
+    features,
+  };
+}
+
+// Taxiway lights from OSM surface geometry: green centerline (reliable) and
+// blue edge (offset by an assumed half-width, since OSM rarely carries taxiway
+// width). Near band only — taxiway lights are the densest, lowest-value layer
+// when zoomed out.
+export function buildTaxiwayLightCollection(
+  surfaceCollection: LightRecord,
+  { band = "near" as RunwayLightingLodBand }: { band?: RunwayLightingLodBand } = {},
+): LightRecord {
+  const base: LightRecord = {
+    type: "FeatureCollection",
+    properties: { source: "Taxiway lighting" },
+    features: [],
+  };
+  if (runwayLightingLodBandRank(band) < runwayLightingLodBandRank("near")) {
+    return base;
+  }
+
+  const halfWidthMeters = ftToM(C.taxiwayDefaultHalfWidthFt);
+  const features: LightRecord[] = [];
+
+  for (const taxiway of surfaceCollection?.features || []) {
+    const kind = String(taxiway?.properties?.kind || "");
+    if (kind !== "taxiway" && kind !== "taxilane") continue;
+    if (taxiway?.geometry?.type !== "LineString") continue;
+    const coordinates = (taxiway.geometry.coordinates || []) as Coordinate2D[];
+
+    const greenCenterline = sampleAlongPolyline(coordinates, ftToM(C.taxiwayCenterlineSpacingFt));
+    greenCenterline.samples.forEach((sample) => {
+      features.push(
+        feature(sample.coordinate, {
+          role: "taxiway-centerline",
+          color: "green",
+          side: "center",
+          lightIndex: sample.index,
+          minBand: "near",
+        }),
+      );
+    });
+
+    const blueEdge = sampleAlongPolyline(coordinates, ftToM(C.taxiwayEdgeSpacingFt));
+    blueEdge.samples.forEach((sample) => {
+      for (const sideSign of [-1, 1]) {
+        features.push(
+          feature(offsetCoordinate(sample.coordinate, sample.vector, halfWidthMeters * sideSign), {
+            role: "taxiway-edge",
+            color: "blue",
+            side: sideSign < 0 ? "left" : "right",
+            lightIndex: sample.index,
+            minBand: "near",
+          }),
+        );
+      }
+    });
+  }
+
+  return { ...base, features };
+}

--- a/src/features/airport/runways/runwayGeometryMap.test.ts
+++ b/src/features/airport/runways/runwayGeometryMap.test.ts
@@ -36,6 +36,27 @@ assert.deepEqual(
 );
 assert.deepEqual(runwayMap.runways[0].centerline.properties.ends, ["04L", "22R"]);
 
+// `lighted` and per-end `displacedThresholdFt` must survive into the runway
+// object so FAA lighting can use them (previously dropped).
+const litRunwayMap = buildRunwayMapFromGeometries({
+  airport: "KBOS",
+  runways: [
+    {
+      lengthFt: 7861,
+      widthFt: 150,
+      lighted: true,
+      le: { ident: "22R", lat: 42.3745, lon: -70.999, displacedThresholdFt: 300 },
+      he: { ident: "04L", lat: 42.3581, lon: -71.0142, displacedThresholdFt: 0 },
+    },
+  ],
+});
+assert.equal(litRunwayMap.runways[0].lighted, true);
+const end22R = litRunwayMap.runways[0].ends.find((end) => end.ident === "22R");
+assert.equal(end22R.displacedThresholdFt, 300);
+
+// Missing `lighted` stays undefined (treated as lighted downstream, for OSM).
+assert.equal(runwayMap.runways[0].lighted, undefined);
+
 const openAipDirectionalRunwayMap = buildRunwayMapFromGeometries({
   airport: "KJFK",
   source: "OpenAIP",

--- a/src/features/airport/runways/runwayGeometryMap.ts
+++ b/src/features/airport/runways/runwayGeometryMap.ts
@@ -44,15 +44,29 @@ export const buildRunwayMapFromGeometries = ({
       .filter((row) => row?.le?.ident && row?.he?.ident)
       .filter((row) => hasFiniteCoord(row.le) && hasFiniteCoord(row.he))
       .map((row) => {
-        const ends = [
-          { ident: String(row.le.ident).toUpperCase(), lat: row.le.lat, lon: row.le.lon },
-          { ident: String(row.he.ident).toUpperCase(), lat: row.he.lat, lon: row.he.lon },
-        ].sort((left, right) => sortKey(left.ident).localeCompare(sortKey(right.ident)));
+        const endFromSide = (side: RunwayGeometryRecord) => ({
+          ident: String(side.ident).toUpperCase(),
+          lat: side.lat,
+          lon: side.lon,
+          // Carried through for FAA lighting: threshold/TDZL start offset and
+          // (where available) heading/elevation.
+          displacedThresholdFt: side.displacedThresholdFt ?? null,
+          headingDegT: side.headingDegT ?? null,
+          elevationFt: side.elevationFt ?? null,
+        });
+        const ends = [endFromSide(row.le), endFromSide(row.he)].sort(
+          (left, right) => sortKey(left.ident).localeCompare(sortKey(right.ident)),
+        );
         const id = ends.map((end) => end.ident).join("/");
         return {
           id,
           lengthFt: row.lengthFt ?? null,
           widthFt: row.widthFt ?? null,
+          // `lighted` drives whether FAA lights render at all. Undefined (e.g.
+          // OSM-derived runways) is treated as lighted downstream; only an
+          // explicit `false` suppresses lights.
+          lighted: typeof row.lighted === "boolean" ? row.lighted : undefined,
+          surface: row.surface || "",
           ends,
           centerline: {
             type: "Feature",

--- a/src/style.css
+++ b/src/style.css
@@ -873,6 +873,14 @@
         oklch(46% 0.06 154) 74%,
         var(--atc-text)
     );
+    /* Filled airport structures (dark theme): terminals teal-accent, other
+       buildings muted slate, aprons a darker pavement tone. */
+    --airport-surface-terminal-fill: oklch(62% 0.11 215 / 0.5);
+    --airport-surface-terminal-stroke: oklch(74% 0.12 215 / 0.85);
+    --airport-surface-building-fill: oklch(58% 0.02 250 / 0.42);
+    --airport-surface-building-stroke: oklch(70% 0.02 250 / 0.7);
+    --airport-surface-apron-fill: oklch(50% 0.015 250 / 0.34);
+    --airport-surface-apron-stroke: oklch(64% 0.02 250 / 0.55);
 
     /* Single map-ink tone for every aircraft regardless of departure/arrival —
        the airport is the only thing painted yellow on the map. */
@@ -1329,6 +1337,14 @@
     );
     --airport-surface-taxiway-line: oklch(72% 0.004 100 / 0.76);
     --airport-surface-taxilane-line: oklch(66% 0.004 100 / 0.64);
+    /* Filled airport structures (light theme): deeper, higher-contrast so the
+       fills read on the bright basemap. */
+    --airport-surface-terminal-fill: oklch(58% 0.12 220 / 0.5);
+    --airport-surface-terminal-stroke: oklch(46% 0.13 220 / 0.92);
+    --airport-surface-building-fill: oklch(60% 0.025 250 / 0.42);
+    --airport-surface-building-stroke: oklch(44% 0.03 250 / 0.78);
+    --airport-surface-apron-fill: oklch(66% 0.018 250 / 0.34);
+    --airport-surface-apron-stroke: oklch(52% 0.02 250 / 0.6);
 
     /* Dark theme: same single light ink for every aircraft. */
     --aircraft-departure: oklch(0.86 0.006 100);

--- a/src/style.css
+++ b/src/style.css
@@ -820,6 +820,14 @@
     --aviation-runway-light-core: #fff0a8;
     --aviation-runway-light: #ffd36a;
     --aviation-runway-light-glow: rgba(255, 207, 93, 0.36);
+    /* FAA AIM Ch.2 §3 light colors (dark basemap): warm white, amber caution,
+       red end, green threshold, blue taxiway. Consumed by the canvas renderer
+       via getComputedStyle — keep these as the source of truth. */
+    --atc-runway-light-white: #fff2c0;
+    --atc-runway-light-amber: #ffce4d;
+    --atc-runway-light-red: #ff5a52;
+    --atc-runway-light-green: #54e08a;
+    --atc-runway-light-blue: #5aa6ff;
     --aviation-runway-night-line: rgba(255, 211, 106, 0.48);
     --aviation-runway-night-beam: #ffd36a;
     --aviation-nearby-runway-line: #24231f;
@@ -1285,6 +1293,13 @@
     --aviation-runway-light-core: oklch(96% 0.042 94);
     --aviation-runway-light: oklch(91% 0.095 91);
     --aviation-runway-light-glow: oklch(86% 0.12 88 / 0.42);
+    /* FAA light colors tuned for the bright basemap: deeper, higher-saturation
+       so white/amber/green stay legible without a dark backdrop. */
+    --atc-runway-light-white: #6b6450;
+    --atc-runway-light-amber: #d98a00;
+    --atc-runway-light-red: #d42f29;
+    --atc-runway-light-green: #1f9d57;
+    --atc-runway-light-blue: #1f6fd4;
     --aircraft-trace-line: var(--aviation-trace-line);
     --aircraft-trace-glow: var(--aviation-trace-glow);
     --aircraft-trace-point: var(--aviation-trace-point);


### PR DESCRIPTION
## Summary

Reworks runway/taxiway lighting to follow **FAA AIM Ch.2 §3** color conventions, rendered on a **canvas** with **zoom level-of-detail** so it stays smooth at busy fields. Replaces the old single warm-gold synthesized look (~1,500–2,000 SVG `circleMarker` DOM nodes, dark-theme only).

## What's new

**FAA color accuracy** (synthesized from geometry — OSM lighting tags are too sparse for global coverage):
- Runway edge: white, **amber** caution zone in the last 2,000 ft of each end
- Centerline: white → alternating **red/white** (3,000–1,000 ft remaining) → **red** (last 1,000 ft), measured symmetrically from the nearer threshold
- **Green** threshold bars + **red** end bars at each end
- Touchdown-zone lights, **flashing REIL** (honors `prefers-reduced-motion`)
- Taxiway: **green** centerline + **blue** edge (from OSM geometry)

**Zoom level-of-detail** (the performance ask):
- **Far** zoom → approach beams only, no point lights
- **Mid** → edge + threshold + ALS dots
- **Near** → full FAA detail
- All point lights on **one shared `L.canvas()`** (constant DOM cost); the canvas rebuilds only on band crossing / airport / theme change, not every zoomend
- Approach beams now render at **all** zooms including farthest (decoupled from `compactZoom`); lights work in **both light and dark themes**

**Tuning note:** light *spacing* is intentionally wider than the exact FAA values (50 ft centerline / 200 ft edge) so individual dots stay legible at the map's max zoom — at true spacing they merge into a solid line. Color *zones* remain distance-accurate.

## Architecture
- `src/features/airport/map/runwayLightingModel.ts` (new) — pure, typed, tested model: roles, color zones, LOD bands, arc-length walk, taxiway lights
- `src/features/airport/map/runwayLightCanvas.ts` (new) — shared canvas renderer + REIL timer; resolves the `--atc-runway-light-*` tokens into canvas colors
- `RunwayAnnotationLayer.tsx` / `AirportSurfaceLayer.tsx` — band-gated canvas effects
- `runwayGeometryMap.ts` — now plumbs `lighted` + per-end `displacedThresholdFt` (previously dropped); `lighted === false` suppresses, `undefined` (OSM) treated as lighted
- `RUNWAY_FAA_LIGHTING_CONFIG` (config/airportMap.ts) — spacing/zone source of truth; `runwayLightingLodForZoom` in `airportMapZoomFeatures.ts`
- `style.css` — FAA color tokens for light + dark themes

## Validation
`Validation: local test + local browser` — `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test` (114 files incl. new `runwayLightingModel.test.ts` covering LOD bands, color zones, spacing, `lighted` gating, arc-length walk, taxiway), and `pnpm build` all pass. Canvas lights visually confirmed at near zoom against the full local stack; bilingual v2.7.1 changelog verified in both `en` and `zh-CN`.

## Notes / possible follow-ups
- Spacing is a deliberate legibility trade-off (see above) — easy to tune via `RUNWAY_FAA_LIGHTING_CONFIG`.
- Deferred (from the v2.7.0 review): splitting the 40-field `ExplorerUiContext` for further re-render wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)