### PR TITLE
[codex] Fix nearby airport route transition stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.8.1",
+  "version": "2.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -26,6 +26,9 @@ export default function HomeScreen() {
       setAirport(null);
       return;
     }
+    setAirport((current) =>
+      airportCode(current) === currentIcao ? current : null,
+    );
     let cancelled = false;
     (async () => {
       try {
@@ -86,7 +89,7 @@ export default function HomeScreen() {
     <div key={screenTransitionKey} className="app-route-transition min-h-dvh">
       <AirportExplorer
         icao={currentIcao}
-        airport={airport}
+        airport={airportCode(airport) === currentIcao ? airport : null}
         onBack={handleBack}
       />
     </div>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.8.2",
+    kind: "patch",
+    title: {
+      en: "Nearby-airport tracking stability",
+      zh: "附近机场追踪稳定性修复",
+    },
+    summary: {
+      en: "Airport-to-airport navigation now keeps the URL airport as the page anchor while the next airport detail resolves, preventing stale nearby-airport previews from rendering the previous airport map.",
+      zh: "机场到机场的跳转现在会以 URL 中的机场作为页面锚点，等待新机场详情解析时不会再用上一座机场的对象渲染地图。",
+    },
+    highlights: [
+      {
+        en: "Nearby airport Track actions no longer reuse the previous airport profile during the route transition",
+        zh: "附近机场的追踪操作在路由切换期间不再复用上一座机场的 profile",
+      },
+      {
+        en: "Airport explorer profile resolution ignores stale airport objects that do not match the current route ICAO",
+        zh: "机场详情页的 profile 解析会忽略与当前路由 ICAO 不匹配的旧机场对象",
+      },
+    ],
+  },
+  {
     version: "v2.8.1",
     kind: "patch",
     title: {

--- a/src/features/airport/explorer/airportExplorerModel.test.ts
+++ b/src/features/airport/explorer/airportExplorerModel.test.ts
@@ -15,8 +15,26 @@ assert.equal(fallbackProfile.name, "Boston Logan");
 assert.equal(fallbackProfile.lat, 42.3656);
 assert.equal(fallbackProfile.lon, -71.0096);
 
-const providedProfile = resolveAirportProfile({
+const staleRouteProfile = resolveAirportProfile({
   icao: "kbos",
+  airport: {
+    icao: "KSEA",
+    iata: "SEA",
+    name: "Seattle-Tacoma International Airport",
+    city: "Seattle",
+    country: "United States",
+    lat: 47.4502,
+    lon: -122.3088,
+  },
+});
+assert.equal(staleRouteProfile.icao, "KBOS");
+assert.equal(staleRouteProfile.iata, "BOS");
+assert.equal(staleRouteProfile.city, "Boston");
+assert.equal(staleRouteProfile.lat, 42.3656);
+assert.equal(staleRouteProfile.lon, -71.0096);
+
+const providedProfile = resolveAirportProfile({
+  icao: "ksea",
   airport: {
     icao: "KSEA",
     iata: "SEA",

--- a/src/features/airport/explorer/airportExplorerModel.ts
+++ b/src/features/airport/explorer/airportExplorerModel.ts
@@ -8,22 +8,45 @@ import { buildNavaidLabels } from "../map/navaidLabelModel";
 type AirportExplorerRecord = Record<string, any>;
 
 export function resolveAirportProfile({ icao = "", airport = null }: AirportExplorerRecord = {}) {
-  const normalizedIcao = String(airport?.icao || icao || "").toUpperCase();
+  const routeIcao = normalizeAirportProfileCode(icao);
+  const airportIcao = normalizeAirportProfileCode(
+    airport?.icao || airport?.code || airport?.ident,
+  );
+  const useAirportDetails = Boolean(
+    airport && (!routeIcao || !airportIcao || airportIcao === routeIcao),
+  );
+  const normalizedIcao = routeIcao || airportIcao;
   const airportFallback = AIRPORT_FALLBACKS[normalizedIcao] || null;
   const airportCodeLabel =
-    airport?.iata || airportFallback?.iata || normalizedIcao;
+    (useAirportDetails ? airport?.iata : "") ||
+    airportFallback?.iata ||
+    normalizedIcao;
 
   return {
     icao: normalizedIcao,
     iata: airportCodeLabel,
-    name: airport?.name || airportFallback?.name || normalizedIcao || "Airport",
-    localizedName: airport?.localizedName || "",
-    city: airport?.city || airportFallback?.city || "",
-    country: airport?.country || airportFallback?.country || "",
-    lat: COORDS[normalizedIcao]?.[0] || airport?.lat || 0,
-    lon: COORDS[normalizedIcao]?.[1] || airport?.lon || 0,
-    elevationFt: airport?.elevationFt ?? null,
+    name:
+      (useAirportDetails ? airport?.name : "") ||
+      airportFallback?.name ||
+      normalizedIcao ||
+      "Airport",
+    localizedName: useAirportDetails ? airport?.localizedName || "" : "",
+    city:
+      (useAirportDetails ? airport?.city : "") || airportFallback?.city || "",
+    country:
+      (useAirportDetails ? airport?.country : "") ||
+      airportFallback?.country ||
+      "",
+    lat: COORDS[normalizedIcao]?.[0] || (useAirportDetails ? airport?.lat : 0) || 0,
+    lon: COORDS[normalizedIcao]?.[1] || (useAirportDetails ? airport?.lon : 0) || 0,
+    elevationFt: useAirportDetails ? airport?.elevationFt ?? null : null,
   };
+}
+
+function normalizeAirportProfileCode(value: unknown) {
+  return String(value || "")
+    .trim()
+    .toUpperCase();
 }
 
 export function enrichAircraftWithRoutes({


### PR DESCRIPTION
## Summary
- Keep airport detail pages anchored to the URL ICAO while the next airport detail resolves.
- Ignore stale airport objects that do not match the current route when resolving the explorer profile.
- Bump the patch version to v2.8.2 and add the changelog entry.

## Root cause
Nearby-airport Track actions navigated directly to `/airport/{icao}`. During the route transition, `HomeScreen` could still hold the previous airport object, and `resolveAirportProfile` preferred that stale object's ICAO over the new route ICAO. On slower resolves this could briefly render the previous airport map, and on mobile could surface an empty/blank transition state.

## Validation
- `pnpm exec tsx src/features/airport/explorer/airportExplorerModel.test.ts`
- `pnpm lint` (existing warnings only)
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- `pnpm debug:local:service`
- Browser: desktop KBOS -> KOWD nearby-airport Track stayed on `/airport/KOWD` with map present and no console warning/error.
- Browser: mobile KBOS -> KBVY nearby-airport Track stayed on `/airport/KBVY` with map present and no console warning/error.