### PR TITLE
Optimize route data reuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.9.0",
+  "version": "2.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -14,7 +14,13 @@ import { setLocaleSearchParam } from "@/features/app-shell/i18n/i18nModel";
 import gsap from "gsap";
 import { MOTION, EASE } from "@/animations/gsap";
 
-export default function AirportDiscoveryPanel({ topics = [], onOpen }) {
+const PREFETCH_INTENT_DELAY_MS = 120;
+
+export default function AirportDiscoveryPanel({
+  topics = [],
+  onOpen,
+  onPrefetch,
+}) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -70,6 +76,7 @@ export default function AirportDiscoveryPanel({ topics = [], onOpen }) {
             key={topic.id}
             topic={topic}
             onOpen={onOpen}
+            onPrefetch={onPrefetch}
           />
         ))}
       </div>
@@ -102,7 +109,7 @@ function NearMeDiscoverySection() {
   );
 }
 
-function AirportDiscoveryTopicSection({ topic, onOpen }) {
+function AirportDiscoveryTopicSection({ topic, onOpen, onPrefetch }) {
   const { t } = useI18n();
 
   return (
@@ -119,6 +126,7 @@ function AirportDiscoveryTopicSection({ topic, onOpen }) {
             key={airport.icao || airport.code || airport.name}
             airport={airport}
             onOpen={onOpen}
+            onPrefetch={onPrefetch}
           />
         ))}
       </ul>
@@ -167,13 +175,36 @@ function NearbyPromptRow({ onRequest }: { onRequest: () => void }) {
   );
 }
 
