### PR TITLE
PR2: split weather into Local + METAR views

### DIFF
--- a/src/components/sidebar/WeatherBriefingStack.tsx
+++ b/src/components/sidebar/WeatherBriefingStack.tsx
@@ -1,8 +1,15 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useAirportWiki } from "../../hooks/useAirportWiki";
 import { useWeatherSlides } from "@/components/weather/useWeatherSlides";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import AsyncStatusLine from "@/components/ui/AsyncStatusLine";
+
+// Two audiences, two densities. The METAR view leads with the flight-rules
+// hero and the coded report for enthusiasts; the Local view is the friendly
+// Open-Meteo picture (current conditions + hourly) for everyone else. A quiet
+// capsule segment switches between them — they are never merged into one card.
+const LOCAL_SLIDE_IDS = ["local", "wind", "hourly"];
+const METAR_SLIDE_IDS = ["rules", "metar", "ceiling", "wind", "temp", "pressure"];
 
 export default function WeatherBriefingStack({
   icao = "",
@@ -21,6 +28,9 @@ export default function WeatherBriefingStack({
   nearMe = false,
 }) {
   const { t } = useI18n();
+  // Default to the operating picture (flight-rules hero); general users can
+  // switch to Local. Near-me has no METAR, so it is Local-only.
+  const [view, setView] = useState("metar");
   const wikiAirport = useMemo(
     () => ({ icao, iata, name, city, country }),
     [icao, iata, name, city, country],
@@ -39,70 +49,107 @@ export default function WeatherBriefingStack({
   });
   const wiki = useAirportWiki(wikiAirport);
 
+  const slideById = useMemo(
+    () => new Map(slides.map((slide) => [slide.id, slide])),
+    [slides],
+  );
+  const effectiveView = nearMe ? "local" : view;
+  const activeSlides = useMemo(() => {
+    const ids = nearMe
+      ? ["hourly"]
+      : effectiveView === "local"
+        ? LOCAL_SLIDE_IDS
+        : METAR_SLIDE_IDS;
+    return ids.map((id) => slideById.get(id)).filter(Boolean);
+  }, [effectiveView, nearMe, slideById]);
+
   return (
     <div className="airport-briefing-stack">
-      {slides.map((slide) => {
-        const showWindStreaks = slide.id === "wind" && windFlowBearing != null;
-        return (
-          <section
-            key={slide.id}
-            className={`airport-briefing-card ${
-              showWindStreaks ? "airport-briefing-card--wind" : ""
-            }`}
-            style={
-              showWindStreaks
-                ? { "--wind-flow": `${windFlowBearing}deg` }
-                : undefined
-            }
-          >
-            {showWindStreaks ? (
-              <div
-                className="airport-briefing-card__streaks"
-                aria-hidden="true"
-              />
-            ) : null}
-            <div className="airport-briefing-card__heading">
-              <span>{slide.navLabel || slide.label}</span>
-            </div>
-            {slide.content}
-          </section>
-        );
-      })}
-
-      {!nearMe && (
-        <section className="airport-briefing-card airport-briefing-card--wiki">
-        <div className="airport-briefing-card__heading">
-          <span>{t("panels.wiki")}</span>
+      {!nearMe ? (
+        <div className="weather-view-segment" role="tablist" aria-label={t("panels.weather")}>
+          {[
+            { id: "metar", label: "METAR" },
+            { id: "local", label: t("weather.local") },
+          ].map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={effectiveView === item.id}
+              data-active={effectiveView === item.id ? "true" : undefined}
+              onClick={() => setView(item.id)}
+              className="weather-view-segment__btn group relative flex-1 rounded-[calc(var(--atc-radius-pill)_-_3px)] border border-transparent px-3 py-1 text-center text-[10px] uppercase tracking-[0.1em] text-atc-dim transition-[background,color,box-shadow] duration-200 hover:text-atc-text data-[active=true]:[background:var(--atc-glass-active-bg)] data-[active=true]:text-[var(--atc-click-fg)] data-[active=true]:shadow-[var(--atc-glass-rim-shadow)] data-[active=true]:[backdrop-filter:var(--atc-glass-active-frost)] data-[active=true]:hover:[background:var(--atc-glass-active-bg)] data-[active=true]:hover:text-[var(--atc-click-fg)]"
+            >
+              {item.label}
+            </button>
+          ))}
         </div>
-        <p className="wiki-copy">
-          {wiki.summary?.extract
-            ? wiki.summary.extract
-            : wiki.loading
-              ? t("panels.wikiLoading")
-              : t("panels.wikiMissing")}
-        </p>
-        <AsyncStatusLine
-          loading={Boolean(wiki.loading)}
-          error={wiki.error || null}
-          statusCode={wiki.statusCode ?? null}
-          cycleKey={`${icao || iata || name || "wiki"}`}
-          pendingLabel={t("panels.wikiLoading")}
-          successLabel={t("panels.wikiLoaded")}
-          errorLabel={t("panels.wikiLoadError")}
-          className="mt-1"
-        />
-        {wiki.summary?.url ? (
-          <a
-            className="airport-briefing-card__link"
-            href={wiki.summary.url}
-            target="_blank"
-            rel="noreferrer"
-          >
-            {t("panels.openWikipedia")}
-          </a>
+      ) : null}
+
+      <div key={effectiveView} className="app-panel-transition weather-view-panel">
+        {activeSlides.map((slide) => {
+          const showWindStreaks = slide.id === "wind" && windFlowBearing != null;
+          return (
+            <section
+              key={slide.id}
+              className={`airport-briefing-card ${
+                showWindStreaks ? "airport-briefing-card--wind" : ""
+              }`}
+              style={
+                showWindStreaks
+                  ? ({ "--wind-flow": `${windFlowBearing}deg` } as any)
+                  : undefined
+              }
+            >
+              {showWindStreaks ? (
+                <div
+                  className="airport-briefing-card__streaks"
+                  aria-hidden="true"
+                />
+              ) : null}
+              <div className="airport-briefing-card__heading">
+                <span>{slide.navLabel || slide.label}</span>
+              </div>
+              {slide.content}
+            </section>
+          );
+        })}
+
+        {!nearMe && effectiveView === "local" ? (
+          <section className="airport-briefing-card airport-briefing-card--wiki">
+            <div className="airport-briefing-card__heading">
+              <span>{t("panels.wiki")}</span>
+            </div>
+            <p className="wiki-copy">
+              {wiki.summary?.extract
+                ? wiki.summary.extract
+                : wiki.loading
+                  ? t("panels.wikiLoading")
+                  : t("panels.wikiMissing")}
+            </p>
+            <AsyncStatusLine
+              loading={Boolean(wiki.loading)}
+              error={wiki.error || null}
+              statusCode={wiki.statusCode ?? null}
+              cycleKey={`${icao || iata || name || "wiki"}`}
+              pendingLabel={t("panels.wikiLoading")}
+              successLabel={t("panels.wikiLoaded")}
+              errorLabel={t("panels.wikiLoadError")}
+              className="mt-1"
+            />
+            {wiki.summary?.url ? (
+              <a
+                className="airport-briefing-card__link"
+                href={wiki.summary.url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {t("panels.openWikipedia")}
+              </a>
+            ) : null}
+          </section>
         ) : null}
-      </section>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -68,6 +68,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "Nearby list rows share one compact two-line form — callsign + distance over route + altitude — with a subtle climb/descend cue; rich detail stays in the preview card",
         zh: "邻近列表统一为紧凑两行：呼号 + 距离在上、航线 + 高度在下，并带轻量的爬升/下降指示；详细信息只留在预览卡片中",
       },
+      {
+        en: "Weather splits into a Local view (friendly current conditions + hourly) and a METAR view (flight-rules hero + raw report + decoded grid), switched by a quiet capsule segment",
+        zh: "天气拆分为 Local（友好的实时天况 + 逐时预报）与 METAR（飞行规则主指标 + 原始报文 + 解码网格）两个视图，由一个安静的玻璃胶囊分段切换",
+      },
     ],
   },
   {

--- a/src/style.css
+++ b/src/style.css
@@ -6081,6 +6081,28 @@ body {
     padding: 0;
 }
 
+/* Quiet capsule segment that switches the weather column between the METAR
+   (operating-picture) view and the friendly Local view. Resting buttons are
+   transparent on a faint frosted track; the active button is the standard
+   glass capsule (--atc-glass-* via the data-[active] utilities on the JSX). */
+.weather-view-segment {
+    display: flex;
+    gap: 4px;
+    margin: 16px var(--airport-sidebar-inset) 2px;
+    padding: 3px;
+    border-radius: var(--atc-radius-pill);
+    background: color-mix(in oklab, var(--app-frost-tint) 28%, transparent);
+    border: 1px solid var(--app-frost-border);
+}
+
+/* Real box (not display:contents) so the app-panel-enter fade replays on each
+   view switch. The cards stack inside via their own border-bottom dividers, so
+   the grid-vs-block-flow difference is invisible. */
+.weather-view-panel {
+    display: block;
+    min-width: 0;
+}
+
 .airport-briefing-card {
     background: transparent;
     border: 0;


### PR DESCRIPTION
## Plan
**Tokens:** none new. New `.weather-view-segment` track + `.weather-view-panel` (real box so the fade replays). Active segment uses `--atc-glass-*` via the documented `data-[active]` utilities.
**Touched:** `WeatherBriefingStack.tsx` (segment + Local/METAR partition), `style.css` (segment track). Reuses all existing slide components.
**New files:** none.

## End state
One quiet capsule segment switches the weather column between **METAR** (flight-rules hero + raw report + decoded grid, for enthusiasts) and **Local** (friendly current conditions + hourly, for everyone). They are never merged into one card.

## Done-when
- [x] Local view: current temp / wind / feels / hourly
- [x] METAR view: flight-rules hero (ok-state green) + raw coded METAR (mono) + decoded ceiling/vis/wind/temp/dew/altimeter
- [x] One quiet segment switches them; ~200ms fade on swap
- [x] Left column stays compact
- [x] Both themes (light: dark capsule segment; dark: bright-glass capsule); `pnpm build` + typecheck clean
- [x] changelog highlight folded into `v2.28.0`

Part of the v2.28.0 design-consistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)