### PR TITLE
Fix nearby airport runway geometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.7.1",
+  "version": "2.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/api/webapi/handler.go
+++ b/services/data-service/internal/api/webapi/handler.go
@@ -51,6 +51,7 @@ type Handler struct {
 	metrics             realtime.MetricsSink
 	authenticator       *ClerkAuthenticator
 	userDataStore       *UserDataStore
+	runwayMapReader     runwayMapReader
 }
 
 type openAIPList struct {
@@ -85,6 +86,7 @@ func New(options Options) *Handler {
 		metrics:             options.Metrics,
 		authenticator:       options.Authenticator,
 		userDataStore:       options.UserDataStore,
+		runwayMapReader:     options.UserDataStore,
 	}
 }
 
@@ -374,12 +376,14 @@ func (h *Handler) nearbyAirports(ctx context.Context, lat, lon float64, exclude 
 			continue
 		}
 		airport["distanceNm"] = distanceNm(lat, lon, numberValue(airport["lat"]), numberValue(airport["lon"]))
-		airport["runwayMap"] = buildRunwayMapFromMappedRunways(
-			firstString(airport["icao"], airport["code"], airport["ident"]),
-			mapRunways(asRecords(item["runways"]), item),
-			"OpenAIP",
-		)
 		out = append(out, airport)
