### PR TITLE
v2.28.1 — Material fidelity: flatter glass, orange reserved for selection (#510)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.28.0",
+  "version": "2.28.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/search/AirportSearchPanel.tsx
+++ b/src/components/airport/search/AirportSearchPanel.tsx
@@ -51,7 +51,7 @@ export default function AirportSearchPanel({
         onSubmit={doSearch}
         className="search-input mx-5 mb-3 flex-none flex items-center gap-2 px-3 py-1.5"
       >
-        <Search className="h-3.5 w-3.5 shrink-0 text-atc-orange" />
+        <Search className="h-3.5 w-3.5 shrink-0 text-atc-dim" />
         <Input
           value={query}
           onChange={(event) => setQuery(event.target.value)}

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -28,7 +28,7 @@ const lineClassName = cn(
 );
 
 const diamondClassName =
-  "inline-block size-[7px] flex-none rotate-45 bg-atc-orange [.airport-map-kit_&]:size-[5px] [.airport-map-menu--mobile_&]:size-1.5";
+  "inline-block size-[7px] flex-none rotate-45 bg-[var(--atc-dim)] [.airport-map-kit_&]:size-[5px] [.airport-map-menu--mobile_&]:size-1.5";
 
 const loadingClassName = cn(
   "min-h-0 max-w-[min(360px,calc(100vw-72px))] overflow-hidden whitespace-normal",
@@ -427,10 +427,10 @@ export default function MapSourceStatusDisplay({
         <span className={lineClassName}>
           {realtimeStatusLabel ? (
             <>
-              <StatusSpan className="inline-flex flex-none items-center gap-1.5 font-mono text-atc-orange">
+              <StatusSpan className="inline-flex flex-none items-center gap-1.5 font-mono text-atc-dim">
                 <span
                   aria-hidden="true"
-                  className="size-1.5 rounded-full bg-atc-orange opacity-80 motion-safe:animate-pulse [.airport-map-kit_&]:size-1"
+                  className="size-1.5 rounded-full bg-[var(--atc-dim)] opacity-80 motion-safe:animate-pulse [.airport-map-kit_&]:size-1"
                 />
                 <span>{realtimeStatusLabel}</span>
               </StatusSpan>
@@ -444,7 +444,7 @@ export default function MapSourceStatusDisplay({
           ) : null}
           {wakeLockActive ? (
             <>
-              <StatusSpan className="flex-none tabular-nums text-atc-orange">
+              <StatusSpan className="flex-none tabular-nums text-atc-dim">
                 ☕ Keep awake
               </StatusSpan>
               {(feedSource || updatedLabel) ? (

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -98,31 +98,51 @@ export default function SidebarViewSwitch({
   }
 
   const headlineLabel = nearMe ? t("sidebar.nearby") : t("sidebar.flights");
+  // The flight-count is the hero only on the traffic view. On the other
+  // sub-views it demotes to a compact summary row so it does not stack a
+  // second hero above that view's own hero (e.g. the weather flight-rules
+  // block). The headline stays a tab back to traffic; structure is unchanged.
+  const isTraffic = activeView === "traffic";
 
   return (
     <div className="px-[var(--airport-sidebar-inset)] pt-3.5">
       <div className="overflow-hidden rounded-[var(--atc-radius-panel)] border border-[var(--app-frost-border)] bg-[var(--atc-control-surface-muted)] shadow-[var(--atc-control-inset-shadow-subtle)]">
         <button
           type="button"
-          data-active={activeView === "traffic" ? "true" : undefined}
+          data-active={isTraffic ? "true" : undefined}
           onClick={() => onViewChange?.("traffic")}
-          aria-pressed={activeView === "traffic"}
-          className="block w-full px-[15px] pb-[11px] pt-[13px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)]"
+          aria-pressed={isTraffic}
+          className={`block w-full px-[15px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)] ${
+            isTraffic ? "pb-[11px] pt-[13px]" : "py-[9px]"
+          }`}
         >
-          <div className="flex items-center justify-between">
-            <span className="text-[12px] font-medium text-atc-dim">
-              {headlineLabel}
-            </span>
-          </div>
-          <div className="mt-[5px] flex items-baseline gap-2">
-            <span className="text-[33px] font-normal leading-none tracking-[-1px] tabular-nums text-atc-text">
-              <NumberFlow value={aircraft.length} />
-            </span>
-          </div>
+          {isTraffic ? (
+            <>
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] font-medium text-atc-dim">
+                  {headlineLabel}
+                </span>
+              </div>
+              <div className="mt-[5px] flex items-baseline gap-2">
+                <span className="text-[33px] font-normal leading-none tracking-[-1px] tabular-nums text-atc-text">
+                  <NumberFlow value={aircraft.length} />
+                </span>
+              </div>
+            </>
+          ) : (
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[12px] font-medium text-atc-dim">
+                {headlineLabel}
+              </span>
+              <span className="text-[15px] font-normal tabular-nums text-atc-text">
+                <NumberFlow value={aircraft.length} />
+              </span>
+            </div>
+          )}
         </button>
         <div className="flex border-t border-[var(--app-frost-border)]">
-          {footerCells.map((cell) => (
-            <StatCell key={cell.key} {...cell} />
+          {footerCells.map(({ key, ...cell }) => (
+            <StatCell key={key} {...cell} />
           ))}
         </div>
       </div>
@@ -137,9 +157,9 @@ function StatCell({ label, value, unit, active, onClick }) {
       data-active={active ? "true" : undefined}
       onClick={onClick}
       aria-pressed={active}
-      className="flex-1 px-[13px] py-[9px] text-left transition-colors [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_0_2px_0_var(--atc-signal-accent)]"
+      className="min-w-0 flex-1 px-[11px] py-[9px] text-left transition-colors [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_0_2px_0_var(--atc-signal-accent)]"
     >
-      <div className="text-[10px] text-atc-faint">{label}</div>
+      <div className="truncate text-[10px] text-atc-faint">{label}</div>
       <div className="mt-[3px]">
         <span className="text-[16px] font-normal tabular-nums text-atc-text">
           {value}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -41,86 +41,36 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 90;
+export const CHANGELOG_TOTAL_COUNT = 92;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.28.0",
-    kind: "feat",
+    version: "v2.28.1",
+    kind: "patch",
     title: {
-      en: "Designed, not aligned — system pass",
-      zh: "为「设计感」而非「对齐」打磨",
+      en: "Material fidelity — flatter glass, quieter accent",
+      zh: "材质回正——更平的玻璃、更克制的强调色",
     },
     summary: {
-      en: "A page-by-page pass applying ADSBao's existing material system with intentional hierarchy, density rhythm, and surface separation. Opens with a typographic foundation: hierarchy now comes from size and luminance, never weight.",
-      zh: "逐页打磨，让 ADSBao 既有的材质系统以更有层次、更有节奏、更分面的方式呈现。首先落地排版基线：层次来自字号与明度，而非字重。",
+      en: "A correction pass on the v2.28 surfaces: frosted panels go back to flat translucent tints instead of painted gradients, the orange signal is reserved for selection again, and the left-column hierarchy reads cleaner over a busy map.",
+      zh: "对 v2.28 表面的一次回正：磨砂面板回到平整的半透明色调而非渐变涂层，橙色信号色重新只用于选择态，左栏层次在繁忙地图上更清爽。",
     },
     highlights: [
       {
-        en: "Typography is light/regular only — no bold/semibold anywhere; weight utilities and tokens remapped at the source",
-        zh: "排版仅用 light/regular，全应用不再有粗体；字重工具类与 token 在源头统一重映射",
+        en: "Frosted surfaces (search box, sidebar, preview cards, toolbars, toasts) drop linear-gradient fills and heavy ambient shadows for one flat tint + a single inset hairline — no more gray mud at the edges over the live map",
+        zh: "磨砂表面（搜索框、侧栏、预览卡片、工具条、提示）去掉线性渐变填充与厚重投影，改为单一平整色调 + 一道内描边——地图之上不再有灰浊边缘",
       },
       {
-        en: "Loaded font weights trimmed to 300/400 for a lighter, more editorial feel",
-        zh: "加载的字重收敛为 300/400，整体更轻、更具编排感",
+        en: "Orange is reserved for selection, the tracked trace, and the Track button again — removed from the search glyph, the map LIVE indicator, and the map menu wash; altitude trend stays glyph + luminance",
+        zh: "橙色重新只用于选择态、追踪轨迹与 Track 按钮——从搜索图标、地图 LIVE 指示与地图菜单底色中移除；高度趋势仍以箭头 + 明度表达",
       },
       {
-        en: "Nearby list rows share one compact two-line form — callsign + distance over route + altitude — with a subtle climb/descend cue; rich detail stays in the preview card",
-        zh: "邻近列表统一为紧凑两行：呼号 + 距离在上、航线 + 高度在下，并带轻量的爬升/下降指示；详细信息只留在预览卡片中",
+        en: "Sidebar filters (targets / route / type / altitude) read as aligned rails instead of a boxed table",
+        zh: "侧栏筛选（目标 / 航路 / 机型 / 高度）改为对齐的导轨，而非方框表格",
       },
       {
-        en: "Weather splits into a Local view (friendly current conditions + hourly) and a METAR view (flight-rules hero + raw report + decoded grid), switched by a quiet capsule segment",
-        zh: "天气拆分为 Local（友好的实时天况 + 逐时预报）与 METAR（飞行规则主指标 + 原始报文 + 解码网格）两个视图，由一个安静的玻璃胶囊分段切换",
-      },
-      {
-        en: "ATC frequencies render as a clean table — role left, channel in mono right-aligned — ordered by operational flow (ATIS → Clearance → Ground → Tower → Approach → Departure)",
-        zh: "ATC 频率改为整洁表格：左侧角色、右侧等宽对齐的频道，并按运行流程排序（ATIS → Clearance → Ground → Tower → Approach → Departure）",
-      },
-      {
-        en: "Nearby / weather / ATC stay unified under one quiet hero-stats segment — only one summary surface shows at a time, with a 240ms cross-fade and regular-weight numerals",
-        zh: "邻近 / 天气 / ATC 统一在一个安静的主指标分段下切换——同一时刻只显示一个汇总面，配 240ms 交叉淡入与常规字重数字",
-      },
-      {
-        en: "First-screen pages (Home / About / Mechanism / Changelog) gain real hierarchy — larger inked titles over smaller, fainter detail, groups separated by whitespace rhythm not dividing lines; search loading / empty / no-result are now designed states",
-        zh: "首屏各页（首页 / 关于 / 机制 / 更新日志）建立真正的层次——更大且着墨的标题搭配更小更淡的细节，分组以留白节奏而非分隔线区隔；搜索的加载 / 空 / 无结果改为有设计感的状态",
-      },
-      {
-        en: "About page reads as a quiet label rail + content axis (version / stack / architecture aligned), and the data sources are grouped by concern — Traffic / Weather / Airport / Context",
-        zh: "关于页改为安静的标签轨 + 内容轴（版本 / 技术栈 / 架构对齐），数据源按主题分组——航迹 / 天气 / 机场 / 背景",
-      },
-      {
-        en: "Mechanism accordion groups separate by whitespace rhythm (no dividing lines); the number rail, expanded flow labels, and detail all read on one content axis",
-        zh: "机制手风琴分组以留白节奏区隔（不再有分隔线）；编号轨、展开的流程标签与细节统一在同一内容轴上",
-      },
-    ],
-  },
-  {
-    version: "v2.27.0",
-    kind: "feat",
-    title: {
-      en: "Frosted interface redesign",
-      zh: "Frosted 界面重构",
-    },
-    summary: {
-      en: "A whole-app frosted-glass visual system: theme-following chrome, one orange signal accent, a shared first-screen type scale, and consistent airport / aircraft / home / static surfaces.",
-      zh: "全应用 Frosted 玻璃视觉系统：跟随主题的界面、统一橙色信号强调色、共享首屏排版梯度，以及一致的机场 / 飞机 / 首页 / 静态页表面。",
-    },
-    highlights: [
-      {
-        en: "Chrome follows the theme — white frosted glass + ink in light, deep-gray glass + white in dark",
-        zh: "界面跟随主题——亮色白 frosted 玻璃 + 黑字，暗色深灰玻璃 + 白字",
-      },
-      {
-        en: "One orange signal accent for row selection, the tracked-flight trace, and the track button",
-        zh: "单一橙色信号色用于行选中、追踪航迹与追踪按钮",
-      },
-      {
-        en: "First-screen pages share one --fs-* type scale; flight telemetry leads with Speed + Altitude",
-        zh: "首屏各页共用一套 --fs-* 排版梯度；飞行遥测以速度 + 高度为主指标",
-      },
-      {
-        en: "Nearby list virtualizes on mobile; selected-row value columns stay aligned",
-        zh: "邻近列表在移动端虚拟化；选中行的数值列保持对齐",
+        en: "Stronger size contrast on Explorer / About list rows; weather view no longer stacks a flight-count hero above its flight-rules hero, and hero footer labels never wrap",
+        zh: "Explorer / About 列表行的字号对比更明确；天气视图不再在飞行规则主指标之上叠加航班数主指标，主指标底部标签不再换行",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -277,6 +277,86 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.28.0",
+    kind: "feat",
+    title: {
+      en: "Designed, not aligned — system pass",
+      zh: "为「设计感」而非「对齐」打磨",
+    },
+    summary: {
+      en: "A page-by-page pass applying ADSBao's existing material system with intentional hierarchy, density rhythm, and surface separation. Opens with a typographic foundation: hierarchy now comes from size and luminance, never weight.",
+      zh: "逐页打磨，让 ADSBao 既有的材质系统以更有层次、更有节奏、更分面的方式呈现。首先落地排版基线：层次来自字号与明度，而非字重。",
+    },
+    highlights: [
+      {
+        en: "Typography is light/regular only — no bold/semibold anywhere; weight utilities and tokens remapped at the source",
+        zh: "排版仅用 light/regular，全应用不再有粗体；字重工具类与 token 在源头统一重映射",
+      },
+      {
+        en: "Loaded font weights trimmed to 300/400 for a lighter, more editorial feel",
+        zh: "加载的字重收敛为 300/400，整体更轻、更具编排感",
+      },
+      {
+        en: "Nearby list rows share one compact two-line form — callsign + distance over route + altitude — with a subtle climb/descend cue; rich detail stays in the preview card",
+        zh: "邻近列表统一为紧凑两行：呼号 + 距离在上、航线 + 高度在下，并带轻量的爬升/下降指示；详细信息只留在预览卡片中",
+      },
+      {
+        en: "Weather splits into a Local view (friendly current conditions + hourly) and a METAR view (flight-rules hero + raw report + decoded grid), switched by a quiet capsule segment",
+        zh: "天气拆分为 Local（友好的实时天况 + 逐时预报）与 METAR（飞行规则主指标 + 原始报文 + 解码网格）两个视图，由一个安静的玻璃胶囊分段切换",
+      },
+      {
+        en: "ATC frequencies render as a clean table — role left, channel in mono right-aligned — ordered by operational flow (ATIS → Clearance → Ground → Tower → Approach → Departure)",
+        zh: "ATC 频率改为整洁表格：左侧角色、右侧等宽对齐的频道，并按运行流程排序（ATIS → Clearance → Ground → Tower → Approach → Departure）",
+      },
+      {
+        en: "Nearby / weather / ATC stay unified under one quiet hero-stats segment — only one summary surface shows at a time, with a 240ms cross-fade and regular-weight numerals",
+        zh: "邻近 / 天气 / ATC 统一在一个安静的主指标分段下切换——同一时刻只显示一个汇总面，配 240ms 交叉淡入与常规字重数字",
+      },
+      {
+        en: "First-screen pages (Home / About / Mechanism / Changelog) gain real hierarchy — larger inked titles over smaller, fainter detail, groups separated by whitespace rhythm not dividing lines; search loading / empty / no-result are now designed states",
+        zh: "首屏各页（首页 / 关于 / 机制 / 更新日志）建立真正的层次——更大且着墨的标题搭配更小更淡的细节，分组以留白节奏而非分隔线区隔；搜索的加载 / 空 / 无结果改为有设计感的状态",
+      },
+      {
+        en: "About page reads as a quiet label rail + content axis (version / stack / architecture aligned), and the data sources are grouped by concern — Traffic / Weather / Airport / Context",
+        zh: "关于页改为安静的标签轨 + 内容轴（版本 / 技术栈 / 架构对齐），数据源按主题分组——航迹 / 天气 / 机场 / 背景",
+      },
+      {
+        en: "Mechanism accordion groups separate by whitespace rhythm (no dividing lines); the number rail, expanded flow labels, and detail all read on one content axis",
+        zh: "机制手风琴分组以留白节奏区隔（不再有分隔线）；编号轨、展开的流程标签与细节统一在同一内容轴上",
+      },
+    ],
+  },
+  {
+    version: "v2.27.0",
+    kind: "feat",
+    title: {
+      en: "Frosted interface redesign",
+      zh: "Frosted 界面重构",
+    },
+    summary: {
+      en: "A whole-app frosted-glass visual system: theme-following chrome, one orange signal accent, a shared first-screen type scale, and consistent airport / aircraft / home / static surfaces.",
+      zh: "全应用 Frosted 玻璃视觉系统：跟随主题的界面、统一橙色信号强调色、共享首屏排版梯度，以及一致的机场 / 飞机 / 首页 / 静态页表面。",
+    },
+    highlights: [
+      {
+        en: "Chrome follows the theme — white frosted glass + ink in light, deep-gray glass + white in dark",
+        zh: "界面跟随主题——亮色白 frosted 玻璃 + 黑字，暗色深灰玻璃 + 白字",
+      },
+      {
+        en: "One orange signal accent for row selection, the tracked-flight trace, and the track button",
+        zh: "单一橙色信号色用于行选中、追踪航迹与追踪按钮",
+      },
+      {
+        en: "First-screen pages share one --fs-* type scale; flight telemetry leads with Speed + Altitude",
+        zh: "首屏各页共用一套 --fs-* 排版梯度；飞行遥测以速度 + 高度为主指标",
+      },
+      {
+        en: "Nearby list virtualizes on mobile; selected-row value columns stay aligned",
+        zh: "邻近列表在移动端虚拟化；选中行的数值列保持对齐",
+      },
+    ],
+  },
+  {
     version: "v2.26.17",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -740,11 +740,6 @@
         var(--primary-bright) 72%,
         white
     );
-    --atc-preview-accent-wash: linear-gradient(
-        135deg,
-        color-mix(in oklab, var(--atc-orange) 10%, transparent),
-        transparent 48%
-    );
     --atc-preview-card-inset: inset 0 1px 0
         color-mix(in oklab, var(--atc-text) 8%, transparent);
     --glass-card-top: color-mix(in oklab, var(--atc-bg) 50%, transparent);
@@ -1056,15 +1051,6 @@
     );
     --tone-orange-edge: color-mix(in oklab, var(--atc-orange) 78%, transparent);
 
-    /* Glow used by active tabs and filter cards. Light mode uses yellow here
-     * because near-black would read as a heavy shadow. */
-    --atc-tab-glow: linear-gradient(
-        to top,
-        color-mix(in oklab, var(--atc-orange) 20%, transparent) 0%,
-        color-mix(in oklab, var(--atc-orange) 10%, transparent) 30%,
-        color-mix(in oklab, var(--atc-orange) 3%, transparent) 58%,
-        transparent 80%
-    );
     --tone-bg-soft: color-mix(in oklab, var(--atc-bg) 62%, transparent);
     --tone-line-soft: color-mix(in oklab, var(--atc-line) 50%, transparent);
     --tone-border-soft: color-mix(
@@ -1224,11 +1210,6 @@
         in oklab,
         var(--primary-bright) 72%,
         white
-    );
-    --atc-preview-accent-wash: linear-gradient(
-        135deg,
-        color-mix(in oklab, var(--atc-orange) 10%, transparent),
-        transparent 48%
     );
     --atc-preview-card-inset: inset 0 1px 0
         color-mix(in oklab, var(--atc-text) 8%, transparent);
@@ -1535,14 +1516,6 @@
     --sidebar-signal: var(--atc-orange);
     --sidebar-ring: var(--atc-accent);
 
-    /* Brighter glow stops for the dark canvas and yellow active state. */
-    --atc-tab-glow: linear-gradient(
-        to top,
-        color-mix(in oklab, var(--atc-accent) 32%, transparent) 0%,
-        color-mix(in oklab, var(--atc-accent) 14%, transparent) 28%,
-        color-mix(in oklab, var(--atc-accent) 4%, transparent) 58%,
-        transparent 85%
-    );
 }
 
 html {
@@ -2355,16 +2328,10 @@ body:has(.dither-page-shell) {
 /* Selectable rows — featured search rows + about data-source rows */
 
 .search-input {
-    background: linear-gradient(
-        145deg,
-        var(--tone-card-strong),
-        var(--tone-elev-strong)
-    );
+    background: var(--tone-card-strong);
     border: 1px solid var(--tone-border-firm);
     border-radius: min(14px, calc(var(--atc-radius-card) + 2px));
-    box-shadow:
-        0 26px 90px var(--tone-bg-soft),
-        inset 0 1px 0 var(--tone-border-soft);
+    box-shadow: inset 0 1px 0 var(--tone-border-soft);
 }
 
 .search-input:focus-within {
@@ -2620,16 +2587,11 @@ body:has(.dither-page-shell) {
 }
 
 .glass-panel {
-    background: linear-gradient(
-        145deg,
-        var(--glass-card-top),
-        var(--glass-card-bottom)
-    );
+    background: var(--glass-card-bottom);
     border: 1px solid var(--glass-card-border);
     border-radius: var(--atc-radius-panel);
     box-shadow:
         0 8px 24px rgba(0, 0, 0, 0.18),
-        0 24px 64px rgba(0, 0, 0, 0.22),
         inset 0 1px 0 var(--glass-card-inset);
     max-height: 250px;
     min-width: 0;
@@ -3060,12 +3022,12 @@ body:has(.dither-page-shell) {
     --fs-eyebrow-color: var(--atc-faint);
 
     --fs-title-font: var(--font-sans);
-    --fs-title-size: 15px;
+    --fs-title-size: 16px;
     --fs-title-weight: var(--weight-regular);
     --fs-title-leading: 1.25;
     --fs-title-color: var(--atc-text);
 
-    --fs-sub-size: 11px;
+    --fs-sub-size: 10.5px;
     --fs-sub-weight: var(--weight-regular);
     --fs-sub-leading: 1.3;
     --fs-sub-color: var(--atc-faint);
@@ -4455,18 +4417,7 @@ body {
     align-items: center;
     -webkit-backdrop-filter: var(--app-frost-strong);
     backdrop-filter: var(--app-frost-strong);
-    background:
-        linear-gradient(
-            90deg,
-            color-mix(in oklab, var(--atc-orange) 12%, transparent),
-            transparent 34%,
-            color-mix(in oklab, var(--atc-accent) 8%, transparent)
-        ),
-        linear-gradient(
-            180deg,
-            color-mix(in oklab, var(--atc-elev) 48%, transparent),
-            color-mix(in oklab, var(--atc-bg) 96%, transparent)
-        );
+    background: var(--atc-toolbar-surface);
     border-bottom: 1px solid var(--atc-line-strong);
     box-sizing: border-box;
     display: flex;
@@ -4506,16 +4457,12 @@ body {
     align-items: center;
     backdrop-filter: var(--app-frost-strong);
     -webkit-backdrop-filter: var(--app-frost-strong);
-    background: linear-gradient(
-        145deg,
-        var(--glass-card-top),
-        var(--glass-card-bottom)
-    );
+    background: var(--atc-toolbar-surface);
     border: 1px solid var(--glass-card-border);
     border-radius: 18px;
     bottom: 14px;
     box-shadow:
-        0 12px 34px rgba(0, 0, 0, 0.24),
+        0 8px 20px rgba(0, 0, 0, 0.16),
         inset 0 1px 0 var(--glass-card-inset);
     box-sizing: border-box;
     display: none;
@@ -6363,11 +6310,7 @@ body {
     width: auto;
     min-height: 0;
     max-width: min(360px, calc(100vw - 32px));
-    background: linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--atc-elev) 34%, transparent),
-        var(--tone-card-strong)
-    );
+    background: var(--tone-card-strong);
     border: 1px solid var(--tone-border-firm);
     border-radius: var(--atc-radius-panel);
     box-shadow:
@@ -6763,11 +6706,7 @@ body {
     padding: 18px;
     border: 1px solid var(--tone-border-firm);
     border-radius: var(--atc-radius-panel);
-    background: linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--atc-card) 90%, transparent),
-        color-mix(in oklab, var(--atc-card) 82%, transparent)
-    );
+    background: color-mix(in oklab, var(--atc-card) 86%, transparent);
     box-shadow:
         var(--preview-card-shadow),
         inset 0 1px 0 color-mix(in oklab, var(--atc-text) 9%, transparent);
@@ -7125,11 +7064,7 @@ body {
     overflow: hidden;
     border: 1px solid var(--tone-border-firm);
     border-radius: var(--atc-radius-panel);
-    background: linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--atc-card) 82%, transparent),
-        color-mix(in oklab, var(--atc-card) 58%, transparent)
-    );
+    background: color-mix(in oklab, var(--atc-card) 70%, transparent);
     box-shadow:
         0 12px 30px color-mix(in oklab, var(--atc-bg) 64%, transparent),
         inset 0 1px 0 color-mix(in oklab, var(--atc-text) 10%, transparent);
@@ -8797,11 +8732,7 @@ body {
        through the sidebar as a soft frosted wash. */
     -webkit-backdrop-filter: var(--app-frost-strong);
     backdrop-filter: var(--app-frost-strong);
-    background: linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--app-frost-tint) 84%, transparent),
-        color-mix(in oklab, var(--app-frost-tint) 87%, transparent)
-    );
+    background: color-mix(in oklab, var(--app-frost-tint) 86%, transparent);
     border: 0;
     box-shadow: var(--app-map-sidebar-shadow);
     color: var(--atc-text);
@@ -8882,17 +8813,19 @@ body {
     padding-top: 2px;
 }
 
-/* The 2-up detail filter strip is collected into one bordered glass block so
-   the four filters read as a single contained unit instead of loose chips —
-   matching the Frosted design and de-cluttering the sidebar. */
+/* The 2-up detail filter strip reads as an aligned rail group, not a boxed
+   table: no outer fill, border, or radius — the four filters track the same
+   sidebar inset as the metric grid and are delimited by a single top/bottom
+   hairline. "Rails, not boxes." */
 .airport-sidebar-panel [data-ui="filter-grid"][data-cols="2"],
 .flight-sidebar-panel [data-ui="filter-grid"][data-cols="2"] {
-    background: color-mix(in oklab, var(--app-frost-tint) 22%, transparent);
-    border: 1px solid var(--app-frost-border);
-    border-radius: var(--atc-radius-card);
+    background: transparent;
+    border: 0;
+    border-top: 1px solid color-mix(in oklab, var(--atc-text) 6%, transparent);
+    border-bottom: 1px solid color-mix(in oklab, var(--atc-text) 6%, transparent);
+    border-radius: 0;
     gap: 2px;
-    overflow: hidden;
-    padding: 4px;
+    padding: 4px 0;
 }
 
 .airport-sidebar-panel [data-ui="metric-card"],


### PR DESCRIPTION
Visual-execution correction for [#510](https://github.com/orriduck/ADSBao/issues/510). **No structure redo** — PR0–PR7 (#502–#509) landed the correct layout; this only fixes material + accent drift. No route / data-flow / map-layer changes (PRODUCT.md principle 5). Material recipes changed as tokens/style rules in `src/style.css`, not at component call sites (DESIGN.md rule 1).

## Scope decisions (confirmed with maintainer)
- **Fix C (DitherPageShell branding video): left untouched** per decision ("no ops on this video"). So this lands as **one PR**, not two.
- **Fix A: full chrome sweep.**
- **Fix B: neutralize** the map LIVE status orange + search glyph; keep the hero/telemetry rail (DESIGN.md sanctions the active-segment rail as a selection state).

## What changed

**A · Flatten material (kill the mud)**
- Replaced `linear-gradient(…)` *surface fills* with one flat translucent tint on: `.search-input`, the map-over airport sidebar, `.aircraft-preview-metadata-card`, `.aircraft-preview-media-card`, `.atc-toast`, `.airport-map-menu`, `.mobile-status-bar`, `.glass-panel`.
- Dropped the heavy `0 26px 90px` ambient shadow (the only one in the file) and the second heavy stack on `.glass-panel`; each surface keeps **one** `inset 0 1px 0` hairline.
- Removed the dead `--atc-preview-accent-wash` and `--atc-tab-glow` gradient tokens (both unreferenced).

**B · Orange discipline** — signal accent reserved for selection / tracked trace / track button.
- Neutralized: the search glyph, the map `LIVE` indicator + "Keep awake" status, and the orange baked into the `.airport-map-menu` gradient.
- Altitude trend already used glyph + luminance (`text-atc-faint`) — unchanged.

**D · Hero**
- The flight-count headline demotes to a compact summary row on non-traffic views, so the **weather view owns its flight-rules hero** (no second stacked hero). Headline stays a tab back to traffic — switcher structure unchanged.
- Footer-cell labels (拍机点 / departures / arrivals) no longer wrap (`truncate` + `min-w-0`, tighter padding).

**E · Sidebar filters → rails** — the 目标/航路/机型/高度 group drops its box (fill + border + radius) and reads as aligned rails delimited by a single top/bottom hairline.

**F · List hierarchy** — `--fs-title-size` 15→16px, `--fs-sub-size` 11→10.5px for a clearer primary/secondary anchor on Explorer / About rows (both themes; weight stays regular).

**Housekeeping**
- Fixed the **pre-existing red `changelog.test`** (on `main`, `CHANGELOG_RECENT` held 2 entries vs `INITIAL_LIMIT` 1, and `TOTAL_COUNT` was off): moved v2.28.0 + v2.27.0 into `changelogHistory.ts`, set `CHANGELOG_TOTAL_COUNT` 90→92.
- Fixed a React `key`-in-spread warning in `SidebarViewSwitch`.
- Bumped version 2.28.0 → 2.28.1 (patch) + added a `V[]` changelog entry (en + zh).

## Validation
- **local test** — `pnpm test` (122 files pass, incl. the now-green changelog test) + `pnpm build` clean.
- **local browser** — verified airport sidebar (hero + list), weather METAR view, Explorer, and About in **both themes** over the live EGLL map (~160 aircraft). Before/after screenshots shared with the maintainer in-session.

Closes #510