### PR TITLE
PR0: light/regular-only typography foundation (v2.28.0)

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400&family=Noto+Sans+SC:wght@300;400&display=swap"
       rel="stylesheet"
     />
     <title>ADSBao - Airport weather and traffic context</title>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.27.0",
+  "version": "2.28.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -122,7 +122,6 @@ function AirportDiscoveryTopicSection({ topic, onOpen, onPrefetch }) {
       <DiscoverySectionHeader
         id={`airport-discovery-${topic.id}`}
         title={t(topic.titleKey)}
-        description={t(topic.descriptionKey)}
       />
 
       <ul className="dither-list mt-2.5 flex flex-col gap-2.5">

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,28 @@ export const CHANGELOG_TOTAL_COUNT = 90;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.28.0",
+    kind: "feat",
+    title: {
+      en: "Designed, not aligned — system pass",
+      zh: "为「设计感」而非「对齐」打磨",
+    },
+    summary: {
+      en: "A page-by-page pass applying ADSBao's existing material system with intentional hierarchy, density rhythm, and surface separation. Opens with a typographic foundation: hierarchy now comes from size and luminance, never weight.",
+      zh: "逐页打磨，让 ADSBao 既有的材质系统以更有层次、更有节奏、更分面的方式呈现。首先落地排版基线：层次来自字号与明度，而非字重。",
+    },
+    highlights: [
+      {
+        en: "Typography is light/regular only — no bold/semibold anywhere; weight utilities and tokens remapped at the source",
+        zh: "排版仅用 light/regular，全应用不再有粗体；字重工具类与 token 在源头统一重映射",
+      },
+      {
+        en: "Loaded font weights trimmed to 300/400 for a lighter, more editorial feel",
+        zh: "加载的字重收敛为 300/400，整体更轻、更具编排感",
+      },
+    ],
+  },
+  {
     version: "v2.27.0",
     kind: "feat",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -47,6 +47,23 @@
     --font-nav: var(--theme-font-nav);
     --font-display: var(--theme-font-display);
 
+    /* Typographic polarity: ADSBao uses only light (300) and regular (400).
+       Hierarchy comes from size, color, tracking, and surface — never weight.
+       Every Tailwind weight utility (font-medium…font-black) collapses to 400;
+       font-light/font-thin stay 300. Tune here, never re-type weights at call
+       sites. The two raw tokens below are reused by hand-authored CSS rules. */
+    --weight-light: 300;
+    --weight-regular: 400;
+    --font-weight-thin: var(--weight-light);
+    --font-weight-extralight: var(--weight-light);
+    --font-weight-light: var(--weight-light);
+    --font-weight-normal: var(--weight-regular);
+    --font-weight-medium: var(--weight-regular);
+    --font-weight-semibold: var(--weight-regular);
+    --font-weight-bold: var(--weight-regular);
+    --font-weight-extrabold: var(--weight-regular);
+    --font-weight-black: var(--weight-regular);
+
     --radius: var(--atc-radius-control);
     --radius-xs: calc(var(--radius) * 0.5);
     --radius-sm: calc(var(--radius) * 0.75);
@@ -1667,7 +1684,7 @@ body:has(.dither-page-shell) {
     display: flex;
     font-family: var(--font-mono);
     font-size: 10px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     height: 18px;
     justify-content: center;
     letter-spacing: normal;
@@ -1712,7 +1729,7 @@ body:has(.dither-page-shell) {
     display: flex;
     font-family: var(--font-mono);
     font-size: 9px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     height: 14px;
     justify-content: center;
     letter-spacing: 0.04em;
@@ -1737,7 +1754,7 @@ body:has(.dither-page-shell) {
 }
 
 .airport-range-ring-label--major {
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     font-size: 10px;
 }
 
@@ -1753,7 +1770,7 @@ body:has(.dither-page-shell) {
     fill: var(--airspace-label-text);
     font-family: var(--font-mono);
     font-size: 10px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
     paint-order: stroke;
     opacity: 0.5;
@@ -1938,7 +1955,7 @@ body:has(.dither-page-shell) {
 
 .navaid-count-marker strong {
     font-size: 11px;
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
     line-height: 1;
 }
@@ -1946,7 +1963,7 @@ body:has(.dither-page-shell) {
 .navaid-count-marker span {
     color: var(--navaid-label-muted);
     font-size: 7px;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
     line-height: 1;
 }
@@ -2050,7 +2067,7 @@ body:has(.dither-page-shell) {
     color: var(--atc-dim);
     font-family: var(--font-mono);
     font-size: 8px;
-    font-weight: 850;
+    font-weight: var(--weight-regular);
     line-height: 1;
     margin-top: 7px;
 }
@@ -2069,7 +2086,7 @@ body:has(.dither-page-shell) {
 .near-me-permission-copy h1 {
     color: var(--atc-text);
     font-size: 18px;
-    font-weight: 850;
+    font-weight: var(--weight-regular);
     line-height: 1.05;
     margin: 0;
 }
@@ -2077,7 +2094,7 @@ body:has(.dither-page-shell) {
 .near-me-permission-copy p {
     color: var(--atc-dim);
     font-size: 10px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     line-height: 1.35;
     margin: 5px 0 0;
 }
@@ -2096,7 +2113,7 @@ body:has(.dither-page-shell) {
     cursor: pointer;
     display: inline-flex;
     font-size: 11px;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     justify-content: center;
     line-height: 1;
     min-height: 30px;
@@ -2757,7 +2774,7 @@ body:has(.dither-page-shell) {
     color: var(--atc-faint);
     font-family: var(--font-mono);
     font-size: 8px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.18em;
     line-height: 1;
     text-transform: uppercase;
@@ -2768,7 +2785,7 @@ body:has(.dither-page-shell) {
     display: block;
     font-family: var(--font-mono);
     font-size: 14px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     line-height: 1.5;
     max-height: 144px;
     overflow: auto;
@@ -2779,7 +2796,7 @@ body:has(.dither-page-shell) {
 .metar-raw--placeholder .metar-raw__code {
     color: var(--atc-faint);
     font-style: italic;
-    font-weight: 500;
+    font-weight: var(--weight-regular);
 }
 
 .metar-instrument {
@@ -2816,7 +2833,7 @@ body:has(.dither-page-shell) {
     color: var(--atc-text);
     font-family: var(--font-mono);
     font-size: 22px;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     line-height: 1;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -2860,7 +2877,7 @@ body:has(.dither-page-shell) {
     color: var(--atc-faint);
     font-family: var(--font-mono);
     font-size: 8px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.18em;
     line-height: 1;
     text-transform: uppercase;
@@ -2870,7 +2887,7 @@ body:has(.dither-page-shell) {
     color: var(--atc-text);
     font-family: var(--font-mono);
     font-size: 22px;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     line-height: 1;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -2880,7 +2897,7 @@ body:has(.dither-page-shell) {
 .weather-token__value--secondary {
     color: var(--atc-dim);
     font-size: 13px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
 }
 
 .weather-metric-line {
@@ -2903,7 +2920,7 @@ body:has(.dither-page-shell) {
 .weather-metric-line strong {
     color: var(--atc-text);
     font-size: 1.1875rem;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     line-height: 1;
 }
 
@@ -2933,7 +2950,7 @@ body:has(.dither-page-shell) {
     border-radius: 6px;
     color: var(--atc-text);
     font-size: 12px;
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     line-height: 1;
     padding: 6px 10px;
 }
@@ -2941,7 +2958,7 @@ body:has(.dither-page-shell) {
 .flight-rule-banner strong {
     color: var(--atc-text);
     font-size: 19px;
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     line-height: 1.05;
 }
 
@@ -3909,7 +3926,7 @@ body {
 .airport-sidebar-display-mono--metric,
 .airport-sidebar-display-mono {
     font-style: normal;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
 }
 
@@ -3973,7 +3990,7 @@ body {
     border-color: var(--atc-click-border);
     box-shadow: none;
     color: var(--atc-click-fg);
-    font-weight: 700;
+    font-weight: var(--weight-regular);
 }
 
 .aircraft-preview-card__track-btn:visited {
@@ -4227,7 +4244,7 @@ body {
     color: var(--atc-faint);
     font-family: var(--font-mono);
     font-size: 10.5px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: .02em;
     line-height: 1;
 }
@@ -4236,14 +4253,14 @@ body {
     color: var(--atc-text);
     font-family: var(--font-mono);
     font-size: 14px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     line-height: 1;
 }
 
 .hourly-card__condition {
     color: var(--atc-dim);
     font-size: 10px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     line-height: 1;
 }
 
@@ -4253,7 +4270,7 @@ body {
     display: flex;
     font-family: var(--font-mono);
     font-size: 10px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     gap: 2px;
     line-height: 1;
 }
@@ -4291,7 +4308,7 @@ body {
 .forecast-tomorrow__label {
     color: var(--atc-faint);
     font-size: 10px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: .04em;
     margin-bottom: 6px;
     text-transform: uppercase;
@@ -4313,14 +4330,14 @@ body {
     color: var(--atc-faint);
     font-family: var(--font-mono);
     font-size: 11px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: .01em;
 }
 
 .forecast-tomorrow__condition {
     color: var(--atc-text);
     font-size: 13px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
 }
 
 .forecast-tomorrow__temps {
@@ -4329,7 +4346,7 @@ body {
     display: flex;
     font-family: var(--font-mono);
     font-size: 14px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     gap: 3px;
     line-height: 1;
     margin-left: auto;
@@ -4343,7 +4360,7 @@ body {
 
 .forecast-tomorrow__lo {
     color: var(--atc-dim);
-    font-weight: 500;
+    font-weight: var(--weight-regular);
 }
 
 .forecast-tomorrow__precip {
@@ -4352,7 +4369,7 @@ body {
     display: flex;
     font-family: var(--font-mono);
     font-size: 11px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     gap: 3px;
     margin-left: 2px;
 }
@@ -4538,7 +4555,7 @@ body {
     color: var(--atc-text);
     display: flex;
     font-size: 13px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     gap: 10px;
     line-height: 1.2;
     min-width: 0;
@@ -4560,7 +4577,7 @@ body {
 .aircraft-label {
     font-family: var(--font-mono);
     font-size: 10px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.3px;
     line-height: 1.05;
     position: absolute;
@@ -4844,14 +4861,14 @@ body {
 .aircraft-trace-label__time {
     color: var(--atc-text);
     font-size: 9px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.4px;
 }
 
 .aircraft-trace-label__alt {
     color: var(--atc-dim);
     font-size: 7.5px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.3px;
     margin-top: 1px;
 }
@@ -4859,7 +4876,7 @@ body {
 .aircraft-trace-label__alt-unit {
     color: var(--atc-faint);
     font-size: 6px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.5px;
     margin-left: 2px;
     text-transform: uppercase;
@@ -4867,7 +4884,7 @@ body {
 
 .aircraft-trace-label__alt--ground {
     color: var(--atc-faint);
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.6px;
     text-transform: uppercase;
 }
@@ -4890,7 +4907,7 @@ body {
 .aircraft-table-route-cycle {
     color: var(--atc-dim);
     font-size: 10px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     height: 14px;
     line-height: 14px;
     overflow: hidden;
@@ -4910,7 +4927,7 @@ body {
     display: inline-flex;
     flex: 0 1 auto;
     font-size: 8.5px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     height: 14px;
     line-height: 1;
     max-width: min(82px, 46%);
@@ -5552,7 +5569,7 @@ body {
     color: var(--atc-text);
     font-family: var(--font-display);
     font-size: 7px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.06em;
     line-height: 1;
     padding: 1px 4px;
@@ -5615,19 +5632,19 @@ body {
 .airport-overlay-label--navaid .airport-overlay-label__code.atc-code-pill {
     font-family: var(--font-mono);
     font-size: 7px;
-    font-weight: 850;
+    font-weight: var(--weight-regular);
 }
 
 .airport-overlay-label--reporting-point .airport-overlay-label__code.atc-code-pill {
     font-family: var(--font-sans);
     font-size: 7px;
-    font-weight: 850;
+    font-weight: var(--weight-regular);
 }
 
 .airport-overlay-label--candidate-spot .airport-overlay-label__code.atc-code-pill {
     font-family: var(--font-sans);
     font-size: 7px;
-    font-weight: 850;
+    font-weight: var(--weight-regular);
     max-width: 76px;
 }
 
@@ -5652,19 +5669,19 @@ body {
 
 .airport-overlay-label__detail-label {
     color: color-mix(in oklab, var(--atc-solid-accent-fg) 65%, transparent);
-    font-weight: 800;
+    font-weight: var(--weight-regular);
 }
 
 .airport-overlay-label__detail-value {
     color: var(--atc-solid-accent-fg);
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     min-width: 1ch;
     text-align: right;
 }
 
 .airport-overlay-label__detail-separator {
     color: color-mix(in oklab, var(--atc-solid-accent-fg) 42%, transparent);
-    font-weight: 800;
+    font-weight: var(--weight-regular);
 }
 
 .airport-overlay-label__detail-part--motion {
@@ -5801,7 +5818,7 @@ body {
     display: inline-block;
     font-family: var(--font-display);
     font-feature-settings: "tnum" 1;
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.04em;
     mask: none;
     -webkit-mask: none;
@@ -5809,13 +5826,13 @@ body {
 }
 
 .airport-sidebar-display-mono--hero {
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     letter-spacing: -0.005em;
     line-height: 0.95;
 }
 
 .airport-sidebar-display-mono--metric {
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     letter-spacing: -0.005em;
     line-height: 0.9;
 }
@@ -6027,7 +6044,7 @@ body {
     color: var(--atc-faint);
     display: inline-block;
     font-size: 0.32em;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
     margin-left: 0.18em;
     text-transform: uppercase;
@@ -6074,7 +6091,7 @@ body {
     color: var(--atc-faint);
     font-family: var(--airport-sidebar-sans);
     font-size: 10px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
     text-transform: uppercase;
 }
@@ -6176,7 +6193,7 @@ body {
 
 .airport-briefing-card .weather-metric-line span {
     font-family: var(--airport-sidebar-sans);
-    font-weight: 600;
+    font-weight: var(--weight-regular);
 }
 
 .airport-briefing-card .wiki-copy {
@@ -6254,7 +6271,7 @@ body {
     color: var(--atc-text);
     font-family: var(--airport-sidebar-sans);
     font-size: 13px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     min-width: 0;
     outline: none;
     width: 100%;
@@ -6338,7 +6355,7 @@ body {
 
 .atc-toast[data-sonner-toast] [data-title] {
     font-size: 12px;
-    font-weight: 500;
+    font-weight: var(--weight-regular);
     color: var(--atc-text);
 }
 
@@ -6455,7 +6472,7 @@ body {
     color: color-mix(in oklab, var(--atc-text) 86%, transparent);
     font-family: var(--font-mono);
     font-size: 7px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     line-height: 1;
     text-align: right;
     text-overflow: ellipsis;
@@ -6523,7 +6540,7 @@ body {
 .aircraft-preview-stat__label {
     font-family: var(--font-mono);
     font-size: 9px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.16em;
     color: var(--atc-faint);
     text-transform: uppercase;
@@ -6540,7 +6557,7 @@ body {
 
 .aircraft-preview-stat__number {
     font-size: 14px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.02em;
     font-variant-numeric: tabular-nums;
 }
@@ -6548,14 +6565,14 @@ body {
 .aircraft-preview-stat__prefix {
     font-family: var(--font-mono);
     font-size: 9px;
-    font-weight: 500;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.06em;
     color: var(--atc-dim);
 }
 
 .aircraft-preview-stat__unit {
     font-size: 9px;
-    font-weight: 500;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.06em;
     color: var(--atc-dim);
     text-transform: uppercase;
@@ -6578,7 +6595,7 @@ body {
 
 .aircraft-preview-meta-row__label {
     font-size: 9px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.16em;
     color: var(--atc-faint);
     text-transform: uppercase;
@@ -6587,7 +6604,7 @@ body {
 .aircraft-preview-meta-row__value {
     margin: 0;
     font-size: 11px;
-    font-weight: 500;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.02em;
     color: var(--atc-dim);
     font-variant-numeric: tabular-nums;
@@ -6739,7 +6756,7 @@ body {
     color: #fff;
     font-family: var(--font-display);
     font-size: 13px;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     font-style: normal;
     letter-spacing: 0.08em;
     line-height: 1.15;
@@ -6849,7 +6866,7 @@ body {
     color: var(--atc-dim);
     font-family: var(--font-mono);
     font-size: 10px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.08em;
     line-height: 1.35;
     margin-top: 0;
@@ -6905,7 +6922,7 @@ body {
     color: var(--atc-dim);
     font-family: var(--font-sans);
     font-size: 10px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.08em;
     line-height: 1;
     text-transform: uppercase;
@@ -6951,7 +6968,7 @@ body {
     color: var(--atc-faint);
     font-family: var(--font-sans);
     font-size: 9px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.1em;
     line-height: 1;
     text-transform: uppercase;
@@ -6968,7 +6985,7 @@ body {
     color: var(--atc-text);
     font-family: var(--font-sans);
     font-size: 12px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     outline: none;
@@ -7004,7 +7021,7 @@ body {
     border-radius: var(--atc-radius-control);
     font-family: var(--font-sans);
     font-size: 10px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.08em;
     line-height: 1;
     text-transform: uppercase;
@@ -7052,7 +7069,7 @@ body {
     color: var(--atc-dim);
     font-family: var(--font-mono);
     font-size: 9px;
-    font-weight: 500;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.06em;
     line-height: 1;
     text-overflow: ellipsis;
@@ -7142,7 +7159,7 @@ body {
     margin: 0;
     font-family: var(--font-sans);
     font-size: 14px;
-    font-weight: 700;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.02em;
     line-height: 1.2;
     color: var(--atc-text);
@@ -7173,7 +7190,7 @@ body {
     margin: -4px 0 0;
     font-family: var(--font-mono);
     font-size: 12px;
-    font-weight: 600;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.08em;
     color: var(--atc-faint);
     text-transform: uppercase;
@@ -7217,7 +7234,7 @@ body {
     display: inline-flex;
     font-family: var(--font-display);
     font-size: 10px;
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     gap: 6px;
     letter-spacing: normal;
     line-height: 1;
@@ -7299,7 +7316,7 @@ body {
     color: var(--atc-dim);
     font-family: var(--font-display);
     font-size: 10px;
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
 }
 
@@ -7311,7 +7328,7 @@ body {
     display: inline-flex;
     font-family: var(--font-display);
     font-size: 9px;
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
     line-height: 1;
     padding: 3px 7px;
@@ -7340,7 +7357,7 @@ body {
     display: inline-flex;
     font-family: var(--font-display);
     font-size: 8px;
-    font-weight: 900;
+    font-weight: var(--weight-regular);
     letter-spacing: normal;
     line-height: 1;
     padding: 2px 6px;
@@ -7366,7 +7383,7 @@ body {
 }
 
 .atc-page-title {
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     letter-spacing: 0.01em;
     text-transform: none;
 }
@@ -7656,7 +7673,7 @@ body {
 .changelog-entry__current {
     color: var(--atc-faint);
     font-size: 6.5px;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
 }
 
 .changelog-entry__body {
@@ -7701,7 +7718,7 @@ body {
     color: var(--atc-faint);
     font-family: var(--font-mono);
     font-size: 9px;
-    font-weight: 800;
+    font-weight: var(--weight-regular);
     letter-spacing: 0;
     line-height: 1;
 }
@@ -8007,7 +8024,7 @@ body {
     color: var(--atc-text);
     display: grid;
     font-size: var(--fs-sub-size);
-    font-weight: 650;
+    font-weight: var(--weight-regular);
     gap: 4px;
     line-height: 1.3;
     list-style: none;
@@ -8155,7 +8172,7 @@ body {
     color: var(--atc-faint);
     font-family: var(--font-mono);
     font-size: 9px;
-    font-weight: 850;
+    font-weight: var(--weight-regular);
     letter-spacing: 0;
     line-height: 1;
 }
@@ -8562,7 +8579,7 @@ body {
     color: var(--atc-dim);
     font-family: var(--font-mono);
     font-size: var(--home-list-code-font);
-    font-weight: 850;
+    font-weight: var(--weight-regular);
     height: auto;
     justify-content: flex-start;
     padding: 0;


### PR DESCRIPTION
## Plan (foundational PR, precedes the page-by-page sweep)
**Tokens:** add `--weight-light` (300) / `--weight-regular` (400); remap Tailwind `--font-weight-*` so every weight utility collapses to 400 and `font-light/thin` → 300.
**Touched:** `src/style.css` (@theme + 81 literal weight declarations), `index.html` (load only 300/400), `src/config/changelog.ts`, `package.json`. Tiny pre-existing typecheck fix in `AirportDiscoveryPanel.tsx`.
**New files:** none.

## Why
DESIGN.md judgment #1 / refactor brief: *hierarchy comes from size and luminance, not weight*. This removes bold/semibold everywhere at the source rather than touching 144 call sites, so the page-by-page PRs inherit a light/regular baseline.

## Done-when
- [x] No bold/semibold renders anywhere (verified: `font-bold`/`font-extrabold` compute to 400 in-browser)
- [x] `pnpm build` + `pnpm typecheck` clean
- [x] changelog `v2.28.0` entry (en + zh); version bumped in sync
- [x] Theme-agnostic (weights are not theme-forked) — both themes inherit identically

Part of the design-consistency sweep tracked under v2.28.0; later page PRs fold highlights into this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)