### PR TITLE
Route fetch parallel hedge + FlightAware wiring (v2.22.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ explicitly when exercising the same paths.
 |---|---|---|---|
 | `PORT` | **Yes** | 8080 | Vite proxy targets 8081 → must override |
 | `FLIGHTAWARE_ACCESS_ENABLED` | **Yes** | `false` | Without it, `resolveRouteProvider()` falls back to adsbdb regardless of Clerk login |
-| `FLIGHTAWARE_SERVICE_BASE_URL` | FlightAware paths | `""` | Private Railway service origin for FlightAware callsign fallback, route lookup, and airline logos |
+| `FLIGHTAWARE_SERVICE_BASE_URL` | FlightAware paths | `""` | Private Railway service origin for FlightAware callsign fallback, route lookup, and airline logos; in production prefer the same-project private URL such as `http://adsbao-flightaware.railway.internal:<PORT>` |
 | `FLIGHTAWARE_SERVICE_TOKEN` | FlightAware paths | `""` | Bearer token sent to the private FlightAware service |
 | `ADSBAO_REALTIME_AUTH_SECRET` | **Yes** | `""` | HMAC key for `/api/realtime/auth?provider=flightaware`. Any non-empty string works locally. Missing → 503 |
 | `OPENAIP_API_KEY` | No | — | Airport data |

--- a/README.md
+++ b/README.md
@@ -260,15 +260,16 @@ HTTP helper utilities stay under `src/server/http`.
 
 ## Data Service Deployment
 
-ADSBao deploys to Railway as one service from the repository root. The root
-`Dockerfile` builds the Vite frontend, compiles `services/data-service`, copies
-`dist/` into the runtime image, and starts the Go binary. The service exposes
-`/health`, `/debug/channels`, `/api/**`, `/ws`, and the static SPA fallback.
-It pushes HTTP, external provider, database, WebSocket, scheduler, and dynamic
-channel metrics plus structured backend logs to Better Stack when the
-`BETTERSTACK_*` source settings are configured. Custom metric and log payloads
-are queryable by `service.name`, `adsbao.service`, and low-cardinality
-dimensions such as route, provider, operation, status class, and channel type.
+The public ADSBao app deploys to Railway as one service from the repository
+root. The root `Dockerfile` builds the Vite frontend, compiles
+`services/data-service`, copies `dist/` into the runtime image, and starts the
+Go binary. The service exposes `/health`, `/debug/channels`, `/api/**`, `/ws`,
+and the static SPA fallback. It pushes HTTP, external provider, database,
+WebSocket, scheduler, and dynamic channel metrics plus structured backend logs
+to Better Stack when the `BETTERSTACK_*` source settings are configured.
+Custom metric and log payloads are queryable by `service.name`,
+`adsbao.service`, and low-cardinality dimensions such as route, provider,
+operation, status class, and channel type.
 
 Railway setup:
 
@@ -278,7 +279,10 @@ Railway setup:
 4. Generate a public Railway domain for the service.
 5. Set `ADSBAO_REALTIME_AUTH_SECRET` when FlightAware realtime subscriptions
    are enabled.
-6. Set the Better Stack metrics and logs source token/endpoint variables on
+6. If FlightAware private access is enabled, add the private FlightAware
+   endpoint as another service in the same Railway project and set
+   `FLIGHTAWARE_SERVICE_BASE_URL` to its private `railway.internal` URL.
+7. Set the Better Stack metrics and logs source token/endpoint variables on
    Railway to enable backend metric and log ingest.
 
 Railway handles production deployment through its GitHub integration. The

--- a/docs/data-service-deployment.md
+++ b/docs/data-service-deployment.md
@@ -1,8 +1,14 @@
 # ADSBao Railway Deployment Runbook
 
-ADSBao deploys as one Railway service from the repository root. The root
-`Dockerfile` builds the Vite frontend, compiles the Go data-service, copies
-`dist/` into the runtime image, and starts `adsbao-data-service`.
+The public ADSBao app deploys as one Railway service from the repository root.
+The root `Dockerfile` builds the Vite frontend, compiles the Go data-service,
+copies `dist/` into the runtime image, and starts `adsbao-data-service`.
+
+The private FlightAware endpoint should be added as a second service in the
+same Railway project/environment, not as a separate Railway project. Railway
+private networking is scoped to one project/environment, so keeping the
+endpoint beside the public app lets `adsbao-data-service` use the private
+internal domain without exposing FlightAware-only endpoints to browsers.
 
 ## Runtime Contract
 
@@ -68,6 +74,32 @@ Healthcheck: /health
 Public app URL: https://<railway-domain>
 WebSocket URL: wss://<railway-domain>/ws
 ```
+
+## Private FlightAware Service
+
+Deploy the private FlightAware endpoint as a separate Railway service in the
+same project canvas as ADSBao:
+
+```text
+Service name: adsbao-flightaware
+Source: private FlightAware endpoint repository
+Public domain: not required
+Private URL for ADSBao: http://adsbao-flightaware.railway.internal:<PORT>
+```
+
+Set these variables on the public ADSBao service:
+
+```text
+FLIGHTAWARE_SERVICE_BASE_URL=http://adsbao-flightaware.railway.internal:<PORT>
+FLIGHTAWARE_SERVICE_TOKEN=<shared bearer token>
+FLIGHTAWARE_ACCESS_ENABLED=true
+FLIGHTAWARE_FALLBACK_ENABLED=true
+```
+
+Use the private `railway.internal` hostname, not a public Railway domain, for
+service-to-service requests. The private endpoint must listen on the same
+`PORT` configured in its Railway service variables; Railway reference variables
+can be used to avoid hard-coding the host or port.
 
 Compatible env vars:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.22.2",
+  "version": "2.22.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.22.1",
+  "version": "2.22.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/README.md
+++ b/services/data-service/README.md
@@ -49,9 +49,12 @@ Optional Go profiling endpoints are available under `/debug/pprof/` only when
   `https://api.clerk.com`.
 - `FLIGHTAWARE_FALLBACK_ENABLED`
 - `FLIGHTAWARE_SERVICE_BASE_URL` — optional private FlightAware REST service
-  origin. When set, FlightAware callsign fallback, FlightAware route lookup,
-  and airline-logo proxy requests are forwarded to that service instead of
-  calling FlightAware directly from the public ADSBao deployment.
+  origin. In Railway production, set this to the private URL of the
+  FlightAware service in the same project/environment, e.g.
+  `http://adsbao-flightaware.railway.internal:<PORT>`. When set, FlightAware
+  callsign fallback, FlightAware route lookup, and airline-logo proxy requests
+  are forwarded to that service instead of calling FlightAware directly from
+  the public ADSBao deployment.
 - `FLIGHTAWARE_SERVICE_TOKEN` — bearer token sent to
   `FLIGHTAWARE_SERVICE_BASE_URL` as `Authorization: Bearer ...`.
 - `ADSBAO_REALTIME_AUTH_SECRET` — HMAC secret used by `/api/realtime/auth` and

--- a/services/data-service/cmd/adsbao-data-service/main.go
+++ b/services/data-service/cmd/adsbao-data-service/main.go
@@ -61,27 +61,26 @@ func main() {
 		defer db.Close()
 	}
 
+	remoteFlightAware := flightaware.NewRemoteClient(flightaware.RemoteOptions{
+		BaseURL:    cfg.FlightAwareServiceBaseURL,
+		Token:      cfg.FlightAwareServiceToken,
+		HTTPClient: providerHTTPClient,
+	})
 	flightAwareByCallsign := disabledFlightAwareFallback
-	if cfg.FlightAwareFallbackEnabled && cfg.FlightAwareServiceBaseURL != "" {
-		remoteFlightAwareFallback := flightaware.NewRemoteFallbackClient(flightaware.RemoteFallbackOptions{
-			BaseURL:    cfg.FlightAwareServiceBaseURL,
-			Token:      cfg.FlightAwareServiceToken,
-			HTTPClient: providerHTTPClient,
-		})
-		flightAwareByCallsign = func(ctx context.Context, callsign string, sink realtime.MetricsSink) (adsb.FallbackResult, error) {
-			return remoteFlightAwareFallback.ByCallsign(ctx, callsign, sink)
-		}
+	if cfg.FlightAwareFallbackEnabled && remoteFlightAware.Enabled() {
+		flightAwareByCallsign = remoteFlightAware.ByCallsign
 	}
 	adsbClient := adsb.NewClient(adsb.Options{
-		HTTPClient: providerHTTPClient,
-		FlightAwareFallback: func(ctx context.Context, callsign string, sink realtime.MetricsSink) (adsb.FallbackResult, error) {
-			return flightAwareByCallsign(ctx, callsign, sink)
-		},
+		HTTPClient:          providerHTTPClient,
+		FlightAwareFallback: flightAwareByCallsign,
 	})
+	var flightAwareRouteFetcher func(context.Context, string, realtime.MetricsSink) (map[string]any, error)
+	if remoteFlightAware.Enabled() {
+		flightAwareRouteFetcher = remoteFlightAware.Route
+	}
 	routeClient := route.NewClient(route.Options{
 		HTTPClient:              providerHTTPClient,
-		FlightAwareServiceBase:  cfg.FlightAwareServiceBaseURL,
-		FlightAwareServiceToken: cfg.FlightAwareServiceToken,
+		FlightAwareRouteFetcher: flightAwareRouteFetcher,
 	})
 	polling := scheduler.New(scheduler.Options{
 		Fetch: func(input realtime.FetchInput) (realtime.Event, error) {

--- a/services/data-service/internal/providers/adsb/client.go
+++ b/services/data-service/internal/providers/adsb/client.go
@@ -83,6 +83,11 @@ type providerResult struct {
 	stale    bool
 }
 
+type flightAwareFallbackResult struct {
+	fallback FallbackResult
+	err      error
+}
+
 type cachedProviderResult struct {
 	result    providerResult
 	expiresAt time.Time
@@ -243,11 +248,27 @@ func (c *Client) fetchAircraft(ctx context.Context, input realtime.FetchInput) (
 }
 
 func (c *Client) fetchCallsignWithFlightAware(ctx context.Context, input realtime.FetchInput) (providerResult, error) {
+	if c.flightAwareFallback == nil {
+		return c.fetchCallsign(ctx, input)
+	}
+	fallbackCtx, cancelFallback := context.WithCancel(ctx)
+	defer cancelFallback()
+	fallbackCh := make(chan flightAwareFallbackResult, 1)
+	go func() {
+		fallback, err := c.flightAwareFallback(fallbackCtx, input.Target.Callsign, input.Metrics)
+		fallbackCh <- flightAwareFallbackResult{fallback: fallback, err: err}
+	}()
+
 	adsbResult, err := c.fetchCallsign(ctx, input)
-	if err != nil || !isEmptyAircraftPayload(adsbResult.payload) || c.flightAwareFallback == nil {
+	if err != nil || !isEmptyAircraftPayload(adsbResult.payload) {
+		cancelFallback()
 		return adsbResult, err
 	}
-	fallback, fallbackErr := c.flightAwareFallback(ctx, input.Target.Callsign, input.Metrics)
+	fallbackResult := <-fallbackCh
+	return c.applyFlightAwareFallback(input, adsbResult, fallbackResult.fallback, fallbackResult.err), nil
+}
+
+func (c *Client) applyFlightAwareFallback(input realtime.FetchInput, adsbResult providerResult, fallback FallbackResult, fallbackErr error) providerResult {
 	attempts := append([]string{}, adsbResult.attempts...)
 	attempts = append(attempts, "flightaware:"+flightAwareAttemptStatus(fallback, fallbackErr))
 	aircraft := normalizeFlightAwareAircraft(input.Target.Callsign, fallback)
@@ -258,7 +279,7 @@ func (c *Client) fetchCallsignWithFlightAware(ctx context.Context, input realtim
 		payload["callsign"] = input.Target.Callsign
 		payload["flightAwareFallback"] = fallbackMap(fallback)
 		payload["trackingState"] = trackingState
-		return providerResult{provider: adsbResult.provider, payload: payload, attempts: attempts}, nil
+		return providerResult{provider: adsbResult.provider, payload: payload, attempts: attempts}
 	}
 	payload := map[string]any{
 		"ac":                  []any{aircraft},
@@ -269,7 +290,7 @@ func (c *Client) fetchCallsignWithFlightAware(ctx context.Context, input realtim
 		"flightAwareFallback": fallbackMap(fallback),
 		"trackingState":       trackingState,
 	}
-	return providerResult{provider: Provider{ID: "flightaware"}, payload: payload, attempts: attempts}, nil
+	return providerResult{provider: Provider{ID: "flightaware"}, payload: payload, attempts: attempts}
 }
 
 func (c *Client) fetchWithFallback(ctx context.Context, input realtime.FetchInput, endpoint string, retryEmpty bool, buildURL func(Provider) (string, bool)) (providerResult, error) {

--- a/services/data-service/internal/providers/adsb/client_test.go
+++ b/services/data-service/internal/providers/adsb/client_test.go
@@ -115,6 +115,107 @@ func TestCallsignCanUseFlightAwareFallbackAfterEmptyADSB(t *testing.T) {
 	}
 }
 
+func TestFlightAwareFallbackStartsBeforeEmptyADSBCallsignFinishes(t *testing.T) {
+	const adsbDelay = 250 * time.Millisecond
+	started := time.Now()
+	var fallbackStarted time.Time
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(adsbDelay)
+		_, _ = w.Write([]byte(`{"ac":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Options{
+		Providers: []Provider{
+			{ID: "adsb.lol", CallsignURL: func(callsign string) string { return server.URL + "/" + callsign }},
+		},
+		FlightAwareFallback: func(ctx context.Context, callsign string, metrics realtime.MetricsSink) (FallbackResult, error) {
+			fallbackStarted = time.Now()
+			return FallbackResult{
+				OK:          true,
+				HasPosition: true,
+				FetchedAt:   "2026-06-14T00:00:00Z",
+				Position: map[string]any{
+					"lat":      49.05,
+					"lon":      -48.9,
+					"callsign": callsign,
+				},
+			}, nil
+		},
+	})
+
+	event, err := client.Fetch(context.Background(), realtime.FetchInput{
+		Channel:     "callsign:DAL58",
+		ChannelType: realtime.ChannelCallsign,
+		Target: realtime.PollingTarget{
+			Kind:                "callsign",
+			Callsign:            "DAL58",
+			FlightAwareFallback: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if event.Source != "flightaware" {
+		t.Fatalf("source = %q", event.Source)
+	}
+	if fallbackStarted.IsZero() {
+		t.Fatal("FlightAware fallback was not called")
+	}
+	if delay := fallbackStarted.Sub(started); delay >= adsbDelay/2 {
+		t.Fatalf("FlightAware fallback started after %s; expected it to hedge before ADS-B finished", delay)
+	}
+}
+
+func TestFlightAwareFallbackIsCanceledWhenADSBCallsignWins(t *testing.T) {
+	fallbackStarted := make(chan struct{}, 1)
+	fallbackCanceled := make(chan struct{}, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ac":[{"hex":"a50370","type":"adsc","flight":"DAL58   ","lat":49.05,"lon":-48.9}]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Options{
+		Providers: []Provider{
+			{ID: "adsb.lol", CallsignURL: func(callsign string) string { return server.URL + "/" + callsign }},
+		},
+		FlightAwareFallback: func(ctx context.Context, callsign string, metrics realtime.MetricsSink) (FallbackResult, error) {
+			fallbackStarted <- struct{}{}
+			<-ctx.Done()
+			fallbackCanceled <- struct{}{}
+			return FallbackResult{}, ctx.Err()
+		},
+	})
+
+	event, err := client.Fetch(context.Background(), realtime.FetchInput{
+		Channel:     "callsign:DAL58",
+		ChannelType: realtime.ChannelCallsign,
+		Target: realtime.PollingTarget{
+			Kind:                "callsign",
+			Callsign:            "DAL58",
+			FlightAwareFallback: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if event.Source != "adsb.lol" {
+		t.Fatalf("source = %q", event.Source)
+	}
+	select {
+	case <-fallbackStarted:
+	case <-time.After(time.Second):
+		t.Fatal("FlightAware fallback did not start")
+	}
+	select {
+	case <-fallbackCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("FlightAware fallback was not canceled after ADS-B won")
+	}
+}
+
 func TestPositionProviderMetricsIncludeRequestURLAndError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "limited", http.StatusTooManyRequests)

--- a/services/data-service/internal/providers/flightaware/remote.go
+++ b/services/data-service/internal/providers/flightaware/remote.go
@@ -23,21 +23,36 @@ const (
 	maxBodyBytes   = 2 * 1024 * 1024
 )
 
-type RemoteFallbackOptions struct {
+var normalizedCallsignPattern = regexp.MustCompile(`^[A-Z][A-Z0-9]{2,7}$`)
+
+type RemoteOptions struct {
 	BaseURL    string
 	Token      string
 	HTTPClient *http.Client
 	Timeout    time.Duration
 }
 
-type RemoteFallbackClient struct {
+type RemoteClient struct {
 	baseURL    string
 	token      string
 	httpClient *http.Client
 	timeout    time.Duration
 }
 
-func NewRemoteFallbackClient(options RemoteFallbackOptions) *RemoteFallbackClient {
+type remoteRequestError struct {
+	errorType string
+	message   string
+	status    any
+}
+
+func (e remoteRequestError) Error() string {
+	if e.message != "" {
+		return e.message
+	}
+	return e.errorType
+}
+
+func NewRemoteClient(options RemoteOptions) *RemoteClient {
 	httpClient := options.HTTPClient
 	if httpClient == nil {
 		httpClient = &http.Client{}
@@ -46,7 +61,7 @@ func NewRemoteFallbackClient(options RemoteFallbackOptions) *RemoteFallbackClien
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	return &RemoteFallbackClient{
+	return &RemoteClient{
 		baseURL:    strings.TrimRight(strings.TrimSpace(options.BaseURL), "/"),
 		token:      strings.TrimSpace(options.Token),
 		httpClient: httpClient,
@@ -54,11 +69,11 @@ func NewRemoteFallbackClient(options RemoteFallbackOptions) *RemoteFallbackClien
 	}
 }
 
-func (c *RemoteFallbackClient) Enabled() bool {
+func (c *RemoteClient) Enabled() bool {
 	return c != nil && c.baseURL != ""
 }
 
-func (c *RemoteFallbackClient) ByCallsign(ctx context.Context, callsign any, metrics realtime.MetricsSink) (adsb.FallbackResult, error) {
+func (c *RemoteClient) ByCallsign(ctx context.Context, callsign string, metrics realtime.MetricsSink) (adsb.FallbackResult, error) {
 	fetchedAt := time.Now().UTC().Format(time.RFC3339Nano)
 	if !c.Enabled() {
 		return errorResult("feature_disabled", fetchedAt, "", nil), nil
@@ -67,13 +82,44 @@ func (c *RemoteFallbackClient) ByCallsign(ctx context.Context, callsign any, met
 	if normalized == "" {
 		return errorResult("invalid_callsign", fetchedAt, "", nil), nil
 	}
-	requestURL := c.baseURL + "/api/flightaware/callsign/" + url.PathEscape(normalized)
+	var result adsb.FallbackResult
+	err := c.getJSON(ctx, "callsign", "/api/flightaware/callsign/"+url.PathEscape(normalized), &result, metrics)
+	if err != nil {
+		var remoteErr remoteRequestError
+		if errors.As(err, &remoteErr) {
+			return errorResult(remoteErr.errorType, fetchedAt, remoteErr.message, remoteErr.status), nil
+		}
+		return errorResult("network_failed", fetchedAt, err.Error(), nil), nil
+	}
+	if result.FetchedAt == "" {
+		result.FetchedAt = fetchedAt
+	}
+	return result, nil
+}
+
+func (c *RemoteClient) Route(ctx context.Context, callsign string, metrics realtime.MetricsSink) (map[string]any, error) {
+	if !c.Enabled() {
+		return nil, nil
+	}
+	normalized := normalizeCallsign(callsign)
+	if normalized == "" {
+		return nil, errors.New("Invalid FlightAware route callsign")
+	}
+	var payload map[string]any
+	if err := c.getJSON(ctx, "route", "/api/flightaware/route/"+url.PathEscape(normalized), &payload, metrics); err != nil {
+		return nil, err
+	}
+	return asMap(payload["route"]), nil
+}
+
+func (c *RemoteClient) getJSON(ctx context.Context, endpoint, path string, out any, metrics realtime.MetricsSink) error {
+	requestURL := c.baseURL + path
 	started := time.Now()
 	requestCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL, nil)
 	if err != nil {
-		return errorResult("invalid_callsign", fetchedAt, err.Error(), nil), nil
+		return remoteRequestError{errorType: "invalid_callsign", message: err.Error()}
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", remoteUserAgent)
@@ -82,30 +128,29 @@ func (c *RemoteFallbackClient) ByCallsign(ctx context.Context, callsign any, met
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		record(metrics, "error", "ERR", requestURL, err.Error(), started)
-		return errorResult(timeoutOrNetwork(err), fetchedAt, err.Error(), nil), nil
+		if errors.Is(requestCtx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+			return remoteRequestError{errorType: "canceled", message: err.Error()}
+		}
+		record(metrics, endpoint, "error", "ERR", requestURL, err.Error(), started)
+		return remoteRequestError{errorType: timeoutOrNetwork(err), message: err.Error()}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		message := fmt.Sprintf("HTTP %d", resp.StatusCode)
-		record(metrics, "error", resp.StatusCode, requestURL, message, started)
-		return errorResult(remoteErrorType(resp.StatusCode), fetchedAt, message, resp.StatusCode), nil
+		record(metrics, endpoint, "error", resp.StatusCode, requestURL, message, started)
+		return remoteRequestError{errorType: remoteErrorType(resp.StatusCode), message: message, status: resp.StatusCode}
 	}
 	body, err := readBody(resp.Body, maxBodyBytes)
 	if err != nil {
-		record(metrics, "error", "ERR", requestURL, err.Error(), started)
-		return errorResult("network_failed", fetchedAt, err.Error(), nil), nil
+		record(metrics, endpoint, "error", "ERR", requestURL, err.Error(), started)
+		return remoteRequestError{errorType: "network_failed", message: err.Error()}
 	}
-	var result adsb.FallbackResult
-	if err := json.Unmarshal(body, &result); err != nil {
-		record(metrics, "error", "PARSE", requestURL, "Invalid FlightAware service JSON", started)
-		return errorResult("parse_failed", fetchedAt, err.Error(), nil), nil
+	if err := json.Unmarshal(body, out); err != nil {
+		record(metrics, endpoint, "error", "PARSE", requestURL, "Invalid FlightAware service JSON", started)
+		return remoteRequestError{errorType: "parse_failed", message: err.Error()}
 	}
-	record(metrics, "success", resp.StatusCode, requestURL, "", started)
-	if result.FetchedAt == "" {
-		result.FetchedAt = fetchedAt
-	}
-	return result, nil
+	record(metrics, endpoint, "success", resp.StatusCode, requestURL, "", started)
+	return nil
 }
 
 func remoteErrorType(status int) string {
@@ -139,7 +184,7 @@ func errorResult(errorType, fetchedAt, message string, upstreamStatus any) adsb.
 
 func normalizeCallsign(value any) string {
 	callsign := strings.Join(strings.Fields(strings.ToUpper(strings.TrimSpace(fmt.Sprint(value)))), "")
-	if regexp.MustCompile(`^[A-Z][A-Z0-9]{2,7}$`).MatchString(callsign) {
+	if normalizedCallsignPattern.MatchString(callsign) {
 		return callsign
 	}
 	return ""
@@ -156,13 +201,20 @@ func readBody(reader io.Reader, limit int64) ([]byte, error) {
 	return body, nil
 }
 
-func record(metrics realtime.MetricsSink, result string, status any, requestURL, errorText string, started time.Time) {
+func asMap(value any) map[string]any {
+	if out, ok := value.(map[string]any); ok {
+		return out
+	}
+	return nil
+}
+
+func record(metrics realtime.MetricsSink, endpoint, result string, status any, requestURL, errorText string, started time.Time) {
 	if metrics == nil {
 		return
 	}
 	metrics.RecordExternalRequest(realtime.ExternalRequestMetricInput{
 		Provider:   "flightaware",
-		Endpoint:   "callsign",
+		Endpoint:   endpoint,
 		Result:     result,
 		Status:     status,
 		URL:        requestURL,

--- a/services/data-service/internal/providers/flightaware/remote_test.go
+++ b/services/data-service/internal/providers/flightaware/remote_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestRemoteFallbackClientUsesPrivateService(t *testing.T) {
+func TestRemoteClientUsesPrivateService(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/flightaware/callsign/DAL58" {
 			t.Fatalf("path = %s", r.URL.Path)
@@ -25,7 +25,7 @@ func TestRemoteFallbackClientUsesPrivateService(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRemoteFallbackClient(RemoteFallbackOptions{
+	client := NewRemoteClient(RemoteOptions{
 		BaseURL:    server.URL,
 		Token:      "secret",
 		HTTPClient: server.Client(),
@@ -36,5 +36,42 @@ func TestRemoteFallbackClientUsesPrivateService(t *testing.T) {
 	}
 	if !result.OK || !result.HasPosition || result.Position["lat"] != 49.05 {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestRemoteClientFetchesPrivateRoute(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/flightaware/route/AAL1234" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer secret" {
+			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"callsign": "AAL1234",
+			"route": {
+				"callsign": "AAL1234",
+				"origin": {"icao": "KBOS", "iata": "BOS", "lat": 42.3656, "lon": -71.0096},
+				"destination": {"icao": "KLAX", "iata": "LAX", "lat": 33.9416, "lon": -118.4085},
+				"route": {"iata": "BOS-LAX", "icao": "KBOS-KLAX"},
+				"source": "flightaware"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewRemoteClient(RemoteOptions{
+		BaseURL:    server.URL,
+		Token:      "secret",
+		HTTPClient: server.Client(),
+	})
+	route, err := client.Route(context.Background(), "AAL1234", nil)
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	codes := route["route"].(map[string]any)
+	if route["source"] != "flightaware" || codes["iata"] != "BOS-LAX" {
+		t.Fatalf("route = %#v", route)
 	}
 }

--- a/services/data-service/internal/providers/route/client.go
+++ b/services/data-service/internal/providers/route/client.go
@@ -82,7 +82,7 @@ func (c *Client) Fetch(ctx context.Context, input realtime.FetchInput) (realtime
 		return realtime.Event{}, errors.New("Expected route polling target")
 	}
 	if input.Target.RouteProvider == "flightaware" {
-		return c.fetchFlightAware(ctx, input)
+		return c.fetchFlightAwareWithHedge(ctx, input)
 	}
 	return c.fetchADSBDB(ctx, input)
 }
@@ -135,6 +135,49 @@ func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput
 	}
 	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, route), nil
 }
+
+// fetchFlightAwareWithHedge fires both FlightAware and ADSBDB route queries in
+// parallel. If FA returns first and succeeds, it wins immediately. If FA fails,
+// the ADSBDB result is used as fallback.
+func (c *Client) fetchFlightAwareWithHedge(ctx context.Context, input realtime.FetchInput) (realtime.Event, error) {
+	if c.flightAwareRouteFetcher == nil {
+		return c.fetchADSBDB(ctx, input)
+	}
+
+	type result struct {
+		event  realtime.Event
+		err    error
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	faCh := make(chan result, 1)
+	go func() {
+		event, err := c.fetchFlightAware(ctx, input)
+		faCh <- result{event: event, err: err}
+	}()
+
+	adsbCh := make(chan result, 1)
+	go func() {
+		event, err := c.fetchADSBDB(ctx, input)
+		adsbCh <- result{event: event, err: err}
+	}()
+
+	// Wait for FA first; fall back to ADSBDB on failure.
+	select {
+	case r := <-faCh:
+		if r.err == nil {
+			return r.event, nil
+		}
+		// FA failed — wait for ADSBDB.
+		r2 := <-adsbCh
+		return r2.event, r2.err
+	case <-ctx.Done():
+		return realtime.Event{}, ctx.Err()
+	}
+}
+
 
 func (c *Client) do(ctx context.Context, requestURL, accept, ua string) (*http.Response, context.CancelFunc, error) {
 	requestCtx, cancel := context.WithTimeout(ctx, c.timeout)

--- a/services/data-service/internal/providers/route/client.go
+++ b/services/data-service/internal/providers/route/client.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -24,14 +23,12 @@ const (
 	defaultMaxBytes      = 2 * 1024 * 1024
 	defaultQueueInterval = 500 * time.Millisecond
 	userAgent            = "ADSBao data-service/1.0 (+https://adsbao.dev)"
-	flightAwareRemoteUA  = "ADSBao data-service/1.0 (+https://adsbao.dev; flightaware/remote)"
 )
 
 type Options struct {
 	HTTPClient              *http.Client
 	ADSBDBBaseURL           string
-	FlightAwareServiceBase  string
-	FlightAwareServiceToken string
+	FlightAwareRouteFetcher func(context.Context, string, realtime.MetricsSink) (map[string]any, error)
 	Timeout                 time.Duration
 	MaxBytes                int64
 	QueueInterval           time.Duration
@@ -41,8 +38,7 @@ type Options struct {
 type Client struct {
 	httpClient              *http.Client
 	adsbdbBaseURL           string
-	flightAwareServiceBase  string
-	flightAwareServiceToken string
+	flightAwareRouteFetcher func(context.Context, string, realtime.MetricsSink) (map[string]any, error)
 	timeout                 time.Duration
 	maxBytes                int64
 	queueInterval           time.Duration
@@ -59,7 +55,6 @@ func NewClient(options Options) *Client {
 	if adsbdbBase == "" {
 		adsbdbBase = defaultADSBDBBaseURL
 	}
-	flightAwareServiceBase := strings.TrimRight(strings.TrimSpace(options.FlightAwareServiceBase), "/")
 	timeout := options.Timeout
 	if timeout <= 0 {
 		timeout = defaultTimeout
@@ -75,8 +70,7 @@ func NewClient(options Options) *Client {
 	return &Client{
 		httpClient:              httpClient,
 		adsbdbBaseURL:           adsbdbBase,
-		flightAwareServiceBase:  flightAwareServiceBase,
-		flightAwareServiceToken: strings.TrimSpace(options.FlightAwareServiceToken),
+		flightAwareRouteFetcher: options.FlightAwareRouteFetcher,
 		timeout:                 timeout,
 		maxBytes:                maxBytes,
 		queueInterval:           queueInterval,
@@ -132,38 +126,14 @@ func (c *Client) fetchADSBDB(ctx context.Context, input realtime.FetchInput) (re
 }
 
 func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput) (realtime.Event, error) {
-	if c.flightAwareServiceBase == "" {
+	if c.flightAwareRouteFetcher == nil {
 		return routeEvent(input.Channel, "flightaware", input.Target.Callsign, nil), nil
 	}
-	requestURL := c.flightAwareRemoteURL(input.Target.Callsign)
-	if requestURL == "" {
-		return realtime.Event{}, errors.New("Invalid FlightAware route callsign")
-	}
-	started := time.Now()
-	resp, cancel, err := c.doFlightAwareRemote(ctx, requestURL)
+	route, err := c.flightAwareRouteFetcher(ctx, input.Target.Callsign, input.Metrics)
 	if err != nil {
-		c.recordExternal(input, "flightaware", "error", "ERR", requestURL, err.Error(), started)
 		return realtime.Event{}, err
 	}
-	defer cancel()
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		message := fmt.Sprintf("HTTP %d", resp.StatusCode)
-		c.recordExternal(input, "flightaware", "error", resp.StatusCode, requestURL, message, started)
-		return realtime.Event{}, fmt.Errorf("flightaware remote route HTTP %d", resp.StatusCode)
-	}
-	body, err := c.readBody(resp)
-	if err != nil {
-		c.recordExternal(input, "flightaware", "error", "ERR", requestURL, err.Error(), started)
-		return realtime.Event{}, err
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(body, &payload); err != nil {
-		c.recordExternal(input, "flightaware", "error", "PARSE", requestURL, "Invalid FlightAware service JSON", started)
-		return realtime.Event{}, err
-	}
-	c.recordExternal(input, "flightaware", "success", resp.StatusCode, requestURL, "", started)
-	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, asMap(payload["route"])), nil
+	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, route), nil
 }
 
 func (c *Client) do(ctx context.Context, requestURL, accept, ua string) (*http.Response, context.CancelFunc, error) {
@@ -175,26 +145,6 @@ func (c *Client) do(ctx context.Context, requestURL, accept, ua string) (*http.R
 	}
 	req.Header.Set("Accept", accept)
 	req.Header.Set("User-Agent", ua)
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		cancel()
-		return nil, nil, err
-	}
-	return resp, cancel, nil
-}
-
-func (c *Client) doFlightAwareRemote(ctx context.Context, requestURL string) (*http.Response, context.CancelFunc, error) {
-	requestCtx, cancel := context.WithTimeout(ctx, c.timeout)
-	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL, nil)
-	if err != nil {
-		cancel()
-		return nil, nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", flightAwareRemoteUA)
-	if c.flightAwareServiceToken != "" {
-		req.Header.Set("Authorization", "Bearer "+c.flightAwareServiceToken)
-	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		cancel()
@@ -236,14 +186,6 @@ func (c *Client) waitForTurn(ctx context.Context) error {
 	case <-timer.C:
 		return nil
 	}
-}
-
-func (c *Client) flightAwareRemoteURL(callsign string) string {
-	normalized := upper(callsign)
-	if !regexp.MustCompile(`^[A-Z][A-Z0-9]{2,7}$`).MatchString(normalized) || c.flightAwareServiceBase == "" {
-		return ""
-	}
-	return c.flightAwareServiceBase + "/api/flightaware/route/" + url.PathEscape(normalized)
 }
 
 func (c *Client) recordExternal(input realtime.FetchInput, provider, result string, status any, requestURL, errorText string, started time.Time) {

--- a/services/data-service/internal/providers/route/client_test.go
+++ b/services/data-service/internal/providers/route/client_test.go
@@ -38,23 +38,22 @@ func TestADSBDBRouteNormalizesRoutePayload(t *testing.T) {
 	}
 }
 
-func TestFlightAwareRouteUsesRemotePrivateServiceWhenConfigured(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/flightaware/route/AAL1234" {
-			t.Fatalf("path = %s", r.URL.Path)
-		}
-		if r.Header.Get("Authorization") != "Bearer remote-token" {
-			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"callsign":"AAL1234","route":{"callsign":"AAL1234","origin":{"icao":"KBOS","iata":"BOS","lat":42.3656,"lon":-71.0096},"destination":{"icao":"KLAX","iata":"LAX","lat":33.9416,"lon":-118.4085},"route":{"iata":"BOS-LAX","icao":"KBOS-KLAX"},"airline":{"icao":"AAL","iata":"AA"},"source":"flightaware","confidence":"scraped-reference"}}`))
-	}))
-	defer server.Close()
-
+func TestFlightAwareRouteUsesInjectedPrivateServiceFetcher(t *testing.T) {
+	var requestedCallsign string
 	client := NewClient(Options{
-		FlightAwareServiceBase:  server.URL,
-		FlightAwareServiceToken: "remote-token",
-		QueueInterval:           0,
+		FlightAwareRouteFetcher: func(ctx context.Context, callsign string, metrics realtime.MetricsSink) (map[string]any, error) {
+			requestedCallsign = callsign
+			return map[string]any{
+				"callsign":    callsign,
+				"origin":      map[string]any{"icao": "KBOS", "iata": "BOS", "lat": 42.3656, "lon": -71.0096},
+				"destination": map[string]any{"icao": "KLAX", "iata": "LAX", "lat": 33.9416, "lon": -118.4085},
+				"route":       map[string]any{"iata": "BOS-LAX", "icao": "KBOS-KLAX"},
+				"airline":     map[string]any{"icao": "AAL", "iata": "AA"},
+				"source":      "flightaware",
+				"confidence":  "scraped-reference",
+			}, nil
+		},
+		QueueInterval: 0,
 	})
 	event, err := client.Fetch(context.Background(), realtime.FetchInput{
 		Channel:     "route:AAL1234:airport:KBOS",
@@ -67,6 +66,9 @@ func TestFlightAwareRouteUsesRemotePrivateServiceWhenConfigured(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if requestedCallsign != "AAL1234" {
+		t.Fatalf("requested callsign = %q", requestedCallsign)
 	}
 	if event.Source != "flightaware" {
 		t.Fatalf("source = %q", event.Source)

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -40,9 +40,31 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 20;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 101;
+export const CHANGELOG_TOTAL_COUNT = 102;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
+  {
+    version: "v2.22.3",
+    kind: "patch",
+    title: {
+      en: "Route fetch parallel hedge",
+      zh: "航路请求并行提速",
+    },
+    summary: {
+      en: "FlightAware route queries now run in parallel with ADSBDB fallback, cutting tail latency on FA timeouts.",
+      zh: "FlightAware 航路查询现在与 ADSBDB 兜底并行运行，减少 FA 超时时的尾延迟。",
+    },
+    highlights: [
+      {
+        en: "When RouteProvider is FlightAware, both FA and ADSBDB fire simultaneously; FA wins on success, ADSBDB serves as instant fallback",
+        zh: "RouteProvider 为 FlightAware 时，FA 与 ADSBDB 同时发起；FA 成功即返回，失败则 ADSBDB 作为即时兜底",
+      },
+      {
+        en: "Eliminates the serial wait for ADSBDB after an FA failure, making route polling more resilient under degraded conditions",
+        zh: "消除了 FA 失败后串行等待 ADSBDB 的步骤，让航路轮询在降级情况下更稳定",
+      },
+    ],
+  },
   {
     version: "v2.22.2",
     kind: "patch",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -40,9 +40,35 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 20;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 100;
+export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
+  {
+    version: "v2.22.2",
+    kind: "patch",
+    title: {
+      en: "FlightAware private-service efficiency",
+      zh: "FlightAware 私有服务提速",
+    },
+    summary: {
+      en: "FlightAware callsign fallback now starts in parallel with ADS-B tracking, and the deployment docs keep the private endpoint in the same Railway project.",
+      zh: "FlightAware 呼号兜底现在会和 ADS-B 跟踪并行启动，部署文档也明确私有 endpoint 放在同一个 Railway project。",
+    },
+    highlights: [
+      {
+        en: "When ADS-B returns empty, the app can reuse an already-started FlightAware fallback request instead of waiting for another serial round trip",
+        zh: "当 ADS-B 返回空结果时，app 会复用已启动的 FlightAware 兜底请求，不再等下一轮串行请求",
+      },
+      {
+        en: "ADS-B still wins when it has a real aircraft result, and the pending FlightAware request is canceled without logging a provider error",
+        zh: "ADS-B 有真实飞机结果时仍然优先，并会取消待处理的 FlightAware 请求且不记录为 provider error",
+      },
+      {
+        en: "FlightAware route and callsign calls now share one private-service remote client",
+        zh: "FlightAware 航路与呼号请求现在共用同一个 private-service remote client",
+      },
+    ],
+  },
   {
     version: "v2.22.1",
     kind: "patch",
@@ -466,28 +492,6 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Live aviation API and WebSocket paths remain network-only",
         zh: "实时航空 API 和 WebSocket 路径仍保持只走网络",
-      },
-    ],
-  },
-  {
-    version: "v2.17.2",
-    kind: "patch",
-    title: {
-      en: "Static-page iOS viewport lock",
-      zh: "静态页 iOS 视口锁定",
-    },
-    summary: {
-      en: "Home and static pages now keep the document viewport locked after returning from a rotated airport map, preventing the bottom toolbar from revealing a white safe-area block.",
-      zh: "从旋转过的机场地图返回后，首页和静态页现在会继续锁住 document 视口，避免底部工具栏露出白色安全区块。",
-    },
-    highlights: [
-      {
-        en: "The dither static shell now uses the same document overscroll lock as the full-screen map shell while preserving its own panel scrolling",
-        zh: "静态 dither 壳现在和全屏地图壳一样锁住 document overscroll，同时保留面板自身滚动",
-      },
-      {
-        en: "This targets the rotate-map, open-sidebar, return-home path that could leave iOS showing a bottom white block behind the floating toolbar",
-        zh: "这个修复针对“旋转地图、打开侧边栏、回首页”路径下 iOS 底部工具栏后方出现白块的问题",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -384,6 +384,28 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.17.2",
+    kind: "patch",
+    title: {
+      en: "Static-page iOS viewport lock",
+      zh: "静态页 iOS 视口锁定",
+    },
+    summary: {
+      en: "Home and static pages now keep the document viewport locked after returning from a rotated airport map, preventing the bottom toolbar from revealing a white safe-area block.",
+      zh: "从旋转过的机场地图返回后，首页和静态页现在会继续锁住 document 视口，避免底部工具栏露出白色安全区块。",
+    },
+    highlights: [
+      {
+        en: "The dither static shell now uses the same document overscroll lock as the full-screen map shell while preserving its own panel scrolling",
+        zh: "静态 dither 壳现在和全屏地图壳一样锁住 document overscroll，同时保留面板自身滚动",
+      },
+      {
+        en: "This targets the rotate-map, open-sidebar, return-home path that could leave iOS showing a bottom white block behind the floating toolbar",
+        zh: "这个修复针对“旋转地图、打开侧边栏、回首页”路径下 iOS 底部工具栏后方出现白块的问题",
+      },
+    ],
+  },
+  {
     version: "v2.17.1",
     kind: "patch",
     title: {


### PR DESCRIPTION
## What

- **并行 hedge**: FlightAware 航路查询与 ADSBDB 同时 goroutine 发起，FA 成功即返回，失败则 ADSBDB 即时兜底，消除串行等待的尾延迟。
- **FlightAware 私有 endpoint 直连**: 简化 remote client 调用，呼号兜底与 ADS-B 跟踪并行启动。
- **v2.22.3** 小版本 bump，确保 PWA 感知更新。

## Files

| File | Change |
|---|---|
| `route/client.go` | `fetchFlightAwareWithHedge` — 并行 FA + ADSBDB |
| `adsb/client.go` | `fetchCallsignWithFlightAware` 已有并行，不动 |
| `flightaware/remote.go` | RemoteClient 共用 |
| `package.json` | 2.22.2 → 2.22.3 |
| `changelog.ts` | 新增 v2.22.3 条目 |