### PR TITLE
v2.28.4: Mechanism redesign + Changelog type scale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.28.3",
+  "version": "2.28.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -173,9 +173,9 @@ function resolveRouteChrome(pathname, t) {
   if (segment === "mechanism") {
     return {
       key: "mechanism",
-      className: "",
+      className: "mechanism-screen",
       title: t("app.mechanismTitle"),
-      description: "",
+      description: t("app.mechanismSubtitle"),
     };
   }
 

--- a/src/components/changelog/ChangelogPanel.tsx
+++ b/src/components/changelog/ChangelogPanel.tsx
@@ -151,6 +151,12 @@ function ChangelogEntry({
     >
       <div className="changelog-entry__rail">
         <span className="changelog-entry__version">{release.version}</span>
+        {release.kind ? (
+          // Same mono code chip as the ICAO / category chips; one shared style.
+          <span className="inline-flex w-fit items-center justify-center whitespace-nowrap rounded-[5px] px-[5px] py-[2.5px] font-code text-[8.5px] [letter-spacing:0.4px] text-atc-dim shadow-[inset_0_0_0_0.5px_var(--atc-line-strong)]">
+            {release.kind.toUpperCase()}
+          </span>
+        ) : null}
         {isLatest && (
           <span className="changelog-entry__current">
             {t("changelog.current")}

--- a/src/components/mechanism/MechanismPanel.tsx
+++ b/src/components/mechanism/MechanismPanel.tsx
@@ -1,9 +1,15 @@
 import { Fragment, useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { MECHANISM_ITEMS } from "@/config/mechanism";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { cn } from "@/lib/utils";
 
 type MechanismItemId = (typeof MECHANISM_ITEMS)[number]["id"];
+
+// Page content sits on the same horizontal inset as the page title.
+const INSET = "px-[var(--airport-sidebar-inset,20px)]";
+// Detail content aligns under the row title: index rail (34px) + grid gap (10px).
+const DETAIL_INDENT = "pl-[44px]";
 
 export default function MechanismPanel() {
   const { t } = useI18n();
@@ -13,19 +19,7 @@ export default function MechanismPanel() {
 
   return (
     <div className="flex flex-none flex-col pb-4">
-      <div className="dither-section-header flex-none px-5 pb-2 pt-4">
-        <div className="atc-section-head">
-          <span className="atc-kicker">{t("mechanism.sidebarLabel")}</span>
-          <span className="atc-section-head__count">
-            {t("mechanism.count", { count: MECHANISM_ITEMS.length })}
-          </span>
-        </div>
-        <p className="fs-desc mt-2 max-w-[40ch]">
-          {t("mechanism.description")}
-        </p>
-      </div>
-
-      <ol className="mechanism-list dither-list dither-list-flow flex flex-col gap-0.5">
+      <ol className="flex flex-col">
         {MECHANISM_ITEMS.map((item, index) => {
           const expanded = item.id === expandedId;
           const panelId = `mechanism-${item.id}`;
@@ -38,62 +32,89 @@ export default function MechanismPanel() {
           return (
             <Fragment key={item.id}>
               {showGroup ? (
-                <li className="mechanism-group-label pb-1 pt-3 first:pt-0">
-                  <span>
+                <li className={cn("pb-2 pt-[22px] first:pt-1", INSET)}>
+                  {/* Upright serif group label + accent tick — same as Explorer. */}
+                  <h2
+                    className={
+                      "flex min-w-0 items-center gap-2 font-serif text-[15px] leading-snug text-atc-dim " +
+                      "before:block before:h-[1.5px] before:w-[9px] before:shrink-0 before:rounded-full " +
+                      "before:bg-[var(--atc-signal-accent)] before:content-['']"
+                    }
+                  >
                     {t(item.groupKey)}
-                  </span>
+                  </h2>
                 </li>
               ) : null}
-              <li key={item.id}>
-                <button
-                  type="button"
-                  className="mechanism-row"
-                  data-expanded={expanded ? "true" : "false"}
-                  aria-expanded={expanded}
-                  aria-controls={panelId}
-                  onClick={() => setExpandedId(expanded ? null : item.id)}
-                >
-                  <span className="mechanism-row__index">
-                    {String(index + 1).padStart(2, "0")}
-                  </span>
-                  <span className="mechanism-row__body">
-                    <span className="mechanism-row__title">
-                      {t(item.titleKey)}
-                    </span>
-                    <span className="mechanism-row__signal">
-                      {t(item.signalKey)}
-                    </span>
-                  </span>
-                </button>
-
+              <li className={INSET}>
                 <div
-                  id={panelId}
-                  className={cn(
-                    "grid transition-[grid-template-rows,opacity] duration-200 motion-reduce:transition-none",
-                    expanded
-                      ? "grid-rows-[1fr] opacity-100"
-                      : "grid-rows-[0fr] opacity-0",
-                  )}
+                  data-expanded={expanded ? "true" : undefined}
+                  className="rounded-[12px] transition-colors duration-150 data-[expanded=true]:bg-[color-mix(in_oklab,var(--atc-text)_3.5%,transparent)]"
                 >
-                  <div className="min-h-0 overflow-hidden">
-                    <div className="mechanism-detail">
-                      <p className="mechanism-detail__body">
-                        {t(item.bodyKey)}
-                      </p>
-                      <MechanismFlow labels={flowLabels} />
-                      <ol className="mechanism-detail__list">
-                        {item.detailKeys.map((key, detailIndex) => (
-                          <li
-                            key={key}
-                            className="mechanism-detail__item"
-                          >
-                            <span className="mechanism-detail__index">
-                              {String(detailIndex + 1).padStart(2, "0")}
-                            </span>
-                            <span className="min-w-0">{t(key)}</span>
-                          </li>
-                        ))}
-                      </ol>
+                  <button
+                    type="button"
+                    data-expanded={expanded ? "true" : "false"}
+                    aria-expanded={expanded}
+                    aria-controls={panelId}
+                    onClick={() => setExpandedId(expanded ? null : item.id)}
+                    className={cn(
+                      "group grid w-full grid-cols-[34px_minmax(0,1fr)_16px] items-start gap-x-2.5",
+                      "rounded-[12px] px-2.5 py-[11px] text-left transition-colors duration-150",
+                      !expanded &&
+                        "hover:bg-[color-mix(in_oklab,var(--atc-text)_3%,transparent)]",
+                      "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-signal-accent)]",
+                    )}
+                  >
+                    <span className="mt-[1px] font-code text-[13px] leading-[1.3] text-atc-faint group-data-[expanded=true]:text-atc-text">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <span className="flex min-w-0 flex-col gap-[3px]">
+                      <span className="text-[15px] leading-[1.25] text-atc-text">
+                        {t(item.titleKey)}
+                      </span>
+                      <span className="text-[11.5px] leading-[1.3] text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]">
+                        {t(item.signalKey)}
+                      </span>
+                    </span>
+                    <ChevronRight
+                      aria-hidden="true"
+                      className="mt-[3px] h-4 w-4 text-atc-faint transition-transform duration-200 group-data-[expanded=true]:rotate-90 group-data-[expanded=true]:text-atc-dim"
+                    />
+                  </button>
+
+                  <div
+                    id={panelId}
+                    className={cn(
+                      "grid transition-[grid-template-rows,opacity] duration-200 motion-reduce:transition-none",
+                      expanded
+                        ? "grid-rows-[1fr] opacity-100"
+                        : "grid-rows-[0fr] opacity-0",
+                    )}
+                  >
+                    <div className="min-h-0 overflow-hidden">
+                      <div className={cn("pb-3 pr-2.5", DETAIL_INDENT)}>
+                        <p className="text-[12px] leading-[1.55] text-[color-mix(in_oklab,var(--atc-text)_55%,transparent)]">
+                          {t(item.bodyKey)}
+                        </p>
+                        <MechanismFlow
+                          label={t("mechanism.flowLabel")}
+                          steps={flowLabels}
+                        />
+                        <ol className="mt-3.5 flex flex-col gap-[7px]">
+                          {item.detailKeys.map((key, detailIndex) => (
+                            <li
+                              key={key}
+                              className="grid grid-cols-[16px_minmax(0,1fr)] gap-2"
+                            >
+                              <span className="font-code text-[10px] leading-[1.5] text-atc-faint">
+                                {String(detailIndex + 1).padStart(2, "0")}
+                              </span>
+                              <span className="min-w-0 text-[11.5px] leading-[1.45] text-[color-mix(in_oklab,var(--atc-text)_55%,transparent)]">
+                                {t(key)}
+                              </span>
+                            </li>
+                          ))}
+                        </ol>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -106,25 +127,46 @@ export default function MechanismPanel() {
   );
 }
 
-function MechanismFlow({
-  labels,
-}: {
-  labels: string[];
-}) {
-  if (!labels.length) return null;
+// Vertical node pipeline: a 1px connector threads the step dots top-to-bottom;
+// only the FINAL node (the produced payload) is the orange signal, the rest
+// are neutral. Step labels are mono so the flow reads as a data path.
+function MechanismFlow({ label, steps }: { label: string; steps: string[] }) {
+  if (!steps.length) return null;
 
   return (
-    <ol className="mechanism-flow">
-      {labels.map((label, index) => (
-        <li
-          key={`${label}-${index}`}
-          className="mechanism-flow__item"
-        >
-          <span className="min-w-0 truncate">
-            {label}
-          </span>
-        </li>
-      ))}
-    </ol>
+    <div className="mt-3.5">
+      {/* `uppercase` is globally disabled (modernization override), so cap in JS. */}
+      <span className="block font-code text-[9px] [letter-spacing:1.4px] text-atc-faint">
+        {label.toUpperCase()}
+      </span>
+      <ol className="relative mt-2 flex flex-col gap-2.5">
+        {/* Connector line spans the first dot center to the last. */}
+        <span
+          aria-hidden="true"
+          className="absolute left-[3px] top-[7px] bottom-[7px] w-px bg-[color-mix(in_oklab,var(--atc-text)_18%,transparent)]"
+        />
+        {steps.map((step, index) => {
+          const isFinal = index === steps.length - 1;
+          return (
+            <li
+              key={`${step}-${index}`}
+              className="relative flex items-center gap-2.5"
+            >
+              <span
+                className={cn(
+                  "z-[1] h-[7px] w-[7px] shrink-0 rounded-full",
+                  isFinal
+                    ? "bg-[var(--atc-signal-accent)]"
+                    : "bg-[color-mix(in_oklab,var(--atc-text)_32%,transparent)]",
+                )}
+              />
+              <span className="min-w-0 truncate font-code text-[11.5px] leading-none text-atc-text">
+                {step}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
   );
 }

--- a/src/components/mechanism/MechanismPanel.tsx
+++ b/src/components/mechanism/MechanismPanel.tsx
@@ -19,7 +19,7 @@ export default function MechanismPanel() {
 
   return (
     <div className="flex flex-none flex-col pb-4">
-      <ol className="flex flex-col">
+      <ol className="flex flex-col gap-1">
         {MECHANISM_ITEMS.map((item, index) => {
           const expanded = item.id === expandedId;
           const panelId = `mechanism-${item.id}`;

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -41,32 +41,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 94;
+export const CHANGELOG_TOTAL_COUNT = 95;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.28.3",
+    version: "v2.28.4",
     kind: "patch",
     title: {
-      en: "About page — same code chips and serif labels as Explorer",
-      zh: "关于页——与机场探索一致的代号芯片与衬线标签",
+      en: "Mechanism redesign + Changelog type scale",
+      zh: "机制页重设计 + 更新日志字号统一",
     },
     summary: {
-      en: "The About sidebar adopts the Explorer design system. The build meta stacks label-over-value, and the data sources reuse the Explorer row with monospace category chips and serif group labels.",
-      zh: "关于页侧栏沿用机场探索的设计语言：构建信息改为标签在上、值在下的堆叠式，数据来源复用机场探索的行样式，配等宽分类芯片与衬线分组标签。",
+      en: "The Mechanism page adopts the Explorer/About design system, and the Changelog aligns to the same type scale. Both join the first-screen family with serif group labels and the accent title tick.",
+      zh: "机制页沿用机场探索 / 关于页的设计语言，更新日志对齐同一套字号。两页都归入首屏家族，配衬线分组标签与强调标题短线。",
     },
     highlights: [
       {
-        en: "Version / Stack / Architecture become a stacked label-over-value meta block (no longer a left-label / right-value rail), separated from the sources by a hairline",
-        zh: "版本 / 技术栈 / 架构改为标签在上、值在下的堆叠式信息块（不再是左标签 / 右值的导轨），并以细线与数据来源分隔",
+        en: "Mechanism rows become numbered accordion entries (mono index, title + signal, chevron); the expanded row gets a faint neutral panel with the data flow drawn as a vertical node pipeline — only the final produced payload is the orange node",
+        zh: "机制行改为带编号的折叠条目（等宽序号、标题 + 信号、折叠箭头）；展开行为淡色面板，数据流以竖向节点管线呈现——仅最终产出的 payload 为橙色节点",
       },
       {
-        en: "Data sources reuse the Explorer row exactly — monospace category chips (ADS-B / METAR / ROUTE) with a hairline rim and an external-link trailing icon",
-        zh: "数据来源完全复用机场探索的行样式——等宽分类芯片（ADS-B / METAR / ROUTE）带细描边，并配外链图标作为尾部",
+        en: "Mechanism group labels switch to the upright serif with an accent tick, and the title gains the accent underline tick + a quiet subtitle (kicker/count dropped)",
+        zh: "机制分组标签改用直立衬线并配强调短线，标题加上强调下划线短线与一行安静副标题（去掉旧的标签 / 计数头）",
       },
       {
-        en: "Section and group labels use the upright serif; the title keeps Manrope with a small accent underline tick, and the data rows carry no orange",
-        zh: "区块与分组标签改用直立衬线；标题仍为 Manrope 并配一道强调下划线短线，数据行不含橙色",
+        en: "Changelog aligns to the shared type scale — 15px entry titles, 11.5px summaries, mono version, and FEAT/PATCH/BREAKING as the shared mono chip — with the accent title tick; structure unchanged",
+        zh: "更新日志对齐共享字号——15px 条目标题、11.5px 摘要、等宽版本号，FEAT/PATCH/BREAKING 采用共享的等宽芯片——并加上强调标题短线；结构不变",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -277,6 +277,32 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.28.3",
+    kind: "patch",
+    title: {
+      en: "About page — same code chips and serif labels as Explorer",
+      zh: "关于页——与机场探索一致的代号芯片与衬线标签",
+    },
+    summary: {
+      en: "The About sidebar adopts the Explorer design system. The build meta stacks label-over-value, and the data sources reuse the Explorer row with monospace category chips and serif group labels.",
+      zh: "关于页侧栏沿用机场探索的设计语言：构建信息改为标签在上、值在下的堆叠式，数据来源复用机场探索的行样式，配等宽分类芯片与衬线分组标签。",
+    },
+    highlights: [
+      {
+        en: "Version / Stack / Architecture become a stacked label-over-value meta block (no longer a left-label / right-value rail), separated from the sources by a hairline",
+        zh: "版本 / 技术栈 / 架构改为标签在上、值在下的堆叠式信息块（不再是左标签 / 右值的导轨），并以细线与数据来源分隔",
+      },
+      {
+        en: "Data sources reuse the Explorer row exactly — monospace category chips (ADS-B / METAR / ROUTE) with a hairline rim and an external-link trailing icon",
+        zh: "数据来源完全复用机场探索的行样式——等宽分类芯片（ADS-B / METAR / ROUTE）带细描边，并配外链图标作为尾部",
+      },
+      {
+        en: "Section and group labels use the upright serif; the title keeps Manrope with a small accent underline tick, and the data rows carry no orange",
+        zh: "区块与分组标签改用直立衬线；标题仍为 Manrope 并配一道强调下划线短线，数据行不含橙色",
+      },
+    ],
+  },
+  {
     version: "v2.28.2",
     kind: "patch",
     title: {

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -10,6 +10,7 @@ const en = {
     aboutTitle: "About",
     aboutSubtitle: "How ADSBao is built",
     mechanismTitle: "Mechanism & Architecture",
+    mechanismSubtitle: "How the realtime system fits together",
     siteDescription:
       "Airport context with METAR weather, nearby aircraft, route hints, and map overlays.",
   },
@@ -121,6 +122,7 @@ const en = {
       "How ADSBao keeps map tracking, here mode, nearby lists, and realtime delivery coordinated.",
     sidebarLabel: "System profile",
     count: "{count} entries",
+    flowLabel: "Flow",
     groups: {
       architecture: "Core Architecture",
       mechanisms: "Core Mechanisms",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -9,6 +9,7 @@ const zhCN = {
     aboutTitle: "关于",
     aboutSubtitle: "ADSBao 是如何构建的",
     mechanismTitle: "机制与架构",
+    mechanismSubtitle: "实时系统如何协同运作",
     siteDescription: "用 METAR 天气、附近飞机、航路提示和地图图层呈现机场运行信息。",
   },
   brand: {
@@ -115,6 +116,7 @@ const zhCN = {
       "ADSBao 如何协调地图追踪、here 模式、附近列表与实时传递。",
     sidebarLabel: "系统剖面",
     count: "{count} 个条目",
+    flowLabel: "数据流",
     groups: {
       architecture: "核心架构",
       mechanisms: "核心机制",

--- a/src/style.css
+++ b/src/style.css
@@ -7647,7 +7647,7 @@ body {
 
 .changelog-entry__version {
     color: var(--fs-rail-color);
-    font-family: var(--fs-rail-font);
+    font-family: var(--font-code);
     font-size: var(--fs-rail-size);
     font-weight: var(--fs-rail-weight);
 }
@@ -7669,17 +7669,17 @@ body {
 .changelog-entry__title {
     color: var(--fs-title-color);
     font-family: var(--fs-title-font);
-    font-size: var(--fs-title-size);
+    font-size: 15px;
     font-weight: var(--fs-title-weight);
     line-height: var(--fs-title-leading);
     margin: 0;
 }
 
 .changelog-entry__summary {
-    color: var(--fs-sub-color);
-    font-size: var(--fs-sub-size);
-    line-height: var(--fs-sub-leading);
-    margin-top: 4px;
+    color: color-mix(in oklab, var(--atc-text) 46%, transparent);
+    font-size: 11.5px;
+    line-height: 1.45;
+    margin-top: 5px;
 }
 
 .changelog-entry__highlights {
@@ -7928,162 +7928,6 @@ body {
     }
 }
 
-.mechanism-list {
-    --mechanism-gap: 7px;
-    --mechanism-rail: 34px;
-}
-
-/* Whitespace groups, not lines: a deliberate gap separates one group from the
-   next (matching the Home / About rhythm) while the quiet eyebrow label sits on
-   the same content axis as the row titles. */
-.mechanism-group-label {
-    margin-top: 16px;
-    padding-bottom: 8px;
-    padding-left: calc(var(--mechanism-rail) + var(--mechanism-gap));
-    padding-top: 24px;
-}
-
-.mechanism-group-label:first-child {
-    margin-top: 0;
-    padding-top: 2px;
-}
-
-.mechanism-group-label span {
-    color: var(--fs-eyebrow-color);
-    font-family: var(--fs-eyebrow-font);
-    font-size: var(--fs-eyebrow-size);
-    font-weight: var(--fs-eyebrow-weight);
-    letter-spacing: var(--fs-eyebrow-tracking);
-    line-height: 1;
-    text-transform: uppercase;
-}
-
-.mechanism-row {
-    align-items: baseline;
-    border-radius: 4px;
-    column-gap: var(--mechanism-gap);
-    display: grid;
-    grid-template-columns: var(--mechanism-rail) minmax(0, 1fr);
-    margin-inline: -8px;
-    min-width: 0;
-    padding: 11px 8px;
-    text-align: left;
-    transition:
-        background-color 150ms ease,
-        color 150ms ease;
-    width: calc(100% + 16px);
-}
-
-.mechanism-row:hover {
-    background: var(--atc-control-surface-hover);
-}
-
-.mechanism-row:focus-visible {
-    outline: 2px solid var(--atc-accent);
-    outline-offset: 2px;
-}
-
-.mechanism-row__index {
-    color: var(--fs-rail-color);
-    font-family: var(--fs-rail-font);
-    font-size: var(--fs-rail-size);
-    font-weight: var(--fs-rail-weight);
-    line-height: 1;
-}
-
-.mechanism-row[data-expanded="true"] .mechanism-row__index,
-.mechanism-row[data-expanded="true"] .mechanism-row__title {
-    color: var(--atc-text);
-}
-
-.mechanism-row__body {
-    display: grid;
-    gap: 3px;
-    min-width: 0;
-}
-
-.mechanism-row__title {
-    color: var(--fs-title-color);
-    font-family: var(--fs-title-font);
-    font-size: var(--fs-title-size);
-    font-weight: var(--fs-title-weight);
-    line-height: var(--fs-title-leading);
-    min-width: 0;
-}
-
-.mechanism-row__signal {
-    color: var(--fs-sub-color);
-    font-size: var(--fs-sub-size);
-    font-weight: var(--fs-sub-weight);
-    line-height: var(--fs-sub-leading);
-    min-width: 0;
-}
-
-.mechanism-detail {
-    margin-left: calc(var(--mechanism-rail) + var(--mechanism-gap));
-    padding: 2px 0 9px;
-}
-
-.mechanism-detail__body,
-.mechanism-detail__item,
-.mechanism-flow {
-    color: var(--fs-body-color);
-    font-size: var(--fs-body-size);
-    line-height: var(--fs-body-leading);
-}
-
-.mechanism-detail__body {
-    margin: 0;
-}
-
-.mechanism-flow {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    list-style: none;
-    margin: 12px 0 0;
-    padding: 0;
-}
-
-.mechanism-flow__item {
-    align-items: center;
-    background: color-mix(in oklab, var(--app-frost-tint) 26%, transparent);
-    border: 1px solid var(--app-frost-border);
-    border-radius: 999px;
-    color: var(--atc-dim);
-    display: inline-flex;
-    font-size: var(--fs-sub-size);
-    line-height: 1;
-    max-width: 100%;
-    min-width: 0;
-    padding: 5px 11px;
-}
-
-.mechanism-flow__index,
-.mechanism-detail__index {
-    color: var(--atc-faint);
-    font-family: var(--font-mono);
-    font-size: 9px;
-    font-weight: var(--weight-regular);
-    letter-spacing: 0;
-    line-height: 1;
-}
-
-.mechanism-detail__list {
-    display: grid;
-    gap: 7px;
-    list-style: none;
-    margin: 14px 0 0;
-    padding: 0;
-}
-
-.mechanism-detail__item {
-    display: grid;
-    gap: 7px;
-    grid-template-columns: 16px minmax(0, 1fr);
-    margin: 0;
-}
-
 @media (min-width: 768px) {
     .dither-page-shell {
         --app-sidebar-width: 17.5rem;
@@ -8205,63 +8049,6 @@ body {
     .search-airport-row small,
     .search-location-row small {
         font-size: 9px;
-    }
-
-    .mechanism-list {
-        --mechanism-gap: 5px;
-        --mechanism-rail: 30px;
-    }
-
-    .mechanism-row__title {
-        font-size: 10.5px;
-    }
-
-    .mechanism-row__signal,
-    .mechanism-detail__body,
-    .mechanism-detail__item,
-    .mechanism-flow {
-        font-size: 9px;
-    }
-
-    .changelog-screen li.changelog-entry {
-        column-gap: 4px;
-        grid-template-columns: 44px minmax(0, 1fr);
-        padding: 6px 0;
-    }
-
-    .changelog-entry__version {
-        font-size: 7px;
-    }
-
-    .changelog-entry__current {
-        font-size: 6px;
-    }
-
-    .changelog-entry__title {
-        font-size: 9.5px;
-        line-height: 1.22;
-    }
-
-    .changelog-entry__summary {
-        font-size: 8.5px;
-        line-height: 1.32;
-        margin-top: 3px;
-    }
-
-    .changelog-entry__highlights {
-        gap: 2px;
-        margin-top: 5px;
-    }
-
-    .changelog-entry__highlights li {
-        font-size: 8px;
-        gap: 3px;
-        grid-template-columns: 12px minmax(0, 1fr);
-        line-height: 1.34;
-    }
-
-    .changelog-entry__highlight-index {
-        font-size: 6.5px;
     }
 
     .aircraft-preview-card {
@@ -8424,9 +8211,11 @@ body {
 
 /* Title flourish: a short accent underline tick under the page title. The
    title stays in Manrope (sitewide consistency); the tick is scoped to the
-   pages that opt in (Home + About). One of the few places orange appears. */
+   first-screen pages that opt in. One of the few places orange appears. */
 .search-screen .dither-page-copy .atc-page-title::after,
-.about-screen .dither-page-copy .atc-page-title::after {
+.about-screen .dither-page-copy .atc-page-title::after,
+.mechanism-screen .dither-page-copy .atc-page-title::after,
+.changelog-screen .dither-page-copy .atc-page-title::after {
     background: var(--atc-signal-accent);
     border-radius: 1px;
     content: "";


### PR DESCRIPTION
Two first-screen pages join the Explorer ([#513](https://github.com/orriduck/ADSBao/pull/513)) / About ([#514](https://github.com/orriduck/ADSBao/pull/514)) design family. **Left content panel only** — the right-side video background, other pages, weather, and ATC are untouched. No route/data changes.

### A. Mechanism — full redesign (inline Tailwind; `mechanism-*` CSS removed)
- Title "Mechanism & Architecture" keeps Manrope + the **26×2px accent tick** and gains a quiet subtitle ("How the realtime system fits together"); the in-panel `SYSTEM PROFILE` kicker / count is dropped.
- Group labels (Core Architecture / Core Mechanisms) → **upright serif + accent tick**, same as Explorer/About.
- Each row is a `[34px mono index][1fr title + signal][16px chevron]` accordion: bare mono index (no box), 15px title, 11.5px ~46% signal, faint chevron that rotates to a down-caret when expanded.
- **Expanded row** → faint neutral panel (`rgba(ink,.035)`, no rail) with body (12px ~55%), the **data flow as a vertical node pipeline** (1px connector + 7px dots, mono labels; **only the final produced payload is the orange node**), and a numbered mono sub-list.
- Hierarchy by size + luminance; light/regular weight only; accent only on the title tick, group ticks, and the final flow node.

### B. Changelog — type scale only (structure unchanged)
- Title gets the accent tick (`changelog-screen` already existed). Entry titles **15px**, summaries **11.5px ~46%**, version in **mono (`--font-code`)**.
- `FEAT/PATCH/BREAKING` now render as the **shared mono code chip** (same style as the ICAO / category chips: `--font-code`, dim, inset hairline).
- Removed the desktop type-shrink (titles were 9.5px on the narrow desktop sidebar) so the scale matches the other first-screen pages.

### Implementation notes
- No new tokens (reuses `--font-serif`, `--font-code`). Extended the title-tick rule to `.mechanism-screen, .changelog-screen` (joining `.search-screen, .about-screen`).
- **Gotcha:** the global `[class*="uppercase"], [class*="tracking-"] { … !important }` "modernization" override (style.css) disables the `uppercase` utility **and** any `tracking-*` letter-spacing app-wide. So the `FLOW` label is capped via JS (`.toUpperCase()`) and spacing uses `[letter-spacing:…]` arbitrary props, not `tracking-*` / `uppercase`.
- Both themes retune through the existing signal-accent + ink tokens — no `--atc-glass-*` fork.

### Before → After
| | Before | After |
|---|---|---|
| Mechanism title | no tick, `SYSTEM PROFILE` kicker + count | accent tick + subtitle, kicker dropped |
| Mechanism groups | uppercase eyebrow | serif + accent tick |
| Mechanism rows | flat index + title, no chevron | accordion w/ chevron, faint expanded panel |
| Mechanism flow | wrapped text pills | vertical node pipeline (final node orange) |
| Changelog | 9.5px titles (desktop), no kind tag | 15px titles, mono version, FEAT/PATCH chip, title tick |

Verified `/mechanism` + `/changelog` in **light and dark** (before/after captured); DOM-checked the flow label casing, connector line, chip font, and the type scale.

### Validation
`Validation: local browser — checked /mechanism + /changelog in light + dark, desktop. Ran pnpm test (122 files pass). Build runs in CI / Railway.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)