### PR TITLE
Frosted interface redesign (v2.27.0)

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -15,3 +15,15 @@ Use Uber-inspired typography: geometric sans, sentence-case headings, tight line
 - Use rounded Spotify-like components for panels, controls, chips, and navigation while avoiding generic card clutter.
 - Use Uber-like type for clarity and confidence: sentence case, no decorative tracking, tight but readable hierarchy.
 - Include flight-specific surfaces in the design and verification: `/aircraft/[callsign]`, selected-aircraft preview/trace, route feedback, lost-signal states, and map/sidebar behavior.
+
+### Material system & tokens — source of truth
+
+This file is only the brief (who it's for, the feel, the principles). The
+**concrete visual system is `DESIGN.md`** and is the single source of truth:
+the Frosted / Liquid-Glass materials, the theme-split **orange** signal accent,
+the `--fs-*` first-screen type scale, the light/dark theme tokens, and the
+per-component patterns all live there — do **not** restate or fork them here.
+
+Before implementing any UI, read **`DESIGN.md`** and `CLAUDE.md` →
+"Styling — Tailwind first". Keep this brief stable; let the changing
+implementation detail live only in `DESIGN.md` so there is one thing to maintain.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,6 +20,43 @@ soft light, deep blur, crisp dark type — not flat SaaS cards and not game UI.
 
 There are exactly **two materials**. Do not invent a third.
 
+## Frosted refinement (current)
+
+The map-context surfaces (`.airport-map-kit` sidebar + toolbars) read as
+genuinely **translucent frosted glass** — the live map diffuses through the
+panel rather than sitting behind an opaque wash. The panel drops to ~0.56
+alpha and leans on a strong saturated blur (`saturate(1.7) blur(26px)`) for
+legibility. Inner cards use the softened geometry tokens (`--atc-radius-card`
+13px, `--atc-radius-panel`/`--atc-radius-shell` 16px).
+
+There is **one orange signal accent** — `--atc-signal-accent`, **theme-split**:
+a warm vivid orange in light theme (`:root`, `oklch(0.66 0.16 50)`) and a
+brighter orange in dark theme (`:root[data-theme="dark"]`, `oklch(0.74 0.15
+55)`). At low alpha its wash reads as light-orange on white and deep-orange on
+the dark canvas. `-soft`/`-strong` derive from the base, so only the base flips
+per theme. It is the *only* chromatic accent in the operational UI and is
+reserved for three things:
+
+1. **List-row selection** — a faint orange wash (`--atc-signal-accent` ~12%)
+   plus a 2px orange rail down the left edge (`inset 2px 0 0`). Row text keeps
+   its resting color; the row glyph tints orange. This replaces the smoke
+   capsule for `.aircraft-table-row--selected` / `AircraftRow`.
+2. **The tracked-flight trace** — `--aviation-trace-line/-glow/-point` resolve
+   to the signal accent.
+3. **The primary "track" button** — `.aircraft-preview-card__track-btn` is a
+   solid orange capsule with white text.
+
+The sidebar's airport metrics are one **joined hero stats block** (a single
+rounded glass container: a big headline metric over a divider row of small
+footer cells), not separate metric cards. Each segment doubles as the
+view-switch control; the active segment shows an orange accent rail (left rail
+on the headline, top rail on a footer cell) + a faint orange wash.
+
+The glass capsule (Material 1) is still used for the remaining *control*
+selection (filter chips, toolbar buttons) — do not put the orange accent there.
+Keep the orange accent to: row-selection, the tracked trace, the track-button,
+and the active hero/telemetry segment.
+
 ## Material 1 — Selected: the glass capsule
 
 Used ONLY for selected/active states: selected metric cards (tabs), active

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.26.23",
+  "version": "2.27.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/about/AboutPanel.tsx
+++ b/src/components/about/AboutPanel.tsx
@@ -84,7 +84,7 @@ export default function AboutPanel() {
         </div>
       </div>
 
-      <ol className="dither-list dither-list-flow mx-5 flex flex-col gap-0.5">
+      <ol className="dither-list dither-list-flow mx-5 flex flex-col gap-2.5">
         {ABOUT_DATA_SOURCES.map((source) => (
           <li key={source.host || source.title || source.glyph}>
             <TextPillListItem

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -486,7 +486,7 @@ function AirportExplorerContent({
     collapseEnabled: !isMobile,
     onCollapse: collapseSidebar,
     onExpand: expandSidebar,
-    fillAircraftList: false,
+    fillAircraftList: true,
   };
 
   return (

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -104,7 +104,7 @@ function NearMeDiscoverySection() {
         id="airport-discovery-nearby"
         title={t("search.discovery.nearby.title")}
       />
-      <ul className="dither-list mt-3 flex flex-col gap-1">
+      <ul className="dither-list mt-2.5 flex flex-col gap-2.5">
         <NearbyPromptRow onRequest={handleOpenNearMe} />
       </ul>
     </section>
@@ -125,7 +125,7 @@ function AirportDiscoveryTopicSection({ topic, onOpen, onPrefetch }) {
         description={t(topic.descriptionKey)}
       />
 
-      <ul className="dither-list mt-3 flex flex-col gap-1">
+      <ul className="dither-list mt-2.5 flex flex-col gap-2.5">
         {topic.airports.map((airport) => (
           <AirportDiscoveryAirportRow
             key={airport.icao || airport.code || airport.name}
@@ -142,21 +142,12 @@ function AirportDiscoveryTopicSection({ topic, onOpen, onPrefetch }) {
 function DiscoverySectionHeader({
   id,
   title,
-  description = "",
 }) {
   return (
     <header className="min-w-0">
-      <h2
-        id={id}
-        className="truncate text-[13px] font-extrabold leading-tight text-atc-text"
-      >
+      <h2 id={id} className="fs-eyebrow block truncate">
         {title}
       </h2>
-      {description ? (
-        <p className="mt-1.5 text-[11px] leading-relaxed text-atc-dim">
-          {description}
-        </p>
-      ) : null}
     </header>
   );
 }

--- a/src/components/airport/search/AirportSearchPanel.tsx
+++ b/src/components/airport/search/AirportSearchPanel.tsx
@@ -55,7 +55,7 @@ export default function AirportSearchPanel({
         <Input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          className="h-6 min-w-0 flex-1 p-0 text-[13px] font-semibold tracking-normal text-atc-text"
+          className="h-6 min-w-0 flex-1 p-0 text-[11px] font-semibold tracking-normal text-atc-text"
           placeholder={t("search.placeholder")}
         />
         <kbd className="atc-chip hidden shrink-0 sm:inline-flex">

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -137,7 +137,7 @@ export default function DitherPageShell({
                   <span className="block break-words">{resolvedTitle}</span>
                 </h1>
                 {hasDescription ? (
-                  <p className="dither-page-description mt-2.5 text-[12px] leading-relaxed text-atc-dim">
+                  <p className="dither-page-description fs-desc mt-2.5">
                     {resolvedDescription}
                   </p>
                 ) : null}

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -862,7 +862,7 @@ function FlightExplorerContent({ callsign }) {
     collapseEnabled: !isMobile,
     onCollapse: collapseSidebar,
     onExpand: expandSidebar,
-    fillAircraftList: false,
+    fillAircraftList: true,
   };
 
   return (

--- a/src/components/map/SelectedAircraftTrace.tsx
+++ b/src/components/map/SelectedAircraftTrace.tsx
@@ -315,9 +315,12 @@ function SingleAircraftTrace({
 
     const pane = ensureAirportMapPane(map, AIRPORT_MAP_PANES.trace);
     const traceStyle = getTraceStyle(theme);
-    const lineColor = accentColor || traceStyle.lineColor;
-    const glowColor = accentColor || traceStyle.glowColor;
-    const dotColor = accentColor || traceStyle.pointColor;
+    // Always the single orange signal accent — the trace no longer borrows
+    // the plane's movement color, so every selected aircraft draws the same
+    // orange trail instead of some orange / some black-or-white.
+    const lineColor = traceStyle.lineColor;
+    const glowColor = traceStyle.glowColor;
+    const dotColor = traceStyle.pointColor;
     const layers = [];
     const gradientEls = [];
     const gradientBase = `${gradientIdPart(aircraftHex)}-${Date.now().toString(36)}`;

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -111,14 +111,14 @@ const LAYER_CONTROLS = [
 ];
 
 const sectionTitleClassName =
-  "mb-px px-0.5 text-[7.5px] font-bold uppercase tracking-normal text-atc-muted";
+  "mb-2 px-1 text-[9px] font-bold uppercase tracking-[0.1em] text-atc-faint";
 
 const settingsListGroupClassName =
-  "map-settings-list-group grid gap-0 overflow-visible";
+  "map-settings-list-group grid gap-0.5 overflow-visible";
 
 const settingsOptionRowClassName = cn(
-  "group map-settings-option-row grid min-h-[25px] w-full grid-cols-[16px_minmax(0,1fr)_3px] items-center gap-1",
-  "rounded-[4px] px-0 py-0.5 text-left text-atc-text transition-[background,color,opacity] duration-150",
+  "group map-settings-option-row grid min-h-[40px] w-full grid-cols-[20px_minmax(0,1fr)_4px] items-center gap-2.5",
+  "rounded-[var(--atc-radius-card)] px-2.5 py-2 text-left text-atc-text transition-[background,color,opacity] duration-150",
   "hover:bg-[var(--atc-control-surface-hover)]",
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-accent)]",
   "data-[active=true]:bg-transparent data-[active=true]:text-atc-text",
@@ -126,8 +126,8 @@ const settingsOptionRowClassName = cn(
 );
 
 const layerToggleRowClassName = cn(
-  "group grid min-h-[25px] w-full grid-cols-[16px_minmax(0,1fr)_22px] items-center gap-1",
-  "rounded-[4px] bg-transparent px-0 py-0.5 text-left text-atc-text",
+  "group grid min-h-[40px] w-full grid-cols-[20px_minmax(0,1fr)_26px] items-center gap-2.5",
+  "rounded-[var(--atc-radius-card)] bg-transparent px-2.5 py-2 text-left text-atc-text",
   "transition-[background,opacity] duration-150",
   "hover:bg-[var(--atc-control-surface-hover)]",
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-accent)]",
@@ -135,7 +135,7 @@ const layerToggleRowClassName = cn(
 );
 
 const unitSegmentButtonClassName = cn(
-  "min-h-4 rounded-[3px] px-1.5 text-[7.5px] font-semibold leading-none text-atc-muted",
+  "min-h-7 rounded-[6px] px-2.5 text-[10.5px] font-semibold leading-none text-atc-muted",
   "transition-[background,color,box-shadow] duration-150",
   "hover:bg-[var(--atc-control-surface-hover)]",
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-accent)]",
@@ -158,14 +158,14 @@ function SettingsOptionRow({
       data-active={active ? "true" : "false"}
       onClick={onClick}
     >
-      <span className="relative flex size-3.5 items-center justify-center rounded-[4px] bg-transparent text-atc-faint transition-colors group-data-[active=true]:text-atc-text group-hover:text-atc-text [&>svg]:size-2.5">
+      <span className="relative flex size-5 items-center justify-center rounded-[6px] bg-transparent text-atc-faint transition-colors group-data-[active=true]:text-atc-text group-hover:text-atc-text [&>svg]:size-3.5">
         <MapControlIcon iconKey={iconKey} />
       </span>
       <span className="min-w-0">
-        <span className="block text-[9.5px] font-semibold leading-[1.08] text-atc-text">
+        <span className="block text-[12px] font-semibold leading-tight text-atc-text">
           {title}
         </span>
-        <span className="block text-[7.5px] leading-[1.08] text-atc-muted">
+        <span className="mt-0.5 block text-[9.5px] leading-snug text-atc-muted">
           {description}
         </span>
       </span>
@@ -225,14 +225,14 @@ function LayerToggleRow({
       disabled={disabled}
       onClick={onClick}
     >
-      <span className="relative flex size-3.5 items-center justify-center rounded-[4px] bg-transparent text-atc-faint transition-colors group-hover:text-atc-text [&>svg]:size-2.5">
+      <span className="relative flex size-5 items-center justify-center rounded-[6px] bg-transparent text-atc-faint transition-colors group-hover:text-atc-text [&>svg]:size-3.5">
         <MapControlIcon iconKey={iconKey} />
       </span>
       <span className="min-w-0">
-        <span className="block text-[9.5px] font-semibold leading-[1.08] text-atc-text">
+        <span className="block text-[12px] font-semibold leading-tight text-atc-text">
           {label}
         </span>
-        <span className="block text-[7.5px] leading-[1.08] text-atc-muted">
+        <span className="mt-0.5 block text-[9.5px] leading-snug text-atc-muted">
           {subtitle}
         </span>
       </span>
@@ -340,16 +340,16 @@ export default function MapSettingsSheet({
         )}
       >
         <div className="flex h-full min-h-0 flex-col">
-          <SheetHeader className="space-y-0.5 px-4 py-1.5 pr-11 text-left">
-            <SheetTitle className="text-[14px] font-semibold leading-tight text-atc-text">
+          <SheetHeader className="space-y-1 px-5 py-3.5 pr-11 text-left">
+            <SheetTitle className="text-[17px] font-semibold leading-tight text-atc-text">
               {t("mapSettings.title")}
             </SheetTitle>
-            <SheetDescription className="text-[9.5px] leading-snug text-atc-muted">
+            <SheetDescription className="text-[11px] leading-snug text-atc-muted">
               {t("mapSettings.description")}
             </SheetDescription>
           </SheetHeader>
 
-          <div className="map-settings-body min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-1.5">
+          <div className="map-settings-body min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-5 py-3.5">
             <section
               className="map-settings-section"
               aria-labelledby={`${id}-base-map`}
@@ -505,9 +505,9 @@ export default function MapSettingsSheet({
                   return (
                     <div
                       key={group.key}
-                      className="map-settings-unit-row grid min-h-6 grid-cols-[minmax(0,1fr)_minmax(88px,auto)] items-center gap-1 px-0 py-0"
+                      className="map-settings-unit-row grid min-h-9 grid-cols-[minmax(0,1fr)_minmax(96px,auto)] items-center gap-2 px-0 py-0.5"
                     >
-                      <span className="min-w-0 text-[9.5px] font-semibold leading-tight text-atc-text">
+                      <span className="min-w-0 text-[12px] font-semibold leading-tight text-atc-text">
                         {t(group.titleKey)}
                       </span>
                       <div

--- a/src/components/mechanism/MechanismPanel.tsx
+++ b/src/components/mechanism/MechanismPanel.tsx
@@ -20,7 +20,7 @@ export default function MechanismPanel() {
             {t("mechanism.count", { count: MECHANISM_ITEMS.length })}
           </span>
         </div>
-        <p className="mt-1 max-w-[36ch] text-[10px] leading-relaxed text-atc-dim">
+        <p className="fs-desc mt-2 max-w-[40ch]">
           {t("mechanism.description")}
         </p>
       </div>
@@ -120,9 +120,6 @@ function MechanismFlow({
           key={`${label}-${index}`}
           className="mechanism-flow__item"
         >
-          <span className="mechanism-flow__index">
-            {String(index + 1).padStart(2, "0")}
-          </span>
           <span className="min-w-0 truncate">
             {label}
           </span>

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -75,7 +75,7 @@ function AircraftRow({
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
       onMouseLeave={onMouseLeave}
-      className={`aircraft-table-card aircraft-table-row-grid aircraft-table-row-shell grid w-full items-center px-[var(--airport-sidebar-inset)] text-left transition-[background,color,box-shadow] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] data-[selected=true]:[background:var(--atc-glass-active-bg)] data-[selected=true]:text-[var(--atc-click-fg)] data-[selected=true]:shadow-[var(--atc-glass-rim-shadow)] data-[selected=true]:[backdrop-filter:var(--atc-glass-active-frost)] data-[selected=true]:[-webkit-backdrop-filter:var(--atc-glass-active-frost)] data-[selected=true]:hover:[background:var(--atc-glass-active-bg)] data-[selected=true]:[&_.text-atc-text]:text-[var(--atc-click-fg)] data-[selected=true]:[&_.text-atc-dim]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.text-atc-faint]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.aircraft-table-route-cycle]:text-[var(--atc-click-muted)] data-[selected=true]:[&_.aircraft-table-row-glyph]:bg-[var(--atc-click-fg)] data-[selected=true]:[&_.aircraft-table-row-glyph]:text-[var(--atc-click-bg)] ${
+      className={`aircraft-table-card aircraft-table-row-grid aircraft-table-row-shell grid w-full items-center px-[var(--airport-sidebar-inset)] text-left transition-[background,color,box-shadow] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] data-[selected=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_12%,transparent)] data-[selected=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)] data-[selected=true]:hover:bg-[color-mix(in_oklab,var(--atc-signal-accent)_15%,transparent)] data-[selected=true]:[&_.aircraft-table-row-glyph]:text-[var(--atc-signal-accent)] ${
         selected ? "aircraft-table-row--selected aircraft-table-row--active" : ""
       }`}
       aria-pressed={selected}
@@ -219,16 +219,21 @@ function NumberWithUnit({ value, unit, format, text, prefix }: Record<string, an
   const hasUnit = Boolean(unit);
 
   if (!hasUnit) {
+    // Mirror the unit branch's 2-column grid (number col + unit col) with an
+    // empty unit cell, so unitless values (— / GND, e.g. the focal aircraft
+    // after selecting it) right-align on the SAME axis as numeric values
+    // instead of shifting to the cell's far edge.
     return (
-      <span className="aircraft-table-number aircraft-table-number--unitless block w-full min-w-0 text-right tabular-nums">
-        {prefix ? (
-          <span className="notranslate text-atc-dim" translate="no">
-            {prefix}
-          </span>
-        ) : null}
-        <span className="notranslate" translate="no">
-          {displayText}
+      <span className="aircraft-table-number aircraft-table-number--unitless grid w-full min-w-0 grid-cols-[minmax(0,1fr)_var(--aircraft-table-unit-width,14px)] items-baseline gap-x-0.5 tabular-nums">
+        <span className="flex min-w-0 items-baseline justify-end">
+          {prefix ? (
+            <span className="notranslate flex-none text-atc-dim" translate="no">
+              {prefix}
+            </span>
+          ) : null}
+          <span className="block min-w-0 text-right">{displayText}</span>
         </span>
+        <span aria-hidden="true" />
       </span>
     );
   }

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -243,7 +243,7 @@ export default function AircraftTable({
       className={cn("aircraft-table-shell flex flex-col", fill && "h-full")}
     >
       <div className="aircraft-table-controls flex-none">
-        <div className="flex items-baseline justify-between px-[var(--airport-sidebar-inset)] pb-1.5 pt-2">
+        <div className="flex items-baseline justify-between px-[var(--airport-sidebar-inset)] pb-1.5 pt-4">
           <span className="atc-kicker atc-kicker--lead">
             {entityFilter === "airports" ? t("sidebar.airports") : t("sidebar.flights")}
           </span>

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -153,7 +153,7 @@ export default function AirportSidebar({
         movementFilter={movementFilter}
         onSelectAircraft={onSelectAircraft}
         onSelectAirport={onSelectAirport}
-        fill={fillAircraftList && !isMobileOverlay}
+        fill={fillAircraftList}
       />
     );
 
@@ -178,7 +178,12 @@ export default function AirportSidebar({
         key={`${activeView}:${movementFilter}`}
         className={
           isMobileOverlay
-            ? "app-panel-transition"
+            ? // The traffic list owns its own (virtualized) scroll, so the
+              // overlay content area clips; every other view (weather / ATC /
+              // spotting) scrolls normally so its content is never cut off.
+              `airport-sidebar-content app-panel-transition flex min-h-0 flex-1 flex-col ${
+                activeView === "traffic" ? "overflow-hidden" : "overflow-y-auto"
+              }`
             : "airport-sidebar-content app-panel-transition flex min-h-0 flex-col"
         }
       >
@@ -214,6 +219,11 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
           <span>Search {normalizedIcao} on LiveATC</span>
           <ExternalLink aria-hidden="true" className="size-3.5" strokeWidth={2.3} />
         </a>
+      ) : null}
+      {frequencies.length === 0 ? (
+        <p className="app-panel-transition rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] bg-[color-mix(in_oklab,var(--app-frost-tint)_22%,transparent)] px-3 py-5 text-center text-[11px] font-medium leading-snug text-atc-dim">
+          No published frequencies for this airport.
+        </p>
       ) : null}
       <div className="app-list-motion grid gap-1">
         {frequencies.map((frequency, index) => {
@@ -267,6 +277,11 @@ function SpottingPanel({
           {t(countKey, { count: spots.length })}
         </span>
       </div>
+      {spots.length === 0 ? (
+        <p className="app-panel-transition rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] bg-[color-mix(in_oklab,var(--app-frost-tint)_22%,transparent)] px-3 py-5 text-center text-[11px] font-medium leading-snug text-atc-dim">
+          {t("watcherMode.empty")}
+        </p>
+      ) : null}
       <div className="app-list-motion grid gap-1">
         {spots.map((spot) => {
           const active = Boolean(selectedSpotId && selectedSpotId === spot.id);

--- a/src/components/sidebar/CollapsibleSidebarChrome.tsx
+++ b/src/components/sidebar/CollapsibleSidebarChrome.tsx
@@ -236,10 +236,14 @@ export function SidebarBrandDock({
     <div
       className={cn(
         "sidebar-brand-dock sticky top-0 z-[calc(var(--z-index-sticky)+1)] flex items-center justify-between gap-2 px-[var(--airport-sidebar-inset)] transition-[padding,background,box-shadow] duration-200 ease-out",
-        "bg-[color-mix(in_oklab,var(--app-frost-tint)_86%,transparent)] [backdrop-filter:var(--app-frost-strong)] [-webkit-backdrop-filter:var(--app-frost-strong)]",
-        "shadow-[0_1px_0_color-mix(in_oklab,var(--atc-line)_56%,transparent)]",
+        // At rest the brand row floats transparently on the frosted sidebar
+        // (no separate opaque strip / hard divider). Only once content
+        // scrolls under it does a faint frost + hairline fade in to mask it.
+        compact
+          ? "bg-[color-mix(in_oklab,var(--app-frost-tint)_52%,transparent)] [backdrop-filter:var(--app-frost)] [-webkit-backdrop-filter:var(--app-frost)] shadow-[0_1px_0_color-mix(in_oklab,var(--app-frost-border)_70%,transparent)]"
+          : "bg-transparent shadow-none",
         compact ? "pb-2 pt-3" : "pb-3 pt-5",
-        "[[data-mobile-overlay=true]_&]:pt-[calc(24px+env(safe-area-inset-top))]",
+        "[[data-mobile-overlay=true]_&]:pb-1 [[data-mobile-overlay=true]_&]:pt-[calc(12px+env(safe-area-inset-top))]",
         className,
       )}
     >

--- a/src/components/sidebar/FlightSidebar.tsx
+++ b/src/components/sidebar/FlightSidebar.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import NumberFlow from "@number-flow/react";
 import AircraftTable from "./AircraftTable";
 import SidebarIdentityHero from "./SidebarIdentityHero";
-import { MetricCard as SidebarMetricCard, MetricGrid as SidebarMetricGrid } from "@/components/ui/MetricCard";
 import SidebarShell from "./SidebarShell";
 import {
   formatFlightRouteLabel,
@@ -54,7 +53,6 @@ export default function FlightSidebar({
   const isMobileOverlay = Boolean(onClose);
   const displayCallsign =
     (aircraft?.callsign || callsign || "").trim() || "—";
-  const hex = aircraft?.icao24 ? aircraft.icao24.toUpperCase() : "";
   const typeDisplay = resolveAircraftDisplayModel(aircraft || {});
   const route = formatFlightRouteLabel(aircraft?.flightRoute) || "";
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
@@ -88,7 +86,6 @@ export default function FlightSidebar({
         track={track}
         onGround={onGround}
         trackingActive={trackingActive}
-        hex={hex}
       />
     </>
   );
@@ -121,7 +118,7 @@ export default function FlightSidebar({
           suppressSelectedAircraftDistance
           onSelectAircraft={onSelectAircraft}
           onSelectAirport={onSelectAirport}
-          fill={fillAircraftList && !isMobileOverlay}
+          fill={fillAircraftList}
         />
       ) : null}
     </SidebarShell>
@@ -198,7 +195,6 @@ function FlightTelemetryGrid({
   track,
   onGround,
   trackingActive,
-  hex,
 }) {
   const { t } = useI18n();
   // Local "highlighted metric" state — clicking any card toggles its
@@ -225,99 +221,137 @@ function FlightTelemetryGrid({
   });
   const trackDirectionKey = resolveTrackDirectionTranslationKey(track);
 
+  const altitudeValue = onGround
+    ? t("aircraft.gnd")
+    : altitudeDisplay
+      ? (
+          <MetricNumberFlow
+            value={altitudeDisplay.value}
+            suffix={altitudeDisplay.suffix}
+          />
+        )
+      : "—";
+  const trackValue =
+    track == null
+      ? "—"
+      : activeMetric === "track"
+        ? trackDirectionKey
+          ? t(trackDirectionKey)
+          : "—"
+        : (
+            <MetricNumberFlow
+              value={Math.round(track)}
+              suffix="°"
+              suffixPosition="sup"
+            />
+          );
+  const phaseValue = onGround
+    ? t("aircraft.ground")
+    : altitude != null || trackingActive
+      ? t("aircraft.airborne")
+      : "—";
+
+  // Speed + Altitude are the primary read; vertical speed / track / phase are
+  // auxiliary. One joined glass block (matching the airport hero stats block):
+  // two large metrics on top, a small three-up footer below.
   return (
-    <SidebarMetricGrid label={t("sidebar.flightTelemetry")}>
-      <SidebarMetricCard
-        label={t("metrics.speed")}
-        value={
-          speedDisplay ? (
-            <MetricNumberFlow
-              value={speedDisplay.value}
-              suffix={speedDisplay.suffix}
-            />
-          ) : (
-            "—"
-          )
-        }
-        active={activeMetric === "speed"}
-        onClick={() => toggle("speed")}
-      />
-      <SidebarMetricCard
-        label={t("metrics.altitude")}
-        value={
-          onGround
-            ? t("aircraft.gnd")
-            : altitudeDisplay
-              ? (
-                  <MetricNumberFlow
-                    value={altitudeDisplay.value}
-                    suffix={altitudeDisplay.suffix}
-                  />
-                )
-              : "—"
-        }
-        active={activeMetric === "altitude"}
-        onClick={() => toggle("altitude")}
-      />
-      <SidebarMetricCard
-        label={t("metrics.verticalSpeed")}
-        value={
-          verticalSpeedDisplay ? (
-            <MetricNumberFlow
-              value={verticalSpeedDisplay.value}
-              format={verticalSpeedDisplay.format}
-              suffix={verticalSpeedDisplay.suffix}
-            />
-          ) : (
-            "—"
-          )
-        }
-        active={activeMetric === "vs"}
-        onClick={() => toggle("vs")}
-      />
-      <SidebarMetricCard
-        label={t("metrics.track")}
-        value={
-          track != null ? (
-            activeMetric === "track" ? (
-              trackDirectionKey ? t(trackDirectionKey) : "—"
-            ) : (
-              <MetricNumberFlow
-                value={Math.round(track)}
-                suffix="°"
-                suffixPosition="sup"
-              />
-            )
-          ) : (
-            "—"
-          )
-        }
-        active={activeMetric === "track"}
-        onClick={() => toggle("track")}
-        valueTranslate={activeMetric === "track"}
-      />
-      <SidebarMetricCard
-        label={t("metrics.icao24")}
-        value={hex || "—"}
-        active={activeMetric === "hex"}
-        onClick={() => toggle("hex")}
-        valueSize="compact"
-      />
-      <SidebarMetricCard
-        label={t("metrics.flightPhase")}
-        value={
-          onGround
-            ? t("aircraft.ground")
-            : altitude != null || trackingActive
-              ? t("aircraft.airborne")
-              : "—"
-        }
-        active={activeMetric === "status"}
-        onClick={() => toggle("status")}
-        valueSize="compact"
-        valueTranslate
-      />
-    </SidebarMetricGrid>
+    <div className="px-[var(--airport-sidebar-inset)] pt-3.5">
+      <div className="overflow-hidden rounded-[var(--atc-radius-panel)] border border-[var(--app-frost-border)] bg-[var(--atc-control-surface-muted)] shadow-[var(--atc-control-inset-shadow-subtle)]">
+        <div className="grid grid-cols-2">
+          <TelemetryPrimary
+            label={t("metrics.speed")}
+            active={activeMetric === "speed"}
+            onClick={() => toggle("speed")}
+            value={
+              speedDisplay ? (
+                <MetricNumberFlow
+                  value={speedDisplay.value}
+                  suffix={speedDisplay.suffix}
+                />
+              ) : (
+                "—"
+              )
+            }
+          />
+          <TelemetryPrimary
+            divider
+            label={t("metrics.altitude")}
+            active={activeMetric === "altitude"}
+            onClick={() => toggle("altitude")}
+            value={altitudeValue}
+          />
+        </div>
+        <div className="flex border-t border-[var(--app-frost-border)]">
+          <TelemetryAux
+            label={t("metrics.verticalSpeed")}
+            active={activeMetric === "vs"}
+            onClick={() => toggle("vs")}
+            value={
+              verticalSpeedDisplay ? (
+                <MetricNumberFlow
+                  value={verticalSpeedDisplay.value}
+                  format={verticalSpeedDisplay.format}
+                  suffix={verticalSpeedDisplay.suffix}
+                />
+              ) : (
+                "—"
+              )
+            }
+          />
+          <TelemetryAux
+            divider
+            label={t("metrics.track")}
+            active={activeMetric === "track"}
+            onClick={() => toggle("track")}
+            value={trackValue}
+          />
+          <TelemetryAux
+            divider
+            label={t("metrics.flightPhase")}
+            active={activeMetric === "status"}
+            onClick={() => toggle("status")}
+            value={phaseValue}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const TELEMETRY_ACTIVE_CLASS =
+  "data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)]";
+
+function TelemetryPrimary({ label, value, active, onClick, divider = false }: FlightSidebarRecord) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      data-active={active ? "true" : undefined}
+      onClick={onClick}
+      className={`px-[15px] pb-[13px] pt-[13px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] ${TELEMETRY_ACTIVE_CLASS} ${divider ? "border-l border-[var(--app-frost-border)]" : ""}`}
+    >
+      <div className="text-[12px] font-medium text-atc-dim">{label}</div>
+      <div className="mt-1.5 text-[26px] font-bold leading-none tracking-[-0.5px] tabular-nums text-atc-text">
+        {value}
+      </div>
+    </button>
+  );
+}
+
+function TelemetryAux({ label, value, active, onClick, divider = false }: FlightSidebarRecord) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      data-active={active ? "true" : undefined}
+      onClick={onClick}
+      className={`min-w-0 flex-1 px-[13px] py-[9px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_0_2px_0_var(--atc-signal-accent)] ${divider ? "border-l border-[var(--app-frost-border)]" : ""}`}
+    >
+      <div className="truncate text-[10px] text-atc-faint">{label}</div>
+      <div className="mt-[3px] truncate text-[15px] font-bold tabular-nums text-atc-text">
+        {value}
+      </div>
+    </button>
   );
 }
 

--- a/src/components/sidebar/SidebarShell.tsx
+++ b/src/components/sidebar/SidebarShell.tsx
@@ -88,6 +88,10 @@ export default function SidebarShell({
         ? "airport-sidebar-panel--mobile"
         : "flight-sidebar-panel--mobile"
       : "",
+    // On the mobile overlay the panel becomes a fixed-height flex column:
+    // the brand/identity/filters stay put and ONLY the list scrolls (so it
+    // can virtualize instead of rendering 100+ rows at once).
+    isMobileOverlay ? "min-h-0 overflow-hidden" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -173,9 +177,21 @@ export default function SidebarShell({
             </div>
           ) : null}
 
-          <div className="sidebar-shell-body flex flex-none flex-col overflow-visible">
+          <div
+            className={
+              isMobileOverlay
+                ? "sidebar-shell-body flex min-h-0 flex-1 flex-col overflow-visible"
+                : "sidebar-shell-body flex flex-none flex-col overflow-visible"
+            }
+          >
             {header ? <div className="flex-none">{header}</div> : null}
-            <div className="sidebar-shell-main flex-none overflow-visible">
+            <div
+              className={
+                isMobileOverlay
+                  ? "sidebar-shell-main flex min-h-0 flex-1 flex-col overflow-visible"
+                  : "sidebar-shell-main flex-none overflow-visible"
+              }
+            >
               {children}
             </div>
           </div>

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import NumberFlow from "@number-flow/react";
-import { MetricCard as SidebarMetricCard, MetricGrid as SidebarMetricGrid } from "@/components/ui/MetricCard";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel";
@@ -10,6 +9,11 @@ import {
   temperatureUnitLabel,
 } from "@/utils/units";
 
+// Frosted "hero stats block": one joined rounded glass container with a big
+// headline metric (nearby flights) over a row of small footer cells
+// (weather / ATC / spotting / movement). Each segment doubles as the
+// view-switch control — the active segment shows the blue accent rail so
+// navigation is preserved while matching the redesign's single-block look.
 export default function SidebarViewSwitch({
   activeView = "briefing",
   onViewChange,
@@ -20,14 +24,7 @@ export default function SidebarViewSwitch({
   frequencies = [],
   candidateSpotCount = 0,
   onOpenSpotting,
-  // Near-me mode: the explorer is centered on the user's location
-  // (not an airport). Keep the metric surface to weather + nearby
-  // aircraft because airport-specific ATC, spotting, and movement
-  // buckets do not apply.
   nearMe = false,
-  // When feature flags haven't resolved yet, hold the layout stable
-  // at its pre-resolution state. Prevents dep/arr cards from
-  // appearing mid-flight when FlightAware flips from unresolved→true.
   featureFlagsResolved = true,
 }) {
   const { t } = useI18n();
@@ -42,9 +39,6 @@ export default function SidebarViewSwitch({
   const spottingCount = Number(candidateSpotCount) || 0;
   const showAtcCard = atcCount > 0;
 
-  // Pre-compute departure / arrival counts only when FlightAware is on.
-  // The aircraft.movement field is already resolved upstream by
-  // enrichAircraftWithRoutes, so this is just two filters.
   const { departureCount, arrivalCount } = useMemo(() => {
     if (routeProvider !== ROUTE_PROVIDER.FLIGHTAWARE) {
       return { departureCount: 0, arrivalCount: 0 };
@@ -58,80 +52,100 @@ export default function SidebarViewSwitch({
     return { departureCount: dep, arrivalCount: arr };
   }, [aircraft, routeProvider]);
 
-  if (nearMe) {
-    return (
-      <SidebarMetricGrid label={t("sidebar.airportViews")}>
-        <SidebarMetricCard
-          label={t("sidebar.weather")}
-          value={temperature.value}
-          unit={temperatureUnit}
-          contentLayout="split"
-          active={activeView === "briefing"}
-          onClick={() => onViewChange?.("briefing")}
-        />
-        <SidebarMetricCard
-          label={t("sidebar.nearby")}
-          value={<NumberFlow value={aircraft.length} />}
-          contentLayout="split"
-          active={activeView === "traffic"}
-          onClick={() => onViewChange?.("traffic")}
-        />
-      </SidebarMetricGrid>
-    );
+  const footerCells = [];
+  footerCells.push({
+    key: "briefing",
+    label: t("sidebar.weather"),
+    value: temperature.value,
+    unit: temperatureUnit,
+    active: activeView === "briefing",
+    onClick: () => onViewChange?.("briefing"),
+  });
+  if (showAtcCard) {
+    footerCells.push({
+      key: "atc",
+      label: t("sidebar.atc"),
+      value: <NumberFlow value={atcCount} />,
+      active: activeView === "atc",
+      onClick: () => onViewChange?.("atc"),
+    });
+  }
+  footerCells.push({
+    key: "spotting",
+    label: t("sidebar.spotting"),
+    value: <NumberFlow value={spottingCount} />,
+    active: activeView === "spotting",
+    onClick: onOpenSpotting,
+  });
+  if (showMovementCards) {
+    footerCells.push({
+      key: "departures",
+      label: t("sidebar.departures"),
+      value: <NumberFlow value={departureCount} />,
+      active: activeView === "departures",
+      onClick: () => onViewChange?.("departures"),
+    });
+    footerCells.push({
+      key: "arrivals",
+      label: t("sidebar.arrivals"),
+      value: <NumberFlow value={arrivalCount} />,
+      active: activeView === "arrivals",
+      onClick: () => onViewChange?.("arrivals"),
+    });
   }
 
+  const headlineLabel = nearMe ? t("sidebar.nearby") : t("sidebar.flights");
+
   return (
-    <SidebarMetricGrid label={t("sidebar.airportViews")}>
-      <SidebarMetricCard
-        label={t("sidebar.weather")}
-        value={temperature.value}
-        unit={temperatureUnit}
-        contentLayout="split"
-        active={activeView === "briefing"}
-        onClick={() => onViewChange?.("briefing")}
-      />
-      <SidebarMetricCard
-        label={t("sidebar.flights")}
-        value={<NumberFlow value={aircraft.length} />}
-        contentLayout="split"
-        active={activeView === "traffic"}
-        onClick={() => onViewChange?.("traffic")}
-      />
-      {showAtcCard && (
-        <SidebarMetricCard
-          label={t("sidebar.atc")}
-          value={<NumberFlow value={atcCount} />}
-          contentLayout="split"
-          active={activeView === "atc"}
-          onClick={() => onViewChange?.("atc")}
-        />
-      )}
-      <SidebarMetricCard
-        label={t("sidebar.spotting")}
-        value={<NumberFlow value={spottingCount} />}
-        contentLayout="split"
-        active={activeView === "spotting"}
-        onClick={onOpenSpotting}
-      />
-      {showMovementCards && (
-        <>
-          <SidebarMetricCard
-            label={t("sidebar.departures")}
-            value={<NumberFlow value={departureCount} />}
-            contentLayout="split"
-            active={activeView === "departures"}
-            onClick={() => onViewChange?.("departures")}
-          />
-          <SidebarMetricCard
-            label={t("sidebar.arrivals")}
-            value={<NumberFlow value={arrivalCount} />}
-            contentLayout="split"
-            active={activeView === "arrivals"}
-            onClick={() => onViewChange?.("arrivals")}
-          />
-        </>
-      )}
-    </SidebarMetricGrid>
+    <div className="px-[var(--airport-sidebar-inset)] pt-3.5">
+      <div className="overflow-hidden rounded-[var(--atc-radius-panel)] border border-[var(--app-frost-border)] bg-[var(--atc-control-surface-muted)] shadow-[var(--atc-control-inset-shadow-subtle)]">
+        <button
+          type="button"
+          data-active={activeView === "traffic" ? "true" : undefined}
+          onClick={() => onViewChange?.("traffic")}
+          aria-pressed={activeView === "traffic"}
+          className="block w-full px-[15px] pb-[11px] pt-[13px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)]"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-[12px] font-medium text-atc-dim">
+              {headlineLabel}
+            </span>
+          </div>
+          <div className="mt-[5px] flex items-baseline gap-2">
+            <span className="text-[33px] font-bold leading-none tracking-[-1px] tabular-nums text-atc-text">
+              <NumberFlow value={aircraft.length} />
+            </span>
+          </div>
+        </button>
+        <div className="flex border-t border-[var(--app-frost-border)]">
+          {footerCells.map((cell) => (
+            <StatCell key={cell.key} {...cell} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCell({ label, value, unit, active, onClick }) {
+  return (
+    <button
+      type="button"
+      data-active={active ? "true" : undefined}
+      onClick={onClick}
+      aria-pressed={active}
+      className="flex-1 px-[13px] py-[9px] text-left transition-colors [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_0_2px_0_var(--atc-signal-accent)]"
+    >
+      <div className="text-[10px] text-atc-faint">{label}</div>
+      <div className="mt-[3px]">
+        <span className="text-[16px] font-bold tabular-nums text-atc-text">
+          {value}
+        </span>
+        {unit ? (
+          <span className="ml-0.5 text-[10px] text-atc-faint">{unit}</span>
+        ) : null}
+      </div>
+    </button>
   );
 }
 

--- a/src/components/ui/FilterCard.tsx
+++ b/src/components/ui/FilterCard.tsx
@@ -228,10 +228,14 @@ export function FilterCardGrid({
   columns = 3,
   ...props
 }: React.ComponentProps<"div"> & { columns?: number }) {
+  // `data-cols` lets the sidebar CSS layer collect the 2-up detail filter
+  // strip into one bordered glass block (de-clutter) while leaving the 3-up
+  // inline arrangement alone.
   return (
     <div
       role="group"
       data-ui="filter-grid"
+      data-cols={String(columns)}
       className={cn(
         "grid gap-0 px-[var(--airport-sidebar-inset)] py-1.5",
         columns === 2

--- a/src/components/ui/TextPillListItem.tsx
+++ b/src/components/ui/TextPillListItem.tsx
@@ -68,11 +68,11 @@ export function TextPillListItem({
         {pill}
       </span>
       <span className="flex min-w-0 flex-col items-start self-center">
-        <span className="block w-full min-w-0 truncate text-[11.5px] font-bold leading-tight text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
+        <span className="fs-title block w-full min-w-0 truncate group-data-[active=true]:text-[var(--atc-click-fg)]">
           {title}
         </span>
         {subtitle ? (
-          <span className="mt-0.5 block w-full min-w-0 truncate text-[9.5px] font-medium leading-snug text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
+          <span className="fs-sub mt-0.5 block w-full min-w-0 truncate group-data-[active=true]:text-[var(--atc-click-muted)]">
             {subtitle}
           </span>
         ) : null}

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -131,8 +131,9 @@ export const Toolbar = forwardRef(function Toolbar(
   );
 });
 
-// Spacing-only separator between toolbar groups. Grouping comes from
-// rhythm and icon alignment rather than another visible rule.
+// A thin 1px rule between toolbar groups — theme-aware (derives from
+// --atc-text so it stays faintly visible on both the dark map-kit pill
+// and the light page-nav pill). Matches the Frosted design's divider.
 export function ToolbarSeparator({
   className,
   ...props
@@ -141,7 +142,7 @@ export function ToolbarSeparator({
     <span
       aria-hidden="true"
       className={cn(
-        "flex-none h-3.5 w-1.5 self-center",
+        "mx-1 h-5 w-px flex-none self-center rounded-full bg-[color-mix(in_oklab,var(--atc-text)_20%,transparent)]",
         className,
       )}
       {...props}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -39,164 +39,38 @@ export function resolveChangelogText(
   return locale === "zh-CN" ? value.zh : value.en;
 }
 
-export const CHANGELOG_INITIAL_LIMIT = 6;
+export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 95;
+export const CHANGELOG_TOTAL_COUNT = 90;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.26.23",
-    kind: "patch",
+    version: "v2.27.0",
+    kind: "feat",
     title: {
-      en: "Quieter traffic controls",
-      zh: "航班控件降噪",
+      en: "Frosted interface redesign",
+      zh: "Frosted 界面重构",
     },
     summary: {
-      en: "The airport traffic sidebar now relies more on aligned rails and less on boxed control surfaces.",
-      zh: "机场航班侧栏现在更多依靠对齐 rail 建立秩序，减少成块控件表面。",
+      en: "A whole-app frosted-glass visual system: theme-following chrome, one orange signal accent, a shared first-screen type scale, and consistent airport / aircraft / home / static surfaces.",
+      zh: "全应用 Frosted 玻璃视觉系统：跟随主题的界面、统一橙色信号强调色、共享首屏排版梯度，以及一致的机场 / 飞机 / 首页 / 静态页表面。",
     },
     highlights: [
       {
-        en: "Metric and filter controls no longer read as a boxed table in the map sidebar",
-        zh: "地图侧栏里的指标和筛选控件不再像一个外框表格",
+        en: "Chrome follows the theme — white frosted glass + ink in light, deep-gray glass + white in dark",
+        zh: "界面跟随主题——亮色白 frosted 玻璃 + 黑字，暗色深灰玻璃 + 白字",
       },
       {
-        en: "The traffic search field is quieter and embedded into the control rail",
-        zh: "航班搜索框更安静，并嵌入控件 rail",
+        en: "One orange signal accent for row selection, the tracked-flight trace, and the track button",
+        zh: "单一橙色信号色用于行选中、追踪航迹与追踪按钮",
       },
       {
-        en: "Selected filters keep their state without the heavier glass shadow",
-        zh: "选中的筛选项保留状态提示，但不再使用较重的玻璃阴影",
-      },
-    ],
-  },
-  {
-    version: "v2.26.22",
-    kind: "patch",
-    title: {
-      en: "Compact interface rails",
-      zh: "界面 rail 压缩",
-    },
-    summary: {
-      en: "Home airport lists and map settings now use tighter aligned rails with quieter surfaces.",
-      zh: "首页机场列表和地图设置现在使用更紧凑的对齐 rail 与更安静的表面。",
-    },
-    highlights: [
-      {
-        en: "Home search, section labels, airport codes, and airport names now share exact rail coordinates",
-        zh: "首页搜索、分组标题、机场代码和机场名现在使用精确一致的 rail 坐标",
+        en: "First-screen pages share one --fs-* type scale; flight telemetry leads with Speed + Altitude",
+        zh: "首屏各页共用一套 --fs-* 排版梯度；飞行遥测以速度 + 高度为主指标",
       },
       {
-        en: "Settings rows are shorter while preserving the same controls and labels",
-        zh: "设置行更短，同时保留原有控件和标签",
-      },
-      {
-        en: "The active base-map option now relies on the right rail marker instead of a filled row",
-        zh: "选中的底图选项现在依靠右侧 rail 标记，不再使用整行填充",
-      },
-    ],
-  },
-  {
-    version: "v2.26.21",
-    kind: "patch",
-    title: {
-      en: "Mechanism inline rails",
-      zh: "机制页内联 rail",
-    },
-    summary: {
-      en: "The mechanism page now uses one compact number rail for rows, flow labels, and expanded detail copy.",
-      zh: "机制页现在用一条紧凑编号 rail 组织行、流程标签和展开说明。",
-    },
-    highlights: [
-      {
-        en: "Mechanism row numbers are quiet rail labels instead of filled code capsules",
-        zh: "机制行编号改为安静 rail 标签，不再是填充 code capsule",
-      },
-      {
-        en: "Expanded flow labels and detail notes now read inline on the same content axis",
-        zh: "展开后的流程标签和说明现在沿同一条内容轴内联阅读",
-      },
-      {
-        en: "The accordion behavior and mechanism copy are unchanged",
-        zh: "折叠行为和机制页文案保持不变",
-      },
-    ],
-  },
-  {
-    version: "v2.26.20",
-    kind: "patch",
-    title: {
-      en: "Home and about rails",
-      zh: "首页与关于页 rail",
-    },
-    summary: {
-      en: "Home airport lists and about-page metadata now share quieter rail alignment with less visual chrome.",
-      zh: "首页机场列表和关于页元信息现在共用更安静的 rail 对齐，并减少视觉 chrome。",
-    },
-    highlights: [
-      {
-        en: "Home discovery and search-result airport rows now keep code, title, and header axes aligned",
-        zh: "首页发现列表与搜索结果机场行现在保持 code、标题和表头轴线一致",
-      },
-      {
-        en: "Version, stack, and architecture rows now share one label rail and one content axis",
-        zh: "版本、技术栈和架构行现在共用同一条标签 rail 与内容轴",
-      },
-      {
-        en: "The oversized version readout is replaced by compact inline metadata",
-        zh: "大号版本读数改为紧凑的行内元信息",
-      },
-    ],
-  },
-  {
-    version: "v2.26.19",
-    kind: "patch",
-    title: {
-      en: "Changelog release rails",
-      zh: "更新日志 release rail",
-    },
-    summary: {
-      en: "The changelog now reads as compact release rails with one stable copy axis instead of pill-led blocks.",
-      zh: "更新日志现在使用紧凑 release rail 和稳定文案轴，不再由 pill 块主导。",
-    },
-    highlights: [
-      {
-        en: "Version and current-state markers move into a narrow mono rail",
-        zh: "版本号和当前状态标记移入窄 mono rail",
-      },
-      {
-        en: "Titles, summaries, and highlights share one aligned content column on desktop and mobile",
-        zh: "标题、摘要和要点在桌面端与移动端共用同一条内容列",
-      },
-      {
-        en: "Rows are denser, so more release history fits in the first viewport without changing loading behavior",
-        zh: "条目更紧凑，首屏能显示更多发布历史，同时不改变加载行为",
-      },
-    ],
-  },
-  {
-    version: "v2.26.18",
-    kind: "patch",
-    title: {
-      en: "Sharper home and here rails",
-      zh: "首页与 Here rail 精修",
-    },
-    summary: {
-      en: "The home airport list and /here permission state now use tighter aligned rails instead of heavier standalone blocks.",
-      zh: "首页机场列表和 /here 权限态现在使用更紧凑的对齐 rail，不再依赖厚重的独立块。",
-    },
-    highlights: [
-      {
-        en: "Home airport codes become a quiet mono rail aligned with the search icon",
-        zh: "首页机场代码改为安静的 mono rail，并与搜索图标对齐",
-      },
-      {
-        en: "Section titles, descriptions, airport names, and search text now share one stable content axis",
-        zh: "分组标题、说明、机场名和搜索文字现在共用同一条稳定内容轴",
-      },
-      {
-        en: "The /here denied and unavailable states move into a compact split workspace without changing location behavior",
-        zh: "/here 拒绝和不可用状态进入紧凑分栏工作区，不改变定位行为",
+        en: "Nearby list virtualizes on mobile; selected-row value columns stay aligned",
+        zh: "邻近列表在移动端虚拟化；选中行的数值列保持对齐",
       },
     ],
   },

--- a/src/style.css
+++ b/src/style.css
@@ -870,9 +870,9 @@
     --airspace-border: var(--airspace-controlled-stroke);
     --airspace-label-text: var(--airspace-boundary-label);
     --airspace-altitude-filtered-state: var(--airspace-info-fill);
-    --aviation-trace-line: #1a1a18;
-    --aviation-trace-glow: #55534e;
-    --aviation-trace-point: #1a1a18;
+    --aviation-trace-line: var(--atc-signal-accent);
+    --aviation-trace-glow: color-mix(in oklab, var(--atc-signal-accent) 58%, white);
+    --aviation-trace-point: var(--atc-signal-accent);
     --aviation-trace-stale-line: color-mix(
         in oklab,
         var(--aviation-trace-line) 54%,
@@ -1351,9 +1351,9 @@
     --airspace-border: var(--airspace-controlled-stroke);
     --airspace-label-text: var(--airspace-boundary-label);
     --airspace-altitude-filtered-state: var(--airspace-info-fill);
-    --aviation-trace-line: var(--primary-bright);
-    --aviation-trace-glow: var(--primary-bright);
-    --aviation-trace-point: var(--primary-bright);
+    --aviation-trace-line: var(--atc-signal-accent);
+    --aviation-trace-glow: color-mix(in oklab, var(--atc-signal-accent) 64%, white);
+    --aviation-trace-point: var(--atc-signal-accent);
     --aviation-trace-stale-line: color-mix(
         in oklab,
         var(--aviation-trace-line) 54%,
@@ -2997,11 +2997,73 @@ body:has(.dither-page-shell) {
     --app-sidebar-width: 20.75rem;
     /* Raycast density pass: keep ADSBao's two glass materials, but tighten
        the shape language into crisp command-panel chrome. */
-    --atc-radius-shell: 12px;
-    --atc-radius-panel: 8px;
-    --atc-radius-card: 6px;
+    /* Frosted geometry — soft, capsule-driven. The redesign uses 13–18px
+       on inner cards and 16–22px on panels/shell; bumped from the prior
+       6/8/12 so every floating surface reads as soft frosted glass. */
+    --atc-radius-shell: 16px;
+    --atc-radius-panel: 16px;
+    --atc-radius-card: 13px;
     --atc-radius-control: 999px;
     --atc-radius-pill: 999px;
+    /* Orange signal accent for the Frosted system (selection bars,
+       tracked-flight track + button, live-feed dot, active segments).
+       Theme-split: this is the LIGHT-theme value (a warm vivid orange on
+       white frost → reads as a light-orange wash at low alpha); the dark
+       theme overrides it to a brighter orange below. -soft/-strong derive
+       from the base so only the base flips per theme. */
+    --atc-signal-accent: oklch(0.66 0.16 50);
+    --atc-signal-accent-soft: color-mix(in oklab, var(--atc-signal-accent) 14%, transparent);
+    --atc-signal-accent-strong: color-mix(in oklab, var(--atc-signal-accent) 82%, black 4%);
+
+    /* ── First-screen sidebar type scale ───────────────────────────────
+       One typographic system shared by Home, About, Changelog and
+       Mechanism. Sizes / weights / tracking are theme-independent; the
+       colors resolve through --atc-text / -dim / -faint, which already
+       carry a light set (:root) and a dark set (dark-theme overrides) —
+       so this is "亮暗各一套" without duplicating the scale. Consume via
+       the .fs-* utility classes; tune here, never at the call site.
+
+       Roles:
+         eyebrow → section / group label (tracked, quiet)
+         title   → row / item heading (the prominent line)
+         sub     → row subtitle / signal
+         rail    → left-rail code or index (ICAO, 01, METAR)
+         body    → expanded detail copy
+         value   → meta value (version, stack item)
+         desc    → page-level description under the H1                    */
+    --fs-eyebrow-font: var(--font-display);
+    --fs-eyebrow-size: 11px;
+    --fs-eyebrow-weight: 800;
+    --fs-eyebrow-tracking: 0.12em;
+    --fs-eyebrow-color: var(--atc-faint);
+
+    --fs-title-font: var(--font-sans);
+    --fs-title-size: 14px;
+    --fs-title-weight: 800;
+    --fs-title-leading: 1.2;
+    --fs-title-color: var(--atc-text);
+
+    --fs-sub-size: 11.5px;
+    --fs-sub-weight: 600;
+    --fs-sub-leading: 1.25;
+    --fs-sub-color: var(--atc-dim);
+
+    --fs-rail-font: var(--font-mono);
+    --fs-rail-size: 11px;
+    --fs-rail-weight: 850;
+    --fs-rail-color: var(--atc-faint);
+
+    --fs-body-size: 11px;
+    --fs-body-leading: 1.5;
+    --fs-body-color: var(--atc-dim);
+
+    --fs-value-size: 13px;
+    --fs-value-weight: 850;
+    --fs-value-color: var(--atc-text);
+
+    --fs-desc-size: 12px;
+    --fs-desc-leading: 1.5;
+    --fs-desc-color: var(--atc-dim);
     /* Frosted-material blur. The single source of truth for every
        floating surface that sits over the map (toolbars, preview cards,
        dropdowns, sheets, desktop sidebar). Strong blur diffuses the map
@@ -3213,6 +3275,9 @@ body:has(.dither-page-shell) {
 }
 
 :root[data-theme="dark"] {
+    /* Brighter orange so the accent pops on the dark-gray canvas; the
+       low-alpha wash then reads as a deep-orange selected background. */
+    --atc-signal-accent: oklch(0.74 0.15 55);
     /* Faint cool-blue edge so frosted panels read as soft atmospheric
        material on the navy canvas rather than hard-bordered cards. */
     --app-frost-border: color-mix(in oklab, #97b6d3 15%, transparent);
@@ -3319,7 +3384,7 @@ body {
     -webkit-overflow-scrolling: touch;
 }
 
-.dither-page-panel:not(.plane-hunter-panel) {
+:root[data-theme="dark"] .dither-page-panel:not(.plane-hunter-panel) {
     --atc-bg: oklch(0.17 0.003 100);
     --atc-card: color-mix(in oklab, oklch(0.235 0.003 100) 76%, transparent);
     --atc-elev: color-mix(in oklab, oklch(0.31 0.003 100) 48%, transparent);
@@ -3403,18 +3468,19 @@ body {
     );
 }
 
-.dither-page-panel:not(.plane-hunter-panel),
-:root[data-theme="dark"] .dither-page-panel:not(.plane-hunter-panel) {
+.dither-page-panel:not(.plane-hunter-panel) {
+    /* Theme-aware frosted panel: --app-frost-tint is near-white in light
+       theme and deep-gray in dark, so the static pages follow the theme. */
     background:
         radial-gradient(
             120% 70% at 16% 0%,
-            color-mix(in oklab, oklch(0.72 0.003 100) 13%, transparent),
+            color-mix(in oklab, white 18%, transparent),
             transparent 48%
         ),
         linear-gradient(
             180deg,
-            color-mix(in oklab, oklch(0.215 0.003 100) 88%, transparent),
-            color-mix(in oklab, oklch(0.145 0.003 100) 90%, transparent)
+            color-mix(in oklab, var(--app-frost-tint) 82%, transparent),
+            color-mix(in oklab, var(--app-frost-tint) 88%, transparent)
         );
     color: var(--atc-text);
 }
@@ -3523,6 +3589,12 @@ body {
     font-size: 16px;
 }
 
+/* Home discovery search sits two sizes down from the global 16px (which
+   stays elsewhere to guard against iOS focus-zoom on in-app search). */
+.search-screen .search-input input {
+    font-size: 13px;
+}
+
 .glass-panel {
     border-radius: var(--atc-radius-card);
     box-shadow: var(--app-card-shadow);
@@ -3565,11 +3637,40 @@ body {
     backdrop-filter: var(--app-frost-strong);
 }
 
+/* Light theme: the chrome follows the theme — a near-white frosted-glass
+   panel over the map (--app-frost-tint is near-white in light), inheriting
+   the base light tokens (milky surfaces, dark-smoke selected capsule). The
+   dark-theme block below overrides to deep-gray glass. */
 .airport-map-kit .airport-desktop-sidebar .sidebar-shell,
 .airport-map-kit .airport-desktop-sidebar .airport-sidebar-panel,
 .airport-map-kit .airport-desktop-sidebar .flight-sidebar-panel,
 .airport-map-kit .airport-sidebar-panel--mobile,
 .airport-map-kit .flight-sidebar-panel--mobile {
+    background:
+        radial-gradient(
+            120% 70% at 18% 0%,
+            color-mix(in oklab, white 26%, transparent),
+            transparent 46%
+        ),
+        linear-gradient(
+            180deg,
+            color-mix(in oklab, var(--app-frost-tint) 58%, transparent),
+            color-mix(in oklab, var(--app-frost-tint) 66%, transparent)
+        );
+    -webkit-backdrop-filter: saturate(1.5) blur(26px);
+    backdrop-filter: saturate(1.5) blur(26px);
+    border-right: 1px solid var(--app-frost-border);
+    box-shadow:
+        inset -1px 0 0 color-mix(in oklab, white 40%, transparent),
+        24px 0 60px -36px color-mix(in oklab, var(--atc-text) 20%, transparent);
+}
+
+/* Dark theme: deep-gray frosted glass with the bright-on-dark capsule. */
+:root[data-theme="dark"] .airport-map-kit .airport-desktop-sidebar .sidebar-shell,
+:root[data-theme="dark"] .airport-map-kit .airport-desktop-sidebar .airport-sidebar-panel,
+:root[data-theme="dark"] .airport-map-kit .airport-desktop-sidebar .flight-sidebar-panel,
+:root[data-theme="dark"] .airport-map-kit .airport-sidebar-panel--mobile,
+:root[data-theme="dark"] .airport-map-kit .flight-sidebar-panel--mobile {
     --atc-bg: oklch(0.17 0.003 100);
     --atc-card: color-mix(in oklab, oklch(0.235 0.003 100) 76%, transparent);
     --atc-elev: color-mix(in oklab, oklch(0.31 0.003 100) 48%, transparent);
@@ -3612,25 +3713,31 @@ body {
     --atc-control-inset-shadow:
         inset 0 1px 0 color-mix(in oklab, var(--atc-text) 12%, transparent),
         inset 0 0 0 1px color-mix(in oklab, var(--atc-text) 7%, transparent);
+    /* Genuinely translucent frosted glass — the live map diffuses through
+       the panel (Frosted redesign), so the surface drops to ~0.56 alpha
+       and leans on a strong saturated blur for legibility instead of
+       opacity. An internal sheen catches light along the top-left. */
     background:
         radial-gradient(
             120% 70% at 18% 0%,
-            color-mix(in oklab, oklch(0.72 0.003 100) 16%, transparent),
+            color-mix(in oklab, oklch(0.72 0.003 100) 14%, transparent),
             transparent 46%
         ),
         linear-gradient(
             180deg,
-            color-mix(in oklab, oklch(0.215 0.003 100) 88%, transparent),
-            color-mix(in oklab, oklch(0.145 0.003 100) 90%, transparent)
+            color-mix(in oklab, oklch(0.215 0.003 100) 56%, transparent),
+            color-mix(in oklab, oklch(0.135 0.003 100) 62%, transparent)
         );
-    border-right: 1px solid color-mix(in oklab, var(--atc-text) 10%, transparent);
+    -webkit-backdrop-filter: saturate(1.7) blur(26px);
+    backdrop-filter: saturate(1.7) blur(26px);
+    border-right: 1px solid color-mix(in oklab, var(--atc-text) 9%, transparent);
     box-shadow:
         inset -1px 0 0 color-mix(in oklab, var(--atc-text) 6%, transparent),
-        0 18px 42px color-mix(in oklab, oklch(0.08 0.003 100) 32%, transparent);
+        24px 0 60px -36px rgba(0, 0, 0, 0.6);
 }
 
-.airport-map-kit [data-ui="toolbar"],
-.page-nav-dock [data-ui="toolbar"] {
+:root[data-theme="dark"] .airport-map-kit [data-ui="toolbar"],
+:root[data-theme="dark"] .page-nav-dock [data-ui="toolbar"] {
     --atc-bg: oklch(0.17 0.003 100);
     --atc-text: oklch(0.94 0.003 100);
     --atc-dim: color-mix(in oklab, var(--atc-text) 68%, transparent);
@@ -6619,17 +6726,17 @@ body {
     margin-top: 14px;
     padding: 11px 14px;
     border: 1px solid
-        color-mix(in oklab, var(--primary-bright) 88%, var(--primary-ink));
+        color-mix(in oklab, var(--atc-signal-accent) 88%, black 8%);
     border-radius: var(--atc-radius-control);
     background: linear-gradient(
         180deg,
-        color-mix(in oklab, var(--primary-bright) 96%, white 4%),
-        var(--primary-bright)
+        color-mix(in oklab, var(--atc-signal-accent) 92%, white 8%),
+        var(--atc-signal-accent)
     );
     box-shadow:
-        0 8px 18px color-mix(in oklab, var(--primary-bright) 22%, transparent),
-        inset 0 -2px 0 color-mix(in oklab, var(--primary-ink) 26%, transparent);
-    color: var(--primary-ink);
+        0 8px 18px color-mix(in oklab, var(--atc-signal-accent) 34%, transparent),
+        inset 0 -2px 0 color-mix(in oklab, black 18%, transparent);
+    color: #fff;
     font-family: var(--font-display);
     font-size: 13px;
     font-weight: 800;
@@ -6651,12 +6758,12 @@ body {
 }
 
 .aircraft-preview-card__track-btn:visited {
-    color: var(--primary-ink);
+    color: #fff;
 }
 
 :root[data-theme="dark"] .aircraft-preview-card__track-btn,
 :root[data-theme="dark"] .aircraft-preview-card__track-btn:visited {
-    color: var(--primary-ink);
+    color: #fff;
 }
 
 .aircraft-preview-card__track-btn:hover {
@@ -7121,6 +7228,65 @@ body {
     color: var(--atc-text);
 }
 
+/* First-screen type-scale utilities — every Home / About / Changelog /
+   Mechanism text role funnels through one of these so the four pages stay
+   in lockstep. Tune the --fs-* tokens, not these rules. */
+.fs-eyebrow {
+    color: var(--fs-eyebrow-color);
+    font-family: var(--fs-eyebrow-font);
+    font-size: var(--fs-eyebrow-size);
+    font-weight: var(--fs-eyebrow-weight);
+    letter-spacing: var(--fs-eyebrow-tracking);
+    line-height: 1;
+    text-transform: uppercase;
+}
+.fs-title {
+    color: var(--fs-title-color);
+    font-family: var(--fs-title-font);
+    font-size: var(--fs-title-size);
+    font-weight: var(--fs-title-weight);
+    line-height: var(--fs-title-leading);
+}
+.fs-sub {
+    color: var(--fs-sub-color);
+    font-size: var(--fs-sub-size);
+    font-weight: var(--fs-sub-weight);
+    line-height: var(--fs-sub-leading);
+}
+.fs-rail {
+    color: var(--fs-rail-color);
+    font-family: var(--fs-rail-font);
+    font-size: var(--fs-rail-size);
+    font-weight: var(--fs-rail-weight);
+    line-height: 1;
+}
+.fs-body {
+    color: var(--fs-body-color);
+    font-size: var(--fs-body-size);
+    line-height: var(--fs-body-leading);
+}
+.fs-value {
+    color: var(--fs-value-color);
+    font-size: var(--fs-value-size);
+    font-weight: var(--fs-value-weight);
+}
+.fs-desc {
+    color: var(--fs-desc-color);
+    font-size: var(--fs-desc-size);
+    line-height: var(--fs-desc-leading);
+}
+
+/* First-screen section-count headers adopt the eyebrow token too, so the
+   "Releases / Data sources / 系统剖面" labels match every group label.
+   Scoped to the dither pages so the airport sidebar kicker is untouched. */
+.dither-page-panel .atc-kicker {
+    font-family: var(--fs-eyebrow-font);
+    font-size: var(--fs-eyebrow-size);
+    font-weight: var(--fs-eyebrow-weight);
+    letter-spacing: var(--fs-eyebrow-tracking);
+    text-transform: uppercase;
+}
+
 .atc-section-head {
     align-items: baseline;
     border-bottom: 0;
@@ -7267,13 +7433,15 @@ body {
 .aircraft-table-row--selected.aircraft-table-row--active,
 .aircraft-table-pin .aircraft-table-row--selected,
 .aircraft-table-pin .aircraft-table-row--selected.aircraft-table-row--active {
-    background: var(--atc-glass-active-bg);
+    /* Frosted selected row: a faint blue wash + a 2px blue rail along the
+       left edge, not the smoke capsule. Text keeps its resting color. */
+    background: color-mix(in oklab, var(--atc-signal-accent) 12%, transparent);
     border-color: transparent;
-    border-radius: var(--atc-radius-card);
-    box-shadow: var(--atc-glass-rim-shadow);
-    color: var(--atc-click-fg);
-    -webkit-backdrop-filter: var(--atc-glass-active-frost);
-    backdrop-filter: var(--atc-glass-active-frost);
+    border-radius: 0;
+    box-shadow: inset 2px 0 0 var(--atc-signal-accent);
+    color: inherit;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
 }
 
 .aircraft-table-row--selected::before,
@@ -7287,13 +7455,7 @@ body {
 .aircraft-table-row--selected.aircraft-table-row--active::after,
 .aircraft-table-pin .aircraft-table-row--selected::after,
 .aircraft-table-pin .aircraft-table-row--selected.aircraft-table-row--active::after {
-    background: var(--atc-glass-sheen);
-    content: "";
-    inset: 0;
-    opacity: 0.88;
-    pointer-events: none;
-    position: absolute;
-    z-index: 0;
+    display: none;
 }
 
 .aircraft-table-row--selected > *,
@@ -7308,7 +7470,7 @@ body {
 .aircraft-table-row--selected.aircraft-table-row--active .text-atc-text,
 .aircraft-table-pin .aircraft-table-row--selected .text-atc-text,
 .aircraft-table-pin .aircraft-table-row--selected.aircraft-table-row--active .text-atc-text {
-    color: var(--atc-click-fg);
+    color: var(--atc-text);
 }
 
 .aircraft-table-row--selected .text-atc-dim,
@@ -7323,16 +7485,16 @@ body {
 .aircraft-table-pin .aircraft-table-row--selected.aircraft-table-row--active .text-atc-dim,
 .aircraft-table-pin .aircraft-table-row--selected.aircraft-table-row--active .text-atc-faint,
 .aircraft-table-pin .aircraft-table-row--selected.aircraft-table-row--active .aircraft-table-route-cycle {
-    color: var(--atc-click-muted);
+    color: var(--atc-dim);
 }
 
 .aircraft-table-row--selected .aircraft-table-row-glyph,
 .aircraft-table-row--selected.aircraft-table-row--active .aircraft-table-row-glyph,
 .aircraft-table-pin .aircraft-table-row--selected .aircraft-table-row-glyph,
 .aircraft-table-pin .aircraft-table-row--selected.aircraft-table-row--active .aircraft-table-row-glyph {
-    background: var(--atc-click-fg);
-    border-color: color-mix(in oklab, var(--atc-click-fg) 72%, transparent);
-    color: var(--atc-click-bg);
+    background: transparent;
+    border-color: transparent;
+    color: var(--atc-signal-accent);
 }
 
 @media (max-width: 767px) {
@@ -7453,10 +7615,14 @@ body {
    content axis so the list reads by alignment rather than chips/cards. */
 .changelog-entry {
     border-radius: 0;
-    column-gap: 5px;
+    column-gap: 8px;
     display: grid;
-    grid-template-columns: 46px minmax(0, 1fr);
-    padding: 5px 0;
+    grid-template-columns: 58px minmax(0, 1fr);
+    padding: 11px 0;
+}
+
+.changelog-entry + .changelog-entry {
+    border-top: 1px solid color-mix(in oklab, var(--app-frost-border) 70%, transparent);
 }
 
 .changelog-entry__rail {
@@ -7477,9 +7643,10 @@ body {
 }
 
 .changelog-entry__version {
-    color: var(--atc-dim);
-    font-size: 7.5px;
-    font-weight: 850;
+    color: var(--fs-rail-color);
+    font-family: var(--fs-rail-font);
+    font-size: var(--fs-rail-size);
+    font-weight: var(--fs-rail-weight);
 }
 
 .changelog-entry[data-current="true"] .changelog-entry__version {
@@ -7497,42 +7664,43 @@ body {
 }
 
 .changelog-entry__title {
-    color: var(--atc-text);
-    font-size: 10.5px;
-    font-weight: 700;
-    line-height: 1.2;
+    color: var(--fs-title-color);
+    font-family: var(--fs-title-font);
+    font-size: var(--fs-title-size);
+    font-weight: var(--fs-title-weight);
+    line-height: var(--fs-title-leading);
     margin: 0;
 }
 
 .changelog-entry__summary {
-    color: var(--atc-dim);
-    font-size: 9px;
-    line-height: 1.3;
-    margin-top: 3px;
+    color: var(--fs-sub-color);
+    font-size: var(--fs-sub-size);
+    line-height: var(--fs-sub-leading);
+    margin-top: 4px;
 }
 
 .changelog-entry__highlights {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    margin-top: 5px;
+    gap: 4px;
+    margin-top: 8px;
     padding: 0;
 }
 
 .changelog-entry__highlights li {
     align-items: baseline;
-    color: var(--atc-dim);
+    color: var(--fs-body-color);
     display: grid;
-    font-size: 8.5px;
-    gap: 3px;
-    grid-template-columns: 12px minmax(0, 1fr);
-    line-height: 1.34;
+    font-size: var(--fs-body-size);
+    gap: 5px;
+    grid-template-columns: 14px minmax(0, 1fr);
+    line-height: var(--fs-body-leading);
 }
 
 .changelog-entry__highlight-index {
     color: var(--atc-faint);
     font-family: var(--font-mono);
-    font-size: 6.5px;
+    font-size: 9px;
     font-weight: 800;
     letter-spacing: 0;
     line-height: 1;
@@ -7557,8 +7725,17 @@ body {
 }
 
 .dither-content-stack {
-    gap: 7px;
+    gap: 10px;
     padding: 0 var(--airport-sidebar-inset, 24px) 18px;
+}
+
+/* Each discovery section (after the first) is delimited by a hairline rule so
+   the eyebrow label unmistakably reads as a NEW group header, not another
+   gray content line. */
+.dither-content-stack > section + section {
+    border-top: 1px solid color-mix(in oklab, var(--app-frost-border) 85%, transparent);
+    margin-top: 4px;
+    padding-top: 14px;
 }
 
 .dither-list {
@@ -7604,10 +7781,10 @@ body {
 }
 
 .dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link {
-    column-gap: 4px;
-    grid-template-columns: 46px minmax(0, 1fr) 12px;
+    column-gap: 8px;
+    grid-template-columns: 50px minmax(0, 1fr) 16px;
     margin-inline: 0;
-    padding: 3px 0;
+    padding: 11px 0;
     width: 100%;
 }
 
@@ -7615,41 +7792,26 @@ body {
     background: transparent;
     border-radius: 0;
     align-self: start;
-    color: var(--atc-dim);
-    font-family: var(--font-mono);
-    font-size: 7.5px;
-    font-weight: 850;
+    color: var(--fs-rail-color);
+    font-family: var(--fs-rail-font);
+    font-size: var(--fs-rail-size);
+    font-weight: var(--fs-rail-weight);
     height: auto;
     justify-content: flex-start;
-    margin-top: 4px;
+    margin-top: 1px;
     padding: 0;
-    width: 46px;
+    width: 50px;
 }
 
 .dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link > span:nth-child(2) {
-    gap: 0;
-}
-
-.dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link
-    > span:nth-child(2)
-    > span:first-child {
-    font-size: 10.5px;
-    line-height: 1.18;
-}
-
-.dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link
-    > span:nth-child(2)
-    > span:nth-child(2) {
-    font-size: 8.5px;
-    line-height: 1.25;
-    margin-top: 1px;
+    gap: 2px;
 }
 
 .dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link > span:last-child {
     align-self: start;
-    margin-top: 5px;
+    margin-top: 3px;
     opacity: 0.55;
-    width: 12px;
+    width: 16px;
 }
 
 .dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link svg {
@@ -7675,10 +7837,10 @@ body {
     color: var(--atc-faint);
 }
 
-.dither-page-panel .sidebar-brand-dock {
-    background: color-mix(in oklab, var(--atc-bg) 72%, transparent) !important;
-    box-shadow: 0 1px 0 color-mix(in oklab, var(--atc-text) 10%, transparent) !important;
-}
+/* Brand dock visuals are owned by the SidebarBrandDock component
+   (transparent at rest, frost + hairline only once content scrolls under
+   it). The previous forced solid fill + bottom rule made the logo read as a
+   divided strip split from the page content — removed. */
 
 .dither-page-panel .brand-logo__mark {
     --brand-logo-disc: color-mix(in oklab, var(--atc-text) 12%, transparent);
@@ -7686,7 +7848,7 @@ body {
     --brand-logo-rim: color-mix(in oklab, var(--atc-text) 18%, transparent);
 }
 
-.map-settings-sheet {
+:root[data-theme="dark"] .map-settings-sheet {
     --atc-bg: oklch(0.17 0.003 100);
     --atc-card: color-mix(in oklab, oklch(0.235 0.003 100) 76%, transparent);
     --atc-elev: color-mix(in oklab, oklch(0.31 0.003 100) 48%, transparent);
@@ -7809,45 +7971,45 @@ body {
 }
 
 .about-meta-row {
-    column-gap: var(--about-meta-gap);
     display: grid;
-    grid-template-columns: var(--about-meta-rail) minmax(0, 1fr);
+    gap: 5px;
     min-width: 0;
-    padding-block: 5px;
+    padding-block: 7px;
 }
 
 .about-meta-label {
-    color: var(--atc-faint);
-    font-family: var(--font-mono);
-    font-size: 7px;
-    font-weight: 850;
-    letter-spacing: 0;
+    color: var(--fs-eyebrow-color);
+    font-family: var(--fs-eyebrow-font);
+    font-size: var(--fs-eyebrow-size);
+    font-weight: var(--fs-eyebrow-weight);
+    letter-spacing: var(--fs-eyebrow-tracking);
     line-height: 1.15;
     margin: 0;
     min-width: 0;
+    text-transform: uppercase;
 }
 
 .about-meta-value {
-    color: var(--atc-text);
-    font-size: 12px;
-    font-weight: 850;
-    line-height: 1;
+    color: var(--fs-value-color);
+    font-size: var(--fs-value-size);
+    font-weight: var(--fs-value-weight);
+    line-height: 1.1;
     min-width: 0;
 }
 
 .about-meta-sections {
     display: grid;
-    gap: 3px;
-    margin-top: 4px;
+    gap: 7px;
+    margin-top: 7px;
 }
 
 .about-meta-list {
     color: var(--atc-text);
     display: grid;
-    font-size: 10px;
+    font-size: var(--fs-sub-size);
     font-weight: 650;
-    gap: 3px;
-    line-height: 1.25;
+    gap: 4px;
+    line-height: 1.3;
     list-style: none;
     margin: 0;
     min-width: 0;
@@ -7864,16 +8026,27 @@ body {
 }
 
 .mechanism-group-label {
+    border-top: 1px solid color-mix(in oklab, var(--app-frost-border) 85%, transparent);
+    margin-top: 14px;
+    padding-bottom: 8px;
     padding-left: calc(var(--mechanism-rail) + var(--mechanism-gap));
+    padding-top: 20px;
+}
+
+.mechanism-group-label:first-child {
+    border-top: 0;
+    margin-top: 0;
+    padding-top: 2px;
 }
 
 .mechanism-group-label span {
-    color: var(--atc-faint);
-    font-family: var(--font-mono);
-    font-size: 8px;
-    font-weight: 850;
-    letter-spacing: 0;
+    color: var(--fs-eyebrow-color);
+    font-family: var(--fs-eyebrow-font);
+    font-size: var(--fs-eyebrow-size);
+    font-weight: var(--fs-eyebrow-weight);
+    letter-spacing: var(--fs-eyebrow-tracking);
     line-height: 1;
+    text-transform: uppercase;
 }
 
 .mechanism-row {
@@ -7884,7 +8057,7 @@ body {
     grid-template-columns: var(--mechanism-rail) minmax(0, 1fr);
     margin-inline: -8px;
     min-width: 0;
-    padding: 5px 8px;
+    padding: 11px 8px;
     text-align: left;
     transition:
         background-color 150ms ease,
@@ -7902,10 +8075,10 @@ body {
 }
 
 .mechanism-row__index {
-    color: var(--atc-faint);
-    font-family: var(--font-mono);
-    font-size: 8.5px;
-    font-weight: 850;
+    color: var(--fs-rail-color);
+    font-family: var(--fs-rail-font);
+    font-size: var(--fs-rail-size);
+    font-weight: var(--fs-rail-weight);
     line-height: 1;
 }
 
@@ -7916,23 +8089,24 @@ body {
 
 .mechanism-row__body {
     display: grid;
-    gap: 2px;
+    gap: 3px;
     min-width: 0;
 }
 
 .mechanism-row__title {
-    color: var(--atc-text);
-    font-size: 11.5px;
-    font-weight: 800;
-    line-height: 1.14;
+    color: var(--fs-title-color);
+    font-family: var(--fs-title-font);
+    font-size: var(--fs-title-size);
+    font-weight: var(--fs-title-weight);
+    line-height: var(--fs-title-leading);
     min-width: 0;
 }
 
 .mechanism-row__signal {
-    color: var(--atc-dim);
-    font-size: 9.5px;
-    font-weight: 600;
-    line-height: 1.18;
+    color: var(--fs-sub-color);
+    font-size: var(--fs-sub-size);
+    font-weight: var(--fs-sub-weight);
+    line-height: var(--fs-sub-leading);
     min-width: 0;
 }
 
@@ -7944,9 +8118,9 @@ body {
 .mechanism-detail__body,
 .mechanism-detail__item,
 .mechanism-flow {
-    color: var(--atc-dim);
-    font-size: 9.5px;
-    line-height: 1.38;
+    color: var(--fs-body-color);
+    font-size: var(--fs-body-size);
+    line-height: var(--fs-body-leading);
 }
 
 .mechanism-detail__body {
@@ -7956,26 +8130,31 @@ body {
 .mechanism-flow {
     display: flex;
     flex-wrap: wrap;
-    gap: 2px 10px;
+    gap: 6px;
     list-style: none;
-    margin: 6px 0 0;
+    margin: 12px 0 0;
     padding: 0;
 }
 
 .mechanism-flow__item {
-    align-items: baseline;
-    display: inline-grid;
-    gap: 3px;
-    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    background: color-mix(in oklab, var(--app-frost-tint) 26%, transparent);
+    border: 1px solid var(--app-frost-border);
+    border-radius: 999px;
+    color: var(--atc-dim);
+    display: inline-flex;
+    font-size: var(--fs-sub-size);
+    line-height: 1;
     max-width: 100%;
     min-width: 0;
+    padding: 5px 11px;
 }
 
 .mechanism-flow__index,
 .mechanism-detail__index {
     color: var(--atc-faint);
     font-family: var(--font-mono);
-    font-size: 7px;
+    font-size: 9px;
     font-weight: 850;
     letter-spacing: 0;
     line-height: 1;
@@ -7983,16 +8162,16 @@ body {
 
 .mechanism-detail__list {
     display: grid;
-    gap: 3px;
+    gap: 7px;
     list-style: none;
-    margin: 7px 0 0;
+    margin: 14px 0 0;
     padding: 0;
 }
 
 .mechanism-detail__item {
     display: grid;
-    gap: 5px;
-    grid-template-columns: 14px minmax(0, 1fr);
+    gap: 7px;
+    grid-template-columns: 16px minmax(0, 1fr);
     margin: 0;
 }
 
@@ -8370,7 +8549,9 @@ body {
     column-gap: var(--home-list-column-gap);
     grid-template-columns: var(--home-list-code-column) minmax(0, 1fr) 16px;
     margin-inline: 0;
-    padding: 4px 8px 4px var(--home-list-rail-inset);
+    /* Roomier padding so the hover highlight breathes around the row text
+       and doesn't crowd the content or the neighbouring rows. */
+    padding: 11px 10px 11px var(--home-list-rail-inset);
     width: 100%;
 }
 
@@ -8562,15 +8743,15 @@ body {
     color: var(--atc-text);
 }
 
-.airport-map-kit .aircraft-table-card .text-atc-text {
+:root[data-theme="dark"] .airport-map-kit .aircraft-table-card .text-atc-text {
     color: oklch(0.94 0.003 100) !important;
 }
 
-.airport-map-kit .aircraft-table-card .text-atc-dim {
+:root[data-theme="dark"] .airport-map-kit .aircraft-table-card .text-atc-dim {
     color: color-mix(in oklab, oklch(0.94 0.003 100) 70%, transparent) !important;
 }
 
-.airport-map-kit .aircraft-table-card .text-atc-faint {
+:root[data-theme="dark"] .airport-map-kit .aircraft-table-card .text-atc-faint {
     color: color-mix(in oklab, oklch(0.94 0.003 100) 48%, transparent) !important;
 }
 
@@ -8637,6 +8818,19 @@ body {
     padding-top: 2px;
 }
 
+/* The 2-up detail filter strip is collected into one bordered glass block so
+   the four filters read as a single contained unit instead of loose chips —
+   matching the Frosted design and de-cluttering the sidebar. */
+.airport-sidebar-panel [data-ui="filter-grid"][data-cols="2"],
+.flight-sidebar-panel [data-ui="filter-grid"][data-cols="2"] {
+    background: color-mix(in oklab, var(--app-frost-tint) 22%, transparent);
+    border: 1px solid var(--app-frost-border);
+    border-radius: var(--atc-radius-card);
+    gap: 2px;
+    overflow: hidden;
+    padding: 4px;
+}
+
 .airport-sidebar-panel [data-ui="metric-card"],
 .airport-sidebar-panel [data-ui="filter-card"],
 .flight-sidebar-panel [data-ui="metric-card"],
@@ -8696,6 +8890,23 @@ body {
 .flight-sidebar-panel [data-ui="filter-card"][data-active="true"]::after,
 .flight-sidebar-panel [data-ui="filter-card"][data-state="open"]::after {
     opacity: 0;
+}
+
+/* The active filter tile is a subtle --atc-text wash (not the ink capsule),
+   so its value/label must stay in resting ink — NOT --atc-click-fg, which is
+   near-white and vanishes on the light wash in light theme. */
+.airport-sidebar-panel [data-ui="filter-card"][data-active="true"] [data-ui="filter-value"],
+.airport-sidebar-panel [data-ui="filter-card"][data-state="open"] [data-ui="filter-value"],
+.flight-sidebar-panel [data-ui="filter-card"][data-active="true"] [data-ui="filter-value"],
+.flight-sidebar-panel [data-ui="filter-card"][data-state="open"] [data-ui="filter-value"] {
+    color: var(--atc-text);
+}
+
+.airport-sidebar-panel [data-ui="filter-card"][data-active="true"] [data-ui="filter-label"],
+.airport-sidebar-panel [data-ui="filter-card"][data-state="open"] [data-ui="filter-label"],
+.flight-sidebar-panel [data-ui="filter-card"][data-active="true"] [data-ui="filter-label"],
+.flight-sidebar-panel [data-ui="filter-card"][data-state="open"] [data-ui="filter-label"] {
+    color: var(--atc-dim);
 }
 
 .airport-sidebar-panel [data-ui="metric-card"][data-layout="split"],


### PR DESCRIPTION
Whole-app **frosted-glass** visual system with theme-following chrome and a single **orange** signal accent.

## Highlights
- **Chrome follows the theme** — the airport/aircraft sidebars, toolbars, and static pages were dark-forced; their dark token blocks are now scoped to `:root[data-theme="dark"]` and light theme inherits a near-white frost via `--app-frost-tint`. Light = white glass + ink; dark = deep-gray glass + white.
- **One orange signal accent** (`--atc-signal-accent`, theme-split) for row selection, the tracked-flight trace, and the track button. Trace no longer borrows movement color → every selected aircraft draws one consistent orange trail.
- **Shared first-screen type scale** (`--fs-*` tokens + `.fs-*` utilities) across Home / About / Changelog / Mechanism, with eyebrow group labels + dividers.
- Airport **hero stats block**; flight **telemetry leads with Speed + Altitude** (auxiliary: Vertical/Track/Phase); ICAO24 removed.
- Mechanism flow steps render as frosted **badges**.
- Nearby list **virtualizes on mobile** (fixed header + internal scroll); selected unitless row values stay aligned with the number column.
- Map settings sheet de-compacted; list hover rows breathe.
- `.impeccable.md` now references `DESIGN.md` as the single source of truth.
- Changelog: collapsed the v2.26.18–23 UI-refinement patches into one **v2.27.0** minor entry.

## Validation
- `pnpm build` clean · `pnpm test` 122/122 pass.
- Verified in browser across light/dark × desktop/mobile on airport, aircraft, home, about, changelog, mechanism, and the map-settings sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)