### PR TITLE
Improve main airport runway load path

### DIFF
--- a/services/data-service/internal/api/webapi/airport_surface_test.go
+++ b/services/data-service/internal/api/webapi/airport_surface_test.go
@@ -140,7 +140,7 @@ func TestAirportSurfaceCacheSkipsNilPayload(t *testing.T) {
 	}
 }
 
-func TestAirportDetailIncludesOptionalSurfaceMap(t *testing.T) {
+func TestAirportDetailDefersSurfaceMapByDefault(t *testing.T) {
 	overpassHits := 0
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -209,6 +209,31 @@ func TestAirportDetailIncludesOptionalSurfaceMap(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("invalid json: %v", err)
 	}
+	if payload["surfaceMap"] != nil {
+		t.Fatalf("surfaceMap should be deferred by default: %#v", payload["surfaceMap"])
+	}
+	if overpassHits != 0 {
+		t.Fatalf("default detail overpass hits = %d", overpassHits)
+	}
+	runwayMap, ok := payload["runwayMap"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing runwayMap: %#v", payload["runwayMap"])
+	}
+	if runwayMap["source"] != "OpenAIP" {
+		t.Fatalf("runwayMap = %#v", runwayMap)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/airport/KBOS/surface", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("surface status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	payload = map[string]any{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid surface json: %v", err)
+	}
 	surfaceMap, ok := payload["surfaceMap"].(map[string]any)
 	if !ok {
 		t.Fatalf("missing surfaceMap: %#v", payload["surfaceMap"])
@@ -218,5 +243,24 @@ func TestAirportDetailIncludesOptionalSurfaceMap(t *testing.T) {
 	}
 	if overpassHits != 1 {
 		t.Fatalf("overpass hits = %d", overpassHits)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/airport/KBOS?includeSurface=1", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("inline status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	payload = map[string]any{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid inline json: %v", err)
+	}
+	surfaceMap, ok = payload["surfaceMap"].(map[string]any)
+	if !ok || surfaceMap["source"] != "OpenStreetMap" {
+		t.Fatalf("inline surfaceMap = %#v", payload["surfaceMap"])
+	}
+	if overpassHits != 1 {
+		t.Fatalf("inline request should reuse cached surface, hits = %d", overpassHits)
 	}
 }

--- a/services/data-service/internal/api/webapi/handler.go
+++ b/services/data-service/internal/api/webapi/handler.go
@@ -95,6 +95,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/api/search":
 		h.handleSearch(w, r)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/airport/") && strings.HasSuffix(r.URL.Path, "/surface"):
+		h.handleAirportSurface(w, r)
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/airport/"):
 		h.handleAirport(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/api/proxy/airports/nearby":
@@ -181,30 +183,17 @@ func (h *Handler) handleAirport(w http.ResponseWriter, r *http.Request) {
 	}
 	radiusNm := intInRange(r.URL.Query().Get("nearbyRadiusNm"), 60, 1, 250)
 	nearbyLimit := intInRange(r.URL.Query().Get("nearbyLimit"), 12, 1, 50)
-	matchDoc, err := h.findAirport(r.Context(), ident)
+	detail, airport, runways, runwayMap, err := h.resolveAirportDetail(r.Context(), ident)
 	if err != nil {
 		writeAPIError(w, err, "Airport detail load failed")
 		return
 	}
-	if matchDoc == nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"error": "Airport not found"})
-		return
-	}
-	id := stringValue(matchDoc["_id"])
-	detail := matchDoc
-	if id != "" {
-		if fetched, err := h.getOpenAIP(r.Context(), "/airports/"+url.PathEscape(id), url.Values{
-			"fields": {strings.Join(airportDetailFields(), ",")},
-		}); err == nil {
-			detail = fetched
-		}
-	}
-	airport := mapAirport(detail)
 	if airport == nil {
 		writeJSON(w, http.StatusNotFound, map[string]any{"error": "Airport not found"})
 		return
 	}
 	lat, lon := numberValue(airport["lat"]), numberValue(airport["lon"])
+	id := stringValue(detail["_id"])
 	nearbyAirports := []map[string]any{}
 	nearbyNavaids := []map[string]any{}
 	airspaces := []map[string]any{}
@@ -235,15 +224,10 @@ func (h *Handler) handleAirport(w http.ResponseWriter, r *http.Request) {
 		}()
 		wg.Wait()
 	}
-	runways := mapRunways(asRecords(detail["runways"]), detail)
-	runwayMap, runwayMapErr := h.userDataStore.readRunwayMap(r.Context(), ident)
-	if runwayMapErr != nil {
-		log.Printf("runway geometry read failed airport=%s error=%v", ident, runwayMapErr)
+	var surfaceMap map[string]any
+	if shouldIncludeAirportSurface(r) {
+		surfaceMap = h.airportSurfaceMap(r.Context(), ident, lat, lon, runwayMap)
 	}
-	if runwayMap == nil {
-		runwayMap = buildRunwayMapFromMappedRunways(ident, runways, "OpenAIP")
-	}
-	surfaceMap := h.airportSurfaceMap(r.Context(), ident, lat, lon, runwayMap)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"airport":         airport,
 		"runways":         runways,
@@ -257,6 +241,42 @@ func (h *Handler) handleAirport(w http.ResponseWriter, r *http.Request) {
 		"surfaceMap":      surfaceMap,
 		"source":          "openaip",
 	})
+}
+
+func (h *Handler) handleAirportSurface(w http.ResponseWriter, r *http.Request) {
+	ident := strings.ToUpper(strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/airport/"), "/surface")))
+	if !match(ident, `^[A-Z0-9]{2,7}$`) {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "Invalid airport ident"})
+		return
+	}
+	_, airport, _, runwayMap, err := h.resolveAirportDetail(r.Context(), ident)
+	if err != nil {
+		writeAPIError(w, err, "Airport surface load failed")
+		return
+	}
+	if airport == nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "Airport not found"})
+		return
+	}
+	lat, lon := numberValue(airport["lat"]), numberValue(airport["lon"])
+	surfaceMap := h.airportSurfaceMap(r.Context(), ident, lat, lon, runwayMap)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"surfaceMap": surfaceMap,
+		"source":     "OpenStreetMap",
+	})
+}
+
+func shouldIncludeAirportSurface(r *http.Request) bool {
+	value := strings.ToLower(strings.TrimSpace(firstString(
+		r.URL.Query().Get("includeSurface"),
+		r.URL.Query().Get("surface"),
+	)))
+	switch value {
+	case "1", "true", "yes", "include", "inline":
+		return true
+	default:
+		return false
+	}
 }
 
 func (h *Handler) handleNearbyAirports(w http.ResponseWriter, r *http.Request) {
@@ -352,6 +372,38 @@ func (h *Handler) findAirport(ctx context.Context, ident string) (map[string]any
 		return nil, nil
 	}
 	return ranked[0], nil
+}
+
+func (h *Handler) resolveAirportDetail(ctx context.Context, ident string) (map[string]any, map[string]any, []map[string]any, map[string]any, error) {
+	matchDoc, err := h.findAirport(ctx, ident)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if matchDoc == nil {
+		return nil, nil, nil, nil, nil
+	}
+	id := stringValue(matchDoc["_id"])
+	detail := matchDoc
+	if id != "" {
+		if fetched, err := h.getOpenAIP(ctx, "/airports/"+url.PathEscape(id), url.Values{
+			"fields": {strings.Join(airportDetailFields(), ",")},
+		}); err == nil {
+			detail = fetched
+		}
+	}
+	airport := mapAirport(detail)
+	if airport == nil {
+		return detail, nil, nil, nil, nil
+	}
+	runways := mapRunways(asRecords(detail["runways"]), detail)
+	runwayMap, runwayMapErr := h.userDataStore.readRunwayMap(ctx, ident)
+	if runwayMapErr != nil {
+		log.Printf("runway geometry read failed airport=%s error=%v", ident, runwayMapErr)
+	}
+	if runwayMap == nil {
+		runwayMap = buildRunwayMapFromMappedRunways(ident, runways, "OpenAIP")
+	}
+	return detail, airport, runways, runwayMap, nil
 }
 
 func (h *Handler) nearbyAirports(ctx context.Context, lat, lon float64, exclude string, radiusNm, limit int) []map[string]any {

--- a/services/data-service/internal/api/webapi/runway_geometry_test.go
+++ b/services/data-service/internal/api/webapi/runway_geometry_test.go
@@ -289,7 +289,7 @@ func TestNearbyAirportsPreferStoredRunwayMapOverOpenAIPApproximation(t *testing.
 	}
 }
 
