### PR TITLE
Optimize page transition performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.8.2",
+  "version": "2.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/api/webapi/airport_surface_test.go
+++ b/services/data-service/internal/api/webapi/airport_surface_test.go
@@ -212,6 +212,12 @@ func TestAirportDetailDefersSurfaceMapByDefault(t *testing.T) {
 	if payload["surfaceMap"] != nil {
 		t.Fatalf("surfaceMap should be deferred by default: %#v", payload["surfaceMap"])
 	}
+	if airspaces, ok := payload["airspaces"].([]any); !ok || len(airspaces) != 0 {
+		t.Fatalf("airspaces should be deferred by default: %#v", payload["airspaces"])
+	}
+	if obstacles, ok := payload["obstacles"].([]any); !ok || len(obstacles) != 0 {
+		t.Fatalf("obstacles should be deferred by default: %#v", payload["obstacles"])
+	}
 	if overpassHits != 0 {
 		t.Fatalf("default detail overpass hits = %d", overpassHits)
 	}
@@ -221,6 +227,24 @@ func TestAirportDetailDefersSurfaceMapByDefault(t *testing.T) {
 	}
 	if runwayMap["source"] != "OpenAIP" {
 		t.Fatalf("runwayMap = %#v", runwayMap)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/airport/KBOS/context", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("context status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	payload = map[string]any{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid context json: %v", err)
+	}
+	if _, ok := payload["airspaces"].([]any); !ok {
+		t.Fatalf("missing context airspaces: %#v", payload["airspaces"])
+	}
+	if _, ok := payload["obstacles"].([]any); !ok {
+		t.Fatalf("missing context obstacles: %#v", payload["obstacles"])
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/api/airport/KBOS/surface", nil)

--- a/services/data-service/internal/api/webapi/handler.go
+++ b/services/data-service/internal/api/webapi/handler.go
@@ -97,6 +97,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleSearch(w, r)
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/airport/") && strings.HasSuffix(r.URL.Path, "/surface"):
 		h.handleAirportSurface(w, r)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/airport/") && strings.HasSuffix(r.URL.Path, "/context"):
+		h.handleAirportContext(w, r)
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/airport/"):
 		h.handleAirport(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/api/proxy/airports/nearby":
@@ -181,8 +183,6 @@ func (h *Handler) handleAirport(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "Invalid airport ident"})
 		return
 	}
-	radiusNm := intInRange(r.URL.Query().Get("nearbyRadiusNm"), 60, 1, 250)
-	nearbyLimit := intInRange(r.URL.Query().Get("nearbyLimit"), 12, 1, 50)
 	detail, airport, runways, runwayMap, err := h.resolveAirportDetail(r.Context(), ident)
 	if err != nil {
 		writeAPIError(w, err, "Airport detail load failed")
@@ -192,40 +192,22 @@ func (h *Handler) handleAirport(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]any{"error": "Airport not found"})
 		return
 	}
-	lat, lon := numberValue(airport["lat"]), numberValue(airport["lon"])
-	id := stringValue(detail["_id"])
 	nearbyAirports := []map[string]any{}
 	nearbyNavaids := []map[string]any{}
 	airspaces := []map[string]any{}
 	reportingPoints := []map[string]any{}
 	obstacles := []map[string]any{}
-	if finite(lat) && finite(lon) {
-		var wg sync.WaitGroup
-		wg.Add(5)
-		go func() {
-			defer wg.Done()
-			nearbyAirports = h.nearbyAirports(r.Context(), lat, lon, ident, radiusNm, nearbyLimit)
-		}()
-		go func() {
-			defer wg.Done()
-			nearbyNavaids = h.nearbyNavaids(r.Context(), lat, lon, radiusNm, nearbyLimit)
-		}()
-		go func() {
-			defer wg.Done()
-			airspaces = h.nearbyAirspaces(r.Context(), lat, lon, radiusNm)
-		}()
-		go func() {
-			defer wg.Done()
-			reportingPoints = h.reportingPoints(r.Context(), id)
-		}()
-		go func() {
-			defer wg.Done()
-			obstacles = h.nearbyObstacles(r.Context(), lat, lon, minInt(radiusNm, 50))
-		}()
-		wg.Wait()
+	if shouldIncludeAirportContext(r) {
+		context := h.airportContext(r.Context(), detail, airport, ident, r)
+		nearbyAirports = context.nearbyAirports
+		nearbyNavaids = context.nearbyNavaids
+		airspaces = context.airspaces
+		reportingPoints = context.reportingPoints
+		obstacles = context.obstacles
 	}
 	var surfaceMap map[string]any
 	if shouldIncludeAirportSurface(r) {
+		lat, lon := numberValue(airport["lat"]), numberValue(airport["lon"])
 		surfaceMap = h.airportSurfaceMap(r.Context(), ident, lat, lon, runwayMap)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -266,6 +248,32 @@ func (h *Handler) handleAirportSurface(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *Handler) handleAirportContext(w http.ResponseWriter, r *http.Request) {
+	ident := strings.ToUpper(strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/airport/"), "/context")))
+	if !match(ident, `^[A-Z0-9]{2,7}$`) {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "Invalid airport ident"})
+		return
+	}
+	detail, airport, _, _, err := h.resolveAirportDetail(r.Context(), ident)
+	if err != nil {
+		writeAPIError(w, err, "Airport context load failed")
+		return
+	}
+	if airport == nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "Airport not found"})
+		return
+	}
+	context := h.airportContext(r.Context(), detail, airport, ident, r)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"nearbyAirports":  context.nearbyAirports,
+		"nearbyNavaids":   context.nearbyNavaids,
+		"airspaces":       context.airspaces,
+		"reportingPoints": context.reportingPoints,
+		"obstacles":       context.obstacles,
+		"source":          "openaip",
+	})
+}
+
 func shouldIncludeAirportSurface(r *http.Request) bool {
 	value := strings.ToLower(strings.TrimSpace(firstString(
 		r.URL.Query().Get("includeSurface"),
@@ -277,6 +285,69 @@ func shouldIncludeAirportSurface(r *http.Request) bool {
 	default:
 		return false
 	}
+}
+
+func shouldIncludeAirportContext(r *http.Request) bool {
+	value := strings.ToLower(strings.TrimSpace(firstString(
+		r.URL.Query().Get("includeContext"),
+		r.URL.Query().Get("context"),
+	)))
+	switch value {
+	case "1", "true", "yes", "include", "inline":
+		return true
+	default:
+		return false
+	}
+}
+
+type airportContextPayload struct {
+	nearbyAirports  []map[string]any
+	nearbyNavaids   []map[string]any
+	airspaces       []map[string]any
+	reportingPoints []map[string]any
+	obstacles       []map[string]any
+}
+
+func (h *Handler) airportContext(ctx context.Context, detail, airport map[string]any, ident string, r *http.Request) airportContextPayload {
+	radiusNm := intInRange(r.URL.Query().Get("nearbyRadiusNm"), 60, 1, 250)
+	nearbyLimit := intInRange(r.URL.Query().Get("nearbyLimit"), 12, 1, 50)
+	lat, lon := numberValue(airport["lat"]), numberValue(airport["lon"])
+	id := stringValue(detail["_id"])
+	context := airportContextPayload{
+		nearbyAirports:  []map[string]any{},
+		nearbyNavaids:   []map[string]any{},
+		airspaces:       []map[string]any{},
+		reportingPoints: []map[string]any{},
+		obstacles:       []map[string]any{},
+	}
+	if !finite(lat) || !finite(lon) {
+		return context
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(5)
+	go func() {
+		defer wg.Done()
+		context.nearbyAirports = h.nearbyAirports(ctx, lat, lon, ident, radiusNm, nearbyLimit)
+	}()
+	go func() {
+		defer wg.Done()
+		context.nearbyNavaids = h.nearbyNavaids(ctx, lat, lon, radiusNm, nearbyLimit)
+	}()
+	go func() {
+		defer wg.Done()
+		context.airspaces = h.nearbyAirspaces(ctx, lat, lon, radiusNm)
+	}()
+	go func() {
+		defer wg.Done()
+		context.reportingPoints = h.reportingPoints(ctx, id)
+	}()
+	go func() {
+		defer wg.Done()
+		context.obstacles = h.nearbyObstacles(ctx, lat, lon, minInt(radiusNm, 50))
+	}()
+	wg.Wait()
+	return context
 }
 
 func (h *Handler) handleNearbyAirports(w http.ResponseWriter, r *http.Request) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,30 @@
+import { lazy, Suspense, type ReactNode } from "react";
 import {
   Navigate,
   Route,
   Routes,
   useParams,
 } from "react-router-dom";
-import DitherPageShell from "@/components/app-shell/DitherPageShell";
-import AboutPanel from "@/components/about/AboutPanel";
-import ChangelogPanel from "@/components/changelog/ChangelogPanel";
-import MechanismPanel from "@/components/mechanism/MechanismPanel";
-import FlightScreen from "@/components/screens/FlightScreen";
-import HomeScreen from "@/components/screens/HomeScreen";
-import NearMeScreen from "@/components/screens/NearMeScreen";
 import { normalizeCallsign } from "@/utils/callsign";
+
+const DitherPageShell = lazy(() => import("@/components/app-shell/DitherPageShell"));
+const AboutPanel = lazy(() => import("@/components/about/AboutPanel"));
+const ChangelogPanel = lazy(() => import("@/components/changelog/ChangelogPanel"));
+const MechanismPanel = lazy(() => import("@/components/mechanism/MechanismPanel"));
+const FlightScreen = lazy(() => import("@/components/screens/FlightScreen"));
+const HomeScreen = lazy(() => import("@/components/screens/HomeScreen"));
+const NearMeScreen = lazy(() => import("@/components/screens/NearMeScreen"));
 
 function FlightRoute() {
   const { callsign = "" } = useParams();
   return <FlightScreen callsign={normalizeCallsign(callsign)} />;
 }
 
-function DitherRoute({ children }: { children: React.ReactNode }) {
+function RouteBoundary({ children }: { children: ReactNode }) {
+  return <Suspense fallback={null}>{children}</Suspense>;
+}
+
+function DitherRoute({ children }: { children: ReactNode }) {
   return <DitherPageShell>{children}</DitherPageShell>;
 }
 
@@ -28,36 +34,65 @@ export default function App() {
       <Route
         path="/"
         element={
-          <DitherRoute>
-            <HomeScreen />
-          </DitherRoute>
+          <RouteBoundary>
+            <DitherRoute>
+              <HomeScreen />
+            </DitherRoute>
+          </RouteBoundary>
         }
       />
-      <Route path="/airport/:icao" element={<HomeScreen />} />
-      <Route path="/aircraft/:callsign" element={<FlightRoute />} />
-      <Route path="/here" element={<NearMeScreen />} />
+      <Route
+        path="/airport/:icao"
+        element={
+          <RouteBoundary>
+            <HomeScreen />
+          </RouteBoundary>
+        }
+      />
+      <Route
+        path="/aircraft/:callsign"
+        element={
+          <RouteBoundary>
+            <FlightRoute />
+          </RouteBoundary>
+        }
+      />
+      <Route
+        path="/here"
+        element={
+          <RouteBoundary>
+            <NearMeScreen />
+          </RouteBoundary>
+        }
+      />
       <Route
         path="/about"
         element={
-          <DitherRoute>
-            <AboutPanel />
-          </DitherRoute>
+          <RouteBoundary>
+            <DitherRoute>
+              <AboutPanel />
+            </DitherRoute>
+          </RouteBoundary>
         }
       />
       <Route
         path="/mechanism"
         element={
-          <DitherRoute>
-            <MechanismPanel />
-          </DitherRoute>
+          <RouteBoundary>
+            <DitherRoute>
+              <MechanismPanel />
+            </DitherRoute>
+          </RouteBoundary>
         }
       />
       <Route
         path="/changelog"
         element={
-          <DitherRoute>
-            <ChangelogPanel />
-          </DitherRoute>
+          <RouteBoundary>
+            <DitherRoute>
+              <ChangelogPanel />
+            </DitherRoute>
+          </RouteBoundary>
         }
       />
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -19,7 +19,6 @@ import MobilePreviewCard, {
   MobilePreviewSecondaryButton,
   MobilePreviewTrackButton,
 } from "./MobilePreviewCard";
-import PlaneHunterStudio from "./PlaneHunterStudio";
 import RouteFeedbackModal from "./RouteFeedbackModal";
 import { useSelectedAircraftTrace } from "@/components/aircraft/trace/SelectedAircraftTraceContext";
 import { useAircraftPhoto } from "@/features/aircraft/preview/useAircraftPhoto";
@@ -31,9 +30,11 @@ import { useAircraftTraceAsyncStatus } from "@/features/aircraft/trace/useAircra
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel";
 import { useSwipeUpToDismiss } from "@/hooks/useSwipeUpToDismiss";
+import dynamic from "@/platform/react/dynamic";
 
 const PHOTO_TONE_DARK = "dark";
 const PHOTO_TONE_LIGHT = "light";
+const PlaneHunterStudio = dynamic(() => import("./PlaneHunterStudio"));
 
 export default function AircraftPreviewCard({
   aircraft = null,

--- a/src/components/effects/BrandingVideoBackground.tsx
+++ b/src/components/effects/BrandingVideoBackground.tsx
@@ -3,106 +3,47 @@
 import { useEffect, useRef, useState } from "react";
 
 const DEFAULT_SOURCE = "/brand/adsbao-aircraft-brand-loop.mp4";
-const CROSSFADE_SECONDS = 1.8;
 
 export default function BrandingVideoBackground({ source = DEFAULT_SOURCE }) {
-  const primaryVideoRef = useRef(null);
-  const secondaryVideoRef = useRef(null);
-  const [visibleIndex, setVisibleIndex] = useState(0);
-  const crossingRef = useRef(false);
-  const visibleIndexRef = useRef(0);
+  const videoRef = useRef(null);
+  const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    visibleIndexRef.current = visibleIndex;
-  }, [visibleIndex]);
+    const video = videoRef.current;
+    if (!video) return undefined;
 
-  useEffect(() => {
-    const videos = [primaryVideoRef.current, secondaryVideoRef.current];
-    if (videos.some((video) => !video)) return undefined;
-
-    let frameId = null;
-    let fadeTimer = null;
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-    const playVideo = (video) => {
-      video.muted = true;
-      const playPromise = video.play();
-      if (playPromise?.catch) {
-        playPromise.catch(() => {});
-      }
-    };
-
-    const resetVideo = (video) => {
-      video.pause();
-      try {
-        video.currentTime = 0;
-      } catch {
-        // Browsers can reject seeks before metadata is available.
-      }
-    };
-
-    const startCrossfade = () => {
-      if (crossingRef.current) return;
-      crossingRef.current = true;
-
-      const currentIndex = visibleIndexRef.current;
-      const nextIndex = currentIndex === 0 ? 1 : 0;
-      const current = videos[currentIndex];
-      const next = videos[nextIndex];
-
-      next.currentTime = 0;
-      playVideo(next);
-      setVisibleIndex(nextIndex);
-
-      fadeTimer = window.setTimeout(() => {
-        resetVideo(current);
-        crossingRef.current = false;
-      }, CROSSFADE_SECONDS * 1000);
-    };
-
-    const tick = () => {
-      const current = videos[visibleIndexRef.current];
-      if (current?.duration && current.duration - current.currentTime <= CROSSFADE_SECONDS) {
-        startCrossfade();
-      }
-      frameId = window.requestAnimationFrame(tick);
-    };
-
     if (reduceMotion) {
-      resetVideo(videos[0]);
-      resetVideo(videos[1]);
-      setVisibleIndex(0);
-      return () => {
-        videos.forEach((video) => video.pause());
-      };
+      video.pause();
+      setVisible(false);
+      return undefined;
     }
 
-    resetVideo(videos[1]);
-    playVideo(videos[0]);
-    frameId = window.requestAnimationFrame(tick);
+    const show = () => setVisible(true);
+    const play = () => {
+      video.muted = true;
+      video.play()?.catch?.(() => {});
+    };
+    video.addEventListener("loadeddata", show);
+    play();
 
     return () => {
-      if (frameId !== null) window.cancelAnimationFrame(frameId);
-      if (fadeTimer !== null) window.clearTimeout(fadeTimer);
-      videos.forEach((video) => video.pause());
+      video.removeEventListener("loadeddata", show);
+      video.pause();
     };
   }, [source]);
 
   return (
     <div className="branding-video-background" aria-hidden="true">
-      {[0, 1].map((index) => (
-        <video
-          key={`${source}-${index}`}
-          ref={index === 0 ? primaryVideoRef : secondaryVideoRef}
-          className={`branding-video-background__media ${
-            visibleIndex === index ? "is-visible" : ""
-          }`.trim()}
-          src={source}
-          muted
-          playsInline
-          preload="auto"
-        />
-      ))}
+      <video
+        ref={videoRef}
+        className={`branding-video-background__media ${visible ? "is-visible" : ""}`.trim()}
+        src={source}
+        muted
+        playsInline
+        loop
+        preload="metadata"
+      />
     </div>
   );
 }

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -590,26 +590,24 @@ function FlightExplorerContent({ callsign }) {
     if (missingCodes.length === 0) return undefined;
 
     const controller = new AbortController();
-    Promise.all(
-      missingCodes.map(async (code) => {
-        try {
-          const response = await fetch(`/api/airport/${encodeURIComponent(code)}`, {
-            signal: controller.signal,
-          });
-          if (!response.ok) return [code, null];
+    missingCodes.forEach((code) => {
+      fetch(`/api/airport/${encodeURIComponent(code)}`, {
+        signal: controller.signal,
+      })
+        .then(async (response) => {
+          if (!response.ok) return null;
           const payload = await response.json();
-          return [code, payload?.airport || null];
-        } catch {
-          return [code, null];
-        }
-      }),
-    ).then((entries) => {
-      if (controller.signal.aborted) return;
-      setRouteAirportDetailsByCode((current) => {
-        const next = { ...current };
-        for (const [code, airport] of entries) next[code] = airport;
-        return next;
-      });
+          return payload?.airport || null;
+        })
+        .catch(() => null)
+        .then((airport) => {
+          if (controller.signal.aborted) return;
+          setRouteAirportDetailsByCode((current) =>
+            current[code] === undefined
+              ? { ...current, [code]: airport }
+              : current,
+          );
+        });
     });
 
     return () => controller.abort();

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname, useRouter } from "@/platform/router/navigation";
 import { toast } from "sonner";
 import AirportExplorer from "@/components/airport/explorer/AirportExplorer";
@@ -18,8 +18,23 @@ export default function HomeScreen() {
   const pathname = usePathname();
   const { locale } = useI18n();
   const currentIcao = normalizePathIcao(pathname);
-  const screenTransitionKey = currentIcao ? `airport:${currentIcao}` : "search";
   const [airport, setAirport] = useState(null);
+  const [routeTransitionActive, setRouteTransitionActive] = useState(true);
+  const hasPlayedInitialRouteTransitionRef = useRef(false);
+
+  useEffect(() => {
+    if (!currentIcao) return undefined;
+    if (!hasPlayedInitialRouteTransitionRef.current) {
+      hasPlayedInitialRouteTransitionRef.current = true;
+      setRouteTransitionActive(true);
+      return undefined;
+    }
+    setRouteTransitionActive(false);
+    const frameId = window.requestAnimationFrame(() => {
+      setRouteTransitionActive(true);
+    });
+    return () => window.cancelAnimationFrame(frameId);
+  }, [currentIcao]);
 
   useEffect(() => {
     if (!currentIcao) {
@@ -30,6 +45,12 @@ export default function HomeScreen() {
       airportCode(current) === currentIcao ? current : null,
     );
     let cancelled = false;
+    let pageLeaving = false;
+    const deferredController = new AbortController();
+    const handlePageHide = () => {
+      pageLeaving = true;
+    };
+    window.addEventListener("pagehide", handlePageHide);
     (async () => {
       try {
         const resolved = await airportDirectoryClient.resolveAirport(currentIcao, {
@@ -38,7 +59,25 @@ export default function HomeScreen() {
         if (cancelled) return;
         setAirport(resolved);
         airportDirectoryClient
-          .resolveAirportSurface(currentIcao)
+          .resolveAirportContext(currentIcao, {
+            signal: deferredController.signal,
+          })
+          .then((context) => {
+            if (cancelled || !context) return;
+            setAirport((current) => {
+              if (airportCode(current) !== currentIcao) return current;
+              return { ...current, ...context };
+            });
+          })
+          .catch((contextError) => {
+            if (!cancelled && !isInterruptedFetch(contextError)) {
+              console.warn("Failed to load airport context", contextError);
+            }
+          });
+        airportDirectoryClient
+          .resolveAirportSurface(currentIcao, {
+            signal: deferredController.signal,
+          })
           .then((surfaceMap) => {
             if (cancelled || !surfaceMap) return;
             setAirport((current) => {
@@ -47,12 +86,22 @@ export default function HomeScreen() {
             });
           })
           .catch((surfaceError) => {
-            if (!cancelled) {
+            if (
+              !cancelled &&
+              !pageLeaving &&
+              !isInterruptedFetch(surfaceError)
+            ) {
               console.warn("Failed to load airport surface", surfaceError);
             }
           });
       } catch (err) {
-        if (cancelled) return;
+        if (
+          cancelled ||
+          pageLeaving ||
+          isInterruptedNavigationFetch(err, currentIcao)
+        ) {
+          return;
+        }
         console.error("Failed to load airport", err);
         toast.error(err?.message || "Airport not found or unavailable", {
           id: "airport-resolve",
@@ -62,6 +111,8 @@ export default function HomeScreen() {
     })();
     return () => {
       cancelled = true;
+      deferredController.abort();
+      window.removeEventListener("pagehide", handlePageHide);
     };
   }, [currentIcao, locale]);
 
@@ -86,7 +137,9 @@ export default function HomeScreen() {
   }
 
   return (
-    <div key={screenTransitionKey} className="app-route-transition min-h-dvh">
+    <div
+      className={`${routeTransitionActive ? "app-route-transition " : ""}min-h-dvh`}
+    >
       <AirportExplorer
         icao={currentIcao}
         airport={airportCode(airport) === currentIcao ? airport : null}
@@ -112,4 +165,15 @@ function airportCode(airport) {
   return String(airport?.icao || airport?.code || airport?.ident || "")
     .trim()
     .toUpperCase();
+}
+
+function isInterruptedNavigationFetch(error, expectedIcao) {
+  if (!isInterruptedFetch(error)) return false;
+  if (typeof window === "undefined") return false;
+  return normalizePathIcao(window.location.pathname) !== expectedIcao;
+}
+
+function isInterruptedFetch(error) {
+  const message = String(error?.message || error || "");
+  return /Failed to fetch|AbortError|aborted/i.test(message);
 }

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -16,6 +16,8 @@ import { formatAltitude } from "@/utils/units";
 import { useCardInteraction } from "@/animations/useCardInteraction";
 import { rowPropsEqual } from "./rowPropsEqual";
 
+const ROUTE_ENTER_MS = 300;
+
 // Tiny self-contained <img> that hides itself if the URL 404s. Avoids
 // stamped broken-image icons in dense list rows when the logo isn't
 // served by the airline-icon CDN.
@@ -170,7 +172,10 @@ function AircraftIdentityCell({
   useEffect(() => {
     if (!hadRoute.current && hasRoute) {
       setRouteEntering(true);
-      const timer = window.setTimeout(() => setRouteEntering(false), 520);
+      const timer = window.setTimeout(
+        () => setRouteEntering(false),
+        ROUTE_ENTER_MS,
+      );
       hadRoute.current = hasRoute;
       return () => window.clearTimeout(timer);
     }

--- a/src/config/aviation.ts
+++ b/src/config/aviation.ts
@@ -7,7 +7,7 @@ export const AIRPORT_MAP_ZOOM = {
 export const AIRPORT_EXPLORER_UI_CONFIG = {
   desktopSidebarWidth: "var(--app-sidebar-width)",
   mobileBreakpointPx: 768,
-  adsbLoadingFadeMs: 500,
+  adsbLoadingFadeMs: 180,
 };
 
 export const AIRCRAFT_TRAFFIC_CONFIG = {

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.9.0",
+    kind: "feat",
+    title: {
+      en: "Faster page transitions",
+      zh: "页面切换提速",
+    },
+    summary: {
+      en: "Airport-to-airport, airport-to-aircraft, and aircraft-to-airport transitions now avoid duplicate payloads, keep more route shell state alive, and move heavy optional modules out of the first page switch.",
+      zh: "机场到机场、机场到飞机、飞机回机场的切换现在会避免重复 payload，保留更多路由外壳状态，并把较重的可选模块移出首次页面切换。",
+    },
+    highlights: [
+      {
+        en: "Airport detail now loads as a lightweight payload first, while large context and surface maps hydrate separately and are cached briefly for return transitions",
+        zh: "机场详情现在先加载轻量 payload，大型上下文与地面图层会分段补齐，并在短时间内缓存以加速返回切换",
+      },
+      {
+        en: "Airport pages no longer remount the full explorer shell on every airport-to-airport route change",
+        zh: "机场页在机场到机场跳转时不再按每个机场强制重建整套 explorer 外壳",
+      },
+      {
+        en: "Route modules and the Plane Hunter studio load on demand, reducing the JavaScript pulled into unrelated airport and aircraft transitions",
+        zh: "路由模块与拍机工作室改为按需加载，减少无关机场与飞机切换时需要拉取的 JavaScript",
+      },
+    ],
+  },
+  {
     version: "v2.8.2",
     kind: "patch",
     title: {

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.ts
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.test.ts
@@ -13,7 +13,7 @@ import {
   shouldTriggerVisibilityRefreshOverlay,
 } from "./aircraftLoadingOverlayModel";
 
-assert.equal(AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS, 1_000);
+assert.equal(AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS, 220);
 
 assert.equal(
   shouldReplayLoadingOverlayOnPageVisible({
@@ -129,7 +129,7 @@ assert.equal(
     now: 1_120,
     minVisibleMs: AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS,
   }),
-  880,
+  100,
 );
 
 assert.equal(

--- a/src/features/aircraft/positions/aircraftLoadingOverlayModel.ts
+++ b/src/features/aircraft/positions/aircraftLoadingOverlayModel.ts
@@ -1,4 +1,4 @@
-export const AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS = 1_000;
+export const AIRCRAFT_LOADING_OVERLAY_MIN_VISIBLE_MS = 220;
 
 type LoadingSettledOptions = {
   aircraftPositionsSettled?: boolean;

--- a/src/features/aircraft/trace/aircraftTraceClient.ts
+++ b/src/features/aircraft/trace/aircraftTraceClient.ts
@@ -18,6 +18,7 @@ export const createAircraftTraceClient = ({
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: "adsb.lol/AircraftTrace",
   });
+  const inFlight = new Map<string, Promise<any>>();
 
   return {
     fetchAircraftTrace({ hex, full = false }: Record<string, any>) {
@@ -27,12 +28,18 @@ export const createAircraftTraceClient = ({
       const path = `${baseUrl}/${encodeURIComponent(normalizedHex)}${
         full ? "?full=1" : ""
       }`;
-      return fetchJson(auditedFetch, path, {
+      const pending = inFlight.get(path);
+      if (pending) return pending;
+      const promise = fetchJson(auditedFetch, path, {
         timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.aircraftTrace,
         // Full traces for long-haul flights can run multi-MB — give the
         // client buffer some headroom too.
         maxBytes: 24 * 1024 * 1024,
+      }).finally(() => {
+        inFlight.delete(path);
       });
+      inFlight.set(path, promise);
+      return promise;
     },
   };
 };

--- a/src/features/aircraft/trace/useAircraftTraceAsyncStatus.ts
+++ b/src/features/aircraft/trace/useAircraftTraceAsyncStatus.ts
@@ -3,10 +3,9 @@
 import { useEffect, useState } from "react";
 import { useAsyncStatus, type AsyncStatusState } from "@/hooks/useAsyncStatus";
 
-// Minimum time the trace-status surface stays visible after entering "loading"
-// so users actually notice the "正在加载航迹…" copy even if the upstream
-// request resolves in a few hundred ms.
-const TRACE_STATUS_MIN_VISIBLE_MS = 4200;
+// Keep the pending label visible for one fast motion beat. Longer trace waits
+// are handled by the async-status fade lifecycle instead of a hard hold.
+const TRACE_STATUS_MIN_VISIBLE_MS = 320;
 
 interface SelectedTraceLike {
   aircraftHex?: string | null;

--- a/src/features/airport/context/useAviationContextTiles.ts
+++ b/src/features/airport/context/useAviationContextTiles.ts
@@ -132,13 +132,14 @@ export function useAviationContextTiles({
       return undefined;
     }
 
-    setLoading(true);
-    setError(null);
-    Promise.allSettled(requestUrls.map(fetchTile)).then((results) => {
+    const payloadsByUrl = new Map<string, ContextTileRecord>();
+    let pendingCount = requestUrls.length;
+    let rejectedReason = null;
+    const commitPayloads = () => {
       if (cancelled) return;
-      const payloads = results
-        .filter((result) => result.status === "fulfilled")
-        .map((result) => result.value);
+      const payloads = requestUrls
+        .map((url) => payloadsByUrl.get(url))
+        .filter(Boolean);
       setAirspaces(
         uniqueBy(
           payloads.flatMap((payload) => payload.airspaces || []),
@@ -163,9 +164,32 @@ export function useAviationContextTiles({
           (item) => item?.id || `${item?.name}:${item?.lat}:${item?.lon}`,
         ),
       );
-      const rejected = results.find((result) => result.status === "rejected");
-      setError(rejected?.reason || null);
-      setLoading(false);
+      setError(rejectedReason);
+    };
+
+    setLoading(true);
+    setError(null);
+    setAirspaces([]);
+    setNavaids([]);
+    setNavaidCounts([]);
+    setWaypoints([]);
+
+    requestUrls.forEach((url) => {
+      fetchTile(url)
+        .then((payload) => {
+          payloadsByUrl.set(url, payload);
+          commitPayloads();
+        })
+        .catch((reason) => {
+          rejectedReason ||= reason;
+          setError(rejectedReason);
+        })
+        .finally(() => {
+          pendingCount -= 1;
+          if (!cancelled && pendingCount === 0) {
+            setLoading(false);
+          }
+        });
     });
 
     return () => {

--- a/src/features/airport/directory/airportDirectoryClient.test.ts
+++ b/src/features/airport/directory/airportDirectoryClient.test.ts
@@ -3,7 +3,12 @@ import assert from "node:assert/strict";
 let fetchImpl;
 globalThis.fetch = ((...args) => fetchImpl(...args)) as any;
 
-const { airportDirectoryClient } = await import("./airportDirectoryClient");
+const { createAirportDirectoryClient } = await import("./airportDirectoryClient");
+
+const createClient = () =>
+  createAirportDirectoryClient({
+    fetchImpl: (...args) => fetchImpl(...args),
+  });
 
 const createJsonResponse = (payload, status = 200) => ({
   ok: status >= 200 && status < 300,
@@ -39,7 +44,7 @@ const KBOS = {
     });
   };
 
-  const result = await airportDirectoryClient.loadAirports({
+  const result = await createClient().loadAirports({
     query: "KBOS",
     country: "us",
     kind: "large_airport",
@@ -64,12 +69,13 @@ const KBOS = {
     return createJsonResponse({ airports: [], source: "openaip" });
   };
 
-  await airportDirectoryClient.loadAirports({ country: "US", kind: "all", limit: 12 });
+  await createClient().loadAirports({ country: "US", kind: "all", limit: 12 });
   assert.equal(calls.length, 1);
   assert.doesNotMatch(calls[0], /type=/);
 }
 
-// resolveAirport hits the fast airport-detail route and unwraps .airport
+// resolveAirport hits the fast airport-detail route and leaves heavy context
+// empty until resolveAirportContext hydrates it separately.
 {
   const calls = [];
   fetchImpl = async (url) => {
@@ -80,10 +86,6 @@ const KBOS = {
         runways: [],
         frequencies: [],
         nearbyAirports: [],
-        nearbyNavaids: [{ ident: "BOS", type: "VORTAC" }],
-        airspaces: [{ id: "asp-1", name: "BOSTON CLASS B" }],
-        reportingPoints: [{ id: "pt-1", name: "HYLND" }],
-        obstacles: [{ id: "obs-1", name: "Tower" }],
         runwayMap: { airport: "KBOS", source: "OurAirports", runways: [] },
         surfaceMap: null,
         source: "openaip",
@@ -92,16 +94,67 @@ const KBOS = {
     throw new Error(`unexpected url: ${url}`);
   };
 
-  const airport = await airportDirectoryClient.resolveAirport("kbos");
+  const airport = await createClient().resolveAirport("kbos");
   assert.deepEqual(calls, ["/api/airport/KBOS"]);
   assert.equal(airport.icao, "KBOS");
   assert.equal(airport.iata, "BOS");
-  assert.deepEqual(airport.nearbyNavaids, [{ ident: "BOS", type: "VORTAC" }]);
-  assert.deepEqual(airport.airspaces, [{ id: "asp-1", name: "BOSTON CLASS B" }]);
-  assert.deepEqual(airport.reportingPoints, [{ id: "pt-1", name: "HYLND" }]);
-  assert.deepEqual(airport.obstacles, [{ id: "obs-1", name: "Tower" }]);
+  assert.deepEqual(airport.nearbyNavaids, []);
+  assert.deepEqual(airport.airspaces, []);
+  assert.deepEqual(airport.reportingPoints, []);
+  assert.deepEqual(airport.obstacles, []);
   assert.deepEqual(airport.runwayMap, { airport: "KBOS", source: "OurAirports", runways: [] });
   assert.equal(airport.surfaceMap, null);
+}
+
+// concurrent identical requests share a single in-flight fetch instead of
+// doubling the route transition wait.
+{
+  const calls = [];
+  let resolveResponse;
+  fetchImpl = async (url) => {
+    calls.push(url);
+    return new Promise((resolve) => {
+      resolveResponse = () =>
+        resolve(
+          createJsonResponse({
+            airport: KBOS,
+            runways: [],
+            frequencies: [],
+          }),
+        );
+    });
+  };
+
+  const client = createClient();
+  const first = client.resolveAirport("kbos");
+  const second = client.resolveAirport("KBOS");
+  assert.equal(calls.length, 1);
+  resolveResponse();
+  const [firstAirport, secondAirport] = await Promise.all([first, second]);
+  assert.equal(firstAirport.icao, "KBOS");
+  assert.equal(secondAirport.icao, "KBOS");
+  assert.deepEqual(calls, ["/api/airport/KBOS"]);
+}
+
+// resolved airport detail responses are kept briefly so returning to the
+// same airport does not re-fetch the static profile/context payloads.
+{
+  const calls = [];
+  fetchImpl = async (url) => {
+    calls.push(url);
+    return createJsonResponse({
+      airport: KBOS,
+      runways: [],
+      frequencies: [],
+    });
+  };
+
+  const client = createClient();
+  const first = await client.resolveAirport("kbos");
+  const second = await client.resolveAirport("KBOS");
+  assert.equal(first.icao, "KBOS");
+  assert.equal(second.icao, "KBOS");
+  assert.deepEqual(calls, ["/api/airport/KBOS"]);
 }
 
 // resolveAirportSurface loads the deferred OSM surface payload separately.
@@ -121,9 +174,35 @@ const KBOS = {
     throw new Error(`unexpected url: ${url}`);
   };
 
-  const surfaceMap = await airportDirectoryClient.resolveAirportSurface("kbos");
+  const surfaceMap = await createClient().resolveAirportSurface("kbos");
   assert.deepEqual(calls, ["/api/airport/KBOS/surface"]);
   assert.equal(surfaceMap.source, "OpenStreetMap");
+}
+
+// resolveAirportContext loads the deferred airspace/navaid/obstacle payload.
+{
+  const calls = [];
+  fetchImpl = async (url) => {
+    calls.push(url);
+    if (url === "/api/airport/KBOS/context") {
+      return createJsonResponse({
+        nearbyAirports: [{ icao: "KOWD" }],
+        nearbyNavaids: [{ ident: "BOS", type: "VORTAC" }],
+        airspaces: [{ id: "asp-1", name: "BOSTON CLASS B" }],
+        reportingPoints: [{ id: "pt-1", name: "HYLND" }],
+        obstacles: [{ id: "obs-1", name: "Tower" }],
+      });
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+
+  const context = await createClient().resolveAirportContext("kbos");
+  assert.deepEqual(calls, ["/api/airport/KBOS/context"]);
+  assert.deepEqual(context.nearbyAirports, [{ icao: "KOWD" }]);
+  assert.deepEqual(context.nearbyNavaids, [{ ident: "BOS", type: "VORTAC" }]);
+  assert.deepEqual(context.airspaces, [{ id: "asp-1", name: "BOSTON CLASS B" }]);
+  assert.deepEqual(context.reportingPoints, [{ id: "pt-1", name: "HYLND" }]);
+  assert.deepEqual(context.obstacles, [{ id: "obs-1", name: "Tower" }]);
 }
 
 // resolveAirport forwards the active locale so the detail route can enrich
@@ -145,7 +224,7 @@ const KBOS = {
     throw new Error(`unexpected url: ${url}`);
   };
 
-  const airport = await airportDirectoryClient.resolveAirport("zspd", { locale: "zh-CN" });
+  const airport = await createClient().resolveAirport("zspd", { locale: "zh-CN" });
   assert.deepEqual(calls, ["/api/airport/ZSPD?locale=zh-CN"]);
   assert.equal(airport.localizedName, "上海浦东国际机场");
 }
@@ -164,7 +243,7 @@ const KBOS = {
     throw new Error(`unexpected url: ${url}`);
   };
 
-  const airport = await airportDirectoryClient.resolveAirport("KBOS");
+  const airport = await createClient().resolveAirport("KBOS");
   assert.equal(calls.length, 2);
   assert.equal(calls[0], "/api/airport/KBOS");
   assert.match(calls[1], /^\/api\/search\?.*q=KBOS/);
@@ -175,13 +254,13 @@ const KBOS = {
 {
   fetchImpl = async () => createJsonResponse({ error: "no" }, 404);
 
-  await assert.rejects(() => airportDirectoryClient.resolveAirport("ZZZZ"), /Airport not found/);
+  await assert.rejects(() => createClient().resolveAirport("ZZZZ"), /Airport not found/);
 }
 
 // resolveAirport rejects empty code
 {
   fetchImpl = async () => createJsonResponse({});
-  await assert.rejects(() => airportDirectoryClient.resolveAirport(""), /Airport code is required/);
+  await assert.rejects(() => createClient().resolveAirport(""), /Airport code is required/);
 }
 
 console.log("airportDirectory.test.ts: ok");

--- a/src/features/airport/directory/airportDirectoryClient.ts
+++ b/src/features/airport/directory/airportDirectoryClient.ts
@@ -4,6 +4,7 @@
 
 const SEARCH_PATH = "/api/search";
 const AIRPORT_PATH = "/api/airport";
+const DEFAULT_RESPONSE_CACHE_TTL_MS = 5 * 60 * 1000;
 
 const defaultFetch = () =>
   typeof globalThis.fetch === "function" ? globalThis.fetch.bind(globalThis) : null;
@@ -38,9 +39,19 @@ const buildAirportSurfaceUrl = ({ baseUrl = "", ident }: Record<string, any>) =>
   return `${baseUrl}${AIRPORT_PATH}/${safeIdent}/surface`;
 };
 
-const requestJson = async (fetchImpl: any, url: string) => {
+const buildAirportContextUrl = ({ baseUrl = "", ident }: Record<string, any>) => {
+  const safeIdent = encodeURIComponent(String(ident || "").trim().toUpperCase());
+  return `${baseUrl}${AIRPORT_PATH}/${safeIdent}/context`;
+};
+
+const requestJson = async (
+  fetchImpl: any,
+  url: string,
+  { signal }: { signal?: AbortSignal } = {},
+) => {
   const response = await fetchImpl(url, {
     headers: { Accept: "application/json" },
+    signal,
   });
   if (response.status === 404) return null;
   if (!response.ok) {
@@ -52,10 +63,45 @@ const requestJson = async (fetchImpl: any, url: string) => {
 const createAirportDirectoryClient = ({
   fetchImpl = defaultFetch(),
   baseUrl = "",
+  responseCacheTtlMs = DEFAULT_RESPONSE_CACHE_TTL_MS,
 }: Record<string, any> = {}) => {
   if (!fetchImpl) {
     throw new Error("Airport directory client requires fetch support");
   }
+
+  const inFlightJson = new Map<string, Promise<any>>();
+  const responseCache = new Map<string, { expiresAt: number; payload: any }>();
+  const requestJsonOnce = (
+    url: string,
+    { signal }: { signal?: AbortSignal } = {},
+  ) => {
+    const cached = responseCache.get(url);
+    if (cached && cached.expiresAt > Date.now()) {
+      return Promise.resolve(cached.payload);
+    }
+    if (cached) {
+      responseCache.delete(url);
+    }
+    if (!signal) {
+      const pending = inFlightJson.get(url);
+      if (pending) return pending;
+    }
+    const promise = requestJson(fetchImpl, url, { signal })
+      .then((payload) => {
+        if (responseCacheTtlMs > 0 && payload !== null) {
+          responseCache.set(url, {
+            expiresAt: Date.now() + responseCacheTtlMs,
+            payload,
+          });
+        }
+        return payload;
+      })
+      .finally(() => {
+        inFlightJson.delete(url);
+      });
+    if (!signal) inFlightJson.set(url, promise);
+    return promise;
+  };
 
   const loadAirports = async ({
     query = "",
@@ -76,7 +122,7 @@ const createAirportDirectoryClient = ({
       limit,
     });
 
-    const payload = (await requestJson(fetchImpl, url)) || {};
+    const payload = (await requestJsonOnce(url)) || {};
     return {
       airports: Array.isArray(payload.airports) ? payload.airports : [],
       source: payload.source || "openaip",
@@ -89,8 +135,7 @@ const createAirportDirectoryClient = ({
       throw new Error("Airport code is required");
     }
 
-    const detail = await requestJson(
-      fetchImpl,
+    const detail = await requestJsonOnce(
       buildAirportUrl({ baseUrl, ident: trimmed, locale }),
     );
     if (detail?.airport) {
@@ -114,8 +159,7 @@ const createAirportDirectoryClient = ({
       };
     }
 
-    const searchPayload = await requestJson(
-      fetchImpl,
+    const searchPayload = await requestJsonOnce(
       buildSearchUrl({ baseUrl, query: trimmed, limit: 1 }),
     );
     const fallback = searchPayload?.airports?.[0];
@@ -124,20 +168,57 @@ const createAirportDirectoryClient = ({
     throw new Error("Airport not found");
   };
 
-  const resolveAirportSurface = async (code: unknown) => {
+  const resolveAirportSurface = async (
+    code: unknown,
+    { signal }: { signal?: AbortSignal } = {},
+  ) => {
     const trimmed = String(code || "").trim().toUpperCase();
     if (!trimmed) {
       throw new Error("Airport code is required");
     }
 
-    const payload = await requestJson(
-      fetchImpl,
+    const payload = await requestJsonOnce(
       buildAirportSurfaceUrl({ baseUrl, ident: trimmed }),
+      { signal },
     );
     return payload?.surfaceMap || null;
   };
 
-  return { loadAirports, resolveAirport, resolveAirportSurface };
+  const resolveAirportContext = async (
+    code: unknown,
+    { signal }: { signal?: AbortSignal } = {},
+  ) => {
+    const trimmed = String(code || "").trim().toUpperCase();
+    if (!trimmed) {
+      throw new Error("Airport code is required");
+    }
+
+    const payload = await requestJsonOnce(
+      buildAirportContextUrl({ baseUrl, ident: trimmed }),
+      { signal },
+    ) || {};
+    return {
+      nearbyAirports: Array.isArray(payload.nearbyAirports)
+        ? payload.nearbyAirports
+        : [],
+      nearbyNavaids: Array.isArray(payload.nearbyNavaids)
+        ? payload.nearbyNavaids
+        : [],
+      airspaces: Array.isArray(payload.airspaces) ? payload.airspaces : [],
+      reportingPoints: Array.isArray(payload.reportingPoints)
+        ? payload.reportingPoints
+        : [],
+      obstacles: Array.isArray(payload.obstacles) ? payload.obstacles : [],
+    };
+  };
+
+  return {
+    loadAirports,
+    resolveAirport,
+    resolveAirportSurface,
+    resolveAirportContext,
+  };
 };
 
 export const airportDirectoryClient = createAirportDirectoryClient();
+export { createAirportDirectoryClient };

--- a/src/features/airport/nearby/nearbyAirportClient.test.ts
+++ b/src/features/airport/nearby/nearbyAirportClient.test.ts
@@ -7,30 +7,45 @@ const { nearbyAirportClient } = await import("./nearbyAirportClient");
 
 {
   const calls = [];
+  let resolveResponse;
   fetchImpl = async (url) => {
     calls.push(url);
-    return {
-      ok: true,
-      status: 200,
-      async json() {
-        return { airports: [{ icao: "KLGA", distanceNm: 9.3 }] };
-      },
-    };
+    return new Promise((resolve) => {
+      resolveResponse = () =>
+        resolve({
+          ok: true,
+          status: 200,
+          async json() {
+            return { airports: [{ icao: "KLGA", distanceNm: 9.3 }] };
+          },
+        });
+    });
   };
 
-  const payload = await nearbyAirportClient.fetchNearbyAirports({
+  const first = nearbyAirportClient.fetchNearbyAirports({
     lat: 40.639928,
     lon: -73.778692,
     icao: "kjfk",
     radiusNm: 30,
     limit: 6,
   });
+  const second = nearbyAirportClient.fetchNearbyAirports({
+    lat: 40.639928,
+    lon: -73.778692,
+    icao: "KJFK",
+    radiusNm: 30,
+    limit: 6,
+  });
+  assert.equal(calls.length, 1);
+  resolveResponse();
+  const [payload, repeatedPayload] = await Promise.all([first, second]);
 
   assert.equal(
     calls[0],
     "/api/proxy/airports/nearby?lat=40.639928&lon=-73.778692&icao=KJFK&radiusNm=30&limit=6",
   );
   assert.equal(payload.airports[0].icao, "KLGA");
+  assert.equal(repeatedPayload.airports[0].icao, "KLGA");
 }
 
 {

--- a/src/features/airport/nearby/nearbyAirportClient.ts
+++ b/src/features/airport/nearby/nearbyAirportClient.ts
@@ -29,19 +29,29 @@ function createNearbyAirportClient({
   basePath = DEFAULT_BASE_PATH,
 }: NearbyAirportClientRecord = {}) {
   if (!fetchImpl) throw new Error("Nearby airport client requires fetch support");
+  const inFlight = new Map<string, Promise<any>>();
 
   return {
     async fetchNearbyAirports(options: NearbyAirportClientRecord = {}) {
       const url = buildNearbyAirportsPath({ ...options, basePath });
-      const response = await fetchImpl(url, {
+      const pending = inFlight.get(url);
+      if (pending) return pending;
+      const promise = fetchImpl(url, {
         headers: { Accept: "application/json" },
         cache: "no-store",
-      });
-      if (response.status === 404) return { airports: [] };
-      if (!response.ok) {
-        throw new Error(`Failed to load nearby airports: HTTP ${response.status}`);
-      }
-      return response.json();
+      })
+        .then((response) => {
+          if (response.status === 404) return { airports: [] };
+          if (!response.ok) {
+            throw new Error(`Failed to load nearby airports: HTTP ${response.status}`);
+          }
+          return response.json();
+        })
+        .finally(() => {
+          inFlight.delete(url);
+        });
+      inFlight.set(url, promise);
+      return promise;
     },
   };
 }

--- a/src/features/aviation/aviationData.test.ts
+++ b/src/features/aviation/aviationData.test.ts
@@ -188,6 +188,27 @@ try {
 
 {
   const calls = [];
+  let resolveResponse;
+  const client = createAircraftTraceClient({
+    fetchImpl: async (url) => {
+      calls.push(url);
+      return new Promise((resolve) => {
+        resolveResponse = () =>
+          resolve(createJsonResponse({ recent: { trace: [] } }));
+      });
+    },
+  });
+
+  const first = client.fetchAircraftTrace({ hex: "a7bbe9", full: true });
+  const second = client.fetchAircraftTrace({ hex: "A7BBE9", full: true });
+  assert.equal(calls.length, 1);
+  resolveResponse();
+  await Promise.all([first, second]);
+  assert.deepEqual(calls, ["/api/proxy/aircraft/trace/A7BBE9?full=1"]);
+}
+
+{
+  const calls = [];
   const client = createLocalWeatherClient({
     fetchImpl: async (url) => {
       calls.push(url);

--- a/src/features/location/reverseGeocodeClient.ts
+++ b/src/features/location/reverseGeocodeClient.ts
@@ -45,6 +45,7 @@ export type ReverseGeocodeResult = {
 };
 
 const CACHE = new Map<string, ReverseGeocodeResult>();
+const IN_FLIGHT = new Map<string, Promise<ReverseGeocodeResult | null>>();
 // Same-origin proxy in front of Nominatim so we don't have to relax
 // the app's CSP `connect-src` and the upstream sees our application
 // User-Agent (set inside the proxy route).
@@ -119,57 +120,66 @@ export async function fetchReverseGeocode(
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
   const key = cacheKey(lat, lon, language);
   if (CACHE.has(key)) return CACHE.get(key) || null;
+  const pending = IN_FLIGHT.get(key);
+  if (pending) return pending;
 
   const url =
     `${ENDPOINT}?lat=${lat}&lon=${lon}` +
     `&language=${encodeURIComponent(buildAcceptLanguage(language))}`;
-  const response = await fetch(url, { cache: "no-store" });
-  if (!response.ok) throw new Error(`reverse-geocode HTTP ${response.status}`);
-  const json = (await response.json()) as NominatimResponse;
-  const address = json?.address || {};
+  const promise = fetch(url, { cache: "no-store" })
+    .then(async (response) => {
+      if (!response.ok) throw new Error(`reverse-geocode HTTP ${response.status}`);
+      const json = (await response.json()) as NominatimResponse;
+      const address = json?.address || {};
 
-  const rawResult: ReverseGeocodeResult = {
-    // City fallback chain — Nominatim populates the most specific
-    // bucket the OSM relation provided. Urban points usually fill
-    // `city`; rural points fill `town` / `village` / `hamlet`.
-    city: firstOsmVariant(
-      firstNonEmpty(
-        address.city,
-        address.town,
-        address.village,
-        address.borough,
-        address.hamlet,
-        address.municipality,
-      ),
-    ),
-    county: firstOsmVariant(
-      firstNonEmpty(
-        address.county,
-        address.district,
-        address.state_district,
-      ),
-    ),
-    state: firstOsmVariant(firstNonEmpty(address.state, address.region)),
-    countryName: firstOsmVariant(normalizeString(address.country)),
-    countryCode: normalizeString(address.country_code).toUpperCase(),
-  };
+      const rawResult: ReverseGeocodeResult = {
+        // City fallback chain — Nominatim populates the most specific
+        // bucket the OSM relation provided. Urban points usually fill
+        // `city`; rural points fill `town` / `village` / `hamlet`.
+        city: firstOsmVariant(
+          firstNonEmpty(
+            address.city,
+            address.town,
+            address.village,
+            address.borough,
+            address.hamlet,
+            address.municipality,
+          ),
+        ),
+        county: firstOsmVariant(
+          firstNonEmpty(
+            address.county,
+            address.district,
+            address.state_district,
+          ),
+        ),
+        state: firstOsmVariant(firstNonEmpty(address.state, address.region)),
+        countryName: firstOsmVariant(normalizeString(address.country)),
+        countryCode: normalizeString(address.country_code).toUpperCase(),
+      };
 
-  // Even with accept-language: zh-Hans,zh-CN OSM data is inconsistent —
-  // many mainland features only carry the contributor-managed `name:zh`
-  // tag which mixes simplified and traditional. Run the localized fields
-  // through a focused t2s converter so simplified-Chinese users get a
-  // canonical simplified rendering.
-  const isSimplifiedChinese = /(^|,)\s*zh-?cn|zh-?hans/i.test(language);
-  const result: ReverseGeocodeResult = isSimplifiedChinese
-    ? {
-        city: toSimplifiedChinese(rawResult.city),
-        county: toSimplifiedChinese(rawResult.county),
-        state: toSimplifiedChinese(rawResult.state),
-        countryName: toSimplifiedChinese(rawResult.countryName),
-        countryCode: rawResult.countryCode,
-      }
-    : rawResult;
+      // Even with accept-language: zh-Hans,zh-CN OSM data is inconsistent —
+      // many mainland features only carry the contributor-managed `name:zh`
+      // tag which mixes simplified and traditional. Run the localized fields
+      // through a focused t2s converter so simplified-Chinese users get a
+      // canonical simplified rendering.
+      const isSimplifiedChinese = /(^|,)\s*zh-?cn|zh-?hans/i.test(language);
+      const result: ReverseGeocodeResult = isSimplifiedChinese
+        ? {
+            city: toSimplifiedChinese(rawResult.city),
+            county: toSimplifiedChinese(rawResult.county),
+            state: toSimplifiedChinese(rawResult.state),
+            countryName: toSimplifiedChinese(rawResult.countryName),
+            countryCode: rawResult.countryCode,
+          }
+        : rawResult;
 
-  CACHE.set(key, result);
-  return result;
+      CACHE.set(key, result);
+      return result;
+    })
+    .finally(() => {
+      IN_FLIGHT.delete(key);
+    });
+  IN_FLIGHT.set(key, promise);
+  return promise;
 }

--- a/src/features/weather/metar/metarClient.ts
+++ b/src/features/weather/metar/metarClient.ts
@@ -16,6 +16,7 @@ export const createMetarClient = ({
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: "AviationWeather/METAR",
   });
+  const inFlight = new Map<string, Promise<any>>();
 
   return {
     fetchMetar(icao) {
@@ -23,13 +24,16 @@ export const createMetarClient = ({
         .trim()
         .toUpperCase();
       if (!normalized) return [];
-      return fetchJson(
-        auditedFetch,
-        `${baseUrl}/${encodeURIComponent(normalized)}`,
-        {
-          timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.metar,
-        },
-      );
+      const url = `${baseUrl}/${encodeURIComponent(normalized)}`;
+      const pending = inFlight.get(url);
+      if (pending) return pending;
+      const promise = fetchJson(auditedFetch, url, {
+        timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.metar,
+      }).finally(() => {
+        inFlight.delete(url);
+      });
+      inFlight.set(url, promise);
+      return promise;
     },
   };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,11 @@ import { ClerkProvider } from "@/platform/auth/clerkClient";
 import ThemedToaster from "@/components/app-shell/ThemedToaster";
 import QueryProvider from "@/features/app-shell/queryProvider";
 import { I18nProvider } from "@/features/app-shell/i18n/i18nProvider";
+import {
+  DEFAULT_LOCALE,
+  normalizeLocaleSelection,
+  resolveLocaleFromSearchParams,
+} from "@/features/app-shell/i18n/i18nModel";
 import { UnitPreferencesProvider } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import WebMcpProvider from "@/features/webmcp/WebMcpProvider";
 import { runtimeEnvValue } from "@/platform/env/runtimeEnv";
@@ -26,7 +31,13 @@ function resolveInitialTheme() {
 
 function resolveInitialLocale() {
   const params = new URLSearchParams(window.location.search);
-  return params.get("lang") || navigator.language || "en";
+  const legacyLocale = params.get("lang");
+  return (
+    resolveLocaleFromSearchParams(window.location.search) ||
+    (legacyLocale ? normalizeLocaleSelection(legacyLocale, DEFAULT_LOCALE) : null) ||
+    navigator.language ||
+    DEFAULT_LOCALE
+  );
 }
 
 function applyDocumentShell() {

--- a/src/style.css
+++ b/src/style.css
@@ -4218,13 +4218,13 @@ body {
 }
 
 .aircraft-table-identity--route-entering .aircraft-table-callsign {
-    animation: aircraft-table-callsign-lift 0.5s cubic-bezier(0.22, 1, 0.36, 1)
+    animation: aircraft-table-callsign-lift 0.28s cubic-bezier(0.22, 1, 0.36, 1)
         both;
 }
 
 .aircraft-table-identity--route-entering .aircraft-table-route-slot {
-    animation: aircraft-table-route-reveal 0.42s cubic-bezier(0.22, 1, 0.36, 1)
-        0.08s both;
+    animation: aircraft-table-route-reveal 0.24s cubic-bezier(0.22, 1, 0.36, 1)
+        0.04s both;
 }
 
 /* Pinned-aircraft slot above the scroll list. The inner row already


### PR DESCRIPTION
## Summary
- Split heavy route modules and optional Plane Hunter UI out of the initial page-transition path.
- Make airport detail lightweight, defer context/surface hydration, cache static airport payloads briefly, and abort stale deferred airport requests when navigating away.
- Deduplicate airport/trace/network requests across quick airport-airport, airport-aircraft, and aircraft-airport transitions, then bump ADSBao to v2.9.0 with changelog coverage.

## Validation
- `pnpm test` -> 116 test files passed
- `pnpm typecheck` -> passed
- `pnpm build` -> passed; expected large AirportMap chunk warning remains
- `go test ./...` in `services/data-service` -> passed
- `pnpm debug:local:service:restart` -> frontend and data-service health checks passed
- `node .codex-tmp/transition-probe.mjs http://localhost:3000` -> verified airport-airport, airport-aircraft, and aircraft-airport transitions; aircraft->airport no longer re-fetches KBOS detail/context/surface, airport->aircraft trace fetches dedupe to one recent plus one full request, and stale airport surface requests abort with zero transfer.