### PR TITLE
[codex] Use OurAirports names and show reporting points

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.18.1",
+  "version": "2.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/api/webapi/airport_names.go
+++ b/services/data-service/internal/api/webapi/airport_names.go
@@ -1,0 +1,89 @@
+package webapi
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type airportNameRecord struct {
+	name string
+	city string
+}
+
+type airportNameReader interface {
+	readAirportNames(ctx context.Context, idents []string) (map[string]airportNameRecord, error)
+}
+
+func (s *UserDataStore) readAirportNames(ctx context.Context, idents []string) (map[string]airportNameRecord, error) {
+	out := map[string]airportNameRecord{}
+	if s == nil || s.db == nil {
+		return out, nil
+	}
+
+	normalizedIdents := make([]string, 0, len(idents))
+	seen := map[string]bool{}
+	for _, ident := range idents {
+		normalizedIdent := normalizeAirportIdent(ident)
+		if normalizedIdent == "" || seen[normalizedIdent] {
+			continue
+		}
+		seen[normalizedIdent] = true
+		normalizedIdents = append(normalizedIdents, normalizedIdent)
+	}
+	if len(normalizedIdents) == 0 {
+		return out, nil
+	}
+
+	placeholders := make([]string, len(normalizedIdents))
+	args := make([]any, 0, len(normalizedIdents))
+	for index, ident := range normalizedIdents {
+		placeholders[index] = fmt.Sprintf("$%d", index+1)
+		args = append(args, ident)
+	}
+	inClause := strings.Join(placeholders, ",")
+	rows, err := s.query(
+		ctx,
+		"read_airport_names",
+		`select ident, icao_code, iata_code, name, municipality
+		 from airports
+		 where name <> ''
+		   and (icao_code in (`+inClause+`) or ident in (`+inClause+`) or iata_code in (`+inClause+`))`,
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var ident, icao, iata, name, city string
+		if err := rows.Scan(&ident, &icao, &iata, &name, &city); err != nil {
+			return nil, err
+		}
+		value := airportNameRecord{
+			name: strings.TrimSpace(name),
+			city: strings.TrimSpace(city),
+		}
+		if value.name == "" {
+			continue
+		}
+		if key := normalizeAirportIdent(icao); key != "" {
+			out[key] = value
+		}
+		if key := normalizeAirportIdent(ident); key != "" {
+			if _, ok := out[key]; !ok {
+				out[key] = value
+			}
+		}
+		if key := normalizeAirportIdent(iata); key != "" {
+			if _, ok := out[key]; !ok {
+				out[key] = value
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/services/data-service/internal/api/webapi/airport_names_test.go
+++ b/services/data-service/internal/api/webapi/airport_names_test.go
@@ -1,0 +1,93 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeAirportNameReader struct {
+	names map[string]airportNameRecord
+}
+
+func (r fakeAirportNameReader) readAirportNames(_ context.Context, idents []string) (map[string]airportNameRecord, error) {
+	out := map[string]airportNameRecord{}
+	for _, ident := range idents {
+		if name, ok := r.names[normalizeAirportIdent(ident)]; ok {
+			out[normalizeAirportIdent(ident)] = name
+		}
+	}
+	return out, nil
+}
+
+func TestAirportNamesUseOurAirportsWithoutOpenAIPFallback(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openaip/airports" {
+			t.Fatalf("unexpected request: %s", r.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[
+			{
+				"_id":"airport-kbos",
+				"icaoCode":"KBOS",
+				"iataCode":"BOS",
+				"name":"OpenAIP Logan Name",
+				"country":"US",
+				"geometry":{"type":"Point","coordinates":[-71.0096,42.3656]}
+			},
+			{
+				"_id":"airport-kzzz",
+				"icaoCode":"KZZZ",
+				"name":"OpenAIP Only Name",
+				"country":"US",
+				"geometry":{"type":"Point","coordinates":[-70.1,42.1]}
+			}
+		]}`))
+	}))
+	defer upstream.Close()
+
+	handler := New(Options{
+		HTTPClient:     upstream.Client(),
+		OpenAIPAPIKey:  "test-key",
+		OpenAIPBaseURL: upstream.URL + "/openaip",
+		Timeout:        time.Second,
+	})
+	handler.airportNameReader = fakeAirportNameReader{names: map[string]airportNameRecord{
+		"KBOS": {
+			name: "General Edward Lawrence Logan International Airport",
+			city: "Boston",
+		},
+	}}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/search?q=K&limit=2", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	airports := payload["airports"].([]any)
+	if len(airports) != 2 {
+		t.Fatalf("expected two airports, got %#v", airports)
+	}
+	byICAO := map[string]map[string]any{}
+	for _, raw := range airports {
+		airport := raw.(map[string]any)
+		byICAO[stringValue(airport["icao"])] = airport
+	}
+	if byICAO["KBOS"]["name"] != "General Edward Lawrence Logan International Airport" ||
+		byICAO["KBOS"]["city"] != "Boston" {
+		t.Fatalf("KBOS did not use OurAirports name: %#v", byICAO["KBOS"])
+	}
+	if strings.Contains(stringValue(byICAO["KZZZ"]["name"]), "OpenAIP") || byICAO["KZZZ"]["name"] != "" {
+		t.Fatalf("KZZZ fell back to OpenAIP name: %#v", byICAO["KZZZ"])
+	}
+}

--- a/services/data-service/internal/api/webapi/handler.go
+++ b/services/data-service/internal/api/webapi/handler.go
@@ -52,6 +52,7 @@ type Handler struct {
 	authenticator       *ClerkAuthenticator
 	userDataStore       *UserDataStore
 	runwayMapReader     runwayMapReader
+	airportNameReader   airportNameReader
 }
 
 type openAIPList struct {
@@ -87,6 +88,7 @@ func New(options Options) *Handler {
 		authenticator:       options.Authenticator,
 		userDataStore:       options.UserDataStore,
 		runwayMapReader:     options.UserDataStore,
+		airportNameReader:   options.UserDataStore,
 	}
 }
 
@@ -168,6 +170,7 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 			airports = append(airports, airport)
 		}
 	}
+	h.applyAirportNames(r.Context(), airports)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"airports": airports,
 		"source":   "openaip",
@@ -454,6 +457,7 @@ func (h *Handler) resolveAirportDetail(ctx context.Context, ident string) (map[s
 	if airport == nil {
 		return detail, nil, nil, nil, nil
 	}
+	h.applyAirportNames(ctx, []map[string]any{airport})
 	runways := mapRunways(asRecords(detail["runways"]), detail)
 	runwayMap, runwayMapErr := h.userDataStore.readRunwayMap(ctx, ident)
 	if runwayMapErr != nil {
@@ -510,6 +514,7 @@ func (h *Handler) nearbyAirports(ctx context.Context, lat, lon float64, exclude 
 			}
 		}
 	}
+	h.applyAirportNames(ctx, out)
 	sort.Slice(out, func(i, j int) bool {
 		return numberValue(out[i]["distanceNm"]) < numberValue(out[j]["distanceNm"])
 	})
@@ -517,6 +522,46 @@ func (h *Handler) nearbyAirports(ctx context.Context, lat, lon float64, exclude 
 		out = out[:limit]
 	}
 	return out
+}
+
+func airportNameLookupIdent(airport map[string]any) string {
+	return normalizeAirportIdent(firstString(airport["icao"], airport["code"], airport["ident"], airport["iata"]))
+}
+
+func (h *Handler) applyAirportNames(ctx context.Context, airports []map[string]any) {
+	names := h.storedAirportNamesForAirports(ctx, airports)
+	for _, airport := range airports {
+		if airport == nil {
+			continue
+		}
+		airport["name"] = ""
+		airport["city"] = ""
+		if name, ok := names[airportNameLookupIdent(airport)]; ok {
+			airport["name"] = name.name
+			airport["city"] = name.city
+		}
+	}
+}
+
+func (h *Handler) storedAirportNamesForAirports(ctx context.Context, airports []map[string]any) map[string]airportNameRecord {
+	if h == nil || h.airportNameReader == nil || len(airports) == 0 {
+		return nil
+	}
+	idents := make([]string, 0, len(airports))
+	for _, airport := range airports {
+		if ident := airportNameLookupIdent(airport); ident != "" {
+			idents = append(idents, ident)
+		}
+	}
+	if len(idents) == 0 {
+		return nil
+	}
+	names, err := h.airportNameReader.readAirportNames(ctx, idents)
+	if err != nil {
+		log.Printf("airport name read failed airports=%s error=%v", strings.Join(idents, ","), err)
+		return nil
+	}
+	return names
 }
 
 func (h *Handler) storedRunwayMapsForAirports(ctx context.Context, airports []map[string]any) map[string]map[string]any {
@@ -687,7 +732,7 @@ func mapAirport(airport map[string]any) map[string]any {
 		"iata":             upper(stringValue(airport["iataCode"])),
 		"code":             code,
 		"openAipId":        stringValue(airport["_id"]),
-		"name":             fallbackString(stringValue(airport["name"]), code),
+		"name":             "",
 		"type":             stringValue(airport["type"]),
 		"type_label":       airportTypeLabel(airport["type"]),
 		"city":             "",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -589,6 +589,7 @@ function AirportExplorerContent({
               aircraft={traffic.aircraft}
               nearbyAirports={nearbyAirports.airports}
               nearbyNavaids={airport?.nearbyNavaids || []}
+              reportingPoints={airport?.reportingPoints || []}
               airspaces={airport?.airspaces || []}
               airport={airport}
               // In near-me mode the airport profile has no ICAO and so

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -8,6 +8,7 @@ import AirspaceLayer from "./AirspaceLayer";
 import NearbyAirportLayer from "./NearbyAirportLayer";
 import NavaidLabelLayer from "./NavaidLabelLayer";
 import NavaidCountLayer from "./NavaidCountLayer";
+import ReportingPointLabelLayer from "./ReportingPointLabelLayer";
 import MapBadgeCollisionLayer from "./MapBadgeCollisionLayer";
 import CandidateWatchingSpotsLayer from "./CandidateWatchingSpotsLayer";
 import AircraftPosition from "./AircraftPosition";
@@ -50,6 +51,7 @@ import {
 } from "../../features/aircraft/positions/aircraftLoadingOverlayModel";
 import { useAviationContextTiles } from "../../features/airport/context/useAviationContextTiles";
 import { shouldUseNavaidCountTiles } from "../../features/airport/context/aviationContextDisplayModel";
+import { shouldShowReportingPointLabels } from "../../features/airport/map/reportingPointLabelModel";
 import { getOffsetMapCenter } from "./mapViewportOffset";
 
 const resolveCurrentTheme = () =>
@@ -72,6 +74,7 @@ export default function AirportMap({
   aircraft = [],
   nearbyAirports = [],
   nearbyNavaids = [],
+  reportingPoints = [],
   airspaces = [],
   contextTileOverlays = false,
   contextTileRefreshKey = "",
@@ -452,6 +455,7 @@ export default function AirportMap({
     fullTraceMode: fullTraceContext,
     zoom: leafletZoom,
   });
+  const showReportingPointLabels = shouldShowReportingPointLabels(leafletZoom);
   const contextTiles = useAviationContextTiles({
     map: mapInstance,
     enabled: contextTileOverlays,
@@ -636,14 +640,21 @@ export default function AirportMap({
             selectedNavaidKey={selectedNavaidKey}
             onSelectNavaid={onSelectNavaid}
           />
+          <ReportingPointLabelLayer
+            points={reportingPoints}
+            theme={currentTheme}
+            visible={showReportingPointLabels}
+          />
           <MapBadgeCollisionLayer
             refreshKey={[
               selectedAirportIcao,
               selectedNavaidKey,
               selectedAirspaceId,
               showNavaidMarkers ? "navaid-on" : "navaid-off",
+              showReportingPointLabels ? "reporting-on" : "reporting-off",
               nearbyAirportLayerDisplay.showAirportBadges ? "airport-on" : "airport-off",
               renderedNavaids.length,
+              reportingPoints.length,
               nearbyAirportLayerDisplay.airports.length,
               leafletZoom,
             ].join("|")}

--- a/src/components/map/ReportingPointLabelLayer.tsx
+++ b/src/components/map/ReportingPointLabelLayer.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import { useMapInstance } from "./MapContext";
+import { AIRPORT_MAP_PANES } from "../../config/airportMap";
+import { ensureAirportMapPane } from "../../features/airport/map/mapPane";
+import {
+  safeAddToMap,
+  safeRemoveFromMap,
+} from "../../features/airport/map/leafletLayerSafety";
+import { buildReportingPointLabels } from "../../features/airport/map/reportingPointLabelModel";
+
+const escapeHtml = (value: unknown) =>
+  String(value || "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+const reportingPointMarkerHtml = (label: Record<string, any>) => `
+  <div
+    class="reporting-point-road-sign notranslate"
+    translate="no"
+    data-map-badge="true"
+    data-map-badge-type="reporting-point"
+  >
+    <span class="reporting-point-road-sign__post" aria-hidden="true"></span>
+    <span class="reporting-point-road-sign__blade">
+      <span class="reporting-point-road-sign__tag" aria-hidden="true">RP</span>
+      <span class="reporting-point-road-sign__name">${escapeHtml(label.name)}</span>
+    </span>
+  </div>
+`;
+
+const reportingPointLabelIcon = (label: Record<string, any>, theme: string) =>
+  L.divIcon({
+    className: [
+      "reporting-point-label-icon",
+      `reporting-point-label-icon--${theme}`,
+    ].join(" "),
+    html: reportingPointMarkerHtml(label),
+    iconSize: [148, 44],
+    iconAnchor: [6, 40],
+  });
+
+export default function ReportingPointLabelLayer({
+  points = [],
+  theme = "dark",
+  visible = false,
+}: Record<string, any>) {
+  const map = useMapInstance();
+  const layerRef = useRef(null);
+
+  useEffect(() => {
+    if (!map || !visible) return undefined;
+
+    safeRemoveFromMap(layerRef.current, map);
+    const labels = buildReportingPointLabels(points);
+    if (!labels.length) return undefined;
+
+    const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.badge);
+    const layer = L.layerGroup(
+      labels.map((label) =>
+        L.marker([label.lat, label.lon], {
+          interactive: false,
+          autoPanOnFocus: false,
+          keyboard: false,
+          title: label.name,
+          icon: reportingPointLabelIcon(label, theme),
+          pane,
+        }),
+      ),
+    );
+
+    const added = safeAddToMap(layer, map, { label: "ReportingPointLabelLayer" });
+    if (!added) return undefined;
+    layerRef.current = layer;
+
+    return () => {
+      safeRemoveFromMap(layer, map);
+      layerRef.current = null;
+    };
+  }, [map, points, theme, visible]);
+
+  return null;
+}

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -43,7 +43,6 @@ import {
   ALTITUDE_LEVEL_OPTIONS,
   ENTITY_FILTER_OPTIONS,
   aircraftMatchesFilters,
-  aircraftTypeLabel,
   getAircraftTypeGroups,
   getNextEntityFilter,
 } from "@/features/aircraft/filters/aircraftFilters";

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -40,9 +40,35 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 20;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 88;
+export const CHANGELOG_TOTAL_COUNT = 89;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
+  {
+    version: "v2.19.0",
+    kind: "feat",
+    title: {
+      en: "OurAirports airport names",
+      zh: "OurAirports 机场名称",
+    },
+    summary: {
+      en: "Airport names now come from the OurAirports database table instead of OpenAIP, with no OpenAIP name fallback.",
+      zh: "机场名称现在来自数据库里的 OurAirports 表，不再回退使用 OpenAIP 名称。",
+    },
+    highlights: [
+      {
+        en: "/api/search, /api/airport, and nearby-airport payloads all apply the same OurAirports name lookup",
+        zh: "/api/search、/api/airport 和附近机场 payload 都使用同一套 OurAirports 名称查询",
+      },
+      {
+        en: "When an OurAirports name is missing, the API leaves the airport name blank instead of exposing the OpenAIP value",
+        zh: "缺少 OurAirports 名称时，API 会留空机场名称，而不是暴露 OpenAIP 值",
+      },
+      {
+        en: "Airport maps can show OpenAIP reporting points at detail range",
+        zh: "机场地图可在近景显示 OpenAIP reporting points",
+      },
+    ],
+  },
   {
     version: "v2.18.1",
     kind: "patch",
@@ -482,32 +508,6 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Landscape phones keep aircraft previews compact in the lower-right corner instead of opening the taller desktop preview",
         zh: "手机横屏时飞机预览保持右下角紧凑移动卡片，不再打开较高的桌面预览",
-      },
-    ],
-  },
-  {
-    version: "v2.15.0",
-    kind: "feat",
-    title: {
-      en: "Landscape mobile cockpit",
-      zh: "移动设备横屏座舱",
-    },
-    summary: {
-      en: "Airport detail now treats phones and tablets as mobile devices even when their landscape viewport uses the desktop sidebar.",
-      zh: "机场详情页现在会按真实设备识别手机和平板，即使横屏视口使用桌面侧栏布局。",
-    },
-    highlights: [
-      {
-        en: "Landscape phones with a Dynamic Island or similar cutout shift the airport sidebar away from the safe-area obstruction",
-        zh: "带灵动岛或类似遮挡的手机横屏时，机场侧栏会避开 safe-area 遮挡",
-      },
-      {
-        en: "Phone and tablet landscape sidebars scroll as one panel, with the search bar and aircraft table header sticking at the top",
-        zh: "手机和平板横屏侧栏改为整面板滚动，搜索栏和飞机表头会在顶部置顶",
-      },
-      {
-        en: "Plane Hunter availability now follows the shared client-device model across preview cards and map settings",
-        zh: "拍机入口现在复用统一客户端设备模型，预览卡与地图设置的设备判断保持一致",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -384,6 +384,32 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.15.0",
+    kind: "feat",
+    title: {
+      en: "Landscape mobile cockpit",
+      zh: "移动设备横屏座舱",
+    },
+    summary: {
+      en: "Airport detail now treats phones and tablets as mobile devices even when their landscape viewport uses the desktop sidebar.",
+      zh: "机场详情页现在会按真实设备识别手机和平板，即使横屏视口使用桌面侧栏布局。",
+    },
+    highlights: [
+      {
+        en: "Landscape phones with a Dynamic Island or similar cutout shift the airport sidebar away from the safe-area obstruction",
+        zh: "带灵动岛或类似遮挡的手机横屏时，机场侧栏会避开 safe-area 遮挡",
+      },
+      {
+        en: "Phone and tablet landscape sidebars scroll as one panel, with the search bar and aircraft table header sticking at the top",
+        zh: "手机和平板横屏侧栏改为整面板滚动，搜索栏和飞机表头会在顶部置顶",
+      },
+      {
+        en: "Plane Hunter availability now follows the shared client-device model across preview cards and map settings",
+        zh: "拍机入口现在复用统一客户端设备模型，预览卡与地图设置的设备判断保持一致",
+      },
+    ],
+  },
+  {
     version: "v2.14.2",
     kind: "patch",
     title: {

--- a/src/features/aircraft/filters/aircraftFilters.ts
+++ b/src/features/aircraft/filters/aircraftFilters.ts
@@ -109,10 +109,10 @@ export function getAircraftTypeGroups(
 ) {
   const typeToEntry = new Map();
   for (const item of aircraft) {
-    const type = aircraftTypeLabel(item);
+    const display = resolveAircraftDisplayModel(item);
+    const type = display.icaoType || display.category;
     if (!type) continue;
     if (typeToEntry.has(type)) continue;
-    const display = resolveAircraftDisplayModel(item);
     const label = getAircraftTypeFilterLabel(display);
     typeToEntry.set(type, {
       category: getAircraftCategoryCode(item),

--- a/src/features/aircraft/trace/aircraftTraceModel.ts
+++ b/src/features/aircraft/trace/aircraftTraceModel.ts
@@ -217,25 +217,28 @@ function traceMinuteBucket(timestampMs: number) {
 
 export function dedupeTracePointsByMinuteLatest(points = []) {
   const buckets = new Map();
-  const normalized = Array.isArray(points)
-    ? points
-        .filter(
-          (point) =>
-            isFiniteNumber(point?.lat) &&
-            isFiniteNumber(point?.lon) &&
-            Number.isFinite(Number(point?.timestampMs ?? point?.time)),
-        )
-        .map((point) => ({
-          ...point,
-          timestampMs: Number(point?.timestampMs ?? point?.time),
-          lat: Number(point.lat),
-          lon: Number(point.lon),
-        }))
-        .sort((a, b) => a.timestampMs - b.timestampMs)
-    : [];
+  if (!Array.isArray(points)) return [];
 
-  for (const point of normalized) {
-    buckets.set(traceMinuteBucket(point.timestampMs), point);
+  for (const point of points) {
+    const timestampMs = Number(point?.timestampMs ?? point?.time);
+    if (
+      !isFiniteNumber(point?.lat) ||
+      !isFiniteNumber(point?.lon) ||
+      !Number.isFinite(timestampMs)
+    ) {
+      continue;
+    }
+    const normalizedPoint = {
+      ...point,
+      timestampMs,
+      lat: Number(point.lat),
+      lon: Number(point.lon),
+    };
+    const bucket = traceMinuteBucket(timestampMs);
+    const existing = buckets.get(bucket);
+    if (!existing || existing.timestampMs <= timestampMs) {
+      buckets.set(bucket, normalizedPoint);
+    }
   }
 
   return Array.from(buckets.values()).sort(

--- a/src/features/aircraft/tracking/trackedFlightPositionResolver.ts
+++ b/src/features/aircraft/tracking/trackedFlightPositionResolver.ts
@@ -134,25 +134,25 @@ export function annotateAdsbPosition(
 }
 
 function pickFreshPrimary(candidates: TrackingRecord[], now: number): TrackingRecord | null {
-  return candidates
-    .filter((candidate) => candidate?.position && hasUsableLatLon(candidate.position))
-    .filter((candidate) => !isAdscPosition(candidate.position))
-    .map((candidate) => ({
-      ...candidate,
-      ageSeconds: getAdsbPositionAgeSeconds(candidate.position, now),
-    }))
-    .filter((candidate) => candidate.ageSeconds <= ADSB_FRESH_MAX_AGE_SECONDS)
-    .sort((a, b) => a.ageSeconds - b.ageSeconds)[0] || null;
+  let best: TrackingRecord | null = null;
+  for (const candidate of candidates) {
+    if (!candidate?.position || !hasUsableLatLon(candidate.position)) continue;
+    if (isAdscPosition(candidate.position)) continue;
+    const ageSeconds = getAdsbPositionAgeSeconds(candidate.position, now);
+    if (ageSeconds > ADSB_FRESH_MAX_AGE_SECONDS) continue;
+    if (!best || ageSeconds < best.ageSeconds) best = { ...candidate, ageSeconds };
+  }
+  return best;
 }
 
 function pickStalePrimary(candidates: TrackingRecord[], now: number): TrackingRecord | null {
-  return candidates
-    .filter((candidate) => candidate?.position && hasUsableLatLon(candidate.position))
-    .map((candidate) => ({
-      ...candidate,
-      ageSeconds: getAdsbPositionAgeSeconds(candidate.position, now),
-    }))
-    .sort((a, b) => a.ageSeconds - b.ageSeconds)[0] || null;
+  let best: TrackingRecord | null = null;
+  for (const candidate of candidates) {
+    if (!candidate?.position || !hasUsableLatLon(candidate.position)) continue;
+    const ageSeconds = getAdsbPositionAgeSeconds(candidate.position, now);
+    if (!best || ageSeconds < best.ageSeconds) best = { ...candidate, ageSeconds };
+  }
+  return best;
 }
 
 function isAdscPosition(position: TrackingRecord | null | undefined) {

--- a/src/features/airport/directory/airportNameModel.test.ts
+++ b/src/features/airport/directory/airportNameModel.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 
 import { applyOurAirportsAirport, chooseAirportName } from "./airportNameModel";
 
-// chooseAirportName: OurAirports wins when present, else the OpenAIP value.
+// chooseAirportName: OurAirports wins when present; OpenAIP is never a name fallback.
 {
   assert.equal(
     chooseAirportName(
@@ -14,10 +14,9 @@ import { applyOurAirportsAirport, chooseAirportName } from "./airportNameModel";
 }
 
 {
-  // No OurAirports name -> keep the OpenAIP value verbatim.
-  assert.equal(chooseAirportName("KBOS", ""), "KBOS");
-  assert.equal(chooseAirportName("KBOS", "   "), "KBOS");
-  assert.equal(chooseAirportName("KBOS", null), "KBOS");
+  assert.equal(chooseAirportName("KBOS", ""), "");
+  assert.equal(chooseAirportName("KBOS", "   "), "");
+  assert.equal(chooseAirportName("KBOS", null), "");
 }
 
 // applyOurAirportsAirport: overrides the truncated name and fills an empty city.
@@ -50,10 +49,10 @@ import { applyOurAirportsAirport, chooseAirportName } from "./airportNameModel";
 }
 
 {
-  // No override -> the record passes through unchanged (same reference).
+  // No override -> name is blank instead of falling back to OpenAIP.
   const airport = { icao: "KBOS", name: "GENERAL EDWARD LAWRENCE LOGAN INTERNATIO" };
-  assert.equal(applyOurAirportsAirport(airport, null), airport);
-  assert.equal(applyOurAirportsAirport(airport, undefined), airport);
+  assert.equal(applyOurAirportsAirport(airport, null).name, "");
+  assert.equal(applyOurAirportsAirport(airport, undefined).name, "");
 }
 
 {

--- a/src/features/airport/directory/airportNameModel.ts
+++ b/src/features/airport/directory/airportNameModel.ts
@@ -1,30 +1,26 @@
-// Decides how an OurAirports override (full, mixed-case name + municipality)
-// combines with a normalized OpenAIP airport record. OpenAIP names are
-// pre-uppercased and truncated to ~40 chars, so when OurAirports has a name we
-// prefer it; otherwise the OpenAIP value (which already falls back to the
-// airport code) stands. City is additive: OpenAIP leaves it blank, so we fill
-// it from the override without ever clobbering a city OpenAIP did provide.
+// Airport display names come only from the OurAirports table. OpenAIP still
+// supplies discovery geometry and metadata, but its airport `name` field is
+// intentionally ignored so truncated OpenAIP names cannot leak into the UI.
 
 type AirportRecord = Record<string, any>;
 type AirportNameOverride = { name?: string; city?: string } | null | undefined;
 
 export const chooseAirportName = (
-  openAipName: unknown,
+  _openAipName: unknown,
   ourAirportsName: unknown,
 ) => {
   const ourAirports = String(ourAirportsName ?? "").trim();
-  if (ourAirports) return ourAirports;
-  return String(openAipName ?? "").trim();
+  return ourAirports;
 };
 
 export const applyOurAirportsAirport = <T extends AirportRecord | null | undefined>(
   airport: T,
   override: AirportNameOverride,
 ): T => {
-  if (!airport || !override) return airport;
-  const name = chooseAirportName(airport.name, override.name);
+  if (!airport) return airport;
+  const name = chooseAirportName(airport.name, override?.name);
   const currentCity = String(airport.city ?? "").trim();
-  const overrideCity = String(override.city ?? "").trim();
+  const overrideCity = String(override?.city ?? "").trim();
   const city = currentCity || overrideCity;
   return { ...airport, name, city };
 };

--- a/src/features/airport/explorer/airportExplorerModel.test.ts
+++ b/src/features/airport/explorer/airportExplorerModel.test.ts
@@ -49,6 +49,17 @@ assert.equal(providedProfile.icao, "KSEA");
 assert.equal(providedProfile.iata, "SEA");
 assert.equal(providedProfile.city, "Seattle");
 
+const emptyNameProfile = resolveAirportProfile({
+  icao: "kbos",
+  airport: {
+    icao: "KBOS",
+    iata: "BOS",
+    name: "",
+    city: "Boston",
+  },
+});
+assert.equal(emptyNameProfile.name, "");
+
 const localizedProfile = resolveAirportProfile({
   icao: "zspd",
   airport: {

--- a/src/features/airport/explorer/airportExplorerModel.ts
+++ b/src/features/airport/explorer/airportExplorerModel.ts
@@ -25,11 +25,9 @@ export function resolveAirportProfile({ icao = "", airport = null }: AirportExpl
   return {
     icao: normalizedIcao,
     iata: airportCodeLabel,
-    name:
-      (useAirportDetails ? airport?.name : "") ||
-      airportFallback?.name ||
-      normalizedIcao ||
-      "Airport",
+    name: useAirportDetails
+      ? String(airport?.name || "")
+      : airportFallback?.name || normalizedIcao || "Airport",
     localizedName: useAirportDetails ? airport?.localizedName || "" : "",
     city:
       (useAirportDetails ? airport?.city : "") || airportFallback?.city || "",

--- a/src/features/airport/map/airportMapModel.ts
+++ b/src/features/airport/map/airportMapModel.ts
@@ -169,6 +169,10 @@ export const getVisibleAircraft = ({
 }: VisibleAircraftOptions) => {
   const airportGroundTrafficHideRadiusNm =
     airportGroundTrafficHideRadiusNmForZoom(zoom);
+  if (airportGroundTrafficHideRadiusNm == null) {
+    return aircraft.filter((ac) => ac.lat != null && ac.lon != null);
+  }
+
   const groundFilters = airportGroundFilters({
     airportLat,
     airportLon,
@@ -178,7 +182,6 @@ export const getVisibleAircraft = ({
 
   return aircraft.filter((ac) => {
     if (ac.lat == null || ac.lon == null) return false;
-    if (airportGroundTrafficHideRadiusNm == null) return true;
     return !groundFilters.some((airport) =>
       isInsideAirportGroundArea(ac, airport, airportGroundTrafficHideRadiusNm),
     );

--- a/src/features/airport/map/reportingPointLabelModel.test.ts
+++ b/src/features/airport/map/reportingPointLabelModel.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+
+import {
+  buildReportingPointLabels,
+  shouldShowReportingPointLabels,
+} from "./reportingPointLabelModel";
+
+assert.equal(shouldShowReportingPointLabels(13.5), true);
+assert.equal(shouldShowReportingPointLabels(12), false);
+
+assert.deepEqual(
+  buildReportingPointLabels([
+    {
+      id: "rp-alpha",
+      name: "ALPHA",
+      lat: 42.37,
+      lon: -71.02,
+      compulsory: true,
+    },
+    {
+      id: "rp-bad",
+      name: "BRAVO",
+      lat: null,
+      lon: -71.01,
+    },
+    {
+      id: "rp-empty",
+      name: "",
+      lat: 42.35,
+      lon: -71.03,
+    },
+  ]),
+  [
+    {
+      key: "rp-alpha-ALPHA",
+      name: "ALPHA",
+      lat: 42.37,
+      lon: -71.02,
+      compulsory: true,
+      country: "",
+      source: "",
+    },
+  ],
+);
+
+console.log("reportingPointLabelModel.test.ts ok");

--- a/src/features/airport/map/reportingPointLabelModel.ts
+++ b/src/features/airport/map/reportingPointLabelModel.ts
@@ -1,0 +1,36 @@
+import { AIRPORT_MAP_ZOOM } from "../../../config/aviation";
+
+type ReportingPointRecord = Record<string, any>;
+
+const numberOrNull = (value: unknown) => {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+export function shouldShowReportingPointLabels(zoom: unknown) {
+  const numericZoom = numberOrNull(zoom);
+  return numericZoom != null && numericZoom >= AIRPORT_MAP_ZOOM.detail;
+}
+
+export const buildReportingPointLabels = (
+  points: ReportingPointRecord[] = [],
+) =>
+  points
+    .map((point) => {
+      const name = String(point?.name || "").trim();
+      const lat = numberOrNull(point?.lat);
+      const lon = numberOrNull(point?.lon);
+      if (!name || lat === null || lon === null) return null;
+
+      return {
+        key: `${point.id ?? name}-${name}`,
+        name,
+        lat,
+        lon,
+        compulsory: Boolean(point.compulsory),
+        country: String(point.country || ""),
+        source: String(point.source || ""),
+      };
+    })
+    .filter(Boolean);

--- a/src/server/dao/airportNames.dao.test.ts
+++ b/src/server/dao/airportNames.dao.test.ts
@@ -32,16 +32,35 @@ const normalizeSql = (sql: string) => sql.replace(/\s+/g, " ").trim();
 
   const byIdent = await repository.readNamesByIdents([" kbos ", "kzzz", "KBOS"]);
 
-  assert.equal(byIdent.size, 1);
+  assert.equal(byIdent.size, 2);
   assert.deepEqual(byIdent.get("KBOS"), {
     name: "General Edward Lawrence Logan International Airport",
     city: "Boston",
   });
+  assert.deepEqual(byIdent.get("BOS"), byIdent.get("KBOS"));
   assert.match(
     normalizeSql(calls[0].text),
-    /from airports where \(icao_code = any\(\$1::text\[\]\) or ident = any\(\$1::text\[\]\)\)/i,
+    /from airports where \( icao_code = any\(\$1::text\[\]\) or ident = any\(\$1::text\[\]\) or iata_code = any\(\$1::text\[\]\) \)/i,
   );
   assert.deepEqual(calls[0].values, [["KBOS", "KZZZ"]]);
+}
+
+{
+  const { queryClient } = createFakePostgresClient([
+    {
+      ident: "US-0001",
+      icao_code: "",
+      iata_code: "BOS",
+      name: "General Edward Lawrence Logan International Airport",
+      municipality: "Boston",
+    },
+  ]);
+  const repository = createAirportNameRepositoryFromEnv({ queryClient });
+  const byIdent = await repository.readNamesByIdents(["bos"]);
+  assert.equal(
+    byIdent.get("BOS")?.name,
+    "General Edward Lawrence Logan International Airport",
+  );
 }
 
 {

--- a/src/server/dao/airportNames.dao.ts
+++ b/src/server/dao/airportNames.dao.ts
@@ -51,7 +51,11 @@ function createAirportNameRepository({
         `
           select ${SELECT_COLUMNS}
           from ${AIRPORTS_TABLE}
-          where (icao_code = any($1::text[]) or ident = any($1::text[]))
+          where (
+            icao_code = any($1::text[])
+            or ident = any($1::text[])
+            or iata_code = any($1::text[])
+          )
         `,
         [normalizedIdents],
       );
@@ -68,6 +72,7 @@ function createAirportNameRepository({
       // `ident` only fills a slot the ICAO code didn't already claim, so an
       // exact ICAO match always wins over an ident-only collision.
       if (mapped.ident && !byIdent.has(mapped.ident)) byIdent.set(mapped.ident, value);
+      if (mapped.iata && !byIdent.has(mapped.iata)) byIdent.set(mapped.iata, value);
     }
     return byIdent;
   };

--- a/src/style.css
+++ b/src/style.css
@@ -1768,7 +1768,8 @@ body:has(.dither-page-shell) {
     );
 }
 
-.leaflet-marker-icon.navaid-label-icon {
+.leaflet-marker-icon.navaid-label-icon,
+.leaflet-marker-icon.reporting-point-label-icon {
     overflow: visible;
     pointer-events: none !important;
 }
@@ -1826,6 +1827,71 @@ body:has(.dither-page-shell) {
 .leaflet-marker-icon.navaid-label-icon .airport-overlay-label--map-badge,
 .leaflet-marker-icon.nearby-airport-marker-icon .airport-overlay-label--map-badge {
     pointer-events: auto;
+}
+
+.reporting-point-road-sign {
+    --map-badge-offset-x: 0px;
+    --map-badge-offset-y: 0px;
+    --map-badge-stack-z: 0;
+    --reporting-point-sign-bg: oklch(0.82 0.14 86);
+    --reporting-point-sign-edge: oklch(0.24 0.02 95);
+    --reporting-point-sign-fg: oklch(0.18 0.012 96);
+    display: inline-flex;
+    filter: drop-shadow(
+        0 2px 4px color-mix(in oklab, var(--atc-bg) 54%, transparent)
+    );
+    opacity: 0.9;
+    padding-bottom: 17px;
+    pointer-events: none;
+    position: relative;
+    transform: translate3d(
+        var(--map-badge-offset-x),
+        var(--map-badge-offset-y),
+        0
+    );
+    width: max-content;
+    z-index: var(--map-badge-stack-z);
+}
+
+.reporting-point-road-sign__post {
+    background: var(--reporting-point-sign-edge);
+    border-radius: 999px;
+    bottom: 0;
+    box-shadow: 0 1px 3px color-mix(in oklab, var(--atc-bg) 50%, transparent);
+    height: 18px;
+    left: 5px;
+    position: absolute;
+    width: 2px;
+}
+
+.reporting-point-road-sign__blade {
+    align-items: center;
+    background: var(--reporting-point-sign-bg);
+    border: 1px solid var(--reporting-point-sign-edge);
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklab, var(--atc-card) 52%, transparent),
+        0 2px 7px color-mix(in oklab, var(--atc-bg) 36%, transparent);
+    clip-path: polygon(0 0, calc(100% - 8px) 0, 100% 50%, calc(100% - 8px) 100%, 0 100%);
+    color: var(--reporting-point-sign-fg);
+    display: inline-flex;
+    font-family: var(--font-mono);
+    font-size: 7.5px;
+    font-weight: 900;
+    gap: 5px;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    min-height: 18px;
+    padding: 4px 12px 4px 4px;
+    white-space: nowrap;
+}
+
+.reporting-point-road-sign__tag {
+    background: var(--reporting-point-sign-fg);
+    border-radius: 1px;
+    color: var(--reporting-point-sign-bg);
+    font-size: 6px;
+    line-height: 1;
+    padding: 2px 3px;
 }
 
 .navaid-count-icon {


### PR DESCRIPTION
## What changed

- Use OurAirports-backed airport names for search, airport detail, and nearby-airport payloads, without falling back to OpenAIP names.
- Show OpenAIP reporting points on airport maps as compact yellow road-sign labels at detail zoom.
- Keep the small aircraft/map model optimizations that were already in the working tree.

## Validation

- `pnpm test src/features/aircraft/filters/aircraftFilters.test.ts src/features/aircraft/trace/aircraftTraceModel.test.ts src/features/aircraft/tracking/trackedFlightPositionResolver.test.ts src/features/airport/map/airportMapModel.test.ts` (repo runner completed 120 test files)
- `pnpm typecheck`
- Earlier before this PR branch: `go test ./internal/api/webapi`, `pnpm build`, `git diff --check`, and local API checks for EGLL reporting points plus KBOS OurAirports naming.