### PR TITLE
Stabilize layout recovery after rotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.15.2",
+  "version": "2.15.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -68,6 +68,24 @@ const initialUiState = {
   mapFollowsAircraft: true,
 };
 
+function getCurrentAirportSidebarMode(clientDeviceProfile) {
+  if (typeof window === "undefined") return "desktop";
+  return getAirportSidebarMode(
+    window.innerWidth,
+    clientDeviceProfile,
+    window.innerHeight,
+  );
+}
+
+function getInitialUiState(clientDeviceProfile) {
+  const sidebarMode = getCurrentAirportSidebarMode(clientDeviceProfile);
+  return {
+    ...initialUiState,
+    sidebarMode,
+    sidebarOpen: getAirportSidebarOpenForMode(sidebarMode),
+  };
+}
+
 function toggleValue(value) {
   return !value;
 }
@@ -372,7 +390,8 @@ export function ExplorerUiProvider({ children }) {
   });
   const [state, dispatch] = useReducer(
     airportExplorerUiReducer,
-    initialUiState,
+    clientDeviceProfile,
+    getInitialUiState,
   );
   const {
     sidebarMode,
@@ -419,14 +438,36 @@ export function ExplorerUiProvider({ children }) {
     const syncSidebarMode = () => {
       dispatch({
         type: "setSidebarMode",
-        sidebarMode: getAirportSidebarMode(window.innerWidth, clientDeviceProfile),
+        sidebarMode: getCurrentAirportSidebarMode(clientDeviceProfile),
       });
     };
+    const syncSidebarModeWhenVisible = () => {
+      if (document.visibilityState === "visible") syncSidebarMode();
+    };
+    const visualViewport = window.visualViewport;
+    const screenOrientation = window.screen?.orientation;
 
     syncSidebarMode();
     window.addEventListener("resize", syncSidebarMode);
+    window.addEventListener("orientationchange", syncSidebarMode);
+    window.addEventListener("pageshow", syncSidebarMode);
+    window.addEventListener("focus", syncSidebarMode);
+    document.addEventListener("visibilitychange", syncSidebarModeWhenVisible);
+    visualViewport?.addEventListener("resize", syncSidebarMode);
+    screenOrientation?.addEventListener?.("change", syncSidebarMode);
 
-    return () => window.removeEventListener("resize", syncSidebarMode);
+    return () => {
+      window.removeEventListener("resize", syncSidebarMode);
+      window.removeEventListener("orientationchange", syncSidebarMode);
+      window.removeEventListener("pageshow", syncSidebarMode);
+      window.removeEventListener("focus", syncSidebarMode);
+      document.removeEventListener(
+        "visibilitychange",
+        syncSidebarModeWhenVisible,
+      );
+      visualViewport?.removeEventListener("resize", syncSidebarMode);
+      screenOrientation?.removeEventListener?.("change", syncSidebarMode);
+    };
   }, [clientDeviceProfile]);
 
   useEffect(() => {

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.15.3",
+    kind: "patch",
+    title: {
+      en: "Rotation recovery",
+      zh: "旋转恢复稳定性",
+    },
+    summary: {
+      en: "Airport and flight pages now recover their mobile or landscape layout after rotation, reversed orientation, and app focus changes.",
+      zh: "机场页和航班页现在会在旋转、倒转和切出切回后恢复到对应的移动端或横屏布局。",
+    },
+    highlights: [
+      {
+        en: "Portrait phones no longer keep the landscape desktop sidebar when the browser reports a stale visual viewport",
+        zh: "当浏览器短暂保留旧的 visual viewport 时，手机竖屏不会继续停留在横屏桌面侧栏布局",
+      },
+      {
+        en: "The layout profile is resampled after orientation, focus, visibility, and page restore events so safe-area edges settle correctly",
+        zh: "布局 profile 会在旋转、聚焦、可见性变化和页面恢复后重新采样，让 safe-area 方向稳定回正",
+      },
+    ],
+  },
+  {
     version: "v2.15.2",
     kind: "patch",
     title: {

--- a/src/features/app-shell/device/clientDeviceModel.test.ts
+++ b/src/features/app-shell/device/clientDeviceModel.test.ts
@@ -3,7 +3,26 @@ import assert from "node:assert/strict";
 import {
   resolveClientDeviceLayoutProfile,
   resolveClientDeviceProfile,
+  resolveClientViewportSnapshot,
 } from "./clientDeviceModel";
+
+{
+  assert.deepEqual(
+    resolveClientViewportSnapshot({
+      layoutViewport: { width: 393, height: 852 },
+      visualViewport: { width: 852, height: 393 },
+    }),
+    { width: 393, height: 852 },
+  );
+
+  assert.deepEqual(
+    resolveClientViewportSnapshot({
+      layoutViewport: { width: 0, height: 0 },
+      visualViewport: { width: 852, height: 393 },
+    }),
+    { width: 852, height: 393 },
+  );
+}
 
 {
   const profile = resolveClientDeviceProfile({

--- a/src/features/app-shell/device/clientDeviceModel.ts
+++ b/src/features/app-shell/device/clientDeviceModel.ts
@@ -177,6 +177,25 @@ function normalizeSafeAreaInsets(
   };
 }
 
+function normalizeViewport(
+  viewport: ClientDeviceViewport | null | undefined,
+): ClientDeviceViewport | null {
+  const width = toFiniteNumber(viewport?.width);
+  const height = toFiniteNumber(viewport?.height);
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+}
+
+export function resolveClientViewportSnapshot({
+  layoutViewport,
+  visualViewport,
+}: {
+  layoutViewport?: ClientDeviceViewport | null;
+  visualViewport?: ClientDeviceViewport | null;
+}): ClientDeviceViewport | null {
+  return normalizeViewport(layoutViewport) || normalizeViewport(visualViewport);
+}
+
 function resolveHasCamera({
   deviceClass,
   mediaDevices,
@@ -321,10 +340,13 @@ export function getClientDeviceSnapshot({
     viewport:
       typeof window === "undefined"
         ? null
-        : {
-            width: visualViewport?.width || window.innerWidth,
-            height: visualViewport?.height || window.innerHeight,
-          },
+        : resolveClientViewportSnapshot({
+            layoutViewport: {
+              width: window.innerWidth,
+              height: window.innerHeight,
+            },
+            visualViewport,
+          }),
     safeAreaInsets: includeSafeAreaInsets ? readClientSafeAreaInsets() : null,
   };
 }

--- a/src/features/app-shell/device/useClientDeviceProfile.ts
+++ b/src/features/app-shell/device/useClientDeviceProfile.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import {
+  type ClientDeviceProfile,
   getClientDeviceSnapshot,
   resolveClientDeviceProfile,
 } from "./clientDeviceModel";
@@ -8,6 +9,25 @@ export const getCurrentClientDeviceProfile = (includeSafeAreaInsets = false) =>
   resolveClientDeviceProfile(
     getClientDeviceSnapshot({ includeSafeAreaInsets }),
   );
+
+function areClientDeviceProfilesEqual(
+  currentProfile: ClientDeviceProfile,
+  nextProfile: ClientDeviceProfile,
+) {
+  return (
+    currentProfile.deviceClass === nextProfile.deviceClass &&
+    currentProfile.system === nextProfile.system &&
+    currentProfile.orientation === nextProfile.orientation &&
+    currentProfile.isMobileDevice === nextProfile.isMobileDevice &&
+    currentProfile.hasCamera === nextProfile.hasCamera &&
+    currentProfile.hasHorizontalViewportObstruction ===
+      nextProfile.hasHorizontalViewportObstruction &&
+    currentProfile.safeAreaInsets.top === nextProfile.safeAreaInsets.top &&
+    currentProfile.safeAreaInsets.right === nextProfile.safeAreaInsets.right &&
+    currentProfile.safeAreaInsets.bottom === nextProfile.safeAreaInsets.bottom &&
+    currentProfile.safeAreaInsets.left === nextProfile.safeAreaInsets.left
+  );
+}
 
 export function useClientDeviceProfile({
   includeSafeAreaInsets = false,
@@ -19,19 +39,60 @@ export function useClientDeviceProfile({
   );
 
   useEffect(() => {
+    let frameId: number | null = null;
+    let timeoutIds: number[] = [];
+    const visualViewport = window.visualViewport;
+    const screenOrientation = window.screen?.orientation;
+
     const syncProfile = () => {
-      setProfile(getCurrentClientDeviceProfile(includeSafeAreaInsets));
+      setProfile((currentProfile) => {
+        const nextProfile = getCurrentClientDeviceProfile(includeSafeAreaInsets);
+        return areClientDeviceProfilesEqual(currentProfile, nextProfile)
+          ? currentProfile
+          : nextProfile;
+      });
     };
 
-    syncProfile();
-    window.addEventListener("resize", syncProfile);
-    window.addEventListener("orientationchange", syncProfile);
-    window.visualViewport?.addEventListener("resize", syncProfile);
+    const scheduleProfileSync = () => {
+      syncProfile();
+
+      if (frameId != null) window.cancelAnimationFrame(frameId);
+      timeoutIds.forEach((timeoutId) => window.clearTimeout(timeoutId));
+
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        syncProfile();
+      });
+      timeoutIds = [120, 360].map((delayMs) =>
+        window.setTimeout(syncProfile, delayMs),
+      );
+    };
+
+    const syncProfileWhenVisible = () => {
+      if (document.visibilityState === "visible") scheduleProfileSync();
+    };
+
+    scheduleProfileSync();
+    window.addEventListener("resize", scheduleProfileSync);
+    window.addEventListener("orientationchange", scheduleProfileSync);
+    window.addEventListener("pageshow", scheduleProfileSync);
+    window.addEventListener("focus", scheduleProfileSync);
+    document.addEventListener("visibilitychange", syncProfileWhenVisible);
+    visualViewport?.addEventListener("resize", scheduleProfileSync);
+    visualViewport?.addEventListener("scroll", scheduleProfileSync);
+    screenOrientation?.addEventListener?.("change", scheduleProfileSync);
 
     return () => {
-      window.removeEventListener("resize", syncProfile);
-      window.removeEventListener("orientationchange", syncProfile);
-      window.visualViewport?.removeEventListener("resize", syncProfile);
+      if (frameId != null) window.cancelAnimationFrame(frameId);
+      timeoutIds.forEach((timeoutId) => window.clearTimeout(timeoutId));
+      window.removeEventListener("resize", scheduleProfileSync);
+      window.removeEventListener("orientationchange", scheduleProfileSync);
+      window.removeEventListener("pageshow", scheduleProfileSync);
+      window.removeEventListener("focus", scheduleProfileSync);
+      document.removeEventListener("visibilitychange", syncProfileWhenVisible);
+      visualViewport?.removeEventListener("resize", scheduleProfileSync);
+      visualViewport?.removeEventListener("scroll", scheduleProfileSync);
+      screenOrientation?.removeEventListener?.("change", scheduleProfileSync);
     };
   }, [includeSafeAreaInsets]);
 

--- a/src/utils/sidebarDisplay.test.ts
+++ b/src/utils/sidebarDisplay.test.ts
@@ -4,7 +4,7 @@ import { getAirportSidebarMode } from "./sidebarDisplay";
 import { resolveClientDeviceProfile } from "@/features/app-shell/device/clientDeviceModel";
 
 {
-  const profile = resolveClientDeviceProfile({
+  const landscapeProfile = resolveClientDeviceProfile({
     userAgent:
       "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1",
     platform: "iPhone",
@@ -12,11 +12,12 @@ import { resolveClientDeviceProfile } from "@/features/app-shell/device/clientDe
     viewport: { width: 667, height: 375 },
   });
 
-  assert.equal(getAirportSidebarMode(667, profile), "desktop");
+  assert.equal(getAirportSidebarMode(667, landscapeProfile, 375), "desktop");
+  assert.equal(getAirportSidebarMode(393, landscapeProfile, 852), "mobile");
 }
 
 {
-  const profile = resolveClientDeviceProfile({
+  const portraitProfile = resolveClientDeviceProfile({
     userAgent:
       "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1",
     platform: "iPhone",
@@ -24,7 +25,8 @@ import { resolveClientDeviceProfile } from "@/features/app-shell/device/clientDe
     viewport: { width: 375, height: 667 },
   });
 
-  assert.equal(getAirportSidebarMode(375, profile), "mobile");
+  assert.equal(getAirportSidebarMode(375, portraitProfile, 667), "mobile");
+  assert.equal(getAirportSidebarMode(667, portraitProfile, 375), "desktop");
 }
 
 assert.equal(getAirportSidebarMode(767), "mobile");

--- a/src/utils/sidebarDisplay.ts
+++ b/src/utils/sidebarDisplay.ts
@@ -4,13 +4,32 @@ import type { ClientDeviceProfile } from "@/features/app-shell/device/clientDevi
 const AIRPORT_SIDEBAR_MOBILE_BREAKPOINT =
   AIRPORT_EXPLORER_UI_CONFIG.mobileBreakpointPx;
 
+function toFiniteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function resolveViewportOrientation(width, height) {
+  const viewportWidth = toFiniteNumber(width);
+  const viewportHeight = toFiniteNumber(height);
+  if (viewportWidth <= 0 || viewportHeight <= 0 || viewportWidth === viewportHeight) {
+    return "unknown";
+  }
+  return viewportWidth > viewportHeight ? "landscape" : "portrait";
+}
+
 export const getAirportSidebarMode = (
   width,
   clientDeviceProfile?: ClientDeviceProfile | null,
-) =>
-  clientDeviceProfile?.isMobileDevice &&
-  clientDeviceProfile.orientation === "landscape"
+  height?: number,
+) => {
+  const viewportOrientation = resolveViewportOrientation(width, height);
+  return clientDeviceProfile?.isMobileDevice === true &&
+    (viewportOrientation === "landscape" ||
+      (viewportOrientation === "unknown" &&
+        clientDeviceProfile.orientation === "landscape"))
     ? "desktop"
     : Number(width) < AIRPORT_SIDEBAR_MOBILE_BREAKPOINT ? "mobile" : "desktop";
+};
 
 export const getAirportSidebarOpenForMode = (mode) => mode === "desktop";


### PR DESCRIPTION
## Summary
- Prefer the layout viewport over `visualViewport` when deriving client orientation, so stale iOS visual viewport values cannot keep portrait phones in landscape layout.
- Resample the shared client device profile after resize, orientation, screen-orientation, focus, visibility, and pageshow restore events, with delayed follow-up samples for settling browser chrome/safe-area values.
- Initialize explorer sidebar state from the current device profile before first paint and guard sidebar mode with live width/height.
- Bump to v2.15.3 and add the changelog entry.

## Validation
- Ponytail audit on PR diff: one small shrink applied in `sidebarDisplay`; no larger simplification cut remains.
- `pnpm exec tsx src/utils/sidebarDisplay.test.ts`
- `pnpm exec tsx src/features/app-shell/device/clientDeviceModel.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with 12 existing warnings)
- `pnpm test` (117 test files passed)
- `pnpm build`
- Local debug restart: `/adsbao-version.json` returns `2.15.3`
- Chrome/CDP layout recovery matrix with stale `visualViewport` held at 852x393:
  - `/airport/KBOS` portrait 393x852 returns `app-detail-shell`, mobile toolbar, no desktop sidebar.
  - `/airport/KBOS` landscape left/right safe-area returns `airport-map-kit`, desktop sidebar, safe-area vars switch sides.
  - `/airport/KBOS` restored portrait returns `app-detail-shell` again despite stale visual viewport.
  - `/aircraft/DAL225` passes the same portrait/landscape/restored portrait checks.
  - `/` home portrait remains portrait; landscape left offsets panel to 59px; landscape right offsets background edge to 59px; restored portrait returns portrait.