### PR TITLE
Polish dither background and preview alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.15.3",
+  "version": "2.15.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -108,10 +108,9 @@ export default function AircraftPreviewCard({
           0,
           Number(safeAreaInsets?.right || 0),
         )}px`,
-        "--mobile-preview-safe-bottom": `${Math.max(
-          0,
-          Number(safeAreaInsets?.bottom || 0),
-        )}px`,
+        // Landscape compact previews align to the map/sidebar inset; only
+        // horizontal safe-area edges shift the card away from obstructions.
+        "--mobile-preview-safe-bottom": "0px",
       } as CSSProperties)
     : undefined;
   const traceStatusSurfaceActive =

--- a/src/components/effects/BrandingVideoBackground.tsx
+++ b/src/components/effects/BrandingVideoBackground.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
 const DEFAULT_SOURCE = "/brand/adsbao-aircraft-brand-loop.mp4";
-const VIDEO_LOAD_DELAY_MS = 3500;
 const BACKGROUND_HIDDEN_QUERY = "(max-width: 720px)";
 
 export default function BrandingVideoBackground({ source = DEFAULT_SOURCE }) {
@@ -22,36 +21,19 @@ export default function BrandingVideoBackground({ source = DEFAULT_SOURCE }) {
       return undefined;
     }
 
-    let cancelled = false;
-    let idleId = 0;
-    let loadTimer = 0;
     const show = () => setVisible(true);
-    const play = () => {
-      if (cancelled) return;
-      video.src = source;
-      video.load();
-      video.muted = true;
-      video.play()?.catch?.(() => {});
-    };
-    const schedulePlay = () => {
-      if ("requestIdleCallback" in window) {
-        idleId = window.requestIdleCallback(play, { timeout: 1500 });
-        return;
-      }
-      play();
-    };
 
     setVisible(false);
     video.removeAttribute("src");
     video.load();
     video.addEventListener("loadeddata", show);
-    // Decorative media should not compete with the interactive first screen.
-    loadTimer = window.setTimeout(schedulePlay, VIDEO_LOAD_DELAY_MS);
+    video.src = source;
+    video.load();
+    video.muted = true;
+    video.play()?.catch?.(() => {});
+    if (video.readyState >= 2) show();
 
     return () => {
-      cancelled = true;
-      window.clearTimeout(loadTimer);
-      if (idleId) window.cancelIdleCallback?.(idleId);
       video.removeEventListener("loadeddata", show);
       video.pause();
       video.removeAttribute("src");
@@ -67,7 +49,7 @@ export default function BrandingVideoBackground({ source = DEFAULT_SOURCE }) {
         muted
         playsInline
         loop
-        preload="none"
+        preload="auto"
       />
     </div>
   );

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.15.4",
+    kind: "patch",
+    title: {
+      en: "Preview and dither polish",
+      zh: "预览卡与点阵背景打磨",
+    },
+    summary: {
+      en: "Landscape preview cards now sit on the same lower edge as the sidebar, and the home dither animation fills behind the floating panel without a poster-frame ghost.",
+      zh: "横屏预览卡现在与侧栏下缘对齐，主页点阵动画会铺到浮动面板背后，并去掉首帧重影。",
+    },
+    highlights: [
+      {
+        en: "Compact mobile preview cards in landscape keep horizontal safe-area offsets while aligning their bottom edge with the sidebar",
+        zh: "横屏紧凑移动预览卡保留左右 safe-area 偏置，同时底边与侧栏对齐",
+      },
+      {
+        en: "The dither video loads directly, stays hidden until ready, and fills the static-page shell behind the frosted sidebar",
+        zh: "点阵视频直接加载、未就绪前隐藏，并铺满静态页外壳、位于磨砂侧栏背后",
+      },
+    ],
+  },
+  {
     version: "v2.15.3",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -1921,9 +1921,11 @@ body:has(.app-detail-shell) {
    The video stays neutral; CSS filters and overlays bind it to theme tokens. */
 .dither-page-background {
     background: var(--atc-bg);
+    inset: 0;
     min-width: 0;
     overflow: hidden;
-    position: relative;
+    pointer-events: none;
+    position: absolute;
     z-index: 0;
 }
 
@@ -2148,25 +2150,6 @@ body:has(.app-detail-shell) {
     z-index: 0;
 }
 
-.branding-video-background::after {
-    background-position: center;
-    background-size: cover;
-    content: "";
-    inset: 0;
-    mix-blend-mode: screen;
-    opacity: 0.72;
-    pointer-events: none;
-    position: absolute;
-    transform: scale(1.015);
-    z-index: 1;
-}
-
-@media (min-width: 721px) {
-    .branding-video-background::after {
-        background-image: url("/brand/adsbao-aircraft-brand-poster.jpg");
-    }
-}
-
 .branding-video-background__media {
     filter: none;
     height: 100%;
@@ -2178,7 +2161,7 @@ body:has(.app-detail-shell) {
     transform: scale(1.015);
     transition: opacity 1.8s cubic-bezier(0.25, 1, 0.5, 1);
     width: 100%;
-    z-index: 2;
+    z-index: 1;
 }
 
 :root[data-theme="dark"] .branding-video-background__media {
@@ -2196,12 +2179,6 @@ body:has(.app-detail-shell) {
 :root[data-theme="light"] .branding-video-background::before {
     filter: blur(84px);
     opacity: 0.37;
-}
-
-:root[data-theme="light"] .branding-video-background::after {
-    filter: invert(1);
-    mix-blend-mode: multiply;
-    opacity: 0.4;
 }
 
 :root[data-theme="light"] .branding-video-background__media {
@@ -3071,16 +3048,17 @@ body {
 }
 
 .dither-page-panel {
-    /* Solid theme color at the TOP (seamless under the Safari clip) with
-       the warm accent moved to a soft wash rising from the BOTTOM —
-       matching the airport / flight detail sidebars. */
+    /* Floating frosted sidebar over the full-bleed dither layer, matching
+       the airport / flight detail sidebars. */
     background:
         linear-gradient(
             to top,
             color-mix(in oklab, var(--atc-orange) 8%, transparent),
             transparent 38%
         ),
-        var(--sidebar);
+        color-mix(in oklab, var(--app-frost-tint) 88%, transparent);
+    -webkit-backdrop-filter: var(--app-frost-strong);
+    backdrop-filter: var(--app-frost-strong);
     border-right: 0;
     border-radius: 0 var(--atc-radius-shell) var(--atc-radius-shell) 0;
     box-shadow: var(--app-panel-shadow);
@@ -3096,22 +3074,17 @@ body {
             color-mix(in oklab, var(--atc-orange) 14%, transparent),
             transparent 40%
         ),
-        var(--sidebar);
+        color-mix(in oklab, var(--app-frost-tint) 84%, transparent);
 }
 
 .dither-page-background {
-    margin: 12px 12px 12px 0;
-    border-radius: var(--atc-radius-shell);
+    border-radius: 0;
+    margin: 0;
 }
 
 .dither-page-shell[data-client-horizontal-obstruction="true"][data-client-orientation="landscape"]
     .dither-page-panel {
     margin-left: calc(12px + var(--app-safe-area-left, 0px));
-}
-
-.dither-page-shell[data-client-horizontal-obstruction="true"][data-client-orientation="landscape"]
-    .dither-page-background {
-    margin-right: calc(12px + var(--app-safe-area-right, 0px));
 }
 
 .dither-page-background.plane-hunter-stage {
@@ -3122,6 +3095,8 @@ body {
         0 18px 42px rgba(14, 15, 16, 0.18);
     display: block;
     margin-left: 12px;
+    pointer-events: auto;
+    position: relative;
 }
 
 .dither-page-panel.plane-hunter-panel {
@@ -6811,8 +6786,8 @@ body {
     }
 
     .dither-page-background {
-        border-radius: var(--atc-radius-shell);
-        margin: 10px 10px 10px 0;
+        border-radius: 0;
+        margin: 0;
     }
 
     .dither-page-header {


### PR DESCRIPTION
## Summary
- Align landscape compact mobile preview cards with the map/sidebar bottom inset while keeping horizontal safe-area offsets.
- Let the Dither/home background layer fill the whole static-page shell behind the sidebar, and make the sidebar a frosted floating panel over it.
- Remove the poster-frame fallback from the Dither video; load the MP4 directly and keep the media hidden until `loadeddata`/readyState confirms it is ready.
- Bump to v2.15.4 and add the changelog entry.

## Validation
- Ponytail audit on PR diff: removed the now-unneeded delayed video loader/cancel wrapper; final diff is net smaller.
- `pnpm typecheck`
- `pnpm lint` (passes with 12 existing warnings)
- `pnpm build`
- Local debug restart: `/adsbao-version.json` returns `2.15.4`
- Chrome/CDP validation:
  - `/airport/KBOS` iPhone landscape, after clicking an aircraft marker: mobile preview placement is `bottom-right`, preview bottom is 12px, sidebar bottom is 12px, computed bottom is `12px`, `--mobile-preview-safe-bottom` is `0px`.
  - `/` desktop 1280x586: `.dither-page-background` rect is `0,0,1280,586`, position `absolute`, pointer-events `none`, and panel backdrop filter is active.
  - `/` with the MP4 request blocked: video has a src but remains hidden (`opacity: 0`, no `is-visible`, readyState 0), and `::after` poster background is `none`.