-func TestNearbyAirportsOmitOpenAIPApproximateRunwayMapWithoutStoredGeometry(t *testing.T) {
+func TestNearbyAirportsBuildOpenAIPRunwayMapWithoutStoredGeometry(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/openaip/airports" {
 			t.Fatalf("unexpected request: %s", r.URL.String())
@@ -333,7 +333,15 @@ func TestNearbyAirportsOmitOpenAIPApproximateRunwayMapWithoutStoredGeometry(t *t
 	}
 	airports := payload["airports"].([]any)
 	airport := airports[0].(map[string]any)
-	if runwayMap := airport["runwayMap"]; runwayMap != nil {
-		t.Fatalf("nearby airport should omit synthetic OpenAIP runway map, got %#v", runwayMap)
+	runwayMap, ok := airport["runwayMap"].(map[string]any)
+	if !ok {
+		t.Fatalf("nearby airport missing OpenAIP runway map: %#v", airport["runwayMap"])
+	}
+	if runwayMap["source"] != "OpenAIP" {
+		t.Fatalf("expected OpenAIP fallback runway map, got %#v", runwayMap)
+	}
+	runways := runwayMap["runways"].([]any)
+	if len(runways) != 1 {
+		t.Fatalf("expected one OpenAIP fallback runway, got %#v", runways)
 	}
 }

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -32,7 +32,22 @@ export default function HomeScreen() {
         const resolved = await airportDirectoryClient.resolveAirport(currentIcao, {
           locale,
         });
-        if (!cancelled) setAirport(resolved);
+        if (cancelled) return;
+        setAirport(resolved);
+        airportDirectoryClient
+          .resolveAirportSurface(currentIcao)
+          .then((surfaceMap) => {
+            if (cancelled || !surfaceMap) return;
+            setAirport((current) => {
+              if (airportCode(current) !== currentIcao) return current;
+              return { ...current, surfaceMap };
+            });
+          })
+          .catch((surfaceError) => {
+            if (!cancelled) {
+              console.warn("Failed to load airport surface", surfaceError);
+            }
+          });
       } catch (err) {
         if (cancelled) return;
         console.error("Failed to load airport", err);
@@ -88,4 +103,10 @@ function normalizePathIcao(pathname) {
   const candidate = airportIndex >= 0 ? segments[airportIndex + 1] : "";
   const normalized = String(candidate || "").trim().toUpperCase();
   return /^[A-Z0-9]{3,4}$/.test(normalized) ? normalized : "";
+}
+
+function airportCode(airport) {
+  return String(airport?.icao || airport?.code || airport?.ident || "")
+    .trim()
+    .toUpperCase();
 }

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -52,6 +52,10 @@ export const CHANGELOG: ChangelogEntry[] = [
         en: "5 new lighting anchors (topBeacon, bottomBeacon, landingLight, taxiLight, logoLight) auto-generated for all 178 aircraft icons via the anchor generator script",
         zh: "5 个新灯光锚点（顶部防撞灯、底部防撞灯、着陆灯、滑行灯、Logo灯）通过锚点生成脚本为全部 178 个飞机图标自动生成",
       },
+      {
+        en: "Airport detail now returns runway geometry before the optional OpenStreetMap surface layer, so the focused airport's runways render without waiting on slow Overpass responses",
+        zh: "机场详情现在先返回跑道几何，再异步补充可选的 OpenStreetMap 地面图层；主机场跑道不再等待较慢的 Overpass 响应",
+      },
     ],
   },
   {

--- a/src/features/airport/directory/airportDirectoryClient.test.ts
+++ b/src/features/airport/directory/airportDirectoryClient.test.ts
@@ -69,7 +69,7 @@ const KBOS = {
   assert.doesNotMatch(calls[0], /type=/);
 }
 
-// resolveAirport hits the airport-detail route and unwraps .airport
+// resolveAirport hits the fast airport-detail route and unwraps .airport
 {
   const calls = [];
   fetchImpl = async (url) => {
@@ -85,7 +85,7 @@ const KBOS = {
         reportingPoints: [{ id: "pt-1", name: "HYLND" }],
         obstacles: [{ id: "obs-1", name: "Tower" }],
         runwayMap: { airport: "KBOS", source: "OurAirports", runways: [] },
-        surfaceMap: { airport: "KBOS", source: "OpenStreetMap", features: { type: "FeatureCollection", features: [] } },
+        surfaceMap: null,
         source: "openaip",
       });
     }
@@ -101,7 +101,29 @@ const KBOS = {
   assert.deepEqual(airport.reportingPoints, [{ id: "pt-1", name: "HYLND" }]);
   assert.deepEqual(airport.obstacles, [{ id: "obs-1", name: "Tower" }]);
   assert.deepEqual(airport.runwayMap, { airport: "KBOS", source: "OurAirports", runways: [] });
-  assert.equal(airport.surfaceMap?.source, "OpenStreetMap");
+  assert.equal(airport.surfaceMap, null);
+}
+
+// resolveAirportSurface loads the deferred OSM surface payload separately.
+{
+  const calls = [];
+  fetchImpl = async (url) => {
+    calls.push(url);
+    if (url === "/api/airport/KBOS/surface") {
+      return createJsonResponse({
+        surfaceMap: {
+          airport: "KBOS",
+          source: "OpenStreetMap",
+          features: { type: "FeatureCollection", features: [] },
+        },
+      });
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+
+  const surfaceMap = await airportDirectoryClient.resolveAirportSurface("kbos");
+  assert.deepEqual(calls, ["/api/airport/KBOS/surface"]);
+  assert.equal(surfaceMap.source, "OpenStreetMap");
 }
 
 // resolveAirport forwards the active locale so the detail route can enrich

--- a/src/features/airport/directory/airportDirectoryClient.ts
+++ b/src/features/airport/directory/airportDirectoryClient.ts
@@ -33,6 +33,11 @@ const buildAirportUrl = ({ baseUrl = "", ident, locale = "" }: Record<string, an
   return baseUrl ? url.toString() : `${url.pathname}${url.search}`;
 };
 
+const buildAirportSurfaceUrl = ({ baseUrl = "", ident }: Record<string, any>) => {
+  const safeIdent = encodeURIComponent(String(ident || "").trim().toUpperCase());
+  return `${baseUrl}${AIRPORT_PATH}/${safeIdent}/surface`;
+};
+
 const requestJson = async (fetchImpl: any, url: string) => {
   const response = await fetchImpl(url, {
     headers: { Accept: "application/json" },
@@ -119,7 +124,20 @@ const createAirportDirectoryClient = ({
     throw new Error("Airport not found");
   };
 
-  return { loadAirports, resolveAirport };
+  const resolveAirportSurface = async (code: unknown) => {
+    const trimmed = String(code || "").trim().toUpperCase();
+    if (!trimmed) {
+      throw new Error("Airport code is required");
+    }
+
+    const payload = await requestJson(
+      fetchImpl,
+      buildAirportSurfaceUrl({ baseUrl, ident: trimmed }),
+    );
+    return payload?.surfaceMap || null;
+  };
+
+  return { loadAirports, resolveAirport, resolveAirportSurface };
 };
 
 export const airportDirectoryClient = createAirportDirectoryClient();


### PR DESCRIPTION
## Summary
- Split the slow OpenStreetMap/Overpass airport surface map out of the default `/api/airport/{ident}` detail response.
- Added `/api/airport/{ident}/surface` for deferred surface loading, while the fast detail response still returns `runwayMap` immediately.
- Updated the airport page to render from the fast detail payload first, then merge `surfaceMap` asynchronously when it arrives.
- Added changelog coverage for the runway loading behavior.

## Root Cause
The focused airport runways appeared after roughly 10 seconds because `/api/airport/KBOS` synchronously waited for `airportSurfaceMap(...)`, which calls Overpass for OSM surface geometry. The frontend could not render even the existing `runwayMap` until that full detail response returned.

## Validation
- `curl http://localhost:8081/api/airport/KBOS?locale=zh-CN`: detail path returned in ~0.70s and no longer includes `surfaceMap` inline.
- `curl http://localhost:8081/api/airport/KBOS/surface`: deferred surface endpoint returned 455 OSM features when Overpass/cache succeeded; Overpass 504s no longer block main runway rendering.
- ego-lite KBOS probe: runway centerlines/approach rendered before the deferred surface request completed; stable-locale sample showed first runway render at ~3.3s in local dev.
- ego-lite medium zoom check: `surfaceRunways=6`, `surfaceFeatures=449`, no framework overlay.
- `go test ./...` in `services/data-service`
- `pnpm test` (115 test files passed)
- `pnpm lint` (0 errors, 14 existing warnings)
- `pnpm build`
- `git diff --check`