### PR TITLE
PR5: hierarchy + density rhythm for first-screen pages

### DIFF
--- a/src/components/airport/search/AirportSearchResults.tsx
+++ b/src/components/airport/search/AirportSearchResults.tsx
@@ -1,6 +1,30 @@
+import { Loader2, Radar, SearchX } from "lucide-react";
 import AirportRow from "./AirportRow";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import AsyncStatusLine from "@/components/ui/AsyncStatusLine";
+
+// Designed state for the search column — a quiet glyph over a primary line and
+// a faint supporting line, framed by whitespace rather than left bare. Shared
+// by the loading / error / no-result branches so each reads as a deliberate
+// state, not an afterthought.
+function SearchState({ icon, title, detail = null, spin = false }) {
+  return (
+    <div className="flex flex-col items-center gap-2.5 px-4 py-10 text-center">
+      <span
+        aria-hidden="true"
+        className={`flex size-9 items-center justify-center rounded-full bg-[color-mix(in_oklab,var(--atc-text)_6%,transparent)] text-atc-faint ${
+          spin ? "[&>svg]:animate-spin" : ""
+        }`}
+      >
+        {icon}
+      </span>
+      <span className="fs-title max-w-[24ch] text-atc-dim">{title}</span>
+      {detail ? (
+        <span className="fs-desc max-w-[28ch] text-atc-faint">{detail}</span>
+      ) : null}
+    </div>
+  );
+}
 
 export function AirportSearchResults({
   query,
@@ -41,17 +65,23 @@ export function AirportSearchResults({
         </div>
 
         {loading && !rows.length ? (
-          <div className="py-7 text-center font-mono text-xs tracking-[0.6px] text-atc-dim">
-            {t("search.searchingAirports")}
-          </div>
+          <SearchState
+            spin
+            icon={<Loader2 size={17} strokeWidth={2} />}
+            title={t("search.searchingAirports")}
+          />
         ) : error ? (
-          <div className="py-7 text-center font-mono text-xs tracking-[0.6px] text-atc-dim">
-            {error}
-          </div>
+          <SearchState
+            icon={<SearchX size={17} strokeWidth={2} />}
+            title={t("search.searchAirportsError")}
+            detail={error}
+          />
         ) : !rows.length ? (
-          <div className="py-7 text-center font-mono text-xs tracking-[0.6px] text-atc-dim">
-            {t("search.noAirportMatched", { query: query.trim() })}
-          </div>
+          <SearchState
+            icon={<Radar size={17} strokeWidth={2} />}
+            title={t("search.noAirportMatched", { query: query.trim() })}
+            detail={t("search.discovery.pageDescription")}
+          />
         ) : (
           <ul className="app-list-motion dither-list mt-3 flex flex-col gap-1">
             {rows.map((airport, index) => (

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -80,6 +80,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "Nearby / weather / ATC stay unified under one quiet hero-stats segment — only one summary surface shows at a time, with a 240ms cross-fade and regular-weight numerals",
         zh: "邻近 / 天气 / ATC 统一在一个安静的主指标分段下切换——同一时刻只显示一个汇总面，配 240ms 交叉淡入与常规字重数字",
       },
+      {
+        en: "First-screen pages (Home / About / Mechanism / Changelog) gain real hierarchy — larger inked titles over smaller, fainter detail, groups separated by whitespace rhythm not dividing lines; search loading / empty / no-result are now designed states",
+        zh: "首屏各页（首页 / 关于 / 机制 / 更新日志）建立真正的层次——更大且着墨的标题搭配更小更淡的细节，分组以留白节奏而非分隔线区隔；搜索的加载 / 空 / 无结果改为有设计感的状态",
+      },
     ],
   },
   {

--- a/src/style.css
+++ b/src/style.css
@@ -3048,34 +3048,39 @@ body:has(.dither-page-shell) {
          body    → expanded detail copy
          value   → meta value (version, stack item)
          desc    → page-level description under the H1                    */
+    /* Hierarchy comes from size + luminance, never weight: every role is
+       light/regular, so the primary (title) is markedly larger and inked while
+       secondary roles (eyebrow / sub) recede in size and contrast. The eyebrow
+       is a quiet tracked label; the title leads each row; the sub is small and
+       faint. Widen these ratios, don't reach for weight. */
     --fs-eyebrow-font: var(--font-display);
-    --fs-eyebrow-size: 11px;
-    --fs-eyebrow-weight: 800;
-    --fs-eyebrow-tracking: 0.12em;
+    --fs-eyebrow-size: 10px;
+    --fs-eyebrow-weight: var(--weight-regular);
+    --fs-eyebrow-tracking: 0.16em;
     --fs-eyebrow-color: var(--atc-faint);
 
     --fs-title-font: var(--font-sans);
-    --fs-title-size: 14px;
-    --fs-title-weight: 800;
-    --fs-title-leading: 1.2;
+    --fs-title-size: 15px;
+    --fs-title-weight: var(--weight-regular);
+    --fs-title-leading: 1.25;
     --fs-title-color: var(--atc-text);
 
-    --fs-sub-size: 11.5px;
-    --fs-sub-weight: 600;
-    --fs-sub-leading: 1.25;
-    --fs-sub-color: var(--atc-dim);
+    --fs-sub-size: 11px;
+    --fs-sub-weight: var(--weight-regular);
+    --fs-sub-leading: 1.3;
+    --fs-sub-color: var(--atc-faint);
 
     --fs-rail-font: var(--font-mono);
     --fs-rail-size: 11px;
-    --fs-rail-weight: 850;
+    --fs-rail-weight: var(--weight-regular);
     --fs-rail-color: var(--atc-faint);
 
     --fs-body-size: 11px;
-    --fs-body-leading: 1.5;
+    --fs-body-leading: 1.55;
     --fs-body-color: var(--atc-dim);
 
-    --fs-value-size: 13px;
-    --fs-value-weight: 850;
+    --fs-value-size: 14px;
+    --fs-value-weight: var(--weight-regular);
     --fs-value-color: var(--atc-text);
 
     --fs-desc-size: 12px;
@@ -7781,13 +7786,13 @@ body {
     padding: 0 var(--airport-sidebar-inset, 24px) 18px;
 }
 
-/* Each discovery section (after the first) is delimited by a hairline rule so
-   the eyebrow label unmistakably reads as a NEW group header, not another
-   gray content line. */
+/* Density is rhythm, not uniform compression: rows inside a group stay tight,
+   but a deliberately larger gap separates one group from the next so the
+   whitespace itself does the grouping (no dividing lines). The quiet eyebrow
+   label sits in that gap and reads as a new group header on its own. */
 .dither-content-stack > section + section {
-    border-top: 1px solid color-mix(in oklab, var(--app-frost-border) 85%, transparent);
-    margin-top: 4px;
-    padding-top: 14px;
+    margin-top: 10px;
+    padding-top: 22px;
 }
 
 .dither-list {


### PR DESCRIPTION
## Plan
**Tokens:** retune `--fs-*` (size + weight + tracking + sub color) in `:root`; rework `.dither-content-stack > section + section` rhythm. **Touched:** `style.css`, `AirportSearchResults.tsx` (designed states). **New files:** none.

## End state
Home discovery reads as scannable groups: one clear size-driven primary per row (airport name), detail recedes (smaller + fainter), groups separated by whitespace rhythm (no dividing lines). Loading / empty / no-result are designed states.

## Done-when
- [x] One clear primary per group (size-driven); rows grouped with whitespace rhythm
- [x] Empty / loading / no-result states designed (glyph chip + primary + supporting copy), not bare
- [x] Hierarchy by size + luminance only — every `--fs-*-weight` is now honest light/regular
- [x] Both themes; `pnpm build` + typecheck clean
- [x] changelog highlight folded into `v2.28.0`

Note: the `--fs-*` scale is shared, so About / Mechanism / Changelog inherit the hierarchy; their page-specific structure is PR6 / PR7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)