### PR TITLE
Refine airport night map detail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.13.0",
+  "version": "2.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -196,6 +196,8 @@ export default function AirportMap({
     const map = L.map(mapEl.current, {
       center: [initialCenter.lat, initialCenter.lon],
       zoom,
+      zoomSnap: 0.25,
+      zoomDelta: 0.5,
       zoomControl: false,
       attributionControl: false,
       scrollWheelZoom: false,

--- a/src/components/map/AirportSurfaceLayer.tsx
+++ b/src/components/map/AirportSurfaceLayer.tsx
@@ -61,9 +61,9 @@ const airportSurfaceStyle = (
       fillOpacity: 0,
       lineCap: "round",
       lineJoin: "round",
-      opacity: lightsActive ? (isLight ? 0.16 : 0.34) : isLight ? 0.28 : 0.68,
+      opacity: lightsActive ? (isLight ? 0.22 : 0.46) : isLight ? 0.28 : 0.68,
       stroke: true,
-      weight: lightsActive ? (isLight ? 1.2 : 2.2) : baseWeight,
+      weight: lightsActive ? (isLight ? 0.9 : 1.35) : baseWeight,
     };
   }
 
@@ -93,9 +93,9 @@ const airportSurfaceStyle = (
       fill: false,
       lineCap: "round",
       lineJoin: "round",
-      opacity: isLight ? 0.24 : 0.3,
+      opacity: isLight ? 0.3 : 0.54,
       stroke: true,
-      weight: isLight ? 1.8 : 3,
+      weight: isLight ? 1.15 : 1.05,
     };
   }
 
@@ -105,9 +105,9 @@ const airportSurfaceStyle = (
     fill: false,
     lineCap: "round",
     lineJoin: "round",
-    opacity: isLight ? 0.3 : 0.38,
+    opacity: isLight ? 0.34 : 0.58,
     stroke: true,
-    weight: isLight ? 2.4 : 4,
+    weight: isLight ? 1.25 : 1.15,
   };
 };
 

