### PR TITLE
Fix reporting point settings persistence

### DIFF
--- a/services/data-service/internal/api/webapi/userdata.go
+++ b/services/data-service/internal/api/webapi/userdata.go
@@ -26,7 +26,7 @@ var (
 	mapModes        = map[string]bool{"spotting": true, "radio": true, "controller": true, "custom": true}
 	selectableModes = map[string]bool{"spotting": true, "radio": true, "controller": true}
 	layerKeys       = map[string]bool{
-		"mapLabels": true, "approachBeams": true, "navaidMarkers": true, "airspaces": true,
+		"mapLabels": true, "approachBeams": true, "navaidMarkers": true, "reportingPoints": true, "airspaces": true,
 		"candidateWatchingSpots": true, "showCallsigns": true, "userLocation": true, "userLocationAudio": true,
 	}
 	baseLayers = map[string]bool{"standard": true, "terrain": true}

--- a/services/data-service/internal/api/webapi/userdata_test.go
+++ b/services/data-service/internal/api/webapi/userdata_test.go
@@ -19,12 +19,13 @@ func TestMergeMapSettingsPreservesExistingLayerOverrides(t *testing.T) {
 
 	next := mergeMapSettings(current, map[string]any{
 		"layerOverrides": map[string]any{
-			"airspaces": true,
+			"airspaces":       true,
+			"reportingPoints": true,
 		},
 	})
 
 	layers := next["layerOverrides"].(map[string]any)
-	if layers["mapLabels"] != false || layers["showCallsigns"] != true || layers["airspaces"] != true {
+	if layers["mapLabels"] != false || layers["showCallsigns"] != true || layers["airspaces"] != true || layers["reportingPoints"] != true {
 		t.Fatalf("expected merged layer overrides, got %#v", layers)
 	}
 	if next["baseLayer"] != "terrain" {


### PR DESCRIPTION
## Summary
- allow reportingPoints through the data-service map-settings layer whitelist
- cover reportingPoints in the layer override merge test

## Test Plan
- go test ./internal/api/webapi
- git diff --check