### PR TITLE
v2.28.2: Explorer sidebar — mono code chips, serif group labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400&family=Noto+Sans+SC:wght@300;400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400&family=JetBrains+Mono:wght@400&family=Manrope:wght@300;400&family=Noto+Sans+SC:wght@300;400&display=swap"
       rel="stylesheet"
     />
     <title>ADSBao - Airport weather and traffic context</title>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.28.1",
+  "version": "2.28.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { ChevronRight } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { TextPillListItem } from "@/components/ui/TextPillListItem";
+import { AirportListRow } from "./AirportListRow";
 import {
   airportDisplayCode,
   airportDisplayName,
@@ -104,7 +104,7 @@ function NearMeDiscoverySection() {
         id="airport-discovery-nearby"
         title={t("search.discovery.nearby.title")}
       />
-      <ul className="dither-list mt-2.5 flex flex-col gap-2.5">
+      <ul className="dither-list mt-2 flex flex-col gap-1">
         <NearbyPromptRow onRequest={handleOpenNearMe} />
       </ul>
     </section>
@@ -124,7 +124,7 @@ function AirportDiscoveryTopicSection({ topic, onOpen, onPrefetch }) {
         title={t(topic.titleKey)}
       />
 
-      <ul className="dither-list mt-2.5 flex flex-col gap-2.5">
+      <ul className="dither-list mt-2 flex flex-col gap-1">
         {topic.airports.map((airport) => (
           <AirportDiscoveryAirportRow
             key={airport.icao || airport.code || airport.name}
@@ -142,9 +142,18 @@ function DiscoverySectionHeader({
   id,
   title,
 }) {
+  // Decorative upright serif group label (regular weight, never bold) with a
+  // small accent tick — one of the three places orange is allowed on this page.
   return (
-    <header className="min-w-0">
-      <h2 id={id} className="fs-eyebrow block truncate">
+    <header className="min-w-0 px-2.5">
+      <h2
+        id={id}
+        className={
+          "flex min-w-0 items-center gap-2 font-serif text-[15px] leading-snug text-atc-dim " +
+          "before:block before:h-[1.5px] before:w-[9px] before:shrink-0 before:rounded-full " +
+          "before:bg-[var(--atc-signal-accent)] before:content-['']"
+        }
+      >
         {title}
       </h2>
     </header>
@@ -158,8 +167,9 @@ function NearbyPromptRow({ onRequest }: { onRequest: () => void }) {
 
   return (
     <li>
-      <TextPillListItem
+      <AirportListRow
         as="button"
+        tone="accent"
         onClick={onRequest}
         pill="HERE"
         title={title}
@@ -200,7 +210,7 @@ function AirportDiscoveryAirportRow({ airport, onOpen, onPrefetch }) {
       onBlur={cancelPrefetch}
       onMouseDown={cancelPrefetch}
     >
-      <TextPillListItem
+      <AirportListRow
         as="button"
         onClick={() => onOpen(airport)}
         pill={code}

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -144,8 +144,9 @@ function DiscoverySectionHeader({
 }) {
   // Decorative upright serif group label (regular weight, never bold) with a
   // small accent tick — one of the three places orange is allowed on this page.
+  // The tick sits flush with the search box's left edge; rows indent past it.
   return (
-    <header className="min-w-0 px-2.5">
+    <header className="min-w-0">
       <h2
         id={id}
         className={

--- a/src/components/airport/search/AirportListRow.tsx
+++ b/src/components/airport/search/AirportListRow.tsx
@@ -43,7 +43,7 @@ export function AirportListRow({
   const chip = (
     <span
       className={cn(
-        "inline-flex w-[46px] items-center justify-center self-center rounded-[6px] py-[3px]",
+        "mt-[2px] inline-flex w-[46px] items-center justify-center self-start rounded-[6px] py-[3px]",
         "whitespace-nowrap font-code text-[10px] leading-none [letter-spacing:0.6px]",
         accent
           ? cn(

--- a/src/components/airport/search/AirportListRow.tsx
+++ b/src/components/airport/search/AirportListRow.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type Tone = "default" | "accent";
+
+type AirportListRowProps = {
+  /** Left code chip — an ICAO (mono) or the "HERE" near-me marker. */
+  pill: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  /** Trailing slot, e.g. a chevron on tappable rows. */
+  trailing?: ReactNode;
+  /** "accent" paints the one orange CTA row (the near-me HERE entry). */
+  tone?: Tone;
+  /** Selected "best match" search row — differs by color/luminance only. */
+  active?: boolean;
+  as?: "button" | "a" | "div";
+  onClick?: (event?: any) => void;
+  className?: string;
+} & Record<string, any>;
+
+// The Explorer (home) discovery / search list row. Hierarchy comes from SIZE
+// + luminance, never weight: a mono code chip on the left rail, a near-black
+// name, and a faint subtitle. Whitespace groups the rows; there are no boxes.
+// The single orange accent (tone="accent") is reserved for the near-me CTA.
+export function AirportListRow({
+  pill,
+  title,
+  subtitle,
+  trailing,
+  tone = "default",
+  active = false,
+  as = "div",
+  onClick,
+  className,
+  ...rest
+}: AirportListRowProps) {
+  const accent = tone === "accent";
+  const interactive = as === "button" || as === "a";
+
+  // Chip typeface / size / shape stays IDENTICAL across states — only the
+  // color (ink, hairline, fill) changes between resting / accent / selected.
+  const chip = (
+    <span
+      className={cn(
+        "inline-flex w-[46px] items-center justify-center self-center rounded-[6px] py-[3px]",
+        "whitespace-nowrap font-code text-[10px] leading-none [letter-spacing:0.6px]",
+        accent
+          ? cn(
+              "text-[var(--atc-signal-accent-strong)]",
+              "bg-[color-mix(in_oklab,var(--atc-signal-accent)_10%,transparent)]",
+              "shadow-[inset_0_0_0_0.5px_color-mix(in_oklab,var(--atc-signal-accent)_30%,transparent)]",
+            )
+          : active
+            ? cn(
+                "text-atc-text",
+                "shadow-[inset_0_0_0_0.5px_color-mix(in_oklab,var(--atc-text)_34%,transparent)]",
+              )
+            : cn(
+                "text-atc-dim",
+                "shadow-[inset_0_0_0_0.5px_var(--atc-line-strong)]",
+              ),
+      )}
+    >
+      {pill}
+    </span>
+  );
+
+  const text = (
+    <span className="flex min-w-0 flex-col gap-0.5 self-center">
+      {/* Primary line: 15.5px near-black, regular weight, wraps (no ellipsis). */}
+      <span className="text-[15.5px] leading-[1.25] text-atc-text">{title}</span>
+      {subtitle ? (
+        <span className="text-[11.5px] leading-[1.3] text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]">
+          {subtitle}
+        </span>
+      ) : null}
+    </span>
+  );
+
+  const chevron = (
+    <span
+      className={cn(
+        "flex w-4 items-center justify-center self-center transition-transform duration-150",
+        accent ? "text-[var(--atc-signal-accent)]" : "text-atc-faint",
+        interactive && "group-hover:translate-x-0.5",
+        interactive && !accent && "group-hover:text-atc-dim",
+      )}
+    >
+      {trailing}
+    </span>
+  );
+
+  const classes = cn(
+    "group grid w-full grid-cols-[46px_minmax(0,1fr)_16px] items-center gap-x-3",
+    "rounded-[10px] px-2.5 py-[9px] text-left",
+    "transition-[background-color,box-shadow] duration-150",
+    accent
+      ? cn(
+          "bg-[color-mix(in_oklab,var(--atc-signal-accent)_7%,transparent)]",
+          "shadow-[inset_2px_0_0_var(--atc-signal-accent)]",
+          interactive &&
+            "hover:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)]",
+        )
+      : active
+        ? "bg-[color-mix(in_oklab,var(--atc-text)_6%,transparent)]"
+        : interactive &&
+          "hover:bg-[color-mix(in_oklab,var(--atc-text)_4.5%,transparent)]",
+    interactive &&
+      "cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-signal-accent)]",
+    className,
+  );
+
+  const Comp = as as any;
+  return (
+    <Comp
+      {...(as === "button" ? { type: "button" } : {})}
+      data-active={active ? "true" : undefined}
+      data-tone={accent ? "accent" : undefined}
+      onClick={onClick}
+      className={classes}
+      {...rest}
+    >
+      {chip}
+      {text}
+      {chevron}
+    </Comp>
+  );
+}

--- a/src/components/airport/search/AirportRow.tsx
+++ b/src/components/airport/search/AirportRow.tsx
@@ -6,7 +6,7 @@ import {
   airportSubtitle,
 } from "@/utils/airport";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
-import { TextPillListItem } from "@/components/ui/TextPillListItem";
+import { AirportListRow } from "./AirportListRow";
 
 const PREFETCH_INTENT_DELAY_MS = 120;
 
@@ -37,9 +37,9 @@ export default function AirportRow({
 
   useEffect(() => cancelPrefetch, [airport, onPrefetch]);
 
-  // Search results render as the shared liquid-glass list tile (GSAP
-  // hover/press lives inside the primitive). The featured best-match row
-  // flips to the active glass capsule so it reads as the obvious pick.
+  // Search results share the home discovery row. The featured best-match row
+  // reads as the obvious pick through luminance only — a quiet inked wash and
+  // a fully-inked chip, not a color shift (orange stays the near-me CTA).
   return (
     <li
       style={motionStyle}
@@ -49,7 +49,7 @@ export default function AirportRow({
       onBlur={cancelPrefetch}
       onMouseDown={cancelPrefetch}
     >
-      <TextPillListItem
+      <AirportListRow
         as="button"
         active={featured}
         onClick={() => onOpen(airport)}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -41,36 +41,36 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 92;
+export const CHANGELOG_TOTAL_COUNT = 93;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.28.1",
+    version: "v2.28.2",
     kind: "patch",
     title: {
-      en: "Material fidelity — flatter glass, quieter accent",
-      zh: "材质回正——更平的玻璃、更克制的强调色",
+      en: "Explorer sidebar — code chips, serif group labels",
+      zh: "机场探索侧栏——代号芯片、衬线分组标签",
     },
     summary: {
-      en: "A correction pass on the v2.28 surfaces: frosted panels go back to flat translucent tints instead of painted gradients, the orange signal is reserved for selection again, and the left-column hierarchy reads cleaner over a busy map.",
-      zh: "对 v2.28 表面的一次回正：磨砂面板回到平整的半透明色调而非渐变涂层，橙色信号色重新只用于选择态，左栏层次在繁忙地图上更清爽。",
+      en: "The home Explorer list trades flat gray text for real design: monospace ICAO chips, an upright serif for group labels, and one orange near-me CTA. Hierarchy comes from size and luminance, never weight.",
+      zh: "首页机场探索列表从扁平灰字升级为真正的设计语言：等宽 ICAO 代号芯片、衬线分组标签，以及唯一的橙色「附近」入口。层次来自字号与明度，而非字重。",
     },
     highlights: [
       {
-        en: "Frosted surfaces (search box, sidebar, preview cards, toolbars, toasts) drop linear-gradient fills and heavy ambient shadows for one flat tint + a single inset hairline — no more gray mud at the edges over the live map",
-        zh: "磨砂表面（搜索框、侧栏、预览卡片、工具条、提示）去掉线性渐变填充与厚重投影，改为单一平整色调 + 一道内描边——地图之上不再有灰浊边缘",
+        en: "ICAO codes become monospace chips (JetBrains Mono) with a hairline rim; the chip keeps one typeface/size/shape across states and changes color only when selected",
+        zh: "ICAO 代号变为带细描边的等宽芯片（JetBrains Mono）；芯片在各状态下保持同一字体/字号/形状，仅在选中时改变颜色",
       },
       {
-        en: "Orange is reserved for selection, the tracked trace, and the Track button again — removed from the search glyph, the map LIVE indicator, and the map menu wash; altitude trend stays glyph + luminance",
-        zh: "橙色重新只用于选择态、追踪轨迹与 Track 按钮——从搜索图标、地图 LIVE 指示与地图菜单底色中移除；高度趋势仍以箭头 + 明度表达",
+        en: "Group labels (Near me / Spotter favorites / hubs) use an upright serif (Fraunces) with a small accent tick; the page title stays in Manrope",
+        zh: "分组标签（附近 / 收藏 / 枢纽）改用直立衬线（Fraunces）并配一道强调短线；页面标题仍为 Manrope",
       },
       {
-        en: "Sidebar filters (targets / route / type / altitude) read as aligned rails instead of a boxed table",
-        zh: "侧栏筛选（目标 / 航路 / 机型 / 高度）改为对齐的导轨，而非方框表格",
+        en: "The near-me row is the one orange CTA — accent chip, faint wash, and a left rail; orange appears in exactly three places (title tick, group ticks, near-me row)",
+        zh: "「附近」行是唯一的橙色入口——强调芯片、淡底色与左侧导轨；橙色全页仅出现三处（标题短线、分组短线、附近行）",
       },
       {
-        en: "Stronger size contrast on Explorer / About list rows; weather view no longer stacks a flight-count hero above its flight-rules hero, and hero footer labels never wrap",
-        zh: "Explorer / About 列表行的字号对比更明确；天气视图不再在飞行规则主指标之上叠加航班数主指标，主指标底部标签不再换行",
+        en: "Airport names lead at a larger inked size and wrap instead of mid-word ellipsis; both light and dark themes retune through the existing signal-accent and ink tokens",
+        zh: "机场名以更大的深色字号领衔，超长时换行而非中途省略；明暗两套主题均通过既有的信号强调色与墨色令牌自动适配",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -277,6 +277,36 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.28.1",
+    kind: "patch",
+    title: {
+      en: "Material fidelity — flatter glass, quieter accent",
+      zh: "材质回正——更平的玻璃、更克制的强调色",
+    },
+    summary: {
+      en: "A correction pass on the v2.28 surfaces: frosted panels go back to flat translucent tints instead of painted gradients, the orange signal is reserved for selection again, and the left-column hierarchy reads cleaner over a busy map.",
+      zh: "对 v2.28 表面的一次回正：磨砂面板回到平整的半透明色调而非渐变涂层，橙色信号色重新只用于选择态，左栏层次在繁忙地图上更清爽。",
+    },
+    highlights: [
+      {
+        en: "Frosted surfaces (search box, sidebar, preview cards, toolbars, toasts) drop linear-gradient fills and heavy ambient shadows for one flat tint + a single inset hairline — no more gray mud at the edges over the live map",
+        zh: "磨砂表面（搜索框、侧栏、预览卡片、工具条、提示）去掉线性渐变填充与厚重投影，改为单一平整色调 + 一道内描边——地图之上不再有灰浊边缘",
+      },
+      {
+        en: "Orange is reserved for selection, the tracked trace, and the Track button again — removed from the search glyph, the map LIVE indicator, and the map menu wash; altitude trend stays glyph + luminance",
+        zh: "橙色重新只用于选择态、追踪轨迹与 Track 按钮——从搜索图标、地图 LIVE 指示与地图菜单底色中移除；高度趋势仍以箭头 + 明度表达",
+      },
+      {
+        en: "Sidebar filters (targets / route / type / altitude) read as aligned rails instead of a boxed table",
+        zh: "侧栏筛选（目标 / 航路 / 机型 / 高度）改为对齐的导轨，而非方框表格",
+      },
+      {
+        en: "Stronger size contrast on Explorer / About list rows; weather view no longer stacks a flight-count hero above its flight-rules hero, and hero footer labels never wrap",
+        zh: "Explorer / About 列表行的字号对比更明确；天气视图不再在飞行规则主指标之上叠加航班数主指标，主指标底部标签不再换行",
+      },
+    ],
+  },
+  {
     version: "v2.28.0",
     kind: "feat",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -46,6 +46,13 @@
     --font-mono: var(--theme-font-mono);
     --font-nav: var(--theme-font-nav);
     --font-display: var(--theme-font-display);
+    /* Decorative families used by the Explorer (home) discovery sidebar
+       only: an upright serif for group labels and a true monospace for the
+       ICAO/HERE code chips. Named --font-code (not --font-mono-*) on purpose:
+       the global `[class*="font-mono"]` reset would otherwise force these
+       chips back onto Manrope. Telemetry stays on --font-mono (Manrope). */
+    --font-serif: var(--theme-font-serif);
+    --font-code: var(--theme-font-code);
 
     /* Typographic polarity: ADSBao uses only light (300) and regular (400).
        Hierarchy comes from size, color, tracking, and surface — never weight.
@@ -628,6 +635,10 @@
         "Manrope", "Noto Sans SC", system-ui, sans-serif;
     --theme-font-display:
         "Manrope", "Noto Sans SC", system-ui, sans-serif;
+    --theme-font-serif:
+        "Fraunces", "Noto Serif SC", Georgia, "Songti SC", serif;
+    --theme-font-code:
+        "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
     --theme-primary-bright: oklch(0.22 0.02 165);
     --theme-primary-deep: oklch(0.22 0.02 165);
     --theme-primary-ink: oklch(0.975 0.005 165);
@@ -8482,14 +8493,14 @@ body {
     }
 }
 
-/* Home airport lists share one rail with the search input. Section labels,
-   airport names, and search text sit on the same axis; codes own the left rail. */
+/* Home search input rail. The discovery / search rows below own their own
+   grid (see AirportListRow); these vars now only drive the search field's
+   icon / input / enter-key columns. */
 .search-screen {
     --home-search-rail-inset: 8px;
     --home-list-rail-inset: 8px;
     --home-list-code-column: 28px;
     --home-list-column-gap: 5px;
-    --home-list-code-font: 8px;
 }
 
 .search-screen .dither-content-stack {
@@ -8517,15 +8528,24 @@ body {
     justify-self: end;
 }
 
-.search-screen .dither-section-flow > header {
-    column-gap: var(--home-list-column-gap);
-    display: grid;
-    grid-template-columns: var(--home-list-code-column) minmax(0, 1fr);
-    padding-left: var(--home-list-rail-inset);
+/* Title flourish: a short accent underline tick under the page title. The
+   title stays in Manrope (sitewide consistency); only the tick is home-scoped.
+   One of the three places orange appears on this page. */
+.search-screen .dither-page-copy .atc-page-title::after {
+    background: var(--atc-signal-accent);
+    border-radius: 1px;
+    content: "";
+    display: block;
+    height: 2px;
+    margin-top: 10px;
+    width: 26px;
 }
 
-.search-screen .dither-section-flow > header > * {
-    grid-column: 2;
+/* Group rhythm: whitespace does the grouping (no boxes / dividing lines) —
+   tight rows inside a group, a 22px gap between one group and the next. */
+.search-screen .dither-content-stack > section + section {
+    margin-top: 0;
+    padding-top: 22px;
 }
 
 .search-screen .dither-section-flow > .atc-section-head {
@@ -8544,43 +8564,14 @@ body {
     justify-self: end;
 }
 
-.search-screen .dither-section-flow [data-ui="text-pill-list-item"] {
-    column-gap: var(--home-list-column-gap);
-    grid-template-columns: var(--home-list-code-column) minmax(0, 1fr) 16px;
-    margin-inline: 0;
-    /* Roomier padding so the hover highlight breathes around the row text
-       and doesn't crowd the content or the neighbouring rows. */
-    padding: 11px 10px 11px var(--home-list-rail-inset);
-    width: 100%;
-}
-
-.search-screen .dither-section-flow [data-ui="text-pill-list-item"] > span:first-child {
-    align-self: center;
-    background: transparent;
-    border-radius: 0;
-    color: var(--atc-dim);
-    font-family: var(--font-mono);
-    font-size: var(--home-list-code-font);
-    font-weight: var(--weight-regular);
-    height: auto;
-    justify-content: flex-start;
-    padding: 0;
-    width: var(--home-list-code-column);
-}
-
 @media (min-width: 768px) {
     .search-screen {
         --home-list-code-column: 26px;
         --home-list-column-gap: 4px;
-        --home-list-code-font: 7.5px;
     }
 
     .search-screen .dither-content-stack {
         padding-inline: var(--airport-sidebar-inset, 16px);
-    }
-
-    .search-screen .dither-section-flow [data-ui="text-pill-list-item"] > span:first-child {
-        padding-inline: 0;
     }
 }
 


### PR DESCRIPTION
Redesigns the **home (`/` 机场探索) Explorer discovery sidebar** — the left content panel only — from flat gray text into the frosted design language from the reference. Scope is strictly the left list column.

**Out of scope (untouched):** the right-side video background, the airport-page sidebar, weather, ATC.

### What changed

1. **ICAO chips** — codes become real monospace chips (JetBrains Mono, 10px, 0.6px tracking, fixed 46px column, 6px radius, centered). Resting: dim ink + `inset 0 0 0 .5px` hairline. Chip typeface/size/shape is **identical in all states**; selected/accent differ by **color only**.
2. **Group labels** — upright serif (Fraunces, regular weight) with a 9×1.5px accent tick. The page title **stays in Manrope** (sitewide consistency).
3. **Hierarchy by size + luminance, never weight** — 15.5px inked name that **wraps instead of mid-word ellipsis**, 11.5px ~46% subtitle, small dim chip.
4. **Group rhythm** — tight rows within a group, 22px gap between groups, whitespace does the grouping (no boxes/lines).
5. **Row grid** `[46px][1fr][16px]`, gap 12px, padding 9px 10px, radius 10px; faint chevron; hover `rgba(ink,.045)`.
6. **Near-me row** is the one orange CTA — accent chip (orange text / .10 bg / .30 hairline), row wash `accent .07` + a 2px left rail. Orange appears in **exactly three places**: title tick, group ticks, near-me row.
7. **Title flourish** — a 26×2px accent underline tick under "Airports".

### Implementation notes

- New tokens `--font-serif` (Fraunces) and `--font-code` (JetBrains Mono). `--font-code` is named to **dodge the global `[class*="font-mono"]` reset**, which would otherwise force the chips back onto Manrope. Telemetry stays on `--font-mono` (Manrope).
- Both webfonts (weight 400 only) added to the existing Google Fonts `<link>`; CSP already allows `fonts.gstatic.com` / `fonts.googleapis.com`.
- New `AirportListRow` primitive (inline Tailwind) drives both discovery and search-result rows. The shared `TextPillListItem` is **untouched**, so About / Mechanism / Changelog / ATC are unaffected.
- Both themes retune entirely through the existing theme-split `--atc-signal-accent` + ink tokens (`--atc-text/-dim/-faint/-line-strong`). **No `--atc-glass-*` fork.**
- Retired the now-dead `.search-screen` row/header CSS overrides (net-negative CSS diff).

### Before → After

| | Before | After |
|---|---|---|
| Codes | bare gray text rail (Manrope, ~8px), names mid-word ellipsis | mono JetBrains-Mono chips with hairline; names wrap |
| Group labels | uppercase tracked eyebrow | upright Fraunces serif + accent tick |
| Near-me | plain row | orange CTA (chip + wash + left rail) |
| Title | plain | + accent underline tick |

Verified in the running app in **both light and dark themes** (desktop). Screenshots (before/after × light/dark) captured during review.

### Validation
`Validation: local browser — checked the home page (/) in light + dark themes, desktop. Ran pnpm build (clean) and pnpm test (122 files pass).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)