--- a/src/config/airportMap.ts
+++ b/src/config/airportMap.ts
@@ -94,17 +94,16 @@ export const RUNWAY_APPROACH_BEAM_CONFIG = {
 // renderer maps each light's semantic color role to a CSS variable so themes
 // stay the source of truth (see --atc-runway-light-* in style.css).
 export const RUNWAY_FAA_LIGHTING_CONFIG = {
-  // Longitudinal spacing along the runway. NOTE: these are intentionally WIDER
-  // than the real FAA spacing (edge 200ft, centerline 50ft). At the map's max
-  // usable zoom, true spacing packs the dots into a solid line; widening the
-  // gaps keeps individual lights legible. Color ZONES below stay distance-exact
-  // (in feet), so the FAA color pattern is preserved regardless of spacing.
-  edgeSpacingFt: 600,
-  centerlineSpacingFt: 400,
+  // Longitudinal spacing along the runway. Near zoom intentionally reads as a
+  // dense night-light diagram: smaller points with tighter spacing, plus a
+  // fine surface line underneath. Color ZONES below stay distance-exact (in
+  // feet), so the FAA color pattern is preserved regardless of spacing.
+  edgeSpacingFt: 260,
+  centerlineSpacingFt: 170,
   // Symmetric color zones, measured from the nearer threshold.
-  edgeCautionFt: 2000, // edge turns amber within last 2000ft (or half, whichever less)
-  centerlineRedFt: 1000, // centerline all-red within last 1000ft
-  centerlineAltFt: 3000, // centerline alternates red/white from 3000ft to 1000ft remaining
+  edgeCautionFt: 700, // compact amber cue near the runway ends
+  centerlineRedFt: 420, // compact red cue near the threshold/end
+  centerlineAltFt: 1100, // short red/white transition so white stays dominant
   // Touchdown zone lights: from `tdzStartFt` past the (displaced) threshold,
   // extending up to `tdzLengthFt` or the runway midpoint, whichever is less.
   tdzStartFt: 100,
@@ -113,30 +112,34 @@ export const RUNWAY_FAA_LIGHTING_CONFIG = {
   tdzBarHalfCount: 2, // lights per side of a single TDZ bar
   // Threshold / runway-end bar: number of lights across the runway width.
   endBarLightCount: 5,
+  endSideLightCount: 3,
+  endSideLightSpacingFt: 75,
+  endSideLightOffsetFt: 14,
   // REIL: a pair of synchronized flashing strobes flanking each threshold.
   reilOffsetFt: 40, // lateral offset outboard of the runway edge
   // Taxiway lights (OSM geometry; width is estimated since OSM rarely has it).
-  // Also widened from real spacing (centerline 50ft, edge 200ft) for legibility.
-  taxiwayCenterlineSpacingFt: 400,
-  taxiwayEdgeSpacingFt: 600,
+  // Tightened so Near zoom forms the dense blue/green airfield network seen in
+  // night-map references without requiring full real-world 50ft spacing.
+  taxiwayCenterlineSpacingFt: 170,
+  taxiwayEdgeSpacingFt: 230,
   taxiwayDefaultHalfWidthFt: 38, // ~11.5m assumed half-width for blue edge offset
   // Per-band decimation: keep mid-zoom point counts sane.
   midCenterlineDecimation: 2, // render every Nth centerline light at mid band
   // Canvas point radius (screen px) per color role bucket — the core dot.
-  // A subtle glow halo (radius × glowMultiplier, low opacity) is drawn
-  // underneath in the canvas renderer.
+  // Keep these sub-pixel at Near zoom so the airport reads as a dense
+  // night-light point field instead of large map markers.
   radius: {
-    edge: 1.0,
-    centerline: 0.6,
-    tdz: 0.6,
-    endBar: 0.85,
-    reil: 1.05,
-    approach: 0.75,
-    taxiway: 0.35,
+    edge: 0.34,
+    centerline: 0.22,
+    tdz: 0.22,
+    endBar: 0.34,
+    reil: 0.44,
+    approach: 0.25,
+    taxiway: 0.12,
   },
   glow: {
-    multiplier: 3.2, // glow halo radius = core radius × this
-    fillOpacity: 0.22,
+    multiplier: 2, // glow halo radius = core radius × this
+    fillOpacity: 0.1,
   },
 } as const;
 

--- a/src/config/aviation.ts
+++ b/src/config/aviation.ts
@@ -1,7 +1,7 @@
 export const AIRPORT_MAP_ZOOM = {
   approach: 10,
   airport: 11,
-  detail: 13,
+  detail: 13.5,
 };
 
 export const AIRPORT_EXPLORER_UI_CONFIG = {

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.13.1",
+    kind: "patch",
+    title: {
+      en: "Airport night map detail",
+      zh: "机场夜间细节图",
+    },
+    summary: {
+      en: "Near airport maps now render tighter, finer runway and taxiway lighting so dense airfields read more like night-light diagrams.",
+      zh: "机场近景地图现在使用更近的视图和更细密的跑道、滑行道灯阵，让大型机场更像夜间灯光图。",
+    },
+    highlights: [
+      {
+        en: "Near range moves closer with fractional zoom support, matching the 0.5 NM inspection view more closely",
+        zh: "近景档位加入 fractional zoom 并推近视图，更贴近 0.5 NM 的检查视角",
+      },
+      {
+        en: "Runway, taxiway, centerline, threshold, and approach lights use smaller micro-dots with reduced halos",
+        zh: "跑道、滑行道、中线、入口和进近灯改为更小的微点，并收短光晕",
+      },
+      {
+        en: "Runway ends add subtle red side cues while the underlying surface lines stay thin",
+        zh: "跑道端部增加低调红色侧向提示，同时底层道面线保持细线效果",
+      },
+    ],
+  },
+  {
     version: "v2.13.0",
     kind: "feat",
     title: {

--- a/src/features/airport/map/runwayLightingModel.test.ts
+++ b/src/features/airport/map/runwayLightingModel.test.ts
@@ -126,6 +126,13 @@ assert.equal(greenBars.length, 10, "two green threshold bars of 5 lights each");
 assert.equal(redBars.length, 10, "two red end bars of 5 lights each");
 assert.ok(greenBars.every((f) => f.properties.color === "green"));
 assert.ok(redBars.every((f) => f.properties.color === "red"));
+const redSideLights = byRole(near, (role) => role === "end-side");
+assert.equal(
+  redSideLights.length,
+  RUNWAY_FAA_LIGHTING_CONFIG.endSideLightCount * 4,
+  "red side lights run along both sides at both runway ends",
+);
+assert.ok(redSideLights.every((f) => f.properties.color === "red"));
 
 // REIL flashing strobes only at the near band.
 const reil = byRole(near, (role) => role === "reil");
@@ -235,7 +242,7 @@ assert.ok(
 );
 
 // --- Radius lookup returns a finite size per role.
-const radiusRoles = ["edge", "centerline", "tdz", "reil", "approach", "taxiway-centerline"] as const;
+const radiusRoles = ["edge", "centerline", "end-side", "tdz", "reil", "approach", "taxiway-centerline"] as const;
 for (const role of radiusRoles) {
   assert.ok(Number.isFinite(runwayLightRadius(role)), `radius for ${role}`);
 }

--- a/src/features/airport/map/runwayLightingModel.ts
+++ b/src/features/airport/map/runwayLightingModel.ts
@@ -39,6 +39,7 @@ export type LightRole =
   | "centerline-red"
   | "threshold"
   | "end"
+  | "end-side"
   | "tdz"
   | "reil"
   | "approach"
@@ -56,6 +57,7 @@ const ROLE_RADIUS_BUCKET: Record<LightRole, keyof typeof C.radius> = {
   "centerline-red": "centerline",
   threshold: "endBar",
   end: "endBar",
+  "end-side": "endBar",
   tdz: "tdz",
   reil: "reil",
   approach: "approach",
@@ -265,6 +267,28 @@ const runwayLightFeatures = (
       }) as Coordinate2D;
       for (let i = 0; i < C.endBarLightCount; i += 1) {
         features.push(barLight(endBarCoord, i, C.endBarLightCount, "end", "red"));
+      }
+      for (const sideSign of [-1, 1]) {
+        for (let i = 0; i < C.endSideLightCount; i += 1) {
+          const longitudinal = -ftToM((i + 1) * C.endSideLightSpacingFt);
+          const lateral = sideSign * (halfWidthMeters + ftToM(C.endSideLightOffsetFt));
+          const center = coordinateFromVectorMeters({
+            end: thresholdEnd,
+            vector: vectorOut,
+            distance: longitudinal,
+          }) as Coordinate2D;
+          features.push(
+            feature(offsetCoordinate(center, vectorOut, lateral), {
+              role: "end-side",
+              color: "red",
+              runwayId: runway.id,
+              runwayEnd: end.ident,
+              side: sideSign < 0 ? "left" : "right",
+              lightIndex: i,
+              minBand: "near",
+            }),
+          );
+        }
       }
 
       // ALS approach centerline dots, extending outward from the threshold.


### PR DESCRIPTION
## Summary
- Tune Near airport maps to 13.5 fractional zoom for the 0.5 NM inspection view
- Render runway/taxiway lights as smaller micro-dots with reduced glow and denser spacing
- Add subtle red runway-end side cues and bump ADSBao to v2.13.1 with changelog entry

## Test Plan
- pnpm typecheck
- pnpm test
- pnpm lint (0 errors, existing warnings)
- pnpm knip
- pnpm build
- git diff --check
- Playwright screenshots: KBOS Near / 0.5 NM in dark and light themes