+	}
+	storedRunwayMaps := h.storedRunwayMapsForAirports(ctx, out)
+	for _, airport := range out {
+		ident := normalizeAirportIdent(firstString(airport["icao"], airport["code"], airport["ident"]))
+		if runwayMap := storedRunwayMaps[ident]; runwayMap != nil {
+			airport["runwayMap"] = runwayMap
+		}
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return numberValue(out[i]["distanceNm"]) < numberValue(out[j]["distanceNm"])
@@ -388,6 +392,29 @@ func (h *Handler) nearbyAirports(ctx context.Context, lat, lon float64, exclude 
 		out = out[:limit]
 	}
 	return out
+}
+
+func (h *Handler) storedRunwayMapsForAirports(ctx context.Context, airports []map[string]any) map[string]map[string]any {
+	if h == nil || h.runwayMapReader == nil || len(airports) == 0 {
+		return nil
+	}
+	idents := make([]string, 0, len(airports))
+	for _, airport := range airports {
+		ident := normalizeAirportIdent(firstString(airport["icao"], airport["code"], airport["ident"]))
+		if ident == "" {
+			continue
+		}
+		idents = append(idents, ident)
+	}
+	if len(idents) == 0 {
+		return nil
+	}
+	runwayMaps, err := h.runwayMapReader.readRunwayMaps(ctx, idents)
+	if err != nil {
+		log.Printf("nearby runway geometry read failed airports=%s error=%v", strings.Join(idents, ","), err)
+		return nil
+	}
+	return runwayMaps
 }
 
 func (h *Handler) nearbyNavaids(ctx context.Context, lat, lon float64, radiusNm, limit int) []map[string]any {

--- a/services/data-service/internal/api/webapi/runway_geometry.go
+++ b/services/data-service/internal/api/webapi/runway_geometry.go
@@ -3,6 +3,7 @@ package webapi
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -19,6 +20,10 @@ type runwayGeometryRow struct {
 	heLongitudeDeg sql.NullFloat64
 }
 
+type runwayMapReader interface {
+	readRunwayMaps(ctx context.Context, idents []string) (map[string]map[string]any, error)
+}
+
 const runwayGeometrySelectColumns = `
 	length_ft,
 	width_ft,
@@ -32,32 +37,63 @@ const runwayGeometrySelectColumns = `
 `
 
 func (s *UserDataStore) readRunwayMap(ctx context.Context, ident string) (map[string]any, error) {
-	if s == nil || s.db == nil {
-		return nil, nil
-	}
 	normalizedIdent := normalizeAirportIdent(ident)
 	if normalizedIdent == "" {
 		return nil, nil
 	}
+	runwayMaps, err := s.readRunwayMaps(ctx, []string{normalizedIdent})
+	if err != nil {
+		return nil, err
+	}
+	return runwayMaps[normalizedIdent], nil
+}
+
+func (s *UserDataStore) readRunwayMaps(ctx context.Context, idents []string) (map[string]map[string]any, error) {
+	out := map[string]map[string]any{}
+	if s == nil || s.db == nil {
+		return out, nil
+	}
+	normalizedIdents := make([]string, 0, len(idents))
+	seen := map[string]bool{}
+	for _, ident := range idents {
+		normalizedIdent := normalizeAirportIdent(ident)
+		if normalizedIdent == "" || seen[normalizedIdent] {
+			continue
+		}
+		seen[normalizedIdent] = true
+		normalizedIdents = append(normalizedIdents, normalizedIdent)
+	}
+	if len(normalizedIdents) == 0 {
+		return out, nil
+	}
+
+	placeholders := make([]string, len(normalizedIdents))
+	args := make([]any, 0, len(normalizedIdents)+1)
+	args = append(args, "ourairports")
+	for index, ident := range normalizedIdents {
+		placeholders[index] = fmt.Sprintf("$%d", index+2)
+		args = append(args, ident)
+	}
 	rows, err := s.db.QueryContext(
 		ctx,
-		`select `+runwayGeometrySelectColumns+`
+		`select airport_ident, `+runwayGeometrySelectColumns+`
 		 from runway_geometries
 		 where source = $1
-		   and airport_ident = $2
+		   and airport_ident in (`+strings.Join(placeholders, ",")+`)
 		 order by airport_ident asc, le_ident asc`,
-		"ourairports",
-		normalizedIdent,
+		args...,
 	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	geometries := []runwayGeometryRow{}
+	geometriesByAirport := map[string][]runwayGeometryRow{}
 	for rows.Next() {
+		var airportIdent string
 		var row runwayGeometryRow
 		if err := rows.Scan(
+			&airportIdent,
 			&row.lengthFt,
 			&row.widthFt,
 			&row.closed,
@@ -70,12 +106,25 @@ func (s *UserDataStore) readRunwayMap(ctx context.Context, ident string) (map[st
 		); err != nil {
 			return nil, err
 		}
-		geometries = append(geometries, row)
+		normalizedAirport := normalizeAirportIdent(airportIdent)
+		if normalizedAirport == "" {
+			continue
+		}
+		geometriesByAirport[normalizedAirport] = append(
+			geometriesByAirport[normalizedAirport],
+			row,
+		)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	return buildRunwayMapFromGeometryRows(normalizedIdent, geometries), nil
+	for _, ident := range normalizedIdents {
+		runwayMap := buildRunwayMapFromGeometryRows(ident, geometriesByAirport[ident])
+		if runwayMap != nil {
+			out[ident] = runwayMap
+		}
+	}
+	return out, nil
 }
 
 func buildRunwayMapFromGeometryRows(airport string, rows []runwayGeometryRow) map[string]any {

--- a/services/data-service/internal/api/webapi/runway_geometry_test.go
+++ b/services/data-service/internal/api/webapi/runway_geometry_test.go
@@ -1,10 +1,29 @@
 package webapi
 
 import (
+	"context"
 	"database/sql"
+	"encoding/json"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 )
+
+type fakeRunwayMapReader struct {
+	maps map[string]map[string]any
+}
+
+func (r fakeRunwayMapReader) readRunwayMaps(_ context.Context, idents []string) (map[string]map[string]any, error) {
+	out := map[string]map[string]any{}
+	for _, ident := range idents {
+		if runwayMap := r.maps[normalizeAirportIdent(ident)]; runwayMap != nil {
+			out[normalizeAirportIdent(ident)] = runwayMap
+		}
+	}
+	return out, nil
+}
 
 func TestBuildRunwayMapFromGeometryRows(t *testing.T) {
 	runwayMap := buildRunwayMapFromGeometryRows("kbos", []runwayGeometryRow{
@@ -184,5 +203,137 @@ func TestOpenAIPDirectionalRunwaysDedupeToPhysicalRunways(t *testing.T) {
 	}
 	if runways[0]["id"] != "04L/22R" || runways[1]["id"] != "13L/31R" {
 		t.Fatalf("unexpected runway ids: %#v", runways)
+	}
+}
+
+func TestNearbyAirportsPreferStoredRunwayMapOverOpenAIPApproximation(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openaip/airports" {
+			t.Fatalf("unexpected request: %s", r.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{
+			"_id":"airport-kbos",
+			"icaoCode":"KBOS",
+			"iataCode":"BOS",
+			"name":"Boston Logan International Airport",
+			"country":"US",
+			"geometry":{"type":"Point","coordinates":[-71.0052,42.3643]},
+			"runways":[{
+				"_id":"openaip-04l",
+				"designator":"04L",
+				"trueHeading":40,
+				"dimension":{"length":{"value":2396},"width":{"value":45}}
+			}]
+		}]}`))
+	}))
+	defer upstream.Close()
+
+	storedRunwayMap := map[string]any{
+		"airport": "KBOS",
+		"source":  "OurAirports",
+		"cycle":   "",
+		"runways": []map[string]any{
+			{
+				"id": "04L/22R",
+				"centerline": map[string]any{
+					"type": "Feature",
+					"geometry": map[string]any{
+						"type": "LineString",
+						"coordinates": []any{
+							[]any{-71.014344, 42.357997},
+							[]any{-71.004511, 42.378322},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	handler := New(Options{
+		HTTPClient:     upstream.Client(),
+		OpenAIPAPIKey:  "test-key",
+		OpenAIPBaseURL: upstream.URL + "/openaip",
+		Timeout:        time.Second,
+	})
+	handler.runwayMapReader = fakeRunwayMapReader{
+		maps: map[string]map[string]any{"KBOS": storedRunwayMap},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/airports/nearby?lat=42.31&lon=-70.98&radiusNm=40&limit=10", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	airports := payload["airports"].([]any)
+	if len(airports) != 1 {
+		t.Fatalf("expected one nearby airport, got %#v", airports)
+	}
+	airport := airports[0].(map[string]any)
+	runwayMap := airport["runwayMap"].(map[string]any)
+	if runwayMap["source"] != "OurAirports" {
+		t.Fatalf("expected stored runway map, got %#v", runwayMap)
+	}
+	runways := runwayMap["runways"].([]any)
+	centerline := runways[0].(map[string]any)["centerline"].(map[string]any)
+	coordinates := centerline["geometry"].(map[string]any)["coordinates"].([]any)
+	first := coordinates[0].([]any)
+	if first[0] != -71.014344 || first[1] != 42.357997 {
+		t.Fatalf("nearby runway map used OpenAIP approximation: %#v", coordinates)
+	}
+}
+
+func TestNearbyAirportsOmitOpenAIPApproximateRunwayMapWithoutStoredGeometry(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openaip/airports" {
+			t.Fatalf("unexpected request: %s", r.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{
+			"_id":"airport-kbos",
+			"icaoCode":"KBOS",
+			"iataCode":"BOS",
+			"name":"Boston Logan International Airport",
+			"country":"US",
+			"geometry":{"type":"Point","coordinates":[-71.0052,42.3643]},
+			"runways":[{
+				"_id":"openaip-04l",
+				"designator":"04L",
+				"trueHeading":40,
+				"dimension":{"length":{"value":2396},"width":{"value":45}}
+			}]
+		}]}`))
+	}))
+	defer upstream.Close()
+
+	handler := New(Options{
+		HTTPClient:     upstream.Client(),
+		OpenAIPAPIKey:  "test-key",
+		OpenAIPBaseURL: upstream.URL + "/openaip",
+		Timeout:        time.Second,
+	})
+	handler.runwayMapReader = fakeRunwayMapReader{maps: map[string]map[string]any{}}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/airports/nearby?lat=42.31&lon=-70.98&radiusNm=40&limit=10", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	airports := payload["airports"].([]any)
+	airport := airports[0].(map[string]any)
+	if runwayMap := airport["runwayMap"]; runwayMap != nil {
+		t.Fatalf("nearby airport should omit synthetic OpenAIP runway map, got %#v", runwayMap)
 	}
 }

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.7.2",
+    kind: "patch",
+    title: {
+      en: "Nearby airport runway geometry fix",
+      zh: "附近机场跑道几何修复",
+    },
+    summary: {
+      en: "Nearby airports in here mode now use stored OurAirports runway geometry when available, so large airports no longer render as synthetic star-shaped runway clusters.",
+      zh: "here 模式的附近机场现在会优先使用已存储的 OurAirports 跑道几何，大型机场不再显示为合成的星型跑道簇。",
+    },
+    highlights: [
+      {
+        en: "The Railway data-service now batch-loads stored runway maps for nearby airport results and omits runway lines when stored geometry is unavailable, instead of showing OpenAIP heading-based approximations",
+        zh: "Railway data-service 会为附近机场结果批量读取已存储的跑道图；没有存储几何时会省略跑道线，不再显示 OpenAIP 基于航向的近似跑道",
+      },
+      {
+        en: "Fixes KBOS near the user's location showing a centered star pattern instead of the real runway layout",
+        zh: "修复用户位置附近的 KBOS 显示成围绕中心展开的星型，而不是实际跑道布局的问题",
+      },
+    ],
+  },
+  {
     version: "v2.7.1",
     kind: "feat",
     title: {


### PR DESCRIPTION
## Summary
- Use stored runway geometry for nearby airport runway maps instead of OpenAIP heading approximations.
- Omit nearby runway line geometry when stored runway coordinates are unavailable, preventing synthetic star-shaped runway overlays like KBOS in here mode.
- Bump ADSBao to v2.7.2 and add a changelog entry for the visible map fix.

## Validation
- `go test ./...` in `services/data-service`
- `go build ./...` in `services/data-service`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm lint` (passes with existing warnings)
- `git diff --check`
- Local nearby airport API smoke: KBOS no longer returns an OpenAIP synthetic `runwayMap` when local stored geometry is unavailable