### PR TITLE
PR4: unify left-column views under one quiet segment

### DIFF
--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -274,7 +274,7 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
         <div className="app-list-motion atc-freq-table flex flex-col">
           {rows.map((row, index) => (
             <div
-              key={row.id || `${row.type}-${row.frequencyMhz}-${index}`}
+              key={row.id || `${row.inferredRole}-${row.frequencyMhz}-${index}`}
               className="flex items-baseline justify-between gap-3 border-b border-[color-mix(in_oklab,var(--atc-line)_55%,transparent)] py-2 last:border-b-0"
             >
               <div className="min-w-0">

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -11,9 +11,12 @@ import {
 
 // Frosted "hero stats block": one joined rounded glass container with a big
 // headline metric (nearby flights) over a row of small footer cells
-// (weather / ATC / spotting / movement). Each segment doubles as the
-// view-switch control — the active segment shows the blue accent rail so
-// navigation is preserved while matching the redesign's single-block look.
+// (weather / ATC / spotting / movement). This is the single quiet segment that
+// switches every left-column view, so only one summary surface shows at a time.
+// Each segment doubles as the view-switch control — the active segment shows
+// the reserved orange accent rail + faint wash (DESIGN.md: row-selection,
+// trace, track button, and the active hero/telemetry segment). Hierarchy comes
+// from size and luminance, not weight — numerals stay regular.
 export default function SidebarViewSwitch({
   activeView = "briefing",
   onViewChange,
@@ -112,7 +115,7 @@ export default function SidebarViewSwitch({
             </span>
           </div>
           <div className="mt-[5px] flex items-baseline gap-2">
-            <span className="text-[33px] font-bold leading-none tracking-[-1px] tabular-nums text-atc-text">
+            <span className="text-[33px] font-normal leading-none tracking-[-1px] tabular-nums text-atc-text">
               <NumberFlow value={aircraft.length} />
             </span>
           </div>
@@ -138,7 +141,7 @@ function StatCell({ label, value, unit, active, onClick }) {
     >
       <div className="text-[10px] text-atc-faint">{label}</div>
       <div className="mt-[3px]">
-        <span className="text-[16px] font-bold tabular-nums text-atc-text">
+        <span className="text-[16px] font-normal tabular-nums text-atc-text">
           {value}
         </span>
         {unit ? (

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -76,6 +76,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "ATC frequencies render as a clean table — role left, channel in mono right-aligned — ordered by operational flow (ATIS → Clearance → Ground → Tower → Approach → Departure)",
         zh: "ATC 频率改为整洁表格：左侧角色、右侧等宽对齐的频道，并按运行流程排序（ATIS → Clearance → Ground → Tower → Approach → Departure）",
       },
+      {
+        en: "Nearby / weather / ATC stay unified under one quiet hero-stats segment — only one summary surface shows at a time, with a 240ms cross-fade and regular-weight numerals",
+        zh: "邻近 / 天气 / ATC 统一在一个安静的主指标分段下切换——同一时刻只显示一个汇总面，配 240ms 交叉淡入与常规字重数字",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Plan
**Tokens:** none. **Touched:** `SidebarViewSwitch.tsx` (font honesty + comment), `AirportSidebar.tsx` (PR3 key typefix). **New files:** none.

## End state
Nearby / weather / ATC switch under the one joined hero-stats block — only one summary surface at a time, active segment = reserved orange accent rail + wash (DESIGN.md), 240ms cross-fade, no layout jump.

## Done-when
- [x] One quiet segment drives the active view (the joined hero-stats block)
- [x] Selected segment uses the established state — orange accent per DESIGN.md (which overrides the brief's "capsule" wording for the hero/telemetry segment)
- [x] Transition 240ms (in the 150-250ms band); no layout jump
- [x] Hero numerals now honest regular weight (no `font-bold`)
- [x] Both themes; `pnpm build` + typecheck clean (also fixes a latent PR3 type error)
- [x] changelog highlight folded into `v2.28.0`

Part of the v2.28.0 design-consistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)