### PR TITLE
v2.28.3: About sidebar — Explorer code chips + serif labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.28.2",
+  "version": "2.28.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/about/AboutPanel.tsx
+++ b/src/components/about/AboutPanel.tsx
@@ -1,5 +1,6 @@
+import type { CSSProperties, ReactNode } from "react";
 import { ArrowUpRight, Github } from "lucide-react";
-import { TextPillListItem } from "@/components/ui/TextPillListItem";
+import { AirportListRow } from "@/components/airport/search/AirportListRow";
 import {
   ABOUT_BUILD_META,
   ABOUT_DATA_SOURCES,
@@ -35,11 +36,22 @@ const SOURCE_CATEGORY: Record<string, string> = {
 };
 const CATEGORY_ORDER = ["traffic", "weather", "airport", "context"];
 const CATEGORY_LABEL: Record<string, { en: string; zh: string }> = {
-  traffic: { en: "Traffic", zh: "航迹" },
+  traffic: { en: "Tracks", zh: "航迹" },
   weather: { en: "Weather", zh: "天气" },
-  airport: { en: "Airport", zh: "机场" },
+  airport: { en: "Airports", zh: "机场" },
   context: { en: "Context", zh: "背景" },
 };
+
+// The source codes (ADS-B / ICONS / METAR / ROUTE) are wider than ICAO codes,
+// so the shared Explorer row gets a wider, slightly smaller chip here via its
+// CSS-var overrides — same chip style, different column.
+const SOURCE_CHIP_STYLE = {
+  "--lr-chip-col": "54px",
+  "--lr-chip-fs": "9.5px",
+} as CSSProperties;
+
+// Page content sits on the same horizontal inset as the page title.
+const INSET = "px-[var(--airport-sidebar-inset,20px)]";
 
 export default function AboutPanel() {
   const { locale, t } = useI18n();
@@ -57,59 +69,51 @@ export default function AboutPanel() {
     : [];
 
   return (
-    <div className="flex flex-none flex-col">
-      <div className="about-meta-grid dither-meta-flow dither-list-flow flex-none">
+    <div className="flex flex-none flex-col pb-2">
+      {/* Meta block — stacked label-over-value, left-aligned to the title.
+          Deliberately NOT a left-label/right-value rail (which competed with
+          the chip column below). */}
+      <div className={`flex flex-col gap-4 pt-1 ${INSET}`}>
         {version ? (
-          <div className="about-meta-row about-meta-version">
-            <span className="about-meta-label">
-              {version.labelKey ? t(version.labelKey) : version.label}
-            </span>
-            <span className="about-meta-value">
-              {resolveCopy(version, t)}
-            </span>
-          </div>
+          <MetaEntry
+            label={version.labelKey ? t(version.labelKey) : version.label}
+            value={
+              <span className="font-code">{resolveCopy(version, t)}</span>
+            }
+          />
         ) : null}
-
-        <div className="about-meta-sections">
-          {sections.map((section) => (
-            <section
-              key={section.label}
-              className="about-meta-row about-meta-section"
-            >
-              <h2 className="about-meta-label">
-                {section.labelKey ? t(section.labelKey) : section.label}
-              </h2>
-              <ul
-                className={
-                  section.layout === "compact-grid"
-                    ? "about-meta-list about-meta-list--grid"
-                    : "about-meta-list"
-                }
-              >
-                {section.items.map((item) => (
-                  <li
-                    key={item}
-                    className="min-w-0"
-                  >
-                    <span className="min-w-0">{resolveCopy(item, t)}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
-        </div>
+        {sections.map((section) => (
+          <MetaEntry
+            key={section.label}
+            label={section.labelKey ? t(section.labelKey) : section.label}
+            value={section.items
+              .map((item) => resolveCopy(item, t))
+              .join(" · ")}
+          />
+        ))}
       </div>
 
-      <div className="dither-section-header flex-none px-5 pb-2 pt-4">
-        <div className="atc-section-head">
-          <span className="atc-kicker">{t("about.dataSources")}</span>
-          <span className="atc-section-head__count">
-            {getDataSourceCountLabel(ABOUT_DATA_SOURCES, locale)}
-          </span>
-        </div>
+      {/* Hairline divider between the meta block and Data sources. */}
+      <div className="mx-[var(--airport-sidebar-inset,20px)] mt-5 mb-4 h-px bg-[color-mix(in_oklab,var(--atc-text)_11%,transparent)]" />
+
+      {/* Section header: serif + accent tick (the one accent here besides the
+          title tick) with a mono source count right-aligned. */}
+      <div className={`flex items-center justify-between gap-3 ${INSET}`}>
+        <h2
+          className={
+            "flex min-w-0 items-center gap-2 font-serif text-[15px] leading-snug text-atc-dim " +
+            "before:block before:h-[1.5px] before:w-[9px] before:shrink-0 before:rounded-full " +
+            "before:bg-[var(--atc-signal-accent)] before:content-['']"
+          }
+        >
+          {t("about.dataSources")}
+        </h2>
+        <span className="shrink-0 font-code text-[10px] [letter-spacing:0.4px] text-atc-faint">
+          {getDataSourceCountLabel(ABOUT_DATA_SOURCES, locale)}
+        </span>
       </div>
 
-      <div className="flex flex-col gap-5">
+      <div className="mt-3 flex flex-col gap-5">
         {CATEGORY_ORDER.map((category) => {
           const sources = ABOUT_DATA_SOURCES.filter(
             (source) => (SOURCE_CATEGORY[source.glyph] || "context") === category,
@@ -119,18 +123,22 @@ export default function AboutPanel() {
             CATEGORY_LABEL[category][locale === "zh-CN" ? "zh" : "en"];
           return (
             <section key={category} className="flex flex-col gap-1.5">
-              <span className="fs-eyebrow mx-[var(--airport-sidebar-inset,20px)]">
+              {/* Sub-group label: plain upright serif, no tick. */}
+              <h3
+                className={`font-serif text-[12px] leading-snug text-atc-dim ${INSET}`}
+              >
                 {label}
-              </span>
-              <ol className="dither-list dither-list-flow flex flex-col gap-1">
+              </h3>
+              <ol className={`flex flex-col gap-1 ${INSET}`}>
                 {sources.map((source) => (
                   <li key={source.host || source.title || source.glyph}>
-                    <TextPillListItem
+                    <AirportListRow
                       as="a"
-                      className="about-data-source-link"
+                      style={SOURCE_CHIP_STYLE}
                       {...getExternalLinkOpenTarget(source.href)}
                       onClick={(event) => openExternalLink(event, source.href)}
                       pill={source.glyph}
+                      trailingAlign="start"
                       title={source.titleKey ? t(source.titleKey) : source.title}
                       subtitle={
                         source.descriptionKey
@@ -149,7 +157,7 @@ export default function AboutPanel() {
         })}
       </div>
 
-      <div className="px-5 pb-4 pt-2 md:px-[16px]">
+      <div className="px-5 pb-4 pt-4 md:px-[16px]">
         <a
           {...getExternalLinkOpenTarget(ABOUT_REPOSITORY.href)}
           onClick={(event) => openExternalLink(event, ABOUT_REPOSITORY.href)}
@@ -178,6 +186,24 @@ export default function AboutPanel() {
           </span>
         </a>
       </div>
+    </div>
+  );
+}
+
+// Stacked meta field: a quiet uppercase micro-label over a regular-weight value.
+function MetaEntry({
+  label,
+  value,
+}: {
+  label: ReactNode;
+  value: ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <span className="text-[10px] uppercase [letter-spacing:1.4px] text-atc-faint">
+        {label}
+      </span>
+      <span className="text-[14px] leading-[1.4] text-atc-text">{value}</span>
     </div>
   );
 }

--- a/src/components/airport/search/AirportListRow.tsx
+++ b/src/components/airport/search/AirportListRow.tsx
@@ -10,6 +10,9 @@ type AirportListRowProps = {
   subtitle?: ReactNode;
   /** Trailing slot, e.g. a chevron on tappable rows. */
   trailing?: ReactNode;
+  /** Vertical placement of the trailing slot. "start" levels it with the
+   *  name's first line; "center" (default) centers it in the row. */
+  trailingAlign?: "center" | "start";
   /** "accent" paints the one orange CTA row (the near-me HERE entry). */
   tone?: Tone;
   /** Selected "best match" search row — differs by color/luminance only. */
@@ -23,11 +26,17 @@ type AirportListRowProps = {
 // + luminance, never weight: a mono code chip on the left rail, a near-black
 // name, and a faint subtitle. Whitespace groups the rows; there are no boxes.
 // The single orange accent (tone="accent") is reserved for the near-me CTA.
+//
+// The chip column width / font-size read CSS vars (--lr-chip-col, --lr-chip-fs)
+// with the Explorer defaults baked in as fallbacks, so the About page can pass
+// `style={{ "--lr-chip-col": "54px", "--lr-chip-fs": "9.5px" }}` for its wider
+// category codes without forking the component.
 export function AirportListRow({
   pill,
   title,
   subtitle,
   trailing,
+  trailingAlign = "center",
   tone = "default",
   active = false,
   as = "div",
@@ -43,8 +52,8 @@ export function AirportListRow({
   const chip = (
     <span
       className={cn(
-        "mt-[2px] inline-flex w-[46px] items-center justify-center self-start rounded-[6px] py-[3px]",
-        "whitespace-nowrap font-code text-[10px] leading-none [letter-spacing:0.6px]",
+        "mt-[2px] inline-flex w-[var(--lr-chip-col,46px)] items-center justify-center self-start rounded-[6px] py-[3px]",
+        "whitespace-nowrap font-code text-[length:var(--lr-chip-fs,10px)] leading-none [letter-spacing:0.6px]",
         accent
           ? cn(
               "text-[var(--atc-signal-accent-strong)]",
@@ -81,7 +90,10 @@ export function AirportListRow({
   const chevron = (
     <span
       className={cn(
-        "flex w-4 items-center justify-center self-center transition-transform duration-150",
+        "flex w-4 items-center justify-center transition-transform duration-150",
+        // Trailing icon sits centered in the row by default; "start" levels it
+        // with the name's first line (matching the chip) for tall, wrapping rows.
+        trailingAlign === "start" ? "mt-[2px] self-start" : "self-center",
         accent ? "text-[var(--atc-signal-accent)]" : "text-atc-faint",
         interactive && "group-hover:translate-x-0.5",
         interactive && !accent && "group-hover:text-atc-dim",
@@ -92,7 +104,7 @@ export function AirportListRow({
   );
 
   const classes = cn(
-    "group grid w-full grid-cols-[46px_minmax(0,1fr)_16px] items-center gap-x-3",
+    "group grid w-full grid-cols-[var(--lr-chip-col,46px)_minmax(0,1fr)_16px] items-center gap-x-3",
     "rounded-[10px] px-2.5 py-[9px] text-left",
     "transition-[background-color,box-shadow] duration-150",
     accent

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -164,9 +164,9 @@ function resolveRouteChrome(pathname, t) {
   if (segment === "about") {
     return {
       key: "about",
-      className: "",
+      className: "about-screen",
       title: t("app.aboutTitle"),
-      description: "",
+      description: t("app.aboutSubtitle"),
     };
   }
 

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -41,36 +41,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 93;
+export const CHANGELOG_TOTAL_COUNT = 94;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.28.2",
+    version: "v2.28.3",
     kind: "patch",
     title: {
-      en: "Explorer sidebar — code chips, serif group labels",
-      zh: "机场探索侧栏——代号芯片、衬线分组标签",
+      en: "About page — same code chips and serif labels as Explorer",
+      zh: "关于页——与机场探索一致的代号芯片与衬线标签",
     },
     summary: {
-      en: "The home Explorer list trades flat gray text for real design: monospace ICAO chips, an upright serif for group labels, and one orange near-me CTA. Hierarchy comes from size and luminance, never weight.",
-      zh: "首页机场探索列表从扁平灰字升级为真正的设计语言：等宽 ICAO 代号芯片、衬线分组标签，以及唯一的橙色「附近」入口。层次来自字号与明度，而非字重。",
+      en: "The About sidebar adopts the Explorer design system. The build meta stacks label-over-value, and the data sources reuse the Explorer row with monospace category chips and serif group labels.",
+      zh: "关于页侧栏沿用机场探索的设计语言：构建信息改为标签在上、值在下的堆叠式，数据来源复用机场探索的行样式，配等宽分类芯片与衬线分组标签。",
     },
     highlights: [
       {
-        en: "ICAO codes become monospace chips (JetBrains Mono) with a hairline rim; the chip keeps one typeface/size/shape across states and changes color only when selected",
-        zh: "ICAO 代号变为带细描边的等宽芯片（JetBrains Mono）；芯片在各状态下保持同一字体/字号/形状，仅在选中时改变颜色",
+        en: "Version / Stack / Architecture become a stacked label-over-value meta block (no longer a left-label / right-value rail), separated from the sources by a hairline",
+        zh: "版本 / 技术栈 / 架构改为标签在上、值在下的堆叠式信息块（不再是左标签 / 右值的导轨），并以细线与数据来源分隔",
       },
       {
-        en: "Group labels (Near me / Spotter favorites / hubs) use an upright serif (Fraunces) with a small accent tick; the page title stays in Manrope",
-        zh: "分组标签（附近 / 收藏 / 枢纽）改用直立衬线（Fraunces）并配一道强调短线；页面标题仍为 Manrope",
+        en: "Data sources reuse the Explorer row exactly — monospace category chips (ADS-B / METAR / ROUTE) with a hairline rim and an external-link trailing icon",
+        zh: "数据来源完全复用机场探索的行样式——等宽分类芯片（ADS-B / METAR / ROUTE）带细描边，并配外链图标作为尾部",
       },
       {
-        en: "The near-me row is the one orange CTA — accent chip, faint wash, and a left rail; orange appears in exactly three places (title tick, group ticks, near-me row)",
-        zh: "「附近」行是唯一的橙色入口——强调芯片、淡底色与左侧导轨；橙色全页仅出现三处（标题短线、分组短线、附近行）",
-      },
-      {
-        en: "Airport names lead at a larger inked size and wrap instead of mid-word ellipsis; both light and dark themes retune through the existing signal-accent and ink tokens",
-        zh: "机场名以更大的深色字号领衔，超长时换行而非中途省略；明暗两套主题均通过既有的信号强调色与墨色令牌自动适配",
+        en: "Section and group labels use the upright serif; the title keeps Manrope with a small accent underline tick, and the data rows carry no orange",
+        zh: "区块与分组标签改用直立衬线；标题仍为 Manrope 并配一道强调下划线短线，数据行不含橙色",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -277,6 +277,36 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.28.2",
+    kind: "patch",
+    title: {
+      en: "Explorer sidebar — code chips, serif group labels",
+      zh: "机场探索侧栏——代号芯片、衬线分组标签",
+    },
+    summary: {
+      en: "The home Explorer list trades flat gray text for real design: monospace ICAO chips, an upright serif for group labels, and one orange near-me CTA. Hierarchy comes from size and luminance, never weight.",
+      zh: "首页机场探索列表从扁平灰字升级为真正的设计语言：等宽 ICAO 代号芯片、衬线分组标签，以及唯一的橙色「附近」入口。层次来自字号与明度，而非字重。",
+    },
+    highlights: [
+      {
+        en: "ICAO codes become monospace chips (JetBrains Mono) with a hairline rim; the chip keeps one typeface/size/shape across states and changes color only when selected",
+        zh: "ICAO 代号变为带细描边的等宽芯片（JetBrains Mono）；芯片在各状态下保持同一字体/字号/形状，仅在选中时改变颜色",
+      },
+      {
+        en: "Group labels (Near me / Spotter favorites / hubs) use an upright serif (Fraunces) with a small accent tick; the page title stays in Manrope",
+        zh: "分组标签（附近 / 收藏 / 枢纽）改用直立衬线（Fraunces）并配一道强调短线；页面标题仍为 Manrope",
+      },
+      {
+        en: "The near-me row is the one orange CTA — accent chip, faint wash, and a left rail; orange appears in exactly three places (title tick, group ticks, near-me row)",
+        zh: "「附近」行是唯一的橙色入口——强调芯片、淡底色与左侧导轨；橙色全页仅出现三处（标题短线、分组短线、附近行）",
+      },
+      {
+        en: "Airport names lead at a larger inked size and wrap instead of mid-word ellipsis; both light and dark themes retune through the existing signal-accent and ink tokens",
+        zh: "机场名以更大的深色字号领衔，超长时换行而非中途省略；明暗两套主题均通过既有的信号强调色与墨色令牌自动适配",
+      },
+    ],
+  },
+  {
     version: "v2.28.1",
     kind: "patch",
     title: {

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -8,6 +8,7 @@ const en = {
     live: "Live",
     airportExplorer: "Airports",
     aboutTitle: "About",
+    aboutSubtitle: "How ADSBao is built",
     mechanismTitle: "Mechanism & Architecture",
     siteDescription:
       "Airport context with METAR weather, nearby aircraft, route hints, and map overlays.",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -7,6 +7,7 @@ const zhCN = {
     live: "实时",
     airportExplorer: "机场",
     aboutTitle: "关于",
+    aboutSubtitle: "ADSBao 是如何构建的",
     mechanismTitle: "机制与架构",
     siteDescription: "用 METAR 天气、附近飞机、航路提示和地图图层呈现机场运行信息。",
   },

--- a/src/features/about/aboutModel.ts
+++ b/src/features/about/aboutModel.ts
@@ -1,7 +1,7 @@
 export const getDataSourceCountLabel = (sources = [], locale = "en") => {
   const count = sources.length;
   if (locale === "zh-CN") return `${count} 个来源`;
-  return `${count} feed${count === 1 ? "" : "s"}`;
+  return `${count} source${count === 1 ? "" : "s"}`;
 };
 
 export const getExternalLinkOpenTarget = (href) => ({

--- a/src/style.css
+++ b/src/style.css
@@ -7783,45 +7783,6 @@ body {
     min-height: 0;
 }
 
-.dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link {
-    column-gap: 8px;
-    grid-template-columns: 50px minmax(0, 1fr) 16px;
-    margin-inline: 0;
-    padding: 11px 0;
-    width: 100%;
-}
-
-.dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link > span:first-child {
-    background: transparent;
-    border-radius: 0;
-    align-self: start;
-    color: var(--fs-rail-color);
-    font-family: var(--fs-rail-font);
-    font-size: var(--fs-rail-size);
-    font-weight: var(--fs-rail-weight);
-    height: auto;
-    justify-content: flex-start;
-    margin-top: 1px;
-    padding: 0;
-    width: 50px;
-}
-
-.dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link > span:nth-child(2) {
-    gap: 2px;
-}
-
-.dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link > span:last-child {
-    align-self: start;
-    margin-top: 3px;
-    opacity: 0.55;
-    width: 16px;
-}
-
-.dither-list-flow [data-ui="text-pill-list-item"].about-data-source-link svg {
-    height: 12px;
-    width: 12px;
-}
-
 .dither-page-panel .search-input {
     background: color-mix(in oklab, var(--atc-bg) 82%, var(--atc-text) 4%);
     -webkit-backdrop-filter: var(--app-frost);
@@ -7965,68 +7926,6 @@ body {
     .map-settings-persistence[data-status="saved"] {
         display: none;
     }
-}
-
-.about-meta-grid {
-    --about-meta-rail: 88px;
-    --about-meta-gap: 16px;
-    margin-inline: var(--airport-sidebar-inset, 20px);
-}
-
-/* One quiet label rail + content axis: the role label sits in a fixed-width
-   left column (quiet, tracked) and the value/list flows in the right axis, so
-   VERSION / STACK / ARCHITECTURE align as a single scannable rail rather than
-   stacking label-over-content. */
-.about-meta-row {
-    display: grid;
-    grid-template-columns: var(--about-meta-rail) minmax(0, 1fr);
-    column-gap: var(--about-meta-gap);
-    align-items: baseline;
-    min-width: 0;
-    padding-block: 8px;
-}
-
-.about-meta-label {
-    color: var(--fs-eyebrow-color);
-    font-family: var(--fs-eyebrow-font);
-    font-size: var(--fs-eyebrow-size);
-    font-weight: var(--fs-eyebrow-weight);
-    letter-spacing: var(--fs-eyebrow-tracking);
-    line-height: 1.15;
-    margin: 0;
-    min-width: 0;
-    text-transform: uppercase;
-}
-
-.about-meta-value {
-    color: var(--fs-value-color);
-    font-size: var(--fs-value-size);
-    font-weight: var(--fs-value-weight);
-    line-height: 1.1;
-    min-width: 0;
-}
-
-.about-meta-sections {
-    display: grid;
-    gap: 7px;
-    margin-top: 7px;
-}
-
-.about-meta-list {
-    color: var(--atc-text);
-    display: grid;
-    font-size: var(--fs-sub-size);
-    font-weight: var(--weight-regular);
-    gap: 4px;
-    line-height: 1.3;
-    list-style: none;
-    margin: 0;
-    min-width: 0;
-    padding: 0;
-}
-
-.about-meta-list--grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .mechanism-list {
@@ -8308,11 +8207,6 @@ body {
         font-size: 9px;
     }
 
-    .about-meta-grid {
-        --about-meta-gap: 4px;
-        margin-inline: var(--airport-sidebar-inset, 16px);
-    }
-
     .mechanism-list {
         --mechanism-gap: 5px;
         --mechanism-rail: 30px;
@@ -8529,9 +8423,10 @@ body {
 }
 
 /* Title flourish: a short accent underline tick under the page title. The
-   title stays in Manrope (sitewide consistency); only the tick is home-scoped.
-   One of the three places orange appears on this page. */
-.search-screen .dither-page-copy .atc-page-title::after {
+   title stays in Manrope (sitewide consistency); the tick is scoped to the
+   pages that opt in (Home + About). One of the few places orange appears. */
+.search-screen .dither-page-copy .atc-page-title::after,
+.about-screen .dither-page-copy .atc-page-title::after {
     background: var(--atc-signal-accent);
     border-radius: 1px;
     content: "";


### PR DESCRIPTION
Redesigns the **About page left column** to adopt the Explorer (home) design system from [#513](https://github.com/orriduck/ADSBao/pull/513), for sitewide consistency. Left content panel only.

**Out of scope (untouched):** the right-side video background, all other pages, weather, ATC. No route/data changes.

### What changed

**A. Meta block (Version / Stack / Architecture)** — now a **stacked label-over-value** block, left-aligned to the title (10px uppercase label over a 14px value; version in mono; Stack/Architecture joined with `·`). This replaces the old left-label / right-value rail that competed with the chip column. A hairline divider separates it from Data sources.

**B. Data sources** — reuse the Explorer row (`AirportListRow`) **exactly**: grid `[54px chip][1fr name+subtitle][16px ↗]`, gap 12px, padding 9px 10px, radius 10px.
- Category chip = the same monospace chip as the ICAO chips (9.5px here for the wider `ADS-B`/`METAR`/`ROUTE` codes), inset .5px hairline, one style in all states.
- Trailing icon is a faint external-link ↗ leveled with the name's first line.
- **"Data sources" header** = serif + accent tick + mono `13 sources` count.
- Sub-group labels (Tracks / Weather / Airports / Context) = plain dim upright serif, no tick.

**Shared with Explorer**
- Title "About" / 关于 stays Manrope with the 26×2px accent underline tick (the tick rule is now shared by the Home + About route scopes).
- Light/regular weight only; hierarchy by size + luminance (15px ink name, 11.5px ~46% description).
- Accent only on the title tick and the "Data sources" tick; data rows carry no orange.
- Both themes retune through the existing `--atc-signal-accent` + ink tokens — no `--atc-glass-*` fork.

### Implementation notes
- `AirportListRow` gains **CSS-var chip overrides** (`--lr-chip-col` / `--lr-chip-fs`) and a `trailingAlign` prop, all defaulting to the Explorer values → **Explorer is byte-for-byte unchanged** (verified live: 46px / 10px / JetBrains Mono).
- No new tokens (reuses `--font-serif`, `--font-code` from #513).
- Added an About subtitle ("How ADSBao is built"), switched the count copy `feeds` → `sources`, renamed the category labels to `Tracks` / `Airports` to match the reference.
- Removed the dead About-only CSS (`about-meta-*`, `.about-data-source-link …`); kept the shared `dither-*` classes used by Mechanism/Changelog.

### Before → After
| | Before | After |
|---|---|---|
| Meta | left-label / right-value rail | stacked label-over-value |
| Codes | bare gray rail (Manrope), ellipsis names | mono category chips with hairline; names wrap |
| Labels | uppercase eyebrows | serif section header (+tick) and serif sub-labels |
| Count | "13 feeds" | "13 sources" |

Verified on `/about` in **light and dark** themes (before/after captured); DOM-checked alignment (title/meta/header at 16px, chips at 26px), chip font (JetBrains Mono 9.5px), and all 14 rows rendering.

### Validation
`Validation: local browser — checked /about in light + dark themes, desktop. Ran pnpm test (122 files pass). Build runs in CI / Railway.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)