-function AirportDiscoveryAirportRow({ airport, onOpen }) {
+function AirportDiscoveryAirportRow({ airport, onOpen, onPrefetch }) {
   const { locale, t } = useI18n();
   const code = airportDisplayCode(airport);
   const label = airport.discoveryLabelKey ? t(airport.discoveryLabelKey) : "";
+  const prefetchTimerRef = useRef<number | null>(null);
+
+  const cancelPrefetch = () => {
+    if (prefetchTimerRef.current == null) return;
+    window.clearTimeout(prefetchTimerRef.current);
+    prefetchTimerRef.current = null;
+  };
+
+  const schedulePrefetch = () => {
+    cancelPrefetch();
+    prefetchTimerRef.current = window.setTimeout(() => {
+      prefetchTimerRef.current = null;
+      onPrefetch?.(airport);
+    }, PREFETCH_INTENT_DELAY_MS);
+  };
+
+  useEffect(() => cancelPrefetch, [airport, onPrefetch]);
 
   return (
-    <li>
+    <li
+      onMouseEnter={schedulePrefetch}
+      onMouseLeave={cancelPrefetch}
+      onFocus={schedulePrefetch}
+      onBlur={cancelPrefetch}
+      onMouseDown={cancelPrefetch}
+    >
       <TextPillListItem
         as="button"
         onClick={() => onOpen(airport)}

--- a/src/components/airport/search/AirportRow.tsx
+++ b/src/components/airport/search/AirportRow.tsx
@@ -1,24 +1,51 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
 import { airportDisplayCode, airportDisplayName, airportSubtitle } from "@/utils/airport";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { TextPillListItem } from "@/components/ui/TextPillListItem";
 
+const PREFETCH_INTENT_DELAY_MS = 120;
+
 export default function AirportRow({
   airport,
   onOpen,
+  onPrefetch,
   featured = false,
   motionOrder = 0,
 }) {
   const { locale } = useI18n();
   const motionStyle = { "--motion-order": motionOrder } as CSSProperties;
+  const prefetchTimerRef = useRef<number | null>(null);
+
+  const cancelPrefetch = () => {
+    if (prefetchTimerRef.current == null) return;
+    window.clearTimeout(prefetchTimerRef.current);
+    prefetchTimerRef.current = null;
+  };
+
+  const schedulePrefetch = () => {
+    cancelPrefetch();
+    prefetchTimerRef.current = window.setTimeout(() => {
+      prefetchTimerRef.current = null;
+      onPrefetch?.(airport);
+    }, PREFETCH_INTENT_DELAY_MS);
+  };
+
+  useEffect(() => cancelPrefetch, [airport, onPrefetch]);
 
   // Search results render as the shared liquid-glass list tile (GSAP
   // hover/press lives inside the primitive). The featured best-match row
   // flips to the active glass capsule so it reads as the obvious pick.
   return (
-    <li style={motionStyle}>
+    <li
+      style={motionStyle}
+      onMouseEnter={schedulePrefetch}
+      onMouseLeave={cancelPrefetch}
+      onFocus={schedulePrefetch}
+      onBlur={cancelPrefetch}
+      onMouseDown={cancelPrefetch}
+    >
       <TextPillListItem
         as="button"
         active={featured}

--- a/src/components/airport/search/AirportSearchPanel.tsx
+++ b/src/components/airport/search/AirportSearchPanel.tsx
@@ -11,7 +11,10 @@ import AirportDiscoveryPanel from "./AirportDiscoveryPanel";
 import { useAirportSearch } from "@/features/airport/search/useAirportSearch";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 
-export default function AirportSearchPanel({ onOpenAirport }) {
+export default function AirportSearchPanel({
+  onOpenAirport,
+  onPrefetchAirport,
+}) {
   const { t } = useI18n();
   const {
     query,
@@ -69,11 +72,13 @@ export default function AirportSearchPanel({ onOpenAirport }) {
             searchCycle={searchCycle}
             countLabel={countLabel}
             onOpen={openAirport}
+            onPrefetch={onPrefetchAirport}
           />
         ) : (
           <AirportDiscoveryPanel
             topics={discoveryTopics}
             onOpen={openAirport}
+            onPrefetch={onPrefetchAirport}
           />
         )}
       </div>

--- a/src/components/airport/search/AirportSearchResults.tsx
+++ b/src/components/airport/search/AirportSearchResults.tsx
@@ -13,6 +13,7 @@ export function AirportSearchResults({
   searchCycle = 0,
   countLabel,
   onOpen,
+  onPrefetch,
 }) {
   const { t } = useI18n();
 
@@ -57,6 +58,7 @@ export function AirportSearchResults({
               airport={airport}
               motionOrder={Math.min(index, 5)}
               onOpen={onOpen}
+              onPrefetch={onPrefetch}
             />
           ))}
         </ul>

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter } from "@/platform/router/navigation";
 import { toast } from "sonner";
 import AirportExplorer from "@/components/airport/explorer/AirportExplorer";
 import AirportSearchPanel from "@/components/airport/search/AirportSearchPanel";
-import { airportDirectoryClient } from "../../features/airport/directory/airportDirectoryClient";
+import {
+  airportProfileCode,
+  prefetchAirportProfile,
+  useAirportProfileQueries,
+} from "@/features/airport/directory/airportProfileQueries";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { setLocaleSearchParam } from "@/features/app-shell/i18n/i18nModel";
 
@@ -18,103 +22,69 @@ export default function HomeScreen() {
   const pathname = usePathname();
   const { locale } = useI18n();
   const currentIcao = normalizePathIcao(pathname);
-  const [airport, setAirport] = useState(null);
-  const [routeTransitionActive, setRouteTransitionActive] = useState(true);
-  const hasPlayedInitialRouteTransitionRef = useRef(false);
+  const seedAirportRef = useRef(null);
+  const pageLeavingRef = useRef(false);
+  const routeTransitionActive = useRouteTransition(currentIcao);
+  const seededAirport = useMemo(
+    () =>
+      airportProfileCode(seedAirportRef.current) === currentIcao
+        ? seedAirportRef.current
+        : null,
+    [currentIcao],
+  );
+  const {
+    airport,
+    detailQuery,
+    contextQuery,
+    surfaceQuery,
+    queryClient,
+  } = useAirportProfileQueries({
+    icao: currentIcao,
+    locale,
+    seedAirport: seededAirport,
+  });
 
   useEffect(() => {
-    if (!currentIcao) return undefined;
-    if (!hasPlayedInitialRouteTransitionRef.current) {
-      hasPlayedInitialRouteTransitionRef.current = true;
-      setRouteTransitionActive(true);
-      return undefined;
-    }
-    setRouteTransitionActive(false);
-    const frameId = window.requestAnimationFrame(() => {
-      setRouteTransitionActive(true);
-    });
-    return () => window.cancelAnimationFrame(frameId);
+    const handlePageHide = () => {
+      pageLeavingRef.current = true;
+    };
+    const handlePageShow = () => {
+      pageLeavingRef.current = false;
+    };
+    window.addEventListener("pagehide", handlePageHide);
+    window.addEventListener("pageshow", handlePageShow);
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide);
+      window.removeEventListener("pageshow", handlePageShow);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!currentIcao) seedAirportRef.current = null;
   }, [currentIcao]);
 
   useEffect(() => {
-    if (!currentIcao) {
-      setAirport(null);
-      return;
-    }
-    setAirport((current) =>
-      airportCode(current) === currentIcao ? current : null,
+    if (!currentIcao || !detailQuery.error) return;
+    if (pageLeavingRef.current) return;
+    if (isInterruptedNavigationFetch(detailQuery.error, currentIcao)) return;
+    console.error("Failed to load airport", detailQuery.error);
+    toast.error(
+      detailQuery.error?.message || "Airport not found or unavailable",
+      { id: "airport-resolve" },
     );
-    let cancelled = false;
-    let pageLeaving = false;
-    const deferredController = new AbortController();
-    const handlePageHide = () => {
-      pageLeaving = true;
-    };
-    window.addEventListener("pagehide", handlePageHide);
-    (async () => {
-      try {
-        const resolved = await airportDirectoryClient.resolveAirport(currentIcao, {
-          locale,
-        });
-        if (cancelled) return;
-        setAirport(resolved);
-        airportDirectoryClient
-          .resolveAirportContext(currentIcao, {
-            signal: deferredController.signal,
-          })
-          .then((context) => {
-            if (cancelled || !context) return;
-            setAirport((current) => {
-              if (airportCode(current) !== currentIcao) return current;
-              return { ...current, ...context };
-            });
-          })
-          .catch((contextError) => {
-            if (!cancelled && !isInterruptedFetch(contextError)) {
-              console.warn("Failed to load airport context", contextError);
-            }
-          });
-        airportDirectoryClient
-          .resolveAirportSurface(currentIcao, {
-            signal: deferredController.signal,
-          })
-          .then((surfaceMap) => {
-            if (cancelled || !surfaceMap) return;
-            setAirport((current) => {
-              if (airportCode(current) !== currentIcao) return current;
-              return { ...current, surfaceMap };
-            });
-          })
-          .catch((surfaceError) => {
-            if (
-              !cancelled &&
-              !pageLeaving &&
-              !isInterruptedFetch(surfaceError)
-            ) {
-              console.warn("Failed to load airport surface", surfaceError);
-            }
-          });
-      } catch (err) {
-        if (
-          cancelled ||
-          pageLeaving ||
-          isInterruptedNavigationFetch(err, currentIcao)
-        ) {
-          return;
-        }
-        console.error("Failed to load airport", err);
-        toast.error(err?.message || "Airport not found or unavailable", {
-          id: "airport-resolve",
-        });
-        setAirport(null);
-      }
-    })();
-    return () => {
-      cancelled = true;
-      deferredController.abort();
-      window.removeEventListener("pagehide", handlePageHide);
-    };
-  }, [currentIcao, locale]);
+  }, [currentIcao, detailQuery.error]);
+
+  useEffect(() => {
+    if (!contextQuery.error || isInterruptedFetch(contextQuery.error)) return;
+    if (pageLeavingRef.current) return;
+    console.warn("Failed to load airport context", contextQuery.error);
+  }, [contextQuery.error]);
+
+  useEffect(() => {
+    if (!surfaceQuery.error || isInterruptedFetch(surfaceQuery.error)) return;
+    if (pageLeavingRef.current) return;
+    console.warn("Failed to load airport surface", surfaceQuery.error);
+  }, [surfaceQuery.error]);
 
   const handleOpenAirport = (selectedAirport) => {
     const nextIcao = String(
@@ -124,8 +94,16 @@ export default function HomeScreen() {
     // Optimistically seed the airport data so the detail view renders
     // without a flash while the resolveAirport effect re-fires off the
     // new pathname.
-    setAirport(selectedAirport);
+    seedAirportRef.current = selectedAirport;
     router.push(setLocaleSearchParam(`/airport/${nextIcao}`, "", locale));
+  };
+
+  const handlePrefetchAirport = (selectedAirport) => {
+    const nextIcao = String(
+      selectedAirport?.icao || selectedAirport?.code || "",
+    ).toUpperCase();
+    if (!nextIcao) return;
+    prefetchAirportProfile(queryClient, { icao: nextIcao, locale });
   };
 
   const handleBack = () => {
@@ -133,7 +111,12 @@ export default function HomeScreen() {
   };
 
   if (!currentIcao) {
-    return <AirportSearchPanel onOpenAirport={handleOpenAirport} />;
+    return (
+      <AirportSearchPanel
+        onOpenAirport={handleOpenAirport}
+        onPrefetchAirport={handlePrefetchAirport}
+      />
+    );
   }
 
   return (
@@ -142,7 +125,7 @@ export default function HomeScreen() {
     >
       <AirportExplorer
         icao={currentIcao}
-        airport={airportCode(airport) === currentIcao ? airport : null}
+        airport={airport}
         onBack={handleBack}
       />
     </div>
@@ -161,10 +144,25 @@ function normalizePathIcao(pathname) {
   return /^[A-Z0-9]{3,4}$/.test(normalized) ? normalized : "";
 }
 
-function airportCode(airport) {
-  return String(airport?.icao || airport?.code || airport?.ident || "")
-    .trim()
-    .toUpperCase();
+function useRouteTransition(currentIcao) {
+  const [routeTransitionActive, setRouteTransitionActive] = useState(true);
+  const hasPlayedInitialRouteTransitionRef = useRef(false);
+
+  useEffect(() => {
+    if (!currentIcao) return undefined;
+    if (!hasPlayedInitialRouteTransitionRef.current) {
+      hasPlayedInitialRouteTransitionRef.current = true;
+      setRouteTransitionActive(true);
+      return undefined;
+    }
+    setRouteTransitionActive(false);
+    const frameId = window.requestAnimationFrame(() => {
+      setRouteTransitionActive(true);
+    });
+    return () => window.cancelAnimationFrame(frameId);
+  }, [currentIcao]);
+
+  return routeTransitionActive;
 }
 
 function isInterruptedNavigationFetch(error, expectedIcao) {

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.10.0",
+    kind: "feat",
+    title: {
+      en: "Route data reuse",
+      zh: "跨页面数据复用",
+    },
+    summary: {
+      en: "Airport detail, deferred context, surface maps, and aircraft photos now share TanStack-backed session data so repeat page switches reuse fresh payloads instead of restarting every request path.",
+      zh: "机场详情、延迟上下文、地面图层和飞机照片现在共享 TanStack 会话数据，重复页面切换会复用新鲜 payload，而不是重新走一遍请求链路。",
+    },
+    highlights: [
+      {
+        en: "Airport-to-airport transitions keep an immediate seeded profile while the full detail, context, and surface payloads hydrate through shared route queries",
+        zh: "机场到机场切换会先保留即时 seed profile，再通过共享 route query 补齐完整详情、上下文与地面 payload",
+      },
+      {
+        en: "Search result opens prefetch the target airport profile before navigation so common airport hops spend less time waiting on the next page",
+        zh: "从搜索结果打开机场时会在导航前预取目标机场 profile，常见机场跳转减少下一页等待时间",
+      },
+      {
+        en: "Aircraft photo lookups now reuse the same query cache across preview and aircraft-detail surfaces",
+        zh: "飞机照片查询现在在 preview 和飞机详情页面之间复用同一份 query cache",
+      },
+    ],
+  },
+  {
     version: "v2.9.0",
     kind: "feat",
     title: {

--- a/src/features/aircraft/preview/useAircraftPhoto.test.ts
+++ b/src/features/aircraft/preview/useAircraftPhoto.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import {
+  aircraftPhotoQueryKeys,
+  buildPhotoKey,
+} from "./useAircraftPhoto";
+
+const aircraft = {
+  icao24: " a1b2c3 ",
+  registration: " n123ab ",
+  type: " b738 ",
+};
+
+assert.equal(buildPhotoKey(aircraft), "A1B2C3:N123AB:B738");
+assert.equal(buildPhotoKey({ registration: "N123AB" }), "");
+assert.equal(buildPhotoKey(null), "");
+assert.deepEqual(aircraftPhotoQueryKeys.detail(aircraft), [
+  "aircraft-photo",
+  "A1B2C3:N123AB:B738",
+]);
+
+console.log("useAircraftPhoto.test.ts: ok");

--- a/src/features/aircraft/preview/useAircraftPhoto.ts
+++ b/src/features/aircraft/preview/useAircraftPhoto.ts
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { createAircraftPhotoClient } from "../photos/aircraftPhotoClient";
 
 const EMPTY_STATE = Object.freeze({ key: "", photo: null, status: "idle" });
+const AIRCRAFT_PHOTO_STALE_TIME_MS = 30 * 60_000;
 const aircraftPhotoClient = createAircraftPhotoClient();
 
 type AircraftPhoto = Record<string, unknown>;
@@ -20,7 +22,16 @@ type AircraftPhotoSubject = {
   type?: unknown;
 };
 
-function buildPhotoKey(aircraft: AircraftPhotoSubject | null | undefined) {
+export const aircraftPhotoQueryKeys = {
+  all: ["aircraft-photo"] as const,
+  detail: (aircraft: AircraftPhotoSubject | null | undefined) =>
+    [
+      ...aircraftPhotoQueryKeys.all,
+      buildPhotoKey(aircraft),
+    ] as const,
+};
+
+export function buildPhotoKey(aircraft: AircraftPhotoSubject | null | undefined) {
   const hex = String(aircraft?.icao24 || "").trim().toUpperCase();
   if (!hex) return "";
   return [
@@ -32,34 +43,35 @@ function buildPhotoKey(aircraft: AircraftPhotoSubject | null | undefined) {
 
 export function useAircraftPhoto(aircraft: AircraftPhotoSubject | null | undefined) {
   const key = buildPhotoKey(aircraft);
-  const [state, setState] = useState<AircraftPhotoState>(EMPTY_STATE as AircraftPhotoState);
-
-  useEffect(() => {
-    if (!key) {
-      setState(EMPTY_STATE);
-      return undefined;
-    }
-
-    let cancelled = false;
-    const [hex, registration, type] = key.split(":");
-    setState({ key, photo: null, status: "loading" });
-
-    aircraftPhotoClient
-      .fetchAircraftPhoto({ hex, registration, type })
-      .then((payload) => {
-        if (!cancelled) {
-          const photo = payload?.photo as AircraftPhoto | null || null;
-          setState({ key, photo, status: photo ? "found" : "missing" });
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setState({ key, photo: null, status: "missing" });
+  const query = useQuery({
+    queryKey: aircraftPhotoQueryKeys.detail(aircraft),
+    queryFn: async ({ queryKey }) => {
+      const [, photoKey] = queryKey;
+      const [hex, registration, type] = String(photoKey).split(":");
+      const payload = await aircraftPhotoClient.fetchAircraftPhoto({
+        hex,
+        registration,
+        type,
       });
+      return (payload?.photo as AircraftPhoto | null) || null;
+    },
+    enabled: Boolean(key),
+    staleTime: AIRCRAFT_PHOTO_STALE_TIME_MS,
+    gcTime: 2 * AIRCRAFT_PHOTO_STALE_TIME_MS,
+    retry: false,
+  });
 
-    return () => {
-      cancelled = true;
-    };
-  }, [key]);
-
-  return state.key === key ? state : { key, photo: null, status: "loading" };
+  const photo = query.data || null;
+  const state = useMemo<AircraftPhotoState>(
+    () =>
+      key
+        ? {
+            key,
+            photo,
+            status: query.isPending ? "loading" : photo ? "found" : "missing",
+          }
+        : (EMPTY_STATE as AircraftPhotoState),
+    [key, photo, query.isPending],
+  );
+  return state;
 }

--- a/src/features/aircraft/trace/aircraftTraceClient.ts
+++ b/src/features/aircraft/trace/aircraftTraceClient.ts
@@ -3,6 +3,7 @@ import {
   AVIATION_REQUEST_TIMEOUT_MS,
 } from "../../../config/aviation";
 import { withAuditLogging } from "../../../utils/apiLogger";
+import { createRequestCache } from "../../../utils/requestCache";
 import { normalizeAircraftHex } from "@/server/http/apiProxySecurity";
 import { fetchJson } from "../../aviation/httpClient";
 
@@ -18,7 +19,7 @@ export const createAircraftTraceClient = ({
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: "adsb.lol/AircraftTrace",
   });
-  const inFlight = new Map<string, Promise<any>>();
+  const requestCache = createRequestCache<any>();
 
   return {
     fetchAircraftTrace({ hex, full = false }: Record<string, any>) {
@@ -28,18 +29,14 @@ export const createAircraftTraceClient = ({
       const path = `${baseUrl}/${encodeURIComponent(normalizedHex)}${
         full ? "?full=1" : ""
       }`;
-      const pending = inFlight.get(path);
-      if (pending) return pending;
-      const promise = fetchJson(auditedFetch, path, {
-        timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.aircraftTrace,
-        // Full traces for long-haul flights can run multi-MB — give the
-        // client buffer some headroom too.
-        maxBytes: 24 * 1024 * 1024,
-      }).finally(() => {
-        inFlight.delete(path);
-      });
-      inFlight.set(path, promise);
-      return promise;
+      return requestCache.request(path, () =>
+        fetchJson(auditedFetch, path, {
+          timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.aircraftTrace,
+          // Full traces for long-haul flights can run multi-MB — give the
+          // client buffer some headroom too.
+          maxBytes: 24 * 1024 * 1024,
+        }),
+      );
     },
   };
 };

--- a/src/features/airport/context/useAviationContextTiles.ts
+++ b/src/features/airport/context/useAviationContextTiles.ts
@@ -4,12 +4,14 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   getContextTilesForBounds,
 } from "./aviationContextTileModel";
+import { createRequestCache } from "@/utils/requestCache";
 
 type ContextTileRecord = Record<string, any>;
 
 const FRONTEND_CACHE_TTL_MS = 5 * 60 * 1000;
-const memoryCache = new Map<string, { expiresAt: number; payload: ContextTileRecord }>();
-const inFlight = new Map<string, Promise<ContextTileRecord>>();
+const tileRequestCache = createRequestCache<ContextTileRecord>({
+  ttlMs: FRONTEND_CACHE_TTL_MS,
+});
 
 function tilePath(resource: string, tile: ContextTileRecord) {
   return `/api/${resource}/${tile.z}/${tile.x}/${tile.y}`;
@@ -32,28 +34,12 @@ function uniqueBy(items = [], keyFn) {
 }
 
 async function fetchTile(url: string) {
-  const now = Date.now();
-  const cached = memoryCache.get(url);
-  if (cached && cached.expiresAt > now) return cached.payload;
-
-  const pending = inFlight.get(url);
-  if (pending) return pending;
-
-  const promise = fetch(url)
-    .then(async (response) => {
+  return tileRequestCache.request(url, () =>
+    fetch(url).then(async (response) => {
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const payload = await response.json();
-      memoryCache.set(url, {
-        expiresAt: Date.now() + FRONTEND_CACHE_TTL_MS,
-        payload,
-      });
-      return payload;
-    })
-    .finally(() => {
-      inFlight.delete(url);
-    });
-  inFlight.set(url, promise);
-  return promise;
+      return response.json();
+    }),
+  );
 }
 
 export function useAviationContextTiles({

--- a/src/features/airport/directory/airportDirectoryClient.ts
+++ b/src/features/airport/directory/airportDirectoryClient.ts
@@ -2,6 +2,8 @@
 // routes. Server routes own OpenAIP access so the API key never reaches the
 // browser bundle.
 
+import { createRequestCache } from "@/utils/requestCache";
+
 const SEARCH_PATH = "/api/search";
 const AIRPORT_PATH = "/api/airport";
 const DEFAULT_RESPONSE_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -69,39 +71,19 @@ const createAirportDirectoryClient = ({
     throw new Error("Airport directory client requires fetch support");
   }
 
-  const inFlightJson = new Map<string, Promise<any>>();
-  const responseCache = new Map<string, { expiresAt: number; payload: any }>();
+  const requestCache = createRequestCache<any>({
+    ttlMs: responseCacheTtlMs,
+    shouldCache: (payload) => payload !== null,
+  });
   const requestJsonOnce = (
     url: string,
     { signal }: { signal?: AbortSignal } = {},
-  ) => {
-    const cached = responseCache.get(url);
-    if (cached && cached.expiresAt > Date.now()) {
-      return Promise.resolve(cached.payload);
-    }
-    if (cached) {
-      responseCache.delete(url);
-    }
-    if (!signal) {
-      const pending = inFlightJson.get(url);
-      if (pending) return pending;
-    }
-    const promise = requestJson(fetchImpl, url, { signal })
-      .then((payload) => {
-        if (responseCacheTtlMs > 0 && payload !== null) {
-          responseCache.set(url, {
-            expiresAt: Date.now() + responseCacheTtlMs,
-            payload,
-          });
-        }
-        return payload;
-      })
-      .finally(() => {
-        inFlightJson.delete(url);
-      });
-    if (!signal) inFlightJson.set(url, promise);
-    return promise;
-  };
+  ) =>
+    requestCache.request(
+      url,
+      () => requestJson(fetchImpl, url, { signal }),
+      { coalesce: !signal },
+    );
 
   const loadAirports = async ({
     query = "",
@@ -129,7 +111,10 @@ const createAirportDirectoryClient = ({
     };
   };
 
-  const resolveAirport = async (code: unknown, { locale = "" }: Record<string, any> = {}) => {
+  const resolveAirport = async (
+    code: unknown,
+    { locale = "", signal }: Record<string, any> = {},
+  ) => {
     const trimmed = String(code || "").trim().toUpperCase();
     if (!trimmed) {
       throw new Error("Airport code is required");
@@ -137,6 +122,7 @@ const createAirportDirectoryClient = ({
 
     const detail = await requestJsonOnce(
       buildAirportUrl({ baseUrl, ident: trimmed, locale }),
+      { signal },
     );
     if (detail?.airport) {
       return {
@@ -161,6 +147,7 @@ const createAirportDirectoryClient = ({
 
     const searchPayload = await requestJsonOnce(
       buildSearchUrl({ baseUrl, query: trimmed, limit: 1 }),
+      { signal },
     );
     const fallback = searchPayload?.airports?.[0];
     if (fallback) return fallback;

--- a/src/features/airport/directory/airportProfileQueries.test.ts
+++ b/src/features/airport/directory/airportProfileQueries.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import {
+  airportProfileCode,
+  airportProfileQueryKeys,
+  mergeAirportProfile,
+  normalizeAirportProfileIcao,
+  normalizeAirportProfileLocale,
+} from "./airportProfileQueries";
+
+assert.equal(normalizeAirportProfileIcao(" kbos "), "KBOS");
+assert.equal(normalizeAirportProfileIcao("bad-code"), "");
+assert.equal(normalizeAirportProfileLocale(" zh-CN "), "zh-CN");
+
+assert.deepEqual(airportProfileQueryKeys.detail("kbos", "zh-CN"), [
+  "airport-profile",
+  "detail",
+  "KBOS",
+  "zh-CN",
+]);
+assert.deepEqual(airportProfileQueryKeys.context(" zspd "), [
+  "airport-profile",
+  "context",
+  "ZSPD",
+]);
+assert.deepEqual(airportProfileQueryKeys.surface("kjfk"), [
+  "airport-profile",
+  "surface",
+  "KJFK",
+]);
+
+assert.equal(airportProfileCode({ ident: "egll" }), "EGLL");
+assert.equal(airportProfileCode({ code: "zbaa", icao: "" }), "ZBAA");
+
+const merged = mergeAirportProfile({
+  detail: {
+    icao: "KBOS",
+    name: "Boston Logan",
+    nearbyAirports: [],
+    surfaceMap: null,
+  },
+  context: {
+    nearbyAirports: [{ icao: "KOWD" }],
+    airspaces: [{ id: "bos-b" }],
+  },
+  surfaceMap: { airport: "KBOS", features: [] },
+});
+
+assert.equal(merged.icao, "KBOS");
+assert.deepEqual(merged.nearbyAirports, [{ icao: "KOWD" }]);
+assert.deepEqual(merged.airspaces, [{ id: "bos-b" }]);
+assert.deepEqual(merged.surfaceMap, { airport: "KBOS", features: [] });
+assert.equal(mergeAirportProfile({ detail: null }), null);
+
+console.log("airportProfileQueries.test.ts: ok");

--- a/src/features/airport/directory/airportProfileQueries.ts
+++ b/src/features/airport/directory/airportProfileQueries.ts
@@ -1,0 +1,159 @@
+import { useMemo } from "react";
+import {
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
+import { airportDirectoryClient } from "./airportDirectoryClient";
+
+const AIRPORT_DETAIL_STALE_TIME_MS = 5 * 60_000;
+const AIRPORT_CONTEXT_STALE_TIME_MS = 5 * 60_000;
+
+export const airportProfileQueryKeys = {
+  all: ["airport-profile"] as const,
+  detail: (icao: unknown, locale: unknown = "") =>
+    [
+      ...airportProfileQueryKeys.all,
+      "detail",
+      normalizeAirportProfileIcao(icao),
+      normalizeAirportProfileLocale(locale),
+    ] as const,
+  context: (icao: unknown) =>
+    [
+      ...airportProfileQueryKeys.all,
+      "context",
+      normalizeAirportProfileIcao(icao),
+    ] as const,
+  surface: (icao: unknown) =>
+    [
+      ...airportProfileQueryKeys.all,
+      "surface",
+      normalizeAirportProfileIcao(icao),
+    ] as const,
+};
+
+export function normalizeAirportProfileIcao(value: unknown) {
+  const normalized = String(value || "").trim().toUpperCase();
+  return /^[A-Z0-9]{3,4}$/.test(normalized) ? normalized : "";
+}
+
+export function normalizeAirportProfileLocale(value: unknown) {
+  return String(value || "").trim();
+}
+
+export function airportProfileCode(airport: any) {
+  return normalizeAirportProfileIcao(
+    airport?.icao || airport?.code || airport?.ident,
+  );
+}
+
+export function mergeAirportProfile({
+  detail,
+  context,
+  surfaceMap,
+}: {
+  detail: any;
+  context?: any;
+  surfaceMap?: any;
+}) {
+  if (!detail) return null;
+  return {
+    ...detail,
+    ...(context || {}),
+    surfaceMap: surfaceMap ?? detail.surfaceMap ?? null,
+  };
+}
+
+function isSeedForIcao(seedAirport: any, icao: string) {
+  return Boolean(seedAirport && airportProfileCode(seedAirport) === icao);
+}
+
+export function prefetchAirportProfile(
+  queryClient: QueryClient,
+  {
+    icao,
+    locale,
+  }: {
+    icao: unknown;
+    locale: unknown;
+  },
+) {
+  const normalizedIcao = normalizeAirportProfileIcao(icao);
+  if (!normalizedIcao) return;
+  const normalizedLocale = normalizeAirportProfileLocale(locale);
+
+  void queryClient.prefetchQuery({
+    queryKey: airportProfileQueryKeys.detail(normalizedIcao, normalizedLocale),
+    queryFn: ({ signal }) =>
+      airportDirectoryClient.resolveAirport(normalizedIcao, {
+        locale: normalizedLocale,
+        signal,
+      }),
+    staleTime: AIRPORT_DETAIL_STALE_TIME_MS,
+  });
+}
+
+export function useAirportProfileQueries({
+  icao,
+  locale,
+  seedAirport = null,
+}: {
+  icao: unknown;
+  locale: unknown;
+  seedAirport?: any;
+}) {
+  const queryClient = useQueryClient();
+  const normalizedIcao = normalizeAirportProfileIcao(icao);
+  const normalizedLocale = normalizeAirportProfileLocale(locale);
+  const enabled = Boolean(normalizedIcao);
+
+  const detailQuery = useQuery({
+    queryKey: airportProfileQueryKeys.detail(normalizedIcao, normalizedLocale),
+    queryFn: ({ signal }) =>
+      airportDirectoryClient.resolveAirport(normalizedIcao, {
+        locale: normalizedLocale,
+        signal,
+      }),
+    enabled,
+    staleTime: AIRPORT_DETAIL_STALE_TIME_MS,
+    placeholderData: () =>
+      isSeedForIcao(seedAirport, normalizedIcao) ? seedAirport : undefined,
+  });
+
+  const canHydrateDeferredPayloads = enabled && Boolean(detailQuery.data);
+
+  const contextQuery = useQuery({
+    queryKey: airportProfileQueryKeys.context(normalizedIcao),
+    queryFn: ({ signal }) =>
+      airportDirectoryClient.resolveAirportContext(normalizedIcao, { signal }),
+    enabled: canHydrateDeferredPayloads,
+    staleTime: AIRPORT_CONTEXT_STALE_TIME_MS,
+  });
+
+  const surfaceQuery = useQuery({
+    queryKey: airportProfileQueryKeys.surface(normalizedIcao),
+    queryFn: ({ signal }) =>
+      airportDirectoryClient.resolveAirportSurface(normalizedIcao, { signal }),
+    enabled: canHydrateDeferredPayloads,
+    staleTime: AIRPORT_CONTEXT_STALE_TIME_MS,
+  });
+
+  const airport = useMemo(
+    () =>
+      mergeAirportProfile({
+        detail: detailQuery.data,
+        context: contextQuery.data,
+        surfaceMap: surfaceQuery.data,
+      }),
+    [contextQuery.data, detailQuery.data, surfaceQuery.data],
+  );
+
+  return {
+    airport:
+      airportProfileCode(airport) === normalizedIcao ? airport : null,
+    detailQuery,
+    contextQuery,
+    surfaceQuery,
+    queryClient,
+  };
+}

--- a/src/features/airport/nearby/nearbyAirportClient.ts
+++ b/src/features/airport/nearby/nearbyAirportClient.ts
@@ -1,3 +1,5 @@
+import { createRequestCache } from "@/utils/requestCache";
+
 const DEFAULT_BASE_PATH = "/api/proxy/airports/nearby";
 
 type NearbyAirportClientRecord = Record<string, any>;
@@ -29,29 +31,23 @@ function createNearbyAirportClient({
   basePath = DEFAULT_BASE_PATH,
 }: NearbyAirportClientRecord = {}) {
   if (!fetchImpl) throw new Error("Nearby airport client requires fetch support");
-  const inFlight = new Map<string, Promise<any>>();
+  const requestCache = createRequestCache<any>();
 
   return {
     async fetchNearbyAirports(options: NearbyAirportClientRecord = {}) {
       const url = buildNearbyAirportsPath({ ...options, basePath });
-      const pending = inFlight.get(url);
-      if (pending) return pending;
-      const promise = fetchImpl(url, {
-        headers: { Accept: "application/json" },
-        cache: "no-store",
-      })
-        .then((response) => {
+      return requestCache.request(url, () =>
+        fetchImpl(url, {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        }).then((response) => {
           if (response.status === 404) return { airports: [] };
           if (!response.ok) {
             throw new Error(`Failed to load nearby airports: HTTP ${response.status}`);
           }
           return response.json();
-        })
-        .finally(() => {
-          inFlight.delete(url);
-        });
-      inFlight.set(url, promise);
-      return promise;
+        }),
+      );
     },
   };
 }

--- a/src/features/location/reverseGeocodeClient.ts
+++ b/src/features/location/reverseGeocodeClient.ts
@@ -9,6 +9,7 @@
 // geolocation jitter floor keep us well under that).
 
 import { toSimplifiedChinese } from "@/utils/chineseSimplified";
+import { createRequestCache } from "@/utils/requestCache";
 
 type NominatimAddress = {
   city?: unknown;
@@ -44,8 +45,10 @@ export type ReverseGeocodeResult = {
   countryCode: string;
 };
 
-const CACHE = new Map<string, ReverseGeocodeResult>();
-const IN_FLIGHT = new Map<string, Promise<ReverseGeocodeResult | null>>();
+const requestCache = createRequestCache<ReverseGeocodeResult | null>({
+  ttlMs: Number.POSITIVE_INFINITY,
+  shouldCache: () => true,
+});
 // Same-origin proxy in front of Nominatim so we don't have to relax
 // the app's CSP `connect-src` and the upstream sees our application
 // User-Agent (set inside the proxy route).
@@ -119,15 +122,12 @@ export async function fetchReverseGeocode(
 ): Promise<ReverseGeocodeResult | null> {
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
   const key = cacheKey(lat, lon, language);
-  if (CACHE.has(key)) return CACHE.get(key) || null;
-  const pending = IN_FLIGHT.get(key);
-  if (pending) return pending;
 
   const url =
     `${ENDPOINT}?lat=${lat}&lon=${lon}` +
     `&language=${encodeURIComponent(buildAcceptLanguage(language))}`;
-  const promise = fetch(url, { cache: "no-store" })
-    .then(async (response) => {
+  return requestCache.request(key, () =>
+    fetch(url, { cache: "no-store" }).then(async (response) => {
       if (!response.ok) throw new Error(`reverse-geocode HTTP ${response.status}`);
       const json = (await response.json()) as NominatimResponse;
       const address = json?.address || {};
@@ -174,12 +174,7 @@ export async function fetchReverseGeocode(
           }
         : rawResult;
 
-      CACHE.set(key, result);
       return result;
-    })
-    .finally(() => {
-      IN_FLIGHT.delete(key);
-    });
-  IN_FLIGHT.set(key, promise);
-  return promise;
+    }),
+  );
 }

--- a/src/features/weather/metar/metarClient.ts
+++ b/src/features/weather/metar/metarClient.ts
@@ -3,6 +3,7 @@ import {
   AVIATION_REQUEST_TIMEOUT_MS,
 } from "../../../config/aviation";
 import { withAuditLogging } from "../../../utils/apiLogger";
+import { createRequestCache } from "../../../utils/requestCache";
 import { fetchJson } from "../../aviation/httpClient";
 
 const env: Record<string, string | undefined> = typeof process !== "undefined" ? process.env : {};
@@ -16,7 +17,7 @@ export const createMetarClient = ({
   const auditedFetch = withAuditLogging(fetchImpl, {
     service: "AviationWeather/METAR",
   });
-  const inFlight = new Map<string, Promise<any>>();
+  const requestCache = createRequestCache<any>();
 
   return {
     fetchMetar(icao) {
@@ -25,15 +26,11 @@ export const createMetarClient = ({
         .toUpperCase();
       if (!normalized) return [];
       const url = `${baseUrl}/${encodeURIComponent(normalized)}`;
-      const pending = inFlight.get(url);
-      if (pending) return pending;
-      const promise = fetchJson(auditedFetch, url, {
-        timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.metar,
-      }).finally(() => {
-        inFlight.delete(url);
-      });
-      inFlight.set(url, promise);
-      return promise;
+      return requestCache.request(url, () =>
+        fetchJson(auditedFetch, url, {
+          timeoutMs: AVIATION_REQUEST_TIMEOUT_MS.metar,
+        }),
+      );
     },
   };
 };

--- a/src/utils/requestCache.test.ts
+++ b/src/utils/requestCache.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { createRequestCache } from "./requestCache";
+
+{
+  const calls = [];
+  let resolvePayload;
+  const cache = createRequestCache();
+
+  const first = cache.request("same", () => {
+    calls.push("load");
+    return new Promise((resolve) => {
+      resolvePayload = () => resolve({ ok: true });
+    });
+  });
+  const second = cache.request("same", () => {
+    calls.push("load");
+    return Promise.resolve({ ok: false });
+  });
+
+  assert.equal(calls.length, 1);
+  resolvePayload();
+  assert.deepEqual(await first, { ok: true });
+  assert.deepEqual(await second, { ok: true });
+}
+
+{
+  const calls = [];
+  const cache = createRequestCache();
+
+  await cache.request("retry", async () => {
+    calls.push("first");
+    return "first";
+  });
+  await cache.request("retry", async () => {
+    calls.push("second");
+    return "second";
+  });
+
+  assert.deepEqual(calls, ["first", "second"]);
+}
+
+{
+  const calls = [];
+  const cache = createRequestCache<null>({
+    ttlMs: 500,
+    shouldCache: () => true,
+  });
+
+  assert.equal(
+    await cache.request("nullable", async () => {
+      calls.push("first");
+      return null;
+    }),
+    null,
+  );
+  assert.equal(
+    await cache.request("nullable", async () => {
+      calls.push("second");
+      return null;
+    }),
+    null,
+  );
+  assert.deepEqual(calls, ["first"]);
+}
+
+{
+  const cache = createRequestCache();
+
+  await assert.rejects(
+    () =>
+      cache.request("throws", () => {
+        throw new Error("sync failure");
+      }),
+    /sync failure/,
+  );
+  assert.equal(
+    await cache.request("throws", async () => "recovered"),
+    "recovered",
+  );
+}
+
+{
+  let now = 1_000;
+  const calls = [];
+  const cache = createRequestCache<string>({
+    ttlMs: 500,
+    now: () => now,
+  });
+
+  assert.equal(
+    await cache.request("cached", async () => {
+      calls.push("first");
+      return "first";
+    }),
+    "first",
+  );
+  assert.equal(
+    await cache.request("cached", async () => {
+      calls.push("second");
+      return "second";
+    }),
+    "first",
+  );
+  now = 1_501;
+  assert.equal(
+    await cache.request("cached", async () => {
+      calls.push("third");
+      return "third";
+    }),
+    "third",
+  );
+  assert.deepEqual(calls, ["first", "third"]);
+}
+
+{
+  const calls = [];
+  const cache = createRequestCache();
+
+  await Promise.all([
+    cache.request(
+      "isolated",
+      async () => {
+        calls.push("first");
+        return "first";
+      },
+      { coalesce: false },
+    ),
+    cache.request(
+      "isolated",
+      async () => {
+        calls.push("second");
+        return "second";
+      },
+      { coalesce: false },
+    ),
+  ]);
+
+  assert.deepEqual(calls, ["first", "second"]);
+}
+
+console.log("requestCache.test.ts: ok");

--- a/src/utils/requestCache.ts
+++ b/src/utils/requestCache.ts
@@ -1,0 +1,79 @@
+type RequestCacheOptions<T> = {
+  ttlMs?: number;
+  shouldCache?: (payload: T) => boolean;
+  now?: () => number;
+};
+
+type RequestOptions = {
+  cache?: boolean;
+  coalesce?: boolean;
+};
+
+export function createRequestCache<T>({
+  ttlMs = 0,
+  shouldCache = (payload) => payload != null,
+  now = () => Date.now(),
+}: RequestCacheOptions<T> = {}) {
+  const inFlight = new Map<string, Promise<T>>();
+  const memory = new Map<string, { expiresAt: number; payload: T }>();
+
+  const readMemory = (key: string) => {
+    const cached = memory.get(key);
+    if (!cached) return { hit: false, payload: undefined as T | undefined };
+    if (cached.expiresAt > now()) return { hit: true, payload: cached.payload };
+    memory.delete(key);
+    return { hit: false, payload: undefined as T | undefined };
+  };
+
+  return {
+    request(
+      key: string,
+      load: () => T | Promise<T>,
+      { cache = true, coalesce = true }: RequestOptions = {},
+    ) {
+      const useMemory = cache && ttlMs > 0;
+      if (useMemory) {
+        const cached = readMemory(key);
+        if (cached.hit) return Promise.resolve(cached.payload as T);
+      }
+
+      if (coalesce) {
+        const pending = inFlight.get(key);
+        if (pending) return pending;
+      }
+
+      let loaded: Promise<T>;
+      try {
+        loaded = Promise.resolve(load());
+      } catch (error) {
+        loaded = Promise.reject(error);
+      }
+
+      const promise = loaded
+        .then((payload) => {
+          if (useMemory && shouldCache(payload)) {
+            memory.set(key, {
+              expiresAt: now() + ttlMs,
+              payload,
+            });
+          }
+          return payload;
+        })
+        .finally(() => {
+          if (inFlight.get(key) === promise) inFlight.delete(key);
+        });
+
+      if (coalesce) inFlight.set(key, promise);
+      return promise;
+    },
+    clear(key?: string) {
+      if (key == null) {
+        inFlight.clear();
+        memory.clear();
+        return;
+      }
+      inFlight.delete(key);
+      memory.delete(key);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add a shared request cache helper and migrate duplicate in-flight request handling for airport, nearby-airport, METAR, trace, context-tile, and reverse-geocode clients.
- Move airport profile loading to TanStack Query so airport detail, deferred context, and surface payloads are shared across route transitions with seeded placeholder rendering.
- Move aircraft photo lookup to TanStack Query, add airport-result intent prefetch, and bump the release line to v2.10.0 with a changelog entry.

## Validation
- `pnpm test` (119 test files passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors, 13 existing warnings)
- `pnpm build` (existing large AirportMap chunk warning)
- `pnpm debug:local:service`
- `node .codex-tmp/transition-probe.mjs http://localhost:3000` covering search -> airport, airport -> airport, airport -> aircraft, and aircraft -> airport transitions

## Notes
- `CLAUDE.md` has a pre-existing local unstaged edit and is intentionally not part of this PR.