### PR TITLE
PR6: About as a quiet label-rail + grouped data sources

### DIFF
--- a/src/components/about/AboutPanel.tsx
+++ b/src/components/about/AboutPanel.tsx
@@ -16,6 +16,31 @@ const resolveCopy = (entry, t) => {
   return entry.valueKey ? t(entry.valueKey) : entry.value;
 };
 
+// Group the data-source list by concern so it reads as scannable clusters
+// rather than one long stack. Categories derive from each source's glyph code
+// (kept here so the static config stays untouched). Labels are bilingual
+// inline — the glyph codes themselves are already untranslated.
+const SOURCE_CATEGORY: Record<string, string> = {
+  "ADS-B": "traffic",
+  ICONS: "traffic",
+  ROUTE: "traffic",
+  METAR: "weather",
+  WX: "weather",
+  DIR: "airport",
+  RWY: "airport",
+  SPOT: "airport",
+  WIKI: "context",
+  MAP: "context",
+  VIDEO: "context",
+};
+const CATEGORY_ORDER = ["traffic", "weather", "airport", "context"];
+const CATEGORY_LABEL: Record<string, { en: string; zh: string }> = {
+  traffic: { en: "Traffic", zh: "航迹" },
+  weather: { en: "Weather", zh: "天气" },
+  airport: { en: "Airport", zh: "机场" },
+  context: { en: "Context", zh: "背景" },
+};
+
 export default function AboutPanel() {
   const { locale, t } = useI18n();
 
@@ -84,26 +109,45 @@ export default function AboutPanel() {
         </div>
       </div>
 
-      <ol className="dither-list dither-list-flow mx-5 flex flex-col gap-2.5">
-        {ABOUT_DATA_SOURCES.map((source) => (
-          <li key={source.host || source.title || source.glyph}>
-            <TextPillListItem
-              as="a"
-              className="about-data-source-link"
-              {...getExternalLinkOpenTarget(source.href)}
-              onClick={(event) => openExternalLink(event, source.href)}
-              pill={source.glyph}
-              title={source.titleKey ? t(source.titleKey) : source.title}
-              subtitle={
-                source.descriptionKey
-                  ? t(source.descriptionKey)
-                  : source.description
-              }
-              trailing={<ArrowUpRight className="h-4 w-4" aria-hidden="true" />}
-            />
-          </li>
-        ))}
-      </ol>
+      <div className="flex flex-col gap-5">
+        {CATEGORY_ORDER.map((category) => {
+          const sources = ABOUT_DATA_SOURCES.filter(
+            (source) => (SOURCE_CATEGORY[source.glyph] || "context") === category,
+          );
+          if (!sources.length) return null;
+          const label =
+            CATEGORY_LABEL[category][locale === "zh-CN" ? "zh" : "en"];
+          return (
+            <section key={category} className="flex flex-col gap-1.5">
+              <span className="fs-eyebrow mx-[var(--airport-sidebar-inset,20px)]">
+                {label}
+              </span>
+              <ol className="dither-list dither-list-flow flex flex-col gap-1">
+                {sources.map((source) => (
+                  <li key={source.host || source.title || source.glyph}>
+                    <TextPillListItem
+                      as="a"
+                      className="about-data-source-link"
+                      {...getExternalLinkOpenTarget(source.href)}
+                      onClick={(event) => openExternalLink(event, source.href)}
+                      pill={source.glyph}
+                      title={source.titleKey ? t(source.titleKey) : source.title}
+                      subtitle={
+                        source.descriptionKey
+                          ? t(source.descriptionKey)
+                          : source.description
+                      }
+                      trailing={
+                        <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                      }
+                    />
+                  </li>
+                ))}
+              </ol>
+            </section>
+          );
+        })}
+      </div>
 
       <div className="px-5 pb-4 pt-2 md:px-[16px]">
         <a

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -84,6 +84,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "First-screen pages (Home / About / Mechanism / Changelog) gain real hierarchy — larger inked titles over smaller, fainter detail, groups separated by whitespace rhythm not dividing lines; search loading / empty / no-result are now designed states",
         zh: "首屏各页（首页 / 关于 / 机制 / 更新日志）建立真正的层次——更大且着墨的标题搭配更小更淡的细节，分组以留白节奏而非分隔线区隔；搜索的加载 / 空 / 无结果改为有设计感的状态",
       },
+      {
+        en: "About page reads as a quiet label rail + content axis (version / stack / architecture aligned), and the data sources are grouped by concern — Traffic / Weather / Airport / Context",
+        zh: "关于页改为安静的标签轨 + 内容轴（版本 / 技术栈 / 架构对齐），数据源按主题分组——航迹 / 天气 / 机场 / 背景",
+      },
     ],
   },
   {

--- a/src/style.css
+++ b/src/style.css
@@ -8022,16 +8022,22 @@ body {
 }
 
 .about-meta-grid {
-    --about-meta-rail: 46px;
-    --about-meta-gap: 5px;
+    --about-meta-rail: 88px;
+    --about-meta-gap: 16px;
     margin-inline: var(--airport-sidebar-inset, 20px);
 }
 
+/* One quiet label rail + content axis: the role label sits in a fixed-width
+   left column (quiet, tracked) and the value/list flows in the right axis, so
+   VERSION / STACK / ARCHITECTURE align as a single scannable rail rather than
+   stacking label-over-content. */
 .about-meta-row {
     display: grid;
-    gap: 5px;
+    grid-template-columns: var(--about-meta-rail) minmax(0, 1fr);
+    column-gap: var(--about-meta-gap);
+    align-items: baseline;
     min-width: 0;
-    padding-block: 7px;
+    padding-block: 8px;
 }
 
 .about-meta-label {


### PR DESCRIPTION
## Plan
**Tokens:** none new. Rework `.about-meta-row` into a label-rail + content-axis grid. **Touched:** `style.css`, `AboutPanel.tsx` (group sources by concern). **New files:** none.

## End state
Version / stack / architecture align as a quiet label rail + content axis; the data-source list is grouped Traffic / Weather / Airport / Context, scannable with whitespace rhythm.

## Done-when
- [x] Version / stack / architecture metadata as one quiet label rail + content axis
- [x] Data-source list grouped and scannable (4 concern groups, quiet eyebrow labels)
- [x] Hierarchy by size + luminance (inherits the PR5 `--fs-*` scale)
- [x] Both themes; `pnpm build` + typecheck clean
- [x] changelog highlight folded into `v2.28.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)