### PR TITLE
PR7: Mechanism groups by whitespace rhythm, one content axis

### DIFF
--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -88,6 +88,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "About page reads as a quiet label rail + content axis (version / stack / architecture aligned), and the data sources are grouped by concern — Traffic / Weather / Airport / Context",
         zh: "关于页改为安静的标签轨 + 内容轴（版本 / 技术栈 / 架构对齐），数据源按主题分组——航迹 / 天气 / 机场 / 背景",
       },
+      {
+        en: "Mechanism accordion groups separate by whitespace rhythm (no dividing lines); the number rail, expanded flow labels, and detail all read on one content axis",
+        zh: "机制手风琴分组以留白节奏区隔（不再有分隔线）；编号轨、展开的流程标签与细节统一在同一内容轴上",
+      },
     ],
   },
   {

--- a/src/style.css
+++ b/src/style.css
@@ -8088,16 +8088,17 @@ body {
     --mechanism-rail: 34px;
 }
 
+/* Whitespace groups, not lines: a deliberate gap separates one group from the
+   next (matching the Home / About rhythm) while the quiet eyebrow label sits on
+   the same content axis as the row titles. */
 .mechanism-group-label {
-    border-top: 1px solid color-mix(in oklab, var(--app-frost-border) 85%, transparent);
-    margin-top: 14px;
+    margin-top: 16px;
     padding-bottom: 8px;
     padding-left: calc(var(--mechanism-rail) + var(--mechanism-gap));
-    padding-top: 20px;
+    padding-top: 24px;
 }
 
 .mechanism-group-label:first-child {
-    border-top: 0;
     margin-top: 0;
     padding-top: 2px;
 }


### PR DESCRIPTION
## Plan
**Tokens:** none. Drop the `.mechanism-group-label` hairline for whitespace rhythm. **Touched:** `style.css`. **New files:** none.

## End state
The mechanism accordion reads on one content axis (number rail + body), groups separated by whitespace, hierarchy by size not weight.

## Done-when
- [x] Accordion rows use the compact number-rail (already in place)
- [x] Expanded flow labels + detail read inline on one content axis (`margin-left` aligns to the body axis)
- [x] Hierarchy by size not weight (inherits the PR5 `--fs-*` scale)
- [x] Group separation is whitespace rhythm, not dividing lines (this PR)
- [x] Both themes; `pnpm build` + typecheck clean
- [x] changelog highlight folded into `v2.28.0`

Final PR of the v2.28.0 design-consistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)