### PR TITLE
PR1: sidebar two-line compact rows + vertical cue

### DIFF
--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -13,6 +13,9 @@ import { useCardInteraction } from "@/animations/useCardInteraction";
 import { rowPropsEqual } from "./rowPropsEqual";
 
 const ROUTE_ENTER_MS = 300;
+// Vertical-rate deadband: below this the aircraft reads as level and gets no
+// climb/descend cue, so cruise noise doesn't flicker an arrow on every row.
+const VERTICAL_CUE_FPM = 64;
 
 // Tiny self-contained <img> that hides itself if the URL 404s. Avoids
 // stamped broken-image icons in dense list rows when the logo isn't
@@ -30,6 +33,13 @@ function AirlineLogo({ src, className }: Record<string, any>) {
       onError={() => setHidden(true)}
     />
   );
+}
+
+function verticalCue(aircraft: Record<string, any>) {
+  if (aircraft?.onGround) return "";
+  const rate = Number(aircraft?.baroRate);
+  if (!Number.isFinite(rate) || Math.abs(rate) < VERTICAL_CUE_FPM) return "";
+  return rate > 0 ? "▲" : "▼";
 }
 
 function AircraftRow({
@@ -50,6 +60,7 @@ function AircraftRow({
   const { preferences: units } = useUnitPreferences();
   const callsign = aircraft.callsign?.trim() || aircraft.icao24 || "-";
   const route = aircraft.flightRouteLabel || "";
+  const registration = String(aircraft.registration || "").trim();
   const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft.flightRoute);
   const routeAccuracyNotice = getFlightRouteAccuracyNotice(aircraft.flightRoute)
     ? t("aircraft.adsbdbRouteAccuracyNotice")
@@ -66,6 +77,7 @@ function AircraftRow({
   const altitudeDisplay = rawAltitude
     ? formatAltitude(aircraft.altitude, units.altitude, { kind: "cruise" })
     : null;
+  const cue = verticalCue(aircraft);
 
   return (
     <button
@@ -75,7 +87,7 @@ function AircraftRow({
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
       onMouseLeave={onMouseLeave}
-      className={`aircraft-table-card aircraft-table-row-grid aircraft-table-row-shell grid w-full items-center px-[var(--airport-sidebar-inset)] text-left transition-[background,color,box-shadow] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] data-[selected=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_12%,transparent)] data-[selected=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)] data-[selected=true]:hover:bg-[color-mix(in_oklab,var(--atc-signal-accent)_15%,transparent)] data-[selected=true]:[&_.aircraft-table-row-glyph]:text-[var(--atc-signal-accent)] ${
+      className={`aircraft-table-card aircraft-table-row-two aircraft-table-row-shell flex w-full items-center gap-2 px-[var(--airport-sidebar-inset)] text-left transition-[background,color,box-shadow] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] data-[selected=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_12%,transparent)] data-[selected=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)] data-[selected=true]:hover:bg-[color-mix(in_oklab,var(--atc-signal-accent)_15%,transparent)] data-[selected=true]:[&_.aircraft-table-row-glyph]:text-[var(--atc-signal-accent)] ${
         selected ? "aircraft-table-row--selected aircraft-table-row--active" : ""
       }`}
       aria-pressed={selected}
@@ -87,37 +99,33 @@ function AircraftRow({
       <AircraftIdentityCell
         callsign={callsign}
         route={route}
+        registration={registration}
         airlineIconUrl={airlineIconUrl}
         routeAccuracyNotice={routeAccuracyNotice}
+        distance={
+          !distanceDisplay ? (
+            <NumberWithUnit text="-" unit="" />
+          ) : distanceDisplay.text ? (
+            <NumberWithUnit text={distanceDisplay.text} unit={distanceDisplay.unit} />
+          ) : (
+            <NumberWithUnit value={distanceDisplay.value} unit={distanceDisplay.unit} />
+          )
+        }
+        altitude={
+          aircraft.onGround ? (
+            <NumberWithUnit text={t("aircraft.gnd")} unit="" />
+          ) : !altitudeDisplay ? (
+            <NumberWithUnit text="-" unit="" />
+          ) : (
+            <NumberWithUnit
+              value={altitudeDisplay.value}
+              unit={altitudeDisplay.unit.toUpperCase()}
+              prefix={altitudeDisplay.prefix}
+            />
+          )
+        }
+        verticalCue={cue}
       />
-      <div className="aircraft-table-cell aircraft-table-cell--distance text-right font-mono text-[12px] font-semibold text-atc-text">
-        {!distanceDisplay ? (
-          <NumberWithUnit text="-" unit="" />
-        ) : distanceDisplay.text ? (
-          <NumberWithUnit
-            text={distanceDisplay.text}
-            unit={distanceDisplay.unit}
-          />
-        ) : (
-          <NumberWithUnit
-            value={distanceDisplay.value}
-            unit={distanceDisplay.unit}
-          />
-        )}
-      </div>
-      <div className="aircraft-table-cell aircraft-table-cell--altitude text-right font-mono text-[12px] font-semibold text-atc-text">
-        {aircraft.onGround ? (
-          <NumberWithUnit text={t("aircraft.gnd")} unit="" />
-        ) : !altitudeDisplay ? (
-          <NumberWithUnit text="-" unit="" />
-        ) : (
-          <NumberWithUnit
-            value={altitudeDisplay.value}
-            unit={altitudeDisplay.unit.toUpperCase()}
-            prefix={altitudeDisplay.prefix}
-          />
-        )}
-      </div>
     </button>
   );
 }
@@ -132,10 +140,12 @@ export default memo(AircraftRow, (prev, next) =>
     nestedFields: [
       "callsign",
       "icao24",
+      "registration",
       "flightRouteLabel",
       "flightRoute",
       "distanceNm",
       "altitude",
+      "baroRate",
       "onGround",
       "flight_position_source",
       "positionQuality",
@@ -143,11 +153,18 @@ export default memo(AircraftRow, (prev, next) =>
   }),
 );
 
+// The compact two-line identity block. Line 1 pairs the callsign with the
+// distance; line 2 pairs the route (or registration) with the altitude. The
+// glyph sits to the left, vertically centred across both lines.
 function AircraftIdentityCell({
   callsign,
   route,
+  registration,
   airlineIconUrl,
   routeAccuracyNotice,
+  distance,
+  altitude,
+  verticalCue: cue,
 }: Record<string, any>) {
   const hasRoute = Boolean(route);
   const hadRoute = useRef(hasRoute);
@@ -169,45 +186,58 @@ function AircraftIdentityCell({
     return undefined;
   }, [hasRoute, route]);
 
-  if (!hasRoute) {
-    return (
-      <div className="aircraft-table-identity aircraft-table-identity--solo min-w-0">
-        <span
-          className="aircraft-table-callsign airport-sidebar-display-mono notranslate truncate text-[12px] font-semibold text-atc-text"
-          translate="no"
-        >
-          {callsign}
-        </span>
-      </div>
-    );
-  }
-
   const routeTitle = routeAccuracyNotice || route;
 
   return (
     <div
-      className={`aircraft-table-identity aircraft-table-identity--routed min-w-0 ${
+      className={`aircraft-table-identity aircraft-table-identity--routed grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] gap-x-2.5 ${
         routeEntering ? "aircraft-table-identity--route-entering" : ""
       }`}
     >
-      <div className="aircraft-table-primary-line flex min-w-0 items-center gap-1.5">
-        <span
-          className="aircraft-table-callsign airport-sidebar-display-mono notranslate min-w-0 truncate text-[12px] font-semibold text-atc-text"
-          translate="no"
-        >
-          {callsign}
-        </span>
-        <AirlineLogo
-          src={airlineIconUrl}
-          className="aircraft-table-airline-logo"
-        />
-        <span
-          title={routeTitle}
-          className="aircraft-table-route-badge notranslate min-w-0 truncate"
-          translate="no"
-        >
-          {route}
-        </span>
+      <span
+        className="aircraft-table-callsign airport-sidebar-display-mono notranslate min-w-0 self-center truncate text-[12.5px] text-atc-text"
+        translate="no"
+      >
+        {callsign}
+      </span>
+      <div className="aircraft-table-metric aircraft-table-metric--distance self-center text-right font-mono text-[11px] text-atc-text">
+        {distance}
+      </div>
+
+      <div className="aircraft-table-subline flex min-h-[12px] min-w-0 items-center gap-1.5 self-center">
+        {hasRoute ? (
+          <>
+            <AirlineLogo
+              src={airlineIconUrl}
+              className="aircraft-table-airline-logo"
+            />
+            <span
+              title={routeTitle}
+              className="aircraft-table-route-badge notranslate min-w-0 truncate"
+              translate="no"
+            >
+              {route}
+            </span>
+          </>
+        ) : registration && registration !== callsign ? (
+          <span
+            className="notranslate min-w-0 truncate text-[10px] tracking-[0.04em] text-atc-faint"
+            translate="no"
+          >
+            {registration}
+          </span>
+        ) : null}
+      </div>
+      <div className="aircraft-table-metric aircraft-table-metric--altitude flex items-center justify-end gap-1 self-center text-right font-mono text-[11px] text-atc-dim">
+        {cue ? (
+          <span
+            aria-hidden="true"
+            className="aircraft-table-vcue text-[8px] leading-none text-atc-faint"
+          >
+            {cue}
+          </span>
+        ) : null}
+        {altitude}
       </div>
     </div>
   );
@@ -249,7 +279,7 @@ function NumberWithUnit({ value, unit, format, text, prefix }: Record<string, an
         <span className="block min-w-0 text-right">{displayText}</span>
       </span>
       <sub
-        className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] font-semibold leading-none text-atc-dim"
+        className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] leading-none text-atc-dim"
         translate="no"
       >
         {unit}

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -330,13 +330,14 @@ export default function AircraftTable({
           fill && "flex-1 min-h-0",
         )}
       >
-        <div className="aircraft-table-header aircraft-table-row-grid grid items-center px-[var(--airport-sidebar-inset)] py-0.5 font-mono text-[7px] uppercase text-atc-faint">
-          <span aria-hidden="true" />
-          <span>{t("sidebar.callsignOrRoute")}</span>
-          <NumericHeader>{t("sidebar.distance")}</NumericHeader>
-          <NumericHeader>
+        <div className="aircraft-table-header flex items-center gap-2 px-[var(--airport-sidebar-inset)] py-0.5 font-mono text-[7px] uppercase text-atc-faint">
+          <span aria-hidden="true" className="w-[18px] flex-none" />
+          <span className="min-w-0 flex-1">{t("sidebar.callsignOrRoute")}</span>
+          <span className="whitespace-nowrap text-right">
+            {t("sidebar.distance")}
+            <span aria-hidden="true" className="mx-1 text-atc-faint/60">·</span>
             {hasRouteEndpointAirports ? t("sidebar.endpoint") : t("sidebar.altitude")}
-          </NumericHeader>
+          </span>
         </div>
 
         {pinnedAircraft && (
@@ -786,19 +787,6 @@ function AircraftAltitudeFilterCard({
 function toNumber(value) {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
-}
-
-// Header cell that mirrors the row's NumberWithUnit 2-column sub-grid (number
-// column + small unit-suffix column). Without this, the header text right-
-// aligns to the cell's edge but row values right-align inside the inner grid,
-// so the header sits ~14px to the right of every value.
-function NumericHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="grid w-full grid-cols-[minmax(0,1fr)_var(--aircraft-table-unit-width,14px)] items-baseline gap-x-0.5">
-      <span className="block min-w-0 text-right">{children}</span>
-      <span aria-hidden="true" />
-    </span>
-  );
 }
 
 function filterAndSortAircraft({

--- a/src/components/sidebar/AirportRow.tsx
+++ b/src/components/sidebar/AirportRow.tsx
@@ -3,15 +3,15 @@ import { TowerControl } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplayModel";
-import { airportCityName, airportDisplayCodeLine, airportDisplayName } from "@/utils/airport";
-import { countryName } from "@/utils/flag";
+import { airportDisplayCodeLine } from "@/utils/airport";
+import { countryName, flagEmoji } from "@/utils/flag";
 import { formatAltitude } from "@/utils/units";
 import { rowPropsEqual } from "./rowPropsEqual";
 
-// Airport equivalent of AircraftRow — same column rhythm so an
+// Airport equivalent of AircraftRow — same two-line rhythm so an
 // "airports & aircraft" mixed list reads as one coherent table.
-// Left: ICAO · IATA / city + country. Right: DIST and ELEV (in place of
-// the aircraft row's GS / ALT).
+// Line 1: ICAO · IATA + distance. Line 2: flag + country + elevation.
+// The full "City, Country" lives in the preview card, not the compact row.
 function AirportRow({
   airport,
   airportId,
@@ -21,11 +21,8 @@ function AirportRow({
   const { locale, t } = useI18n();
   const { preferences: units } = useUnitPreferences();
   const code = airportDisplayCodeLine(airport);
-  const city = airportCityName(airport?.city, locale);
+  const flag = flagEmoji(airport?.country);
   const country = countryName(airport?.country, locale) || airport?.country || "";
-  const placeText =
-    [city, country].filter(Boolean).join(", ") ||
-    airportDisplayName(airport, locale);
   const dist = toFiniteNumber(airport?.distanceNm);
   const distanceDisplay = formatNearbyDistanceDisplay(dist, units.distance);
   const elevation = toFiniteNumber(airport?.elevationFt);
@@ -45,48 +42,55 @@ function AirportRow({
   return (
     <button
       type="button"
-      className={`aircraft-table-card aircraft-table-row-grid aircraft-table-row-shell grid w-full items-center px-[var(--airport-sidebar-inset)] text-left transition-[background,color] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] ${
-        selected ? "aircraft-table-row--active" : ""
+      className={`aircraft-table-card aircraft-table-row-two aircraft-table-row-shell flex w-full items-center gap-2 px-[var(--airport-sidebar-inset)] text-left transition-[background,color,box-shadow] hover:bg-[color-mix(in_oklab,var(--atc-elev)_55%,transparent)] data-[selected=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_12%,transparent)] data-[selected=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)] data-[selected=true]:hover:bg-[color-mix(in_oklab,var(--atc-signal-accent)_15%,transparent)] data-[selected=true]:[&_.aircraft-table-row-glyph]:text-[var(--atc-signal-accent)] ${
+        selected ? "aircraft-table-row--selected aircraft-table-row--active" : ""
       }`}
+      data-selected={selected ? "true" : undefined}
       aria-pressed={selected}
       onClick={() => airportId && onSelectAirport?.(airportId)}
     >
       <span aria-hidden="true" className="aircraft-table-row-glyph">
         <TowerControl size={13} strokeWidth={2.4} />
       </span>
-      <div className="aircraft-table-identity aircraft-table-identity--solo min-w-0">
+      <div className="aircraft-table-identity grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] gap-x-2.5">
         <span
-          className="aircraft-table-callsign airport-sidebar-display-mono notranslate truncate text-[12px] font-semibold text-atc-text"
+          className="aircraft-table-callsign airport-sidebar-display-mono notranslate min-w-0 self-center truncate text-[12.5px] text-atc-text"
           translate="no"
         >
           {code}
         </span>
-        {placeText ? (
-          <span className="truncate text-[9.5px] text-atc-dim">{placeText}</span>
-        ) : null}
-      </div>
-      <div className="aircraft-table-cell aircraft-table-cell--distance text-right font-mono text-[12px] font-semibold text-atc-text">
-        {!distanceDisplay ? (
-          <NumberWithUnit text="-" unit="" />
-        ) : distanceDisplay.text ? (
-          <NumberWithUnit text={distanceDisplay.text} unit={distanceDisplay.unit} />
-        ) : (
-          <NumberWithUnit value={distanceDisplay.value} unit={distanceDisplay.unit} />
-        )}
-      </div>
-      <div className="aircraft-table-cell aircraft-table-cell--altitude text-right font-mono text-[12px] font-semibold text-atc-text">
-        {endpointLabel ? (
-          <span className="text-[9px] uppercase tracking-normal text-atc-dim">
-            {endpointLabel}
-          </span>
-        ) : !elevationDisplay ? (
-          <NumberWithUnit text="-" unit="" />
-        ) : (
-          <NumberWithUnit
-            value={elevationDisplay.value}
-            unit={elevationDisplay.unit.toUpperCase()}
-          />
-        )}
+        <div className="aircraft-table-metric aircraft-table-metric--distance self-center text-right font-mono text-[11px] text-atc-text">
+          {!distanceDisplay ? (
+            <NumberWithUnit text="-" unit="" />
+          ) : distanceDisplay.text ? (
+            <NumberWithUnit text={distanceDisplay.text} unit={distanceDisplay.unit} />
+          ) : (
+            <NumberWithUnit value={distanceDisplay.value} unit={distanceDisplay.unit} />
+          )}
+        </div>
+
+        <div className="aircraft-table-subline flex min-h-[12px] min-w-0 items-center gap-1.5 self-center text-[10px] text-atc-faint">
+          {flag ? (
+            <span aria-hidden="true" className="flex-none leading-none">
+              {flag}
+            </span>
+          ) : null}
+          {country ? <span className="min-w-0 truncate">{country}</span> : null}
+        </div>
+        <div className="aircraft-table-metric aircraft-table-metric--altitude self-center text-right font-mono text-[11px] text-atc-dim">
+          {endpointLabel ? (
+            <span className="text-[9px] uppercase tracking-normal text-atc-dim">
+              {endpointLabel}
+            </span>
+          ) : !elevationDisplay ? (
+            <NumberWithUnit text="-" unit="" />
+          ) : (
+            <NumberWithUnit
+              value={elevationDisplay.value}
+              unit={elevationDisplay.unit.toUpperCase()}
+            />
+          )}
+        </div>
       </div>
     </button>
   );
@@ -101,7 +105,6 @@ export default memo(AirportRow, (prev, next) =>
     nestedFields: [
       "icao",
       "iata",
-      "city",
       "country",
       "distanceNm",
       "elevationFt",
@@ -118,7 +121,7 @@ function NumberWithUnit({ value, unit, format, text }: Record<string, any>) {
     <span className="aircraft-table-number grid w-full grid-cols-[minmax(0,1fr)_var(--aircraft-table-unit-width,14px)] items-baseline gap-x-0.5 tabular-nums">
       <span className="block min-w-0 text-right">{displayText}</span>
       <sub
-        className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] font-semibold leading-none text-atc-dim"
+        className="aircraft-table-unit notranslate relative top-[0.22em] block text-left text-[7px] leading-none text-atc-dim"
         translate="no"
       >
         {unit}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -64,6 +64,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "Loaded font weights trimmed to 300/400 for a lighter, more editorial feel",
         zh: "加载的字重收敛为 300/400，整体更轻、更具编排感",
       },
+      {
+        en: "Nearby list rows share one compact two-line form — callsign + distance over route + altitude — with a subtle climb/descend cue; rich detail stays in the preview card",
+        zh: "邻近列表统一为紧凑两行：呼号 + 距离在上、航线 + 高度在下，并带轻量的爬升/下降指示；详细信息只留在预览卡片中",
+      },
     ],
   },
   {

--- a/src/style.css
+++ b/src/style.css
@@ -5326,6 +5326,19 @@ body {
     padding-block: 5px;
 }
 
+/* Two-line compact row: callsign + distance on top, route + altitude below.
+   Height grows from the single-line 42px to fit both lines; the metric column
+   shares one unit-width so distance and altitude align on their number/unit
+   split. The virtualizer measures the real height per element, so this min is
+   just a floor. */
+.aircraft-table-row-two {
+    --aircraft-table-unit-width: 16px;
+    height: auto;
+    min-height: 48px;
+    padding-block: 6px;
+    row-gap: 2px;
+}
+
 .aircraft-table-list-card {
     background: transparent;
     -webkit-backdrop-filter: none;


### PR DESCRIPTION
## Plan
**Tokens:** none new. Add `.aircraft-table-row-two` (height floor + shared unit-width). Selection already uses `--atc-signal-accent`. Vertical cue is shape-only (▲/▼) in `--atc-dim` — no new color, accent reserved.
**Touched:** `AircraftRow.tsx`, `AirportRow.tsx`, `AircraftTable.tsx` (header + drop unused `NumericHeader`), `style.css`. Preview card audited — already complete, unchanged.
**New files:** none.

## End state
Every nearby row is one compact two-line form — **callsign + distance** over **route (or registration) + altitude** — so the list is for scanning and all rich detail stays in the preview card.

## Done-when
- [x] All rows identical compact two-line layout; no inline buttons
- [x] Preview card holds identity / route / telemetry (GS·ALT·V/S·track) / status / Track / Plane-Hunter
- [x] Selection = orange wash + `inset 2px 0 0` rail + tinted glyph only
- [x] Vertical climb/descend cue on the altitude value (shape, not color; 64 fpm deadband)
- [x] Both themes verified over a busy map (light: dark selection wash; dark: bright-glass preview, map desaturates under frost)
- [x] `pnpm build` + `pnpm typecheck` clean
- [x] changelog highlight folded into `v2.28.0`

Part of the v2.28.0 design-consistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)