### PR TITLE
Fix mobile landscape safe areas and previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.15.0",
+  "version": "2.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -1,4 +1,5 @@
 import { lazy, useEffect, useState } from "react";
+import type { CSSProperties } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import AircraftPreviewMediaCard from "./AircraftPreviewMediaCard";
 import AircraftPreviewMetadataCard from "./AircraftPreviewMetadataCard";
@@ -46,6 +47,8 @@ export default function AircraftPreviewCard({
   onApplyTemporaryRoute,
   onDismiss,
   suppressMobileWhenAlreadyTracking = false,
+  preferMobilePreview = false,
+  safeAreaInsets = null,
 }) {
   const { t } = useI18n();
   const selectedTrace = useSelectedAircraftTrace();
@@ -92,11 +95,30 @@ export default function AircraftPreviewCard({
     !sidebarOpen &&
     Boolean(entity) &&
     !(suppressMobileWhenAlreadyTracking && alreadyTracking);
+  const showPreferredMobilePreview =
+    preferMobilePreview && !isMobile && Boolean(entity);
+  const showMobilePreview = showMobile || showPreferredMobilePreview;
+  const mobilePreviewSafeAreaStyle = showPreferredMobilePreview
+    ? ({
+        "--mobile-preview-safe-left": `${Math.max(
+          0,
+          Number(safeAreaInsets?.left || 0),
+        )}px`,
+        "--mobile-preview-safe-right": `${Math.max(
+          0,
+          Number(safeAreaInsets?.right || 0),
+        )}px`,
+        "--mobile-preview-safe-bottom": `${Math.max(
+          0,
+          Number(safeAreaInsets?.bottom || 0),
+        )}px`,
+      } as CSSProperties)
+    : undefined;
   const traceStatusSurfaceActive =
     isAircraftPreview &&
     Boolean(aircraftIdentity) &&
     Boolean(entity) &&
-    (isMobile ? showMobile : !isMobile);
+    (isMobile ? showMobile : showPreferredMobilePreview || !preferMobilePreview);
   const { visible: traceStatusVisible, state: traceAsyncState } =
     useAircraftTraceAsyncStatus({
       aircraftIdentity,
@@ -124,7 +146,7 @@ export default function AircraftPreviewCard({
   // enough that a normal Leaflet pan doesn't trigger; the user has to
   // flick up >100px in <600ms. Only registered when `onDismiss` is
   // wired AND the mobile card is currently visible.
-  useSwipeUpToDismiss(showMobile && typeof onDismiss === "function", () => {
+  useSwipeUpToDismiss(showMobilePreview && typeof onDismiss === "function", () => {
     onDismiss?.();
   });
 
@@ -136,7 +158,7 @@ export default function AircraftPreviewCard({
   const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
   const aircraftCallsign = (aircraft?.callsign || "").trim().toUpperCase();
   const showMobileFeedbackTrigger =
-    showMobile &&
+    showMobilePreview &&
     !isAirport &&
     !isNavaid &&
     Boolean(aircraftCallsign) &&
@@ -144,7 +166,7 @@ export default function AircraftPreviewCard({
   const planeHunterDeviceAllowed = usePlaneHunterDeviceAllowed();
   const showPlaneHunterTrigger =
     planeHunterDeviceAllowed && isAircraftPreview && Boolean(entity);
-  const showMobilePlaneHunterTrigger = showMobile && showPlaneHunterTrigger;
+  const showMobilePlaneHunterTrigger = showMobilePreview && showPlaneHunterTrigger;
   const mobileFeedbackLabel = aircraft?.flightRouteLabel
     ? t("routeFeedback.suggestCorrection")
     : t("routeFeedback.suggestRight");
@@ -176,7 +198,7 @@ export default function AircraftPreviewCard({
 
   return (
     <>
-      {entity && !isMobile && (
+      {entity && !isMobile && !preferMobilePreview && (
         <aside
           key={identityKey}
           className={`aircraft-preview-card app-preview-transition aircraft-preview-card--desktop-reveal ${
@@ -221,11 +243,13 @@ export default function AircraftPreviewCard({
           )}
         </aside>
       )}
-      {showMobile && (
+      {showMobilePreview && (
         <MobilePreviewCard
           key={`mobile-${identityKey}`}
           ariaLabel={previewAriaLabel}
           compact={!isAirport && !isNavaid && !isAirspace && !isCandidateWatchingSpot}
+          placement={showPreferredMobilePreview ? "bottomRight" : "top"}
+          style={mobilePreviewSafeAreaStyle}
           actions={
             (showMobileTrackButton || showMobilePlaneHunterTrigger || showMobileFeedbackTrigger) ? (
               <MobilePreviewActions>

--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -20,6 +20,8 @@ export default function MobilePreviewCard({
   children,
   actions = null,
   compact = false,
+  placement = "top",
+  style,
 }: Record<string, any>) {
   // NOTE: the enter animation replays on entity change via a `key` on the
   // *call site* (<MobilePreviewCard key=...>), not a prop here — a `key`
@@ -28,11 +30,23 @@ export default function MobilePreviewCard({
     <aside
       aria-label={ariaLabel}
       data-density={compact ? "compact" : undefined}
+      data-placement={placement === "bottomRight" ? "bottom-right" : "top"}
       data-ui="mobile-preview-card"
+      style={style}
       className={cn(
-        "fixed left-1/2 z-popover",
-        "top-[calc(12px+env(safe-area-inset-top))]",
-        "w-[min(342px,calc(100vw-24px))] max-w-[calc(100vw-24px)]",
+        "fixed z-popover",
+        placement === "bottomRight"
+          ? [
+              "bottom-[calc(12px+var(--mobile-preview-safe-bottom,env(safe-area-inset-bottom)))]",
+              "right-[calc(12px+var(--mobile-preview-safe-right,env(safe-area-inset-right)))]",
+              "w-[min(332px,calc(100vw-24px-var(--mobile-preview-safe-left,0px)-var(--mobile-preview-safe-right,0px)))]",
+              "max-w-[calc(100vw-24px-var(--mobile-preview-safe-left,0px)-var(--mobile-preview-safe-right,0px))]",
+            ]
+          : [
+              "left-1/2",
+              "top-[calc(12px+env(safe-area-inset-top))]",
+              "w-[min(342px,calc(100vw-24px))] max-w-[calc(100vw-24px)]",
+            ],
         "isolate overflow-hidden select-none pointer-events-none",
         "app-preview-transition mobile-preview-card-enter",
         "rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] text-atc-text",
@@ -49,8 +63,9 @@ export default function MobilePreviewCard({
         // actions row so the gap around the Track button reads as
         // equal on the left, right, and bottom.
         "flex flex-col gap-[3px] pb-[14px]",
-        compact &&
+        compact && placement !== "bottomRight" &&
           "top-[calc(10px+env(safe-area-inset-top))] w-[min(332px,calc(100vw-20px))] max-w-[calc(100vw-20px)] gap-0 pb-[10px]",
+        compact && placement === "bottomRight" && "gap-0 pb-[10px]",
       )}
     >
       {children}

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -32,6 +32,7 @@ import { useCandidateWatchingSpots } from "@/features/airport/watcher/useCandida
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUserLocationAircraftAudio } from "@/hooks/useUserLocationAircraftAudio";
 import { useWakeLock } from "@/hooks/useWakeLock";
+import { resolveClientDeviceLayoutProfile } from "@/features/app-shell/device/clientDeviceModel";
 import { MAP_MODE_IDS } from "@/features/airport/map-settings/mapSettingsModel";
 import { ZOOM_APPROACH, ZOOM_DETAIL } from "@/utils/airportMapDisplay";
 
@@ -457,22 +458,12 @@ function AirportExplorerContent({
       {...toolbarContextProps}
     />
   );
-  const clientDeviceOrientation = clientDeviceProfile?.orientation || "unknown";
-  const clientDeviceIsMobile = clientDeviceProfile?.isMobileDevice === true;
-  const clientDeviceHasHorizontalObstruction =
-    clientDeviceProfile?.hasHorizontalViewportObstruction === true;
-  const clientDeviceIsLandscape = clientDeviceOrientation === "landscape";
-  const sidebarSafeOffsetLeftPx =
-    !isMobile && clientDeviceIsLandscape && clientDeviceHasHorizontalObstruction
-      ? Math.max(0, Number(clientDeviceProfile?.safeAreaInsets?.left || 0))
-      : 0;
-  const useWholeSidebarScroll =
-    !isMobile && clientDeviceIsMobile && clientDeviceIsLandscape;
-  const mapShellStyle = sidebarSafeOffsetLeftPx > 0
-    ? ({
-        "--airport-sidebar-safe-offset-left": `${sidebarSafeOffsetLeftPx}px`,
-      } as CSSProperties)
-    : undefined;
+  const clientDeviceLayout = resolveClientDeviceLayoutProfile({
+    isMobileLayout: isMobile,
+    profile: clientDeviceProfile,
+  });
+  const mapShellStyle =
+    clientDeviceLayout.safeAreaCssVariables as CSSProperties | undefined;
   const sidebarProps = {
     icao: airportProfile.icao,
     iata: airportProfile.iata,
@@ -514,7 +505,7 @@ function AirportExplorerContent({
     onBack,
     onMap: closeSidebar,
     mobileToolbar: mobileSidebarToolbar,
-    fillAircraftList: !useWholeSidebarScroll,
+    fillAircraftList: !clientDeviceLayout.useDesktopMobileLandscapeLayout,
   };
 
   return (
@@ -536,14 +527,20 @@ function AirportExplorerContent({
             airportProfile={airportProfile}
             onApplyTemporaryRoute={traffic.applyTemporaryRoute}
             onDismiss={clearAllPreviewSelections}
+            preferMobilePreview={
+              clientDeviceLayout.useDesktopMobileLandscapeLayout
+            }
+            safeAreaInsets={clientDeviceLayout.safeAreaInsets}
           />
         </Suspense>
       )}
       <div
-        data-client-orientation={clientDeviceOrientation}
-        data-client-mobile-device={clientDeviceIsMobile ? "true" : "false"}
+        data-client-orientation={clientDeviceLayout.orientation}
+        data-client-mobile-device={
+          clientDeviceLayout.isMobileDevice ? "true" : "false"
+        }
         data-client-horizontal-obstruction={
-          clientDeviceHasHorizontalObstruction ? "true" : "false"
+          clientDeviceLayout.hasHorizontalViewportObstruction ? "true" : "false"
         }
         style={mapShellStyle}
         className={`font-sans text-atc-text ${

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 import { useNavigate } from "react-router-dom";
 import FlightSidebar from "@/components/sidebar/FlightSidebar";
 import ExplorerMapMenu from "@/components/explorer/ExplorerMapMenu";
@@ -48,6 +49,7 @@ import { useNearbyAirports } from "@/hooks/useNearbyAirports";
 import { useTrackedAircraft } from "@/hooks/useTrackedAircraft";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel";
+import { resolveClientDeviceLayoutProfile } from "@/features/app-shell/device/clientDeviceModel";
 import { normalizeCallsign } from "@/utils/callsign";
 import { formatFlightRouteLabel } from "@/utils/flightRouteDisplay";
 import { getDistanceNm } from "@/utils/aircraftTrafficIntent";
@@ -84,6 +86,7 @@ function FlightExplorerContent({ callsign }) {
   const routeProvider = resolveRouteProvider({ flightAwareEnabled });
   const {
     desktopSidebarWidth,
+    clientDeviceProfile,
     sidebarOpen,
     isMobile,
     mapZoom,
@@ -781,6 +784,12 @@ function FlightExplorerContent({ callsign }) {
       {...toolbarContextProps}
     />
   );
+  const clientDeviceLayout = resolveClientDeviceLayoutProfile({
+    isMobileLayout: isMobile,
+    profile: clientDeviceProfile,
+  });
+  const mapShellStyle =
+    clientDeviceLayout.safeAreaCssVariables as CSSProperties | undefined;
 
   const sidebarProps = {
     callsign,
@@ -801,6 +810,7 @@ function FlightExplorerContent({ callsign }) {
     onBack: handleBack,
     onMap: closeSidebar,
     mobileToolbar: mobileSidebarToolbar,
+    fillAircraftList: !clientDeviceLayout.useDesktopMobileLandscapeLayout,
   };
 
   return (
@@ -824,8 +834,18 @@ function FlightExplorerContent({ callsign }) {
         sidebarOpen={sidebarOpen}
         onApplyTemporaryRoute={applyTemporaryRoute}
         onDismiss={clearAllPreviewSelections}
+        preferMobilePreview={clientDeviceLayout.useDesktopMobileLandscapeLayout}
+        safeAreaInsets={clientDeviceLayout.safeAreaInsets}
       />
       <div
+        data-client-orientation={clientDeviceLayout.orientation}
+        data-client-mobile-device={
+          clientDeviceLayout.isMobileDevice ? "true" : "false"
+        }
+        data-client-horizontal-obstruction={
+          clientDeviceLayout.hasHorizontalViewportObstruction ? "true" : "false"
+        }
+        style={mapShellStyle}
         className={`font-sans text-atc-text ${
           isMobile
             ? "app-detail-shell fixed inset-0 z-0 flex overflow-hidden overscroll-y-none"

--- a/src/components/map/MapRangeLegend.tsx
+++ b/src/components/map/MapRangeLegend.tsx
@@ -26,12 +26,17 @@ export default function MapRangeLegend() {
     if (!map || !map.getContainer?.() || typeof map.getSize !== "function") return;
 
     const update = () => {
-      const size = map.getSize();
-      if (!size?.x || !size?.y) return;
-      const midY = size.y / 2;
-      const left = map.containerPointToLatLng([0, midY]);
-      const right = map.containerPointToLatLng([DESKTOP_TARGET_PX, midY]);
-      const meters = map.distance(left, right);
+      let meters = 0;
+      try {
+        const size = map.getSize();
+        if (!size?.x || !size?.y) return;
+        const midY = size.y / 2;
+        const left = map.containerPointToLatLng([0, midY]);
+        const right = map.containerPointToLatLng([DESKTOP_TARGET_PX, midY]);
+        meters = map.distance(left, right);
+      } catch {
+        return;
+      }
       if (!Number.isFinite(meters) || meters <= 0) return;
       const nmPerPx = meters / METERS_PER_NM / DESKTOP_TARGET_PX;
 
@@ -45,11 +50,16 @@ export default function MapRangeLegend() {
       setScale({ desktopNm: dNm, desktopPx: dNm / nmPerPx, mobileNm: mNm, mobilePx: mNm / nmPerPx });
     };
 
-    update();
+    const frame = window.requestAnimationFrame(update);
     map.on("zoomend", update);
     map.on("moveend", update);
     map.on("resize", update);
-    return () => { map.off("zoomend", update); map.off("moveend", update); map.off("resize", update); };
+    return () => {
+      window.cancelAnimationFrame(frame);
+      map.off("zoomend", update);
+      map.off("moveend", update);
+      map.off("resize", update);
+    };
   }, [map]);
 
   if (!scale) return null;

--- a/src/components/sidebar/FlightSidebar.tsx
+++ b/src/components/sidebar/FlightSidebar.tsx
@@ -44,6 +44,7 @@ export default function FlightSidebar({
   onMap = null,
   onClose = null,
   mobileToolbar = null,
+  fillAircraftList = true,
 }) {
   const { t } = useI18n();
   const isMobileOverlay = Boolean(onClose);
@@ -112,7 +113,7 @@ export default function FlightSidebar({
           suppressSelectedAircraftDistance
           onSelectAircraft={onSelectAircraft}
           onSelectAirport={onSelectAirport}
-          fill={!isMobileOverlay}
+          fill={fillAircraftList && !isMobileOverlay}
         />
       ) : null}
     </SidebarShell>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.15.1",
+    kind: "patch",
+    title: {
+      en: "Landscape safe-area polish",
+      zh: "横屏安全区打磨",
+    },
+    summary: {
+      en: "Landscape mobile map pages now share the same safe-area handling and use the compact mobile preview when the desktop sidebar is active.",
+      zh: "移动设备横屏地图页现在复用同一套安全区处理，并在桌面侧栏布局下改用紧凑移动预览卡。",
+    },
+    highlights: [
+      {
+        en: "Airport and flight detail pages offset the sidebar or map controls based on the active left or right safe-area inset",
+        zh: "机场页和航班页会按当前左侧或右侧 safe-area inset 偏置侧栏与地图控件",
+      },
+      {
+        en: "Reversed landscape orientation follows the obstruction side instead of assuming the same edge every time",
+        zh: "反向横屏时会跟随遮挡所在一侧，不再固定假设同一边",
+      },
+      {
+        en: "Landscape phones keep aircraft previews compact in the lower-right corner instead of opening the taller desktop preview",
+        zh: "手机横屏时飞机预览保持右下角紧凑移动卡片，不再打开较高的桌面预览",
+      },
+    ],
+  },
+  {
     version: "v2.15.0",
     kind: "feat",
     title: {

--- a/src/features/airport/context/useAviationContextTiles.ts
+++ b/src/features/airport/context/useAviationContextTiles.ts
@@ -66,20 +66,26 @@ export function useAviationContextTiles({
     }
 
     const updateTiles = () => {
-      const nextTiles = getContextTilesForBounds({
-        bounds: map.getBounds?.(),
-        zoom: map.getZoom?.(),
-      });
+      let nextTiles = [];
+      try {
+        nextTiles = getContextTilesForBounds({
+          bounds: map.getBounds?.(),
+          zoom: map.getZoom?.(),
+        });
+      } catch {
+        return;
+      }
       const signature = nextTiles.map(tileSignature).join("|");
       if (signature === lastTileSignatureRef.current) return;
       lastTileSignatureRef.current = signature;
       setTiles(nextTiles);
     };
 
-    updateTiles();
+    const frame = window.requestAnimationFrame(updateTiles);
     map.on?.("moveend", updateTiles);
     map.on?.("zoomend", updateTiles);
     return () => {
+      window.cancelAnimationFrame(frame);
       map.off?.("moveend", updateTiles);
       map.off?.("zoomend", updateTiles);
     };

--- a/src/features/app-shell/device/clientDeviceModel.test.ts
+++ b/src/features/app-shell/device/clientDeviceModel.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  resolveClientDeviceLayoutProfile,
   resolveClientDeviceProfile,
 } from "./clientDeviceModel";
 
@@ -22,6 +23,39 @@ import {
   assert.equal(profile.isMobileDevice, true);
   assert.equal(profile.hasCamera, true);
   assert.equal(profile.hasHorizontalViewportObstruction, true);
+
+  const layout = resolveClientDeviceLayoutProfile({
+    isMobileLayout: false,
+    profile,
+  });
+  assert.equal(layout.useDesktopMobileLandscapeLayout, true);
+  assert.deepEqual(layout.safeAreaCssVariables, {
+    "--app-safe-area-left": "47px",
+    "--app-safe-area-right": "47px",
+    "--app-safe-area-bottom": "21px",
+  });
+}
+
+{
+  const profile = resolveClientDeviceProfile({
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1",
+    platform: "iPhone",
+    maxTouchPoints: 5,
+    viewport: { width: 852, height: 393 },
+    safeAreaInsets: { top: "0px", right: "47px", bottom: "21px", left: "0px" },
+  });
+  const layout = resolveClientDeviceLayoutProfile({
+    isMobileLayout: false,
+    profile,
+  });
+
+  assert.equal(layout.useDesktopMobileLandscapeLayout, true);
+  assert.deepEqual(layout.safeAreaCssVariables, {
+    "--app-safe-area-left": "0px",
+    "--app-safe-area-right": "47px",
+    "--app-safe-area-bottom": "21px",
+  });
 }
 
 {
@@ -57,4 +91,11 @@ import {
   assert.equal(profile.isMobileDevice, false);
   assert.equal(profile.hasCamera, true);
   assert.equal(profile.hasHorizontalViewportObstruction, false);
+  assert.equal(
+    resolveClientDeviceLayoutProfile({
+      isMobileLayout: false,
+      profile,
+    }).useDesktopMobileLandscapeLayout,
+    false,
+  );
 }

--- a/src/features/app-shell/device/clientDeviceModel.ts
+++ b/src/features/app-shell/device/clientDeviceModel.ts
@@ -59,6 +59,15 @@ export type ClientDeviceProfile = {
   safeAreaInsets: ClientDeviceSafeAreaInsets;
 };
 
+export type ClientDeviceLayoutProfile = {
+  orientation: ClientDeviceOrientation;
+  isMobileDevice: boolean;
+  hasHorizontalViewportObstruction: boolean;
+  safeAreaInsets: ClientDeviceSafeAreaInsets;
+  safeAreaCssVariables?: Record<string, string>;
+  useDesktopMobileLandscapeLayout: boolean;
+};
+
 const EMPTY_SAFE_AREA_INSETS: ClientDeviceSafeAreaInsets = Object.freeze({
   top: 0,
   right: 0,
@@ -216,6 +225,43 @@ export function resolveClientDeviceProfile(
     hasHorizontalViewportObstruction:
       safeAreaInsets.left > 0 || safeAreaInsets.right > 0,
     safeAreaInsets,
+  };
+}
+
+export function resolveClientDeviceLayoutProfile({
+  isMobileLayout = false,
+  profile,
+}: {
+  isMobileLayout?: boolean;
+  profile: ClientDeviceProfile | null | undefined;
+}): ClientDeviceLayoutProfile {
+  const orientation = profile?.orientation || "unknown";
+  const isMobileDevice = profile?.isMobileDevice === true;
+  const hasHorizontalViewportObstruction =
+    profile?.hasHorizontalViewportObstruction === true;
+  const safeAreaInsets =
+    orientation === "landscape" && hasHorizontalViewportObstruction
+      ? normalizeSafeAreaInsets(profile?.safeAreaInsets)
+      : EMPTY_SAFE_AREA_INSETS;
+  const shouldApplySafeAreaVariables =
+    orientation === "landscape" && hasHorizontalViewportObstruction;
+  const useDesktopMobileLandscapeLayout =
+    !isMobileLayout && isMobileDevice && orientation === "landscape";
+  const safeAreaCssVariables = shouldApplySafeAreaVariables
+    ? {
+        "--app-safe-area-left": `${safeAreaInsets.left}px`,
+        "--app-safe-area-right": `${safeAreaInsets.right}px`,
+        "--app-safe-area-bottom": `${safeAreaInsets.bottom}px`,
+      }
+    : undefined;
+
+  return {
+    orientation,
+    isMobileDevice,
+    hasHorizontalViewportObstruction,
+    safeAreaInsets,
+    safeAreaCssVariables,
+    useDesktopMobileLandscapeLayout,
   };
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -259,6 +259,17 @@
     }
 }
 
+@keyframes mobile-preview-card-enter-bottom-right {
+    from {
+        opacity: 0;
+        transform: translateY(14px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 .candidate-watching-spot-preview-motion {
     animation: candidate-watching-spot-preview-enter 380ms
         cubic-bezier(0.22, 1, 0.36, 1) both;
@@ -299,6 +310,11 @@
     transform: translate(-50%, 0);
     animation: mobile-preview-card-enter var(--motion-ui-med)
         var(--motion-ease-out) both;
+}
+
+.mobile-preview-card-enter[data-placement="bottom-right"] {
+    transform: translateY(0);
+    animation-name: mobile-preview-card-enter-bottom-right;
 }
 
 .mobile-trace-status-dot {
@@ -7174,7 +7190,7 @@ body {
 
 .airport-map-kit[data-client-horizontal-obstruction="true"][data-client-orientation="landscape"]
     .airport-desktop-sidebar {
-    left: calc(var(--map-kit-inset) + var(--airport-sidebar-safe-offset-left, 0px));
+    left: calc(var(--map-kit-inset) + var(--app-safe-area-left, 0px));
 }
 
 .airport-map-kit--sidebar-open .airport-desktop-sidebar {
@@ -7226,7 +7242,8 @@ body {
     background: transparent;
     border: 0;
     height: auto;
-    inset: var(--map-kit-inset) var(--map-kit-inset) auto auto;
+    inset: var(--map-kit-inset)
+        calc(var(--map-kit-inset) + var(--app-safe-area-right, 0px)) auto auto;
     padding: 0;
     transform: none;
 }


### PR DESCRIPTION
## Summary
- Share mobile-landscape safe-area handling across airport and flight map pages, including left/right obstruction changes after rotation.
- Use the compact mobile aircraft preview in the bottom-right when a mobile device is in landscape desktop-sidebar layout.
- Bump the app patch version to v2.15.1 and add the changelog entry.
- Guard early Leaflet geometry reads that could crash the flight detail page before the map pane finishes initializing.

## Validation
- Ponytail audit on PR diff: Lean already. Ship.
- `pnpm exec tsx src/features/app-shell/device/clientDeviceModel.test.ts`
- `pnpm exec tsx src/features/airport/map-settings/mapSettingsModel.test.ts`
- `pnpm exec tsx src/features/aircraft/preview/planeHunterDeviceModel.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with 12 existing warnings)
- `pnpm test` (116 test files passed)
- `pnpm build`
- Local debug restart: `/adsbao-version.json` returns `2.15.1`
- Playwright/Chrome validation:
  - KBOS desktop keeps desktop preview and hides Plane Hunter.
  - KBOS iPhone landscape left obstruction: sidebar left 59px, map menu right 13px, mobile preview right 12px, Plane Hunter visible.
  - KBOS iPhone landscape right obstruction: sidebar left 12px, map menu right 60px, mobile preview right 59px, Plane Hunter visible.
  - KBOS iPad landscape uses bottom-right mobile preview.
  - Flight detail iPhone landscape left/right obstruction uses the same safe-area offsets with no page errors.