### PR TITLE
[codex] Add app version refresh toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/httpapi/server.go
+++ b/services/data-service/internal/httpapi/server.go
@@ -140,6 +140,11 @@ func (s *Server) serveStaticOrSPA(w http.ResponseWriter, r *http.Request) {
 	// Try to serve the requested file directly
 	info, err := os.Stat(fsPath)
 	if err == nil && !info.IsDir() {
+		if filepath.Clean(r.URL.Path) == "/adsbao-version.json" {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-store")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+		}
 		http.ServeFile(w, r, fsPath)
 		return
 	}

--- a/services/data-service/internal/httpapi/server_test.go
+++ b/services/data-service/internal/httpapi/server_test.go
@@ -233,6 +233,33 @@ func TestStaticAssetServedWhenExists(t *testing.T) {
 	}
 }
 
+func TestAppVersionManifestServedNoStore(t *testing.T) {
+	staticDir := t.TempDir()
+	manifestPath := filepath.Join(staticDir, "adsbao-version.json")
+	if err := os.WriteFile(manifestPath, []byte(`{"version":"2.11.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	server := New(ServerOptions{
+		StaticDir:     staticDir,
+		DebugChannels: fakeDebugScheduler{}.DebugChannels,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/adsbao-version.json", nil)
+	rr := httptest.NewRecorder()
+	server.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200", rr.Code)
+	}
+	if rr.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("Cache-Control = %q", rr.Header().Get("Cache-Control"))
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	if strings.TrimSpace(rr.Body.String()) != `{"version":"2.11.0"}` {
+		t.Fatalf("body = %q, want version manifest", rr.Body.String())
+	}
+}
+
 func TestMissingStaticAssetReturns404(t *testing.T) {
 	staticDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<html>SPA</html>"), 0o644); err != nil {

--- a/src/components/app-shell/AppUpdateToast.tsx
+++ b/src/components/app-shell/AppUpdateToast.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { ADSBAO_SITE_VERSION } from "@/config/siteMeta";
+import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import {
+  APP_UPDATE_TOAST_ID,
+  resolveAppVersionUpdate,
+  versionManifestUrl,
+} from "@/features/app-shell/appVersionModel";
+
+const APP_VERSION_CHECK_INTERVAL_MS = 5 * 60_000;
+
+type AppVersionManifest = {
+  version?: unknown;
+};
+
+async function fetchLatestAppVersion(signal?: AbortSignal) {
+  const response = await fetch(versionManifestUrl(), {
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+    signal,
+  });
+  if (!response.ok) return "";
+  const manifest = (await response.json()) as AppVersionManifest;
+  return manifest.version;
+}
+
+export default function AppUpdateToast({
+  currentVersion = ADSBAO_SITE_VERSION,
+  checkIntervalMs = APP_VERSION_CHECK_INTERVAL_MS,
+}: {
+  currentVersion?: string;
+  checkIntervalMs?: number;
+}) {
+  const { t } = useI18n();
+  const latestToastVersionRef = useRef("");
+
+  useEffect(() => {
+    let disposed = false;
+    const controller = new AbortController();
+
+    const checkForUpdate = async () => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      try {
+        const latestVersion = await fetchLatestAppVersion(controller.signal);
+        if (disposed) return;
+        const update = resolveAppVersionUpdate({
+          currentVersion,
+          latestVersion,
+        });
+        if (!update) return;
+        if (latestToastVersionRef.current === update.latestVersion) return;
+        latestToastVersionRef.current = update.latestVersion;
+        toast.info(t("appUpdate.title"), {
+          id: APP_UPDATE_TOAST_ID,
+          description: t("appUpdate.description", {
+            currentVersion: update.currentVersion,
+            latestVersion: update.latestVersion,
+          }),
+          action: {
+            label: t("appUpdate.refresh"),
+            onClick: () => window.location.reload(),
+          },
+          duration: Infinity,
+        });
+      } catch {
+        // Version checks are advisory; network failures should not interrupt
+        // live tracking or airport workflows.
+      }
+    };
+
+    void checkForUpdate();
+    const interval = window.setInterval(
+      checkForUpdate,
+      Math.max(60_000, Number(checkIntervalMs) || APP_VERSION_CHECK_INTERVAL_MS),
+    );
+    const checkWhenVisible = () => {
+      if (typeof document === "undefined" || !document.hidden) {
+        void checkForUpdate();
+      }
+    };
+    document.addEventListener("visibilitychange", checkWhenVisible);
+    window.addEventListener("focus", checkWhenVisible);
+
+    return () => {
+      disposed = true;
+      controller.abort();
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", checkWhenVisible);
+      window.removeEventListener("focus", checkWhenVisible);
+    };
+  }, [checkIntervalMs, currentVersion, t]);
+
+  return null;
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.11.0",
+    kind: "feat",
+    title: {
+      en: "Version refresh prompt",
+      zh: "新版刷新提示",
+    },
+    summary: {
+      en: "Open ADSBao tabs now check the latest deployed build and show a persistent refresh toast when a newer version is available.",
+      zh: "已打开的 ADSBao 页面现在会检查最新部署版本；当有新版可用时，会显示持续的刷新提示。",
+    },
+    highlights: [
+      {
+        en: "The Vite build emits a no-store version manifest that old tabs can compare against their current bundle",
+        zh: "Vite 构建会产出 no-store 版本 manifest，旧页面可用它与当前 bundle 版本比较",
+      },
+      {
+        en: "A localized Sonner toast offers a one-click refresh action and re-checks after tab focus or visibility changes",
+        zh: "本地化 Sonner toast 提供一键刷新，并在页面重新聚焦或可见性变化后再次检查",
+      },
+    ],
+  },
+  {
     version: "v2.10.0",
     kind: "feat",
     title: {

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -15,6 +15,12 @@ const en = {
   brand: {
     wordmarkZh: "拍机宝",
   },
+  appUpdate: {
+    title: "New ADSBao version available",
+    description:
+      "You are running {currentVersion}. Refresh to load {latestVersion}.",
+    refresh: "Refresh",
+  },
   nav: {
     home: "ADSBao",
     homePage: "Home",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -13,6 +13,11 @@ const zhCN = {
   brand: {
     wordmarkZh: "拍机宝",
   },
+  appUpdate: {
+    title: "ADSBao 有新版本",
+    description: "当前是 {currentVersion}，刷新后载入 {latestVersion}。",
+    refresh: "刷新",
+  },
   nav: {
     home: "ADSBao",
     homePage: "首页",

--- a/src/features/app-shell/appVersionModel.test.ts
+++ b/src/features/app-shell/appVersionModel.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import {
+  normalizeAppVersion,
+  resolveAppVersionUpdate,
+} from "./appVersionModel";
+
+assert.equal(normalizeAppVersion(" v2.10.0 "), "2.10.0");
+assert.equal(normalizeAppVersion("2.10.0"), "2.10.0");
+assert.equal(normalizeAppVersion(null), "");
+
+assert.deepEqual(
+  resolveAppVersionUpdate({
+    currentVersion: "2.10.0",
+    latestVersion: "v2.11.0",
+  }),
+  {
+    currentVersion: "2.10.0",
+    latestVersion: "2.11.0",
+  },
+);
+
+assert.equal(
+  resolveAppVersionUpdate({
+    currentVersion: "v2.10.0",
+    latestVersion: "2.10.0",
+  }),
+  null,
+);
+
+assert.equal(
+  resolveAppVersionUpdate({
+    currentVersion: "2.10.0",
+    latestVersion: "",
+  }),
+  null,
+);

--- a/src/features/app-shell/appVersionModel.ts
+++ b/src/features/app-shell/appVersionModel.ts
@@ -1,0 +1,31 @@
+export const APP_VERSION_MANIFEST_PATH = "/adsbao-version.json";
+export const APP_UPDATE_TOAST_ID = "app-update-available";
+
+export type AppVersionUpdate = {
+  currentVersion: string;
+  latestVersion: string;
+};
+
+export function normalizeAppVersion(value: unknown) {
+  return typeof value === "string" ? value.trim().replace(/^v/i, "") : "";
+}
+
+export function resolveAppVersionUpdate({
+  currentVersion,
+  latestVersion,
+}: {
+  currentVersion: unknown;
+  latestVersion: unknown;
+}): AppVersionUpdate | null {
+  const current = normalizeAppVersion(currentVersion);
+  const latest = normalizeAppVersion(latestVersion);
+  if (!current || !latest || current === latest) return null;
+  return {
+    currentVersion: current,
+    latestVersion: latest,
+  };
+}
+
+export function versionManifestUrl(nowMs = Date.now()) {
+  return `${APP_VERSION_MANIFEST_PATH}?t=${Math.max(0, Math.floor(nowMs))}`;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { ClerkProvider } from "@/platform/auth/clerkClient";
+import AppUpdateToast from "@/components/app-shell/AppUpdateToast";
 import ThemedToaster from "@/components/app-shell/ThemedToaster";
 import QueryProvider from "@/features/app-shell/queryProvider";
 import { I18nProvider } from "@/features/app-shell/i18n/i18nProvider";
@@ -76,6 +77,7 @@ createRoot(root).render(
           <QueryProvider>
             <UnitPreferencesProvider>
               <WebMcpProvider />
+              <AppUpdateToast />
               <div className="min-h-dvh bg-atc-bg text-atc-text">
                 <App />
               </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,39 @@
-import { defineConfig, loadEnv } from "vite";
+import { readFileSync } from "node:fs";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+) as { version?: string };
+const ADSBAO_APP_VERSION = String(packageJson.version || "0.0.0");
+
+function appVersionManifestPlugin(version: string): Plugin {
+  const payload = () => `${JSON.stringify({ version }, null, 2)}\n`;
+  return {
+    name: "adsbao-app-version-manifest",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url?.split("?")[0] !== "/adsbao-version.json") {
+          next();
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
+        res.setHeader("Cache-Control", "no-store");
+        res.setHeader("X-Content-Type-Options", "nosniff");
+        res.end(payload());
+      });
+    },
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "adsbao-version.json",
+        source: payload(),
+      });
+    },
+  };
+}
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
@@ -21,7 +54,7 @@ export default defineConfig(({ mode }) => {
   };
 
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), appVersionManifestPlugin(ADSBAO_APP_VERSION)],
     server: {
       host: "0.0.0.0",
       port: 3000,


### PR DESCRIPTION
## Summary
- Add a no-store app version manifest emitted by Vite dev/build and served by the Go static server.
- Add an app-shell Sonner watcher that compares the current bundle version with the latest manifest and offers a refresh action when a newer version is available.
- Bump ADSBao to v2.11.0 and add the changelog entry for the user-visible update prompt.

## Validation
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings remain)
- `go test ./...` in `services/data-service`
- Browser validation on local preview: forced manifest `2.12.0` against bundle `2.11.0`, confirmed the Sonner toast, version copy, and refresh button reload behavior.