### PR TITLE
[codex] Fix landscape rotation scroll recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.15.4",
+  "version": "2.15.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -86,6 +86,19 @@ function getInitialUiState(clientDeviceProfile) {
   };
 }
 
+function resetExplorerMapViewportScroll() {
+  const kit = document.querySelector(".airport-map-kit");
+  if (!kit) return;
+
+  window.scrollTo(0, 0);
+  document.documentElement.scrollTop = 0;
+  document.body.scrollTop = 0;
+  kit.querySelectorAll<HTMLElement>(".sidebar-shell").forEach((element) => {
+    element.scrollTop = 0;
+    element.scrollLeft = 0;
+  });
+}
+
 function toggleValue(value) {
   return !value;
 }
@@ -469,6 +482,29 @@ export function ExplorerUiProvider({ children }) {
       screenOrientation?.removeEventListener?.("change", syncSidebarMode);
     };
   }, [clientDeviceProfile]);
+
+  useEffect(() => {
+    if (
+      sidebarMode !== "desktop" ||
+      clientDeviceProfile.orientation !== "landscape"
+    ) {
+      return undefined;
+    }
+
+    resetExplorerMapViewportScroll();
+    const frameId = window.requestAnimationFrame(resetExplorerMapViewportScroll);
+    const timeoutId = window.setTimeout(resetExplorerMapViewportScroll, 180);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [
+    sidebarMode,
+    clientDeviceProfile.orientation,
+    clientDeviceProfile.safeAreaInsets.left,
+    clientDeviceProfile.safeAreaInsets.right,
+  ]);
 
   useEffect(() => {
     setMapSettingsSaveStatus("idle");

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -29,6 +29,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.15.5",
+    kind: "patch",
+    title: {
+      en: "Rotation scroll recovery",
+      zh: "旋转滚动恢复",
+    },
+    summary: {
+      en: "Airport and flight maps now clear stale page and sidebar scroll after repeated phone rotations, keeping the landscape shell pinned to the viewport.",
+      zh: "机场和航班地图现在会在手机多次旋转后清理残留页面与侧栏滚动，让横屏地图外壳固定在可视区域。",
+    },
+    highlights: [
+      {
+        en: "The full-screen landscape map shell participates in the same document scroll lock as portrait map pages",
+        zh: "横屏全屏地图外壳与竖屏地图页使用同一套 document 滚动锁",
+      },
+      {
+        en: "Returning to landscape resets the sidebar scroll position so the header does not reopen midway down the panel",
+        zh: "回到横屏时会重置侧栏滚动位置，避免侧栏从面板中段重新打开",
+      },
+    ],
+  },
+  {
     version: "v2.15.4",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -1494,12 +1494,14 @@ body {
 /* iOS Safari rubber-bands the document body even when no element is
    scrollable, so dragging up on an airport / flight detail page slides
    the whole map UI and exposes the page background. Lock document
-   overscroll only while a `.app-detail-shell` (full-viewport map
-   layout) is mounted — static pages keep their normal scroll, and
-   in-component gestures (preview-card swipe-to-dismiss, map drag)
-   stay live because we don't touch `touch-action`. */
+   overscroll only while a full-viewport map shell is mounted — static
+   pages keep their normal scroll, and in-component gestures
+   (preview-card swipe-to-dismiss, map drag) stay live because we don't
+   touch `touch-action`. */
 html:has(.app-detail-shell),
-body:has(.app-detail-shell) {
+body:has(.app-detail-shell),
+html:has(.airport-map-kit),
+body:has(.airport-map-kit) {
     overflow: hidden;
     overscroll-behavior: none;
 }
@@ -7102,9 +7104,10 @@ body {
     background: var(--atc-bg);
     height: 100vh;
     height: 100dvh;
+    inset: 0;
     min-height: 100vh;
     padding: 0;
-    position: relative;
+    position: fixed;
     width: 100vw;
 }
 


### PR DESCRIPTION
## Summary
- Locks the landscape map shell the same way portrait full-screen map pages are locked, so iOS rotation cannot expose page background above the map.
- Pins `.airport-map-kit` to the viewport and clears stale page/sidebar scroll when returning to landscape desktop-style layout.
- Bumps ADSBao to `v2.15.5` with a release-facing changelog entry.

## Root Cause
Repeated phone rotations could leave the landscape map route outside the portrait map shell's document scroll lock. Mobile landscape sidebars are intentionally scrollable, so stale page or sidebar scroll could survive orientation settling and reopen the layout with a blank top band or a sidebar starting midway down.

## Validation
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm build`
- `pnpm test` (117 test files passed)
- CDP mobile Safari-style rotation check on `/airport/KBOS`: landscape left -> landscape right and landscape -> portrait -> landscape both ended with `kitTop=0`, `scrollY=0`, `docTop=0`, `sidebarScrollTop=0`, `body/html overflow:hidden`, and `.airport-map-kit position:fixed`.

## Ponytail Audit
Lean already. Ship.