### PR TITLE
Fix home landscape safe areas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.15.1",
+  "version": "2.15.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import type { CSSProperties } from "react";
 import { useLocation } from "react-router-dom";
 import BrandingVideoBackground from "@/components/effects/BrandingVideoBackground";
 import PageNavigationDock from "@/components/navigation/PageNavigationDock";
@@ -6,6 +7,8 @@ import SidebarBrandMark from "@/components/sidebar/SidebarBrandMark";
 import { CHANGELOG } from "@/config/changelog";
 import { SITE_DESCRIPTION } from "@/config/site";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { resolveClientDeviceLayoutProfile } from "@/features/app-shell/device/clientDeviceModel";
+import { useClientDeviceProfile } from "@/features/app-shell/device/useClientDeviceProfile";
 import { usePageEntrance } from "@/animations/usePageEntrance";
 
 export default function DitherPageShell({
@@ -17,6 +20,14 @@ export default function DitherPageShell({
   const { locale, t } = useI18n();
   const { pathname } = useLocation();
   const shellRef = useRef<HTMLDivElement>(null);
+  const clientDeviceProfile = useClientDeviceProfile({
+    includeSafeAreaInsets: true,
+  });
+  const clientDeviceLayout = resolveClientDeviceLayoutProfile({
+    profile: clientDeviceProfile,
+  });
+  const shellStyle =
+    clientDeviceLayout.safeAreaCssVariables as CSSProperties | undefined;
   const routeChrome = resolveRouteChrome(pathname, t);
   usePageEntrance(shellRef, {
     triggerKey: `${routeChrome.key}:${locale}`,
@@ -40,6 +51,14 @@ export default function DitherPageShell({
   return (
     <div
       ref={shellRef}
+      data-client-orientation={clientDeviceLayout.orientation}
+      data-client-mobile-device={
+        clientDeviceLayout.isMobileDevice ? "true" : "false"
+      }
+      data-client-horizontal-obstruction={
+        clientDeviceLayout.hasHorizontalViewportObstruction ? "true" : "false"
+      }
+      style={shellStyle}
       className={`dither-page-shell flex h-screen text-atc-text ${resolvedClassName}`.trim()}
     >
       <PageNavigationDock />

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -11,9 +11,8 @@ import {
 import { useAuth, useUser } from "@/platform/auth/clerkClient";
 import { AIRPORT_EXPLORER_UI_CONFIG } from "@/config/aviation";
 import {
-  getClientDeviceSnapshot,
-  resolveClientDeviceProfile,
-} from "@/features/app-shell/device/clientDeviceModel";
+  useClientDeviceProfile,
+} from "@/features/app-shell/device/useClientDeviceProfile";
 import {
   DEFAULT_AIRPORT_EXPLORER_UI_STATE,
   resolveSelectedAirspaceIdForLayerVisibility,
@@ -47,11 +46,6 @@ import {
 const ExplorerUiContext = createContext(null);
 const DEFAULT_USER_LOCATION_PREFERENCES =
   mapSettingsToUserLocationPreferences(DEFAULT_MAP_SETTINGS);
-
-const getCurrentClientDeviceProfile = (includeSafeAreaInsets = false) =>
-  resolveClientDeviceProfile(
-    getClientDeviceSnapshot({ includeSafeAreaInsets }),
-  );
 
 const initialUiState = {
   ...DEFAULT_AIRPORT_EXPLORER_UI_STATE,
@@ -373,9 +367,9 @@ export function ExplorerUiProvider({ children }) {
   const [mapSettingsSaveStatus, setMapSettingsSaveStatus] = useState("idle");
   const [mapSettingsSaveStatusCode, setMapSettingsSaveStatusCode] = useState<number | null>(null);
   const [mapSettingsSaveCycle, setMapSettingsSaveCycle] = useState(0);
-  const [clientDeviceProfile, setClientDeviceProfile] = useState(() =>
-    getCurrentClientDeviceProfile(true),
-  );
+  const clientDeviceProfile = useClientDeviceProfile({
+    includeSafeAreaInsets: true,
+  });
   const [state, dispatch] = useReducer(
     airportExplorerUiReducer,
     initialUiState,
@@ -422,27 +416,10 @@ export function ExplorerUiProvider({ children }) {
   }, [getToken]);
 
   useEffect(() => {
-    const syncClientDeviceProfile = () => {
-      setClientDeviceProfile(getCurrentClientDeviceProfile(true));
-    };
-
-    syncClientDeviceProfile();
-    window.addEventListener("resize", syncClientDeviceProfile);
-    window.addEventListener("orientationchange", syncClientDeviceProfile);
-    window.visualViewport?.addEventListener("resize", syncClientDeviceProfile);
-
-    return () => {
-      window.removeEventListener("resize", syncClientDeviceProfile);
-      window.removeEventListener("orientationchange", syncClientDeviceProfile);
-      window.visualViewport?.removeEventListener("resize", syncClientDeviceProfile);
-    };
-  }, []);
-
-  useEffect(() => {
     const syncSidebarMode = () => {
       dispatch({
         type: "setSidebarMode",
-        sidebarMode: getAirportSidebarMode(window.innerWidth),
+        sidebarMode: getAirportSidebarMode(window.innerWidth, clientDeviceProfile),
       });
     };
 
@@ -450,7 +427,7 @@ export function ExplorerUiProvider({ children }) {
     window.addEventListener("resize", syncSidebarMode);
 
     return () => window.removeEventListener("resize", syncSidebarMode);
-  }, []);
+  }, [clientDeviceProfile]);
 
   useEffect(() => {
     setMapSettingsSaveStatus("idle");

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.15.2",
+    kind: "patch",
+    title: {
+      en: "Home landscape safe area",
+      zh: "主页横屏安全区",
+    },
+    summary: {
+      en: "Home and map pages now keep the sidebar layout consistent on landscape phones with left or right safe-area obstructions.",
+      zh: "主页和地图页现在会在手机横屏左右安全区遮挡下保持一致的侧栏布局。",
+    },
+    highlights: [
+      {
+        en: "The home sidebar offsets from the active landscape safe-area edge instead of staying pinned to the physical screen edge",
+        zh: "主页侧栏横屏时会避开当前 safe-area 边缘，不再贴住物理屏幕边",
+      },
+      {
+        en: "Landscape mobile airport views stay in desktop-sidebar mode instead of occasionally falling into the mobile map-only toolbar state",
+        zh: "移动设备横屏机场页会保持桌面侧栏布局，不再偶发落入只有地图和移动工具栏的状态",
+      },
+    ],
+  },
+  {
     version: "v2.15.1",
     kind: "patch",
     title: {

--- a/src/features/app-shell/device/useClientDeviceProfile.ts
+++ b/src/features/app-shell/device/useClientDeviceProfile.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import {
+  getClientDeviceSnapshot,
+  resolveClientDeviceProfile,
+} from "./clientDeviceModel";
+
+export const getCurrentClientDeviceProfile = (includeSafeAreaInsets = false) =>
+  resolveClientDeviceProfile(
+    getClientDeviceSnapshot({ includeSafeAreaInsets }),
+  );
+
+export function useClientDeviceProfile({
+  includeSafeAreaInsets = false,
+}: {
+  includeSafeAreaInsets?: boolean;
+} = {}) {
+  const [profile, setProfile] = useState(() =>
+    getCurrentClientDeviceProfile(includeSafeAreaInsets),
+  );
+
+  useEffect(() => {
+    const syncProfile = () => {
+      setProfile(getCurrentClientDeviceProfile(includeSafeAreaInsets));
+    };
+
+    syncProfile();
+    window.addEventListener("resize", syncProfile);
+    window.addEventListener("orientationchange", syncProfile);
+    window.visualViewport?.addEventListener("resize", syncProfile);
+
+    return () => {
+      window.removeEventListener("resize", syncProfile);
+      window.removeEventListener("orientationchange", syncProfile);
+      window.visualViewport?.removeEventListener("resize", syncProfile);
+    };
+  }, [includeSafeAreaInsets]);
+
+  return profile;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -2228,6 +2228,11 @@ body:has(.app-detail-shell) {
         display: none;
     }
 
+    .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
+        .airport-desktop-sidebar {
+        display: block;
+    }
+
     .flight-sidebar-panel .airport-sidebar-identity__rule {
         display: none;
     }
@@ -3097,6 +3102,16 @@ body {
 .dither-page-background {
     margin: 12px 12px 12px 0;
     border-radius: var(--atc-radius-shell);
+}
+
+.dither-page-shell[data-client-horizontal-obstruction="true"][data-client-orientation="landscape"]
+    .dither-page-panel {
+    margin-left: calc(12px + var(--app-safe-area-left, 0px));
+}
+
+.dither-page-shell[data-client-horizontal-obstruction="true"][data-client-orientation="landscape"]
+    .dither-page-background {
+    margin-right: calc(12px + var(--app-safe-area-right, 0px));
 }
 
 .dither-page-background.plane-hunter-stage {
@@ -7477,6 +7492,7 @@ body {
         padding: 0;
     }
 
+    .airport-map-kit .airport-map-menu--mobile,
     .airport-map-menu--mobile {
         align-items: center;
         -webkit-backdrop-filter: none;

--- a/src/utils/sidebarDisplay.test.ts
+++ b/src/utils/sidebarDisplay.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+
+import { getAirportSidebarMode } from "./sidebarDisplay";
+import { resolveClientDeviceProfile } from "@/features/app-shell/device/clientDeviceModel";
+
+{
+  const profile = resolveClientDeviceProfile({
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1",
+    platform: "iPhone",
+    maxTouchPoints: 5,
+    viewport: { width: 667, height: 375 },
+  });
+
+  assert.equal(getAirportSidebarMode(667, profile), "desktop");
+}
+
+{
+  const profile = resolveClientDeviceProfile({
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1",
+    platform: "iPhone",
+    maxTouchPoints: 5,
+    viewport: { width: 375, height: 667 },
+  });
+
+  assert.equal(getAirportSidebarMode(375, profile), "mobile");
+}
+
+assert.equal(getAirportSidebarMode(767), "mobile");
+assert.equal(getAirportSidebarMode(768), "desktop");

--- a/src/utils/sidebarDisplay.ts
+++ b/src/utils/sidebarDisplay.ts
@@ -1,9 +1,16 @@
 import { AIRPORT_EXPLORER_UI_CONFIG } from "../config/aviation";
+import type { ClientDeviceProfile } from "@/features/app-shell/device/clientDeviceModel";
 
 const AIRPORT_SIDEBAR_MOBILE_BREAKPOINT =
   AIRPORT_EXPLORER_UI_CONFIG.mobileBreakpointPx;
 
-export const getAirportSidebarMode = (width) =>
-  Number(width) < AIRPORT_SIDEBAR_MOBILE_BREAKPOINT ? "mobile" : "desktop";
+export const getAirportSidebarMode = (
+  width,
+  clientDeviceProfile?: ClientDeviceProfile | null,
+) =>
+  clientDeviceProfile?.isMobileDevice &&
+  clientDeviceProfile.orientation === "landscape"
+    ? "desktop"
+    : Number(width) < AIRPORT_SIDEBAR_MOBILE_BREAKPOINT ? "mobile" : "desktop";
 
 export const getAirportSidebarOpenForMode = (mode) => mode === "desktop";


### PR DESCRIPTION
## Summary
- Apply the shared client-device safe-area profile to static Dither/home pages so the home sidebar offsets in landscape like airport detail.
- Keep mobile devices in desktop-sidebar mode while landscape, including narrow iPhone landscape widths.
- Fix the mobile map-toolbar specificity fallback so portrait mobile remains a bottom toolbar instead of the mixed top-toolbar state.
- Bump to v2.15.2 and add the changelog entry.

## Validation
- Ponytail audit on PR diff: lean already; no simplification cut found.
- `pnpm exec tsx src/utils/sidebarDisplay.test.ts`
- `pnpm exec tsx src/features/app-shell/device/clientDeviceModel.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with 12 existing warnings)
- `pnpm test` (117 test files passed)
- `pnpm build`
- Local debug restart: `/adsbao-version.json` returns `2.15.2`
- Playwright/Chrome validation:
  - Home iPhone landscape left obstruction: home panel left 59px.
  - Home iPhone landscape right obstruction: background right 59px while panel stays left 12px.
  - KBOS 667px iPhone landscape stays in desktop sidebar map kit; sidebar left 63px, desktop map menu, no open-details button.
  - KBOS portrait mobile remains map-only with bottom mobile toolbar.