### PR TITLE
[codex] Match reporting point labels to navaids

### DIFF
--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -51,7 +51,6 @@ import {
 } from "../../features/aircraft/positions/aircraftLoadingOverlayModel";
 import { useAviationContextTiles } from "../../features/airport/context/useAviationContextTiles";
 import { shouldUseNavaidCountTiles } from "../../features/airport/context/aviationContextDisplayModel";
-import { shouldShowReportingPointLabels } from "../../features/airport/map/reportingPointLabelModel";
 import { getOffsetMapCenter } from "./mapViewportOffset";
 
 const resolveCurrentTheme = () =>
@@ -455,7 +454,6 @@ export default function AirportMap({
     fullTraceMode: fullTraceContext,
     zoom: leafletZoom,
   });
-  const showReportingPointLabels = shouldShowReportingPointLabels(leafletZoom);
   const contextTiles = useAviationContextTiles({
     map: mapInstance,
     enabled: contextTileOverlays,
@@ -643,7 +641,7 @@ export default function AirportMap({
           <ReportingPointLabelLayer
             points={reportingPoints}
             theme={currentTheme}
-            visible={showReportingPointLabels}
+            visible={reportingPoints.length > 0}
           />
           <MapBadgeCollisionLayer
             refreshKey={[
@@ -651,7 +649,7 @@ export default function AirportMap({
               selectedNavaidKey,
               selectedAirspaceId,
               showNavaidMarkers ? "navaid-on" : "navaid-off",
-              showReportingPointLabels ? "reporting-on" : "reporting-off",
+              reportingPoints.length ? "reporting-on" : "reporting-off",
               nearbyAirportLayerDisplay.showAirportBadges ? "airport-on" : "airport-off",
               renderedNavaids.length,
               reportingPoints.length,

--- a/src/components/map/MapBadgeCollisionLayer.tsx
+++ b/src/components/map/MapBadgeCollisionLayer.tsx
@@ -113,6 +113,7 @@ function badgePriority(element: HTMLElement) {
   const type = element.dataset.mapBadgeType || "";
   if (type === "airport") return 90;
   if (type === "nearby-airport") return 70;
+  if (type === "reporting-point") return 60;
   if (type === "navaid") return 60;
   return 50;
 }

--- a/src/components/map/ReportingPointLabelLayer.tsx
+++ b/src/components/map/ReportingPointLabelLayer.tsx
@@ -8,27 +8,19 @@ import {
   safeRemoveFromMap,
 } from "../../features/airport/map/leafletLayerSafety";
 import { buildReportingPointLabels } from "../../features/airport/map/reportingPointLabelModel";
-
-const escapeHtml = (value: unknown) =>
-  String(value || "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
+import { airportLabelBadgeHtml } from "@/components/ui/AirportLabelBadge";
 
 const reportingPointMarkerHtml = (label: Record<string, any>) => `
-  <div
-    class="reporting-point-road-sign notranslate"
-    translate="no"
-    data-map-badge="true"
-    data-map-badge-type="reporting-point"
-  >
-    <span class="reporting-point-road-sign__post" aria-hidden="true"></span>
-    <span class="reporting-point-road-sign__blade">
-      <span class="reporting-point-road-sign__tag" aria-hidden="true">RP</span>
-      <span class="reporting-point-road-sign__name">${escapeHtml(label.name)}</span>
-    </span>
+  <div class="navaid-map-marker reporting-point-map-marker notranslate" translate="no">
+    <span class="navaid-map-marker__dot" aria-hidden="true"></span>
+    <div class="navaid-map-marker__badge">
+      ${airportLabelBadgeHtml({
+        code: label.name,
+        icon: "navaid",
+        badgeType: "reporting-point",
+        className: "airport-overlay-label--map-badge airport-overlay-label--navaid airport-overlay-label--reporting-point",
+      })}
+    </div>
   </div>
 `;
 
@@ -39,8 +31,8 @@ const reportingPointLabelIcon = (label: Record<string, any>, theme: string) =>
       `reporting-point-label-icon--${theme}`,
     ].join(" "),
     html: reportingPointMarkerHtml(label),
-    iconSize: [148, 44],
-    iconAnchor: [6, 40],
+    iconSize: [136, 78],
+    iconAnchor: [4, 4],
   });
 
 export default function ReportingPointLabelLayer({

--- a/src/features/airport/map/reportingPointLabelModel.test.ts
+++ b/src/features/airport/map/reportingPointLabelModel.test.ts
@@ -1,12 +1,6 @@
 import assert from "node:assert/strict";
 
-import {
-  buildReportingPointLabels,
-  shouldShowReportingPointLabels,
-} from "./reportingPointLabelModel";
-
-assert.equal(shouldShowReportingPointLabels(13.5), true);
-assert.equal(shouldShowReportingPointLabels(12), false);
+import { buildReportingPointLabels } from "./reportingPointLabelModel";
 
 assert.deepEqual(
   buildReportingPointLabels([

--- a/src/features/airport/map/reportingPointLabelModel.ts
+++ b/src/features/airport/map/reportingPointLabelModel.ts
@@ -1,5 +1,3 @@
-import { AIRPORT_MAP_ZOOM } from "../../../config/aviation";
-
 type ReportingPointRecord = Record<string, any>;
 
 const numberOrNull = (value: unknown) => {
@@ -7,11 +5,6 @@ const numberOrNull = (value: unknown) => {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : null;
 };
-
-export function shouldShowReportingPointLabels(zoom: unknown) {
-  const numericZoom = numberOrNull(zoom);
-  return numericZoom != null && numericZoom >= AIRPORT_MAP_ZOOM.detail;
-}
 
 export const buildReportingPointLabels = (
   points: ReportingPointRecord[] = [],

--- a/src/style.css
+++ b/src/style.css
@@ -1825,73 +1825,9 @@ body:has(.dither-page-shell) {
 }
 
 .leaflet-marker-icon.navaid-label-icon .airport-overlay-label--map-badge,
+.leaflet-marker-icon.reporting-point-label-icon .airport-overlay-label--map-badge,
 .leaflet-marker-icon.nearby-airport-marker-icon .airport-overlay-label--map-badge {
     pointer-events: auto;
-}
-
-.reporting-point-road-sign {
-    --map-badge-offset-x: 0px;
-    --map-badge-offset-y: 0px;
-    --map-badge-stack-z: 0;
-    --reporting-point-sign-bg: oklch(0.82 0.14 86);
-    --reporting-point-sign-edge: oklch(0.24 0.02 95);
-    --reporting-point-sign-fg: oklch(0.18 0.012 96);
-    display: inline-flex;
-    filter: drop-shadow(
-        0 2px 4px color-mix(in oklab, var(--atc-bg) 54%, transparent)
-    );
-    opacity: 0.9;
-    padding-bottom: 17px;
-    pointer-events: none;
-    position: relative;
-    transform: translate3d(
-        var(--map-badge-offset-x),
-        var(--map-badge-offset-y),
-        0
-    );
-    width: max-content;
-    z-index: var(--map-badge-stack-z);
-}
-
-.reporting-point-road-sign__post {
-    background: var(--reporting-point-sign-edge);
-    border-radius: 999px;
-    bottom: 0;
-    box-shadow: 0 1px 3px color-mix(in oklab, var(--atc-bg) 50%, transparent);
-    height: 18px;
-    left: 5px;
-    position: absolute;
-    width: 2px;
-}
-
-.reporting-point-road-sign__blade {
-    align-items: center;
-    background: var(--reporting-point-sign-bg);
-    border: 1px solid var(--reporting-point-sign-edge);
-    box-shadow:
-        inset 0 1px 0 color-mix(in oklab, var(--atc-card) 52%, transparent),
-        0 2px 7px color-mix(in oklab, var(--atc-bg) 36%, transparent);
-    clip-path: polygon(0 0, calc(100% - 8px) 0, 100% 50%, calc(100% - 8px) 100%, 0 100%);
-    color: var(--reporting-point-sign-fg);
-    display: inline-flex;
-    font-family: var(--font-mono);
-    font-size: 7.5px;
-    font-weight: 900;
-    gap: 5px;
-    letter-spacing: 0.04em;
-    line-height: 1;
-    min-height: 18px;
-    padding: 4px 12px 4px 4px;
-    white-space: nowrap;
-}
-
-.reporting-point-road-sign__tag {
-    background: var(--reporting-point-sign-fg);
-    border-radius: 1px;
-    color: var(--reporting-point-sign-bg);
-    font-size: 6px;
-    line-height: 1;
-    padding: 2px 3px;
 }
 
 .navaid-count-icon {


### PR DESCRIPTION
## What changed

- Render OpenAIP reporting points with the same dot + map badge treatment used by navaids.
- Remove the reporting-point zoom gate so labels are created whenever reporting point data is available.
- Keep reporting point badges in the shared map-badge collision stack with navaid-level priority.
- Delete the custom yellow road-sign CSS.

## Validation

- `pnpm test src/features/airport/map/reportingPointLabelModel.test.ts` (repo runner completed 120 test files)
- `pnpm typecheck`
- `git diff --check`
- `pnpm build`
- Local Chrome headless DOM check on `/airport/EGLL`: 13 reporting point badges, 0 old `.reporting-point-road-sign` nodes, 13 navaid-style reporting labels, and reporting badges carry `data-map-badge="true"`.