### PR TITLE
v2.28.5: Aircraft preview card — selection state (desktop + mobile)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.28.4",
+  "version": "2.28.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -1,7 +1,9 @@
 import { lazy, useEffect, useState } from "react";
 import type { CSSProperties } from "react";
+import { Camera, Hand } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import AircraftPreviewMediaCard from "./AircraftPreviewMediaCard";
+import AircraftPreviewMetadata from "./AircraftPreviewMetadata";
 import AircraftPreviewMetadataCard from "./AircraftPreviewMetadataCard";
 import AircraftPreviewMobileCard from "./AircraftPreviewMobileCard";
 import AirportPreviewMetadataCard from "./AirportPreviewMetadataCard";
@@ -16,8 +18,7 @@ import ReportingPointPreviewMetadataCard from "./ReportingPointPreviewMetadataCa
 import ReportingPointPreviewMobileCard from "./ReportingPointPreviewMobileCard";
 import MobilePreviewCard, {
   MobilePreviewActions,
-  MobilePreviewFeedbackLink,
-  MobilePreviewSecondaryButton,
+  MobilePreviewIconButton,
   MobilePreviewTrackButton,
 } from "./MobilePreviewCard";
 import RouteFeedbackModal from "./RouteFeedbackModal";
@@ -233,8 +234,8 @@ export default function AircraftPreviewCard({
     : isCandidateWatchingSpot
       ? t("preview.candidateWatchingSpotPreview")
     : alreadyTracking
-      ? t("preview.trackingTrace")
-      : t("preview.trackTrace");
+      ? t("preview.tracking")
+      : t("preview.track");
   const showMobileTrackButton =
     Boolean(cardTrackHref) && !(alreadyTracking && isAircraftPreview);
   const previewAriaLabel = isAirport
@@ -249,6 +250,34 @@ export default function AircraftPreviewCard({
         ? t("preview.candidateWatchingSpotPreview")
       : t("preview.aircraftPreview");
   const [planeHunterOpen, setPlaneHunterOpen] = useState(false);
+
+  // Only the aircraft mobile card is the compact, drag-to-expand sheet.
+  const mobileCompact =
+    !isAirport &&
+    !isNavaid &&
+    !isReportingPoint &&
+    !isAirspace &&
+    !isCandidateWatchingSpot;
+  // Revealed on expand: the photo + the HEX / Track / Distance identity rows
+  // (the same content the desktop card shows inline).
+  const mobileExpandedContent =
+    mobileCompact && isAircraftPreview ? (
+      <div className="pt-1">
+        {hasPhoto ? (
+          <div className="px-[12px] [[data-density=compact]_&]:px-[10px]">
+            <img
+              src={photo.src}
+              alt=""
+              draggable="false"
+              className="block max-h-[150px] w-full rounded-[12px] object-cover"
+            />
+          </div>
+        ) : null}
+        <div className="px-[12px] pb-1 pt-2 [[data-density=compact]_&]:px-[10px]">
+          <AircraftPreviewMetadata aircraft={aircraft} />
+        </div>
+      </div>
+    ) : null;
 
   return (
     <>
@@ -317,13 +346,10 @@ export default function AircraftPreviewCard({
         <MobilePreviewCard
           key={`mobile-${identityKey}`}
           ariaLabel={previewAriaLabel}
-          compact={
-            !isAirport &&
-            !isNavaid &&
-            !isReportingPoint &&
-            !isAirspace &&
-            !isCandidateWatchingSpot
-          }
+          compact={mobileCompact}
+          expandable={mobileCompact}
+          grabberLabel={previewAriaLabel}
+          expandedContent={mobileExpandedContent}
           placement={
             showPreferredMobilePreview ? "bottomRight" : "top"
           }
@@ -334,63 +360,43 @@ export default function AircraftPreviewCard({
               showMobileFeedbackTrigger ||
               showMobileSpotNavigationTrigger) ? (
               <MobilePreviewActions>
-                {showMobilePlaneHunterTrigger && showMobileTrackButton ? (
-                  <div className="grid grid-cols-2 gap-1">
-                    <MobilePreviewSecondaryButton
-                      onClick={() => setPlaneHunterOpen(true)}
-                      className="plane-hunter-rainbow-btn"
-                    >
-                      {t("preview.planeHunter")}
-                    </MobilePreviewSecondaryButton>
+                <div className="flex items-stretch gap-1.5">
+                  {showMobileTrackButton && (
                     <MobilePreviewTrackButton
+                      className="flex-1"
                       onClick={handleMobileTap}
                       disabled={alreadyTracking}
                     >
                       {mobileTrackLabel}
                     </MobilePreviewTrackButton>
-                    {showMobileFeedbackTrigger && (
-                      <MobilePreviewFeedbackLink
-                        onClick={() => setFeedbackModalOpen(true)}
-                        className="col-start-2"
-                      >
-                        {mobileFeedbackLabel}
-                      </MobilePreviewFeedbackLink>
-                    )}
-                  </div>
-                ) : (
-                  <>
-                    {showMobilePlaneHunterTrigger && (
-                      <MobilePreviewSecondaryButton
-                        onClick={() => setPlaneHunterOpen(true)}
-                        className="plane-hunter-rainbow-btn"
-                      >
-                        {t("preview.planeHunter")}
-                      </MobilePreviewSecondaryButton>
-                    )}
-                    {showMobileTrackButton && (
-                      <MobilePreviewTrackButton
-                        onClick={handleMobileTap}
-                        disabled={alreadyTracking}
-                      >
-                        {mobileTrackLabel}
-                      </MobilePreviewTrackButton>
-                    )}
-                    {showMobileSpotNavigationTrigger && (
-                      <MobilePreviewTrackButton
-                        onClick={onOpenCandidateWatchingSpotNavigation}
-                      >
-                        {t("preview.goToSpot")}
-                      </MobilePreviewTrackButton>
-                    )}
-                  </>
-                )}
-                {showMobileFeedbackTrigger && !(showMobilePlaneHunterTrigger && showMobileTrackButton) && (
-                  <MobilePreviewFeedbackLink
-                    onClick={() => setFeedbackModalOpen(true)}
-                  >
-                    {mobileFeedbackLabel}
-                  </MobilePreviewFeedbackLink>
-                )}
+                  )}
+                  {showMobileSpotNavigationTrigger && (
+                    <MobilePreviewTrackButton
+                      className="flex-1"
+                      onClick={onOpenCandidateWatchingSpotNavigation}
+                    >
+                      {t("preview.goToSpot")}
+                    </MobilePreviewTrackButton>
+                  )}
+                  {showMobilePlaneHunterTrigger && (
+                    <MobilePreviewIconButton
+                      onClick={() => setPlaneHunterOpen(true)}
+                      aria-label={t("preview.planeHunter")}
+                      title={t("preview.planeHunter")}
+                    >
+                      <Camera aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+                    </MobilePreviewIconButton>
+                  )}
+                  {showMobileFeedbackTrigger && (
+                    <MobilePreviewIconButton
+                      onClick={() => setFeedbackModalOpen(true)}
+                      aria-label={mobileFeedbackLabel}
+                      title={mobileFeedbackLabel}
+                    >
+                      <Hand aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+                    </MobilePreviewIconButton>
+                  )}
+                </div>
               </MobilePreviewActions>
             ) : null
           }

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -203,12 +203,11 @@ export default function AircraftPreviewCard({
   // outside the card so closing it doesn't reuse the preview reveal.
   const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
   const aircraftCallsign = (aircraft?.callsign || "").trim().toUpperCase();
-  const showMobileFeedbackTrigger =
-    showMobilePreview &&
-    !isAirport &&
-    !isNavaid &&
+  const feedbackAvailable =
+    isAircraftPreview &&
     Boolean(aircraftCallsign) &&
     typeof onApplyTemporaryRoute === "function";
+  const showMobileFeedbackTrigger = showMobilePreview && feedbackAvailable;
   const planeHunterDeviceAllowed =
     shouldEnablePlaneHunterForClientDeviceProfile(clientDeviceProfile);
   const showPlaneHunterTrigger =
@@ -297,12 +296,14 @@ export default function AircraftPreviewCard({
           ) : (
             <AircraftPreviewMetadataCard
               aircraft={aircraft}
-              photo={photo}
-              airportProfile={airportProfile}
-              onApplyTemporaryRoute={onApplyTemporaryRoute}
               onOpenPlaneHunter={
                 showPlaneHunterTrigger
                   ? () => setPlaneHunterOpen(true)
+                  : undefined
+              }
+              onSuggestCorrection={
+                feedbackAvailable
+                  ? () => setFeedbackModalOpen(true)
                   : undefined
               }
               traceStatusVisible={traceStatusVisible}
@@ -422,7 +423,7 @@ export default function AircraftPreviewCard({
           )}
         </MobilePreviewCard>
       )}
-      {showMobileFeedbackTrigger && (
+      {feedbackAvailable && (
         <RouteFeedbackModal
           aircraft={aircraft}
           airportProfile={airportProfile}

--- a/src/components/aircraft/preview/AircraftPreviewIdentity.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewIdentity.tsx
@@ -1,71 +1,38 @@
-import AirlineLogo from "./AirlineLogo";
-import AircraftPreviewType from "./AircraftPreviewType";
-import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { getAircraftPreviewTypeDisplay } from "@/features/aircraft/preview/aircraftPreviewTypeModel";
-import {
-  getFlightRouteAccuracyNotice,
-  getFlightRouteAirlineIconUrl,
-} from "@/utils/flightRouteDisplay";
+import AircraftPreviewRouteLine from "./AircraftPreviewRouteLine";
 
-// Callsign + parsed route. Mirrors the sidebar row's identity cell so the
-// hover state feels like a richer continuation rather than new data.
+// Card header: callsign on the left, TYPE / CATEGORY (e.g. "B739 / A3") on the
+// right — no registration. The visual route line sits below. Hierarchy is size
+// + luminance: the callsign leads, the type recedes.
 export default function AircraftPreviewIdentity({ aircraft }) {
-  const { t } = useI18n();
   const callsign =
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
-  const route = aircraft?.flightRouteLabel || "";
-  const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
-  const routeAccuracyNotice = getFlightRouteAccuracyNotice(aircraft?.flightRoute)
-    ? t("aircraft.adsbdbRouteAccuracyNotice")
-    : "";
   const typeDisplay = getAircraftPreviewTypeDisplay(aircraft);
+  const typeLabel = [typeDisplay.primary, typeDisplay.category]
+    .filter(Boolean)
+    .join(" / ");
 
   return (
-    <div className="mb-2.5 flex flex-col gap-1 md:mb-2 md:gap-[3px]">
-      <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_max-content] items-start gap-x-[14px] md:gap-x-[11px]">
+    <div className="mb-2.5 flex flex-col gap-[9px] md:mb-2 md:gap-[7px]">
+      <div className="flex min-w-0 items-baseline justify-between gap-3">
         <span
-          className="notranslate min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[22px] font-extrabold leading-none text-atc-text md:text-[18px]"
+          className="notranslate min-w-0 truncate font-mono text-[21px] leading-none tracking-[0.02em] text-atc-text md:text-[18px]"
           translate="no"
           title={callsign}
         >
           {callsign}
         </span>
-        <AircraftPreviewType aircraft={aircraft} />
-      </div>
-      <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_minmax(84px,156px)] items-center gap-x-[14px] md:grid-cols-[minmax(0,1fr)_minmax(74px,132px)] md:gap-x-[11px]">
-        {route ? (
+        {typeLabel ? (
           <span
-            className="notranslate inline-flex min-w-0 items-center gap-1.5 overflow-hidden font-mono text-[11px] tracking-[0.04em] text-atc-dim md:gap-[5px] md:text-[9px]"
+            className="notranslate flex-none whitespace-nowrap font-mono text-[12.5px] tracking-[0.04em] text-atc-dim md:text-[11px]"
             translate="no"
-            title={routeAccuracyNotice || route}
+            title={typeLabel}
           >
-            <AirlineLogo
-              src={airlineIconUrl}
-              className="h-4 w-[26px] flex-none rounded-[2px] bg-[var(--aviation-logo-plate)] object-contain px-[2px] py-[1px] md:h-[13px] md:w-[21px]"
-            />
-            <span className="min-w-0 truncate">{route}</span>
+            {typeLabel}
           </span>
-        ) : (
-          <span className="min-w-0 truncate font-mono text-[11px] italic tracking-[0.02em] text-atc-faint md:text-[9px]">
-            {t("aircraft.noRoute")}
-          </span>
-        )}
-        <span className="notranslate flex min-w-0 items-center justify-end gap-1.5 text-right font-mono text-[10px] font-semibold uppercase tracking-normal text-atc-faint md:text-[8px]" translate="no">
-          {typeDisplay.secondary ? (
-            <span className="min-w-0 truncate" title={typeDisplay.secondary}>
-              {typeDisplay.secondary}
-            </span>
-          ) : null}
-          {typeDisplay.category ? (
-            <span
-              className="flex-none rounded-[3px] border border-atc-line px-1 py-[1px] text-[9px] leading-none text-atc-dim md:text-[7px]"
-              title={typeDisplay.category}
-            >
-              {typeDisplay.category}
-            </span>
-          ) : null}
-        </span>
+        ) : null}
       </div>
+      <AircraftPreviewRouteLine aircraft={aircraft} />
     </div>
   );
 }

--- a/src/components/aircraft/preview/AircraftPreviewMediaCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMediaCard.tsx
@@ -1,3 +1,5 @@
+import { useI18n } from "@/features/app-shell/i18n/useI18n";
+
 const CARD_WIDTH_PX = 280;
 const PHOTO_VISIBLE_HEIGHT_RATIO = 0.9;
 const DEFAULT_PHOTO_ASPECT_HEIGHT_RATIO = 2 / 3;
@@ -14,6 +16,8 @@ function resolveVisiblePhotoHeight(photo) {
 }
 
 export default function AircraftPreviewMediaCard({ photo }) {
+  const { t } = useI18n();
+  const credit = photo?.photographer || photo?.source || "";
   const style = {
     "--aircraft-preview-media-height": `${resolveVisiblePhotoHeight(photo)}px`,
   };
@@ -21,7 +25,6 @@ export default function AircraftPreviewMediaCard({ photo }) {
   return (
     <div
       className="aircraft-preview-media-card aircraft-preview-media-card--photo"
-      aria-hidden="true"
       style={style}
     >
       <div className="aircraft-preview-media-card__photo">
@@ -34,9 +37,16 @@ export default function AircraftPreviewMediaCard({ photo }) {
           draggable="false"
         />
       </div>
-      <span className="aircraft-preview-photo__credit">
-        {photo.photographer || photo.source}
+      <span className="aircraft-preview-tracking-pill" aria-hidden="true">
+        <span className="aircraft-preview-tracking-pill__dot" />
+        {t("preview.trackingPill")}
       </span>
+      {credit ? (
+        <span className="aircraft-preview-photo__credit">
+          {t("preview.photoCreditPrefix")}
+          {credit}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/components/aircraft/preview/AircraftPreviewMetadata.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMetadata.tsx
@@ -2,7 +2,6 @@ import type { ComponentProps, ReactNode } from "react";
 import NumberFlow from "@number-flow/react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
-import { getAircraftPositionSourceBadge } from "@/features/aviation/sourceDisplayModel";
 import { toFiniteNumber } from "@/utils/math";
 import { convertDistanceFromNm, distanceUnitLabel } from "@/utils/units";
 
@@ -42,12 +41,10 @@ export default function AircraftPreviewMetadata({ aircraft }: AircraftPreviewMet
   const distance = toFiniteNumber(aircraft?.distanceNm);
   const distanceConverted =
     distance == null ? null : convertDistanceFromNm(distance, units.distance);
-  const sourceBadge = getAircraftPositionSourceBadge(aircraft?.positionQuality);
 
   return (
     <dl className="aircraft-preview-metadata">
       <TextMeta label={t("metrics.hex")} value={hex} />
-      {sourceBadge ? <TextMeta label="Source" value={sourceBadge} /> : null}
       <NumericMeta
         label={t("metrics.track")}
         value={track != null ? Math.round(track) : null}

--- a/src/components/aircraft/preview/AircraftPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMetadataCard.tsx
@@ -1,24 +1,21 @@
 import { Link, useLocation } from "react-router-dom";
+import { Camera, Hand } from "lucide-react";
 import AircraftPreviewIdentity from "./AircraftPreviewIdentity";
 import AircraftPreviewMetadata from "./AircraftPreviewMetadata";
 import AircraftPreviewTelemetry from "./AircraftPreviewTelemetry";
-import RouteFeedbackForm from "./RouteFeedbackForm";
 import { AsyncStatusLineDisplay } from "@/components/ui/AsyncStatusLine";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 
 export default function AircraftPreviewMetadataCard({
   aircraft,
-  photo,
-  airportProfile = null,
-  onApplyTemporaryRoute,
   onOpenPlaneHunter,
+  onSuggestCorrection,
   traceStatusVisible = false,
   traceStatusState = null,
   traceStatusLabels = null,
 }) {
   const { t } = useI18n();
   const { pathname } = useLocation();
-  const credit = photo?.photographer || null;
   const trackCallsign = (aircraft?.callsign || "").trim().toUpperCase();
   const alreadyTracking =
     Boolean(trackCallsign) && pathname === `/aircraft/${trackCallsign}`;
@@ -26,11 +23,6 @@ export default function AircraftPreviewMetadataCard({
 
   return (
     <div className="aircraft-preview-metadata-card">
-      {credit && (
-        <span className="aircraft-preview-metadata-card__credit">
-          {t("preview.creditPrefix")}{credit}
-        </span>
-      )}
       <AircraftPreviewIdentity aircraft={aircraft} />
       <AircraftPreviewTelemetry aircraft={aircraft} />
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
@@ -53,37 +45,49 @@ export default function AircraftPreviewMetadataCard({
           ) : null}
         </div>
       )}
-      {typeof onOpenPlaneHunter === "function" && (
-        <button
-          type="button"
-          className="aircraft-preview-card__track-btn plane-hunter-rainbow-btn"
-          onClick={onOpenPlaneHunter}
-        >
-          {t("preview.planeHunter")}
-        </button>
-      )}
-      {trackHref && !alreadyTracking ? (
-        <Link
-          to={trackHref}
-          className="aircraft-preview-card__track-btn"
-          aria-label={`${t("preview.trackTrace")} ${trackCallsign}`}
-        >
-          {t("preview.trackTrace")}
-        </Link>
-      ) : trackHref ? (
-        <button
-          type="button"
-          className="aircraft-preview-card__track-btn"
-          disabled
-        >
-          {alreadyTracking ? t("preview.trackingTrace") : t("preview.trackTrace")}
-        </button>
+      {trackHref ? (
+        <div className="aircraft-preview-card__actions">
+          {!alreadyTracking ? (
+            <Link
+              to={trackHref}
+              className="aircraft-preview-card__track-btn"
+              aria-label={`${t("preview.track")} ${trackCallsign}`}
+            >
+              {t("preview.track")}
+            </Link>
+          ) : (
+            <button
+              type="button"
+              className="aircraft-preview-card__track-btn"
+              disabled
+            >
+              {t("preview.tracking")}
+            </button>
+          )}
+          {typeof onOpenPlaneHunter === "function" && (
+            <button
+              type="button"
+              className="aircraft-preview-card__icon-btn"
+              onClick={onOpenPlaneHunter}
+              aria-label={t("preview.planeHunter")}
+              title={t("preview.planeHunter")}
+            >
+              <Camera aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+            </button>
+          )}
+          {typeof onSuggestCorrection === "function" && (
+            <button
+              type="button"
+              className="aircraft-preview-card__icon-btn"
+              onClick={onSuggestCorrection}
+              aria-label={t("routeFeedback.suggestCorrection")}
+              title={t("routeFeedback.suggestCorrection")}
+            >
+              <Hand aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+            </button>
+          )}
+        </div>
       ) : null}
-      <RouteFeedbackForm
-        aircraft={aircraft}
-        airportProfile={airportProfile}
-        onApplyTemporaryRoute={onApplyTemporaryRoute}
-      />
     </div>
   );
 }

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -53,6 +53,7 @@ type StatProps = {
   plain?: string;
   prefix?: string;
   format?: NumberFlowFormat;
+  accent?: boolean;
 };
 
 // Same self-hiding-on-error pattern as the list row's logo. Keeps the
@@ -138,6 +139,7 @@ export default function AircraftPreviewMobileCard({
         value={Math.round(vs)}
         unit="fpm"
         format={{ signDisplay: "exceptZero" }}
+        accent
       />,
     );
   }
@@ -233,7 +235,7 @@ function TraceStatusDot({
   );
 }
 
-function Stat({ value = 0, unit, plain, prefix, format }: StatProps) {
+function Stat({ value = 0, unit, plain, prefix, format, accent = false }: StatProps) {
   return (
     <>
       {plain != null ? (
@@ -248,14 +250,22 @@ function Stat({ value = 0, unit, plain, prefix, format }: StatProps) {
           <NumberFlow
             value={value}
             format={format}
-            className="tabular-nums"
+            className={cn(
+              "tabular-nums",
+              accent && "text-[var(--atc-signal-accent)]",
+            )}
           />
         </>
       )}
       {unit && (
         <span
           translate="no"
-          className="notranslate text-[8px] font-medium lowercase text-atc-faint"
+          className={cn(
+            "notranslate text-[8px] font-medium lowercase",
+            accent
+              ? "text-[color-mix(in_oklab,var(--atc-signal-accent)_68%,transparent)]"
+              : "text-atc-faint",
+          )}
         >
           {unit}
         </span>

--- a/src/components/aircraft/preview/AircraftPreviewRouteLine.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewRouteLine.tsx
@@ -1,0 +1,47 @@
+import { Plane } from "lucide-react";
+import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import {
+  getFlightRouteAccuracyNotice,
+  getFlightRouteEndpoints,
+} from "@/utils/flightRouteDisplay";
+
+// Visual route line: ORIGIN ——✈—— DESTINATION. A hairline on each side of the
+// accent plane glyph (the one place the accent appears in the route block).
+// Falls back to a quiet "no route" so the header height stays stable.
+export default function AircraftPreviewRouteLine({ aircraft }) {
+  const { t } = useI18n();
+  const route = aircraft?.flightRoute;
+  const { origin, destination } = getFlightRouteEndpoints(route);
+  const accuracyNotice = getFlightRouteAccuracyNotice(route)
+    ? t("aircraft.adsbdbRouteAccuracyNotice")
+    : "";
+
+  if (!origin || !destination) {
+    return (
+      <span className="font-mono text-[11px] italic tracking-[0.02em] text-atc-faint md:text-[10px]">
+        {t("aircraft.noRoute")}
+      </span>
+    );
+  }
+
+  return (
+    <div
+      className="flex min-w-0 items-center gap-2.5 font-mono text-[13px] tracking-[0.06em] text-atc-dim md:gap-2 md:text-[12px]"
+      title={accuracyNotice || `${origin} → ${destination}`}
+    >
+      <span className="notranslate flex-none" translate="no">
+        {origin}
+      </span>
+      <span aria-hidden="true" className="h-px min-w-[14px] flex-1 bg-atc-line" />
+      <Plane
+        aria-hidden="true"
+        strokeWidth={1.6}
+        className="size-[15px] flex-none rotate-45 fill-current text-[var(--atc-signal-accent)] md:size-[14px]"
+      />
+      <span aria-hidden="true" className="h-px min-w-[14px] flex-1 bg-atc-line" />
+      <span className="notranslate flex-none" translate="no">
+        {destination}
+      </span>
+    </div>
+  );
+}

--- a/src/components/aircraft/preview/MobilePreviewCard.tsx
+++ b/src/components/aircraft/preview/MobilePreviewCard.tsx
@@ -15,6 +15,16 @@ import { cn } from "@/lib/utils";
 // the empty edges of the card; the Track button / suggest link
 // re-enable interaction inside `MobilePreviewActions`.
 
+// Whether the sheet is expanded — read by the variant content to reveal the
+// full detail. Provided by MobilePreviewCard.
+const MobilePreviewExpandedContext = React.createContext(false);
+export function useMobilePreviewExpanded() {
+  return React.useContext(MobilePreviewExpandedContext);
+}
+
+// Drag distance (px) past which the grabber flips collapsed <-> expanded.
+const SHEET_DRAG_THRESHOLD = 26;
+
 export default function MobilePreviewCard({
   ariaLabel,
   children,
@@ -22,15 +32,71 @@ export default function MobilePreviewCard({
   compact = false,
   placement = "top",
   style,
+  expandable = false,
+  grabberLabel,
+  expandedContent = null,
 }: Record<string, any>) {
   // NOTE: the enter animation replays on entity change via a `key` on the
   // *call site* (<MobilePreviewCard key=...>), not a prop here — a `key`
   // on this root <aside> would be a no-op (React reads key at the call site).
+  const [expanded, setExpanded] = React.useState(false);
+  const dragRef = React.useRef<{ y: number } | null>(null);
+  // Portrait = top sheet, drags DOWN to expand. Landscape = bottom sheet,
+  // drags UP to expand. expandDir is the sign of "open".
+  const isTop = placement !== "bottomRight";
+  const expandDir = isTop ? 1 : -1;
+
+  const onGrabberPointerDown = (event: React.PointerEvent) => {
+    dragRef.current = { y: event.clientY };
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+  const onGrabberPointerMove = (event: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const delta = (event.clientY - drag.y) * expandDir;
+    if (delta > SHEET_DRAG_THRESHOLD) setExpanded(true);
+    else if (delta < -SHEET_DRAG_THRESHOLD) setExpanded(false);
+  };
+  const onGrabberPointerUp = (event: React.PointerEvent) => {
+    dragRef.current = null;
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+  };
+
+  const grabber = expandable ? (
+    <button
+      type="button"
+      className="mobile-preview-grabber pointer-events-auto"
+      data-edge={isTop ? "bottom" : "top"}
+      aria-label={grabberLabel}
+      aria-expanded={expanded}
+      onClick={() => setExpanded((value) => !value)}
+      onPointerDown={onGrabberPointerDown}
+      onPointerMove={onGrabberPointerMove}
+      onPointerUp={onGrabberPointerUp}
+      onPointerCancel={onGrabberPointerUp}
+    >
+      <span aria-hidden="true" className="mobile-preview-grabber__bar" />
+    </button>
+  ) : null;
+
+  const reveal =
+    expandable && expandedContent ? (
+      <div
+        className={cn(
+          "pointer-events-auto grid transition-[grid-template-rows,opacity] duration-[var(--motion-ui-slow)] ease-[var(--motion-ease-out)] motion-reduce:transition-none",
+          expanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="min-h-0 overflow-hidden">{expandedContent}</div>
+      </div>
+    ) : null;
+
   return (
     <aside
       aria-label={ariaLabel}
       data-density={compact ? "compact" : undefined}
       data-placement={placement === "bottomRight" ? "bottom-right" : "top"}
+      data-expanded={expanded ? "true" : undefined}
       data-ui="mobile-preview-card"
       style={style}
       className={cn(
@@ -64,8 +130,17 @@ export default function MobilePreviewCard({
         compact && placement === "bottomRight" && "gap-0 pb-[9px]",
       )}
     >
-      {children}
-      {actions}
+      <MobilePreviewExpandedContext.Provider value={expanded}>
+        {/* Landscape bottom-sheet: grabber rides the top edge (drag up). */}
+        {!isTop ? grabber : null}
+        {children}
+        {/* Expanded detail reveals between the collapsed content and the
+            actions so the action row stays put as the sheet grows. */}
+        {reveal}
+        {actions}
+        {/* Portrait top-sheet: grabber rides the bottom edge (drag down). */}
+        {isTop ? grabber : null}
+      </MobilePreviewExpandedContext.Provider>
     </aside>
   );
 }
@@ -260,6 +335,33 @@ export const MobilePreviewFeedbackLink = React.forwardRef(
           "[-webkit-tap-highlight-color:transparent]",
           "transition-[color,opacity,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
           "hover:text-atc-text hover:opacity-90 active:text-atc-text active:scale-[0.97]",
+          "focus-visible:outline-2 focus-visible:outline-[var(--atc-action-focus-ring)] focus-visible:outline-offset-[3px]",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+// Square frosted icon button — camera (Plane Hunter) / raise-hand (suggest
+// correction) beside the Track pill. Neutral; the accent stays on Track.
+export const MobilePreviewIconButton = React.forwardRef(
+  function MobilePreviewIconButton(
+    { className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>,
+    ref: React.ForwardedRef<HTMLButtonElement>,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(
+          "pointer-events-auto flex aspect-square min-h-[34px] flex-none items-center justify-center cursor-pointer [[data-density=compact]_&]:min-h-[30px]",
+          "rounded-[calc(var(--atc-radius-card)-3px)] border border-atc-line",
+          "bg-[var(--atc-control-surface)] text-atc-dim",
+          "[-webkit-tap-highlight-color:transparent]",
+          "transition-[background-color,color,transform] duration-[var(--motion-ui-fast)] ease-[var(--motion-ease-out)]",
+          "hover:bg-[var(--atc-control-surface-hover)] hover:text-atc-text active:scale-[0.96]",
           "focus-visible:outline-2 focus-visible:outline-[var(--atc-action-focus-ring)] focus-visible:outline-offset-[3px]",
           className,
         )}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -41,32 +41,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 95;
+export const CHANGELOG_TOTAL_COUNT = 96;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.28.4",
+    version: "v2.28.5",
     kind: "patch",
     title: {
-      en: "Mechanism redesign + Changelog type scale",
-      zh: "机制页重设计 + 更新日志字号统一",
+      en: "Aircraft preview card — clearer selection state",
+      zh: "飞机预览卡片——更清晰的选中态",
     },
     summary: {
-      en: "The Mechanism page adopts the Explorer/About design system, and the Changelog aligns to the same type scale. Both join the first-screen family with serif group labels and the accent title tick.",
-      zh: "机制页沿用机场探索 / 关于页的设计语言，更新日志对齐同一套字号。两页都归入首屏家族，配衬线分组标签与强调标题短线。",
+      en: "Tapping an aircraft now opens a refreshed frosted preview card on desktop and a drag-to-expand sheet on mobile, with one signal accent and no rainbow button.",
+      zh: "点选飞机后，桌面端打开焕新的磨砂预览卡片，移动端为可下拉展开的卡片；统一单一信号强调色，去掉彩虹按钮。",
     },
     highlights: [
       {
-        en: "Mechanism rows become numbered accordion entries (mono index, title + signal, chevron); the expanded row gets a faint neutral panel with the data flow drawn as a vertical node pipeline — only the final produced payload is the orange node",
-        zh: "机制行改为带编号的折叠条目（等宽序号、标题 + 信号、折叠箭头）；展开行为淡色面板，数据流以竖向节点管线呈现——仅最终产出的 payload 为橙色节点",
+        en: "Desktop card: a photo header with a 'tracking' pill, callsign + TYPE / CATEGORY (no registration), an ORIGIN ——✈—— DEST route line, accent vertical-speed, HEX / Track / Distance, and a Track button beside camera + suggest-correction icon buttons",
+        zh: "桌面卡片：带「追踪」徽标的照片头、呼号 + 机型 / 类别（不再显示注册号）、ORIGIN ——✈—— DEST 航路线、强调色垂直速度、HEX / 航向 / 距离，以及 Track 按钮搭配相机 + 建议纠正图标按钮",
       },
       {
-        en: "Mechanism group labels switch to the upright serif with an accent tick, and the title gains the accent underline tick + a quiet subtitle (kicker/count dropped)",
-        zh: "机制分组标签改用直立衬线并配强调短线，标题加上强调下划线短线与一行安静副标题（去掉旧的标签 / 计数头）",
+        en: "Mobile: a top-anchored drag-to-expand sheet (drag the grabber down) — collapsed shows callsign / type / telemetry / actions; expanded reveals the photo and identity rows. Landscape anchors to the bottom and expands up",
+        zh: "移动端：顶部吸附、可下拉展开的卡片（向下拖动把手）——收起时显示呼号 / 机型 / 参数 / 操作，展开后显示照片与身份信息；横屏改为底部吸附、向上展开",
       },
       {
-        en: "Changelog aligns to the shared type scale — 15px entry titles, 11.5px summaries, mono version, and FEAT/PATCH/BREAKING as the shared mono chip — with the accent title tick; structure unchanged",
-        zh: "更新日志对齐共享字号——15px 条目标题、11.5px 摘要、等宽版本号，FEAT/PATCH/BREAKING 采用共享的等宽芯片——并加上强调标题短线；结构不变",
+        en: "The list-row selection (orange wash + accent rail + accent glyph) and the single signal accent are reused throughout; the multicolour Plane Hunter button is gone",
+        zh: "沿用列表行选中态（橙色底色 + 强调导轨 + 强调图标）与单一信号强调色；移除多彩的拍机按钮",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -277,6 +277,32 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.28.4",
+    kind: "patch",
+    title: {
+      en: "Mechanism redesign + Changelog type scale",
+      zh: "机制页重设计 + 更新日志字号统一",
+    },
+    summary: {
+      en: "The Mechanism page adopts the Explorer/About design system, and the Changelog aligns to the same type scale. Both join the first-screen family with serif group labels and the accent title tick.",
+      zh: "机制页沿用机场探索 / 关于页的设计语言，更新日志对齐同一套字号。两页都归入首屏家族，配衬线分组标签与强调标题短线。",
+    },
+    highlights: [
+      {
+        en: "Mechanism rows become numbered accordion entries (mono index, title + signal, chevron); the expanded row gets a faint neutral panel with the data flow drawn as a vertical node pipeline — only the final produced payload is the orange node",
+        zh: "机制行改为带编号的折叠条目（等宽序号、标题 + 信号、折叠箭头）；展开行为淡色面板，数据流以竖向节点管线呈现——仅最终产出的 payload 为橙色节点",
+      },
+      {
+        en: "Mechanism group labels switch to the upright serif with an accent tick, and the title gains the accent underline tick + a quiet subtitle (kicker/count dropped)",
+        zh: "机制分组标签改用直立衬线并配强调短线，标题加上强调下划线短线与一行安静副标题（去掉旧的标签 / 计数头）",
+      },
+      {
+        en: "Changelog aligns to the shared type scale — 15px entry titles, 11.5px summaries, mono version, and FEAT/PATCH/BREAKING as the shared mono chip — with the accent title tick; structure unchanged",
+        zh: "更新日志对齐共享字号——15px 条目标题、11.5px 摘要、等宽版本号，FEAT/PATCH/BREAKING 采用共享的等宽芯片——并加上强调标题短线；结构不变",
+      },
+    ],
+  },
+  {
     version: "v2.28.3",
     kind: "patch",
     title: {

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -345,6 +345,9 @@ const en = {
     airspaceSource: "Source",
     trackTrace: "Track trace",
     trackingTrace: "Tracking trace",
+    track: "Track",
+    tracking: "Tracking",
+    trackingPill: "tracking",
     loadingTrace: "Loading trace...",
     loadedTrace: "Trace loaded",
     traceLoadError: "Trace unavailable",
@@ -353,6 +356,7 @@ const en = {
     goToSpot: "Go",
     planeHunter: "Plane Hunter",
     creditPrefix: "credit@",
+    photoCreditPrefix: "photo @ ",
   },
   planeHunter: {
     title: "Plane Hunter",

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -339,6 +339,9 @@ const zhCN = {
     airportPlace: "位置",
     trackTrace: "追踪航迹",
     trackingTrace: "正在追踪航迹",
+    track: "追踪",
+    tracking: "追踪中",
+    trackingPill: "追踪中",
     loadingTrace: "正在加载航迹…",
     loadedTrace: "航迹已加载",
     traceLoadError: "航迹不可用",
@@ -347,6 +350,7 @@ const zhCN = {
     goToSpot: "前往",
     planeHunter: "开始拍机",
     creditPrefix: "图源@",
+    photoCreditPrefix: "照片 @ ",
   },
   planeHunter: {
     title: "拍机工作室",

--- a/src/style.css
+++ b/src/style.css
@@ -6531,6 +6531,20 @@ body {
     justify-content: flex-end;
 }
 
+/* Vertical speed is the one accent in the telemetry row — the value reads
+   orange so climb/descent is the live signal; speed and altitude stay ink. */
+.aircraft-preview-telemetry
+    .aircraft-preview-stat:last-child
+    .aircraft-preview-stat__number {
+    color: var(--atc-signal-accent);
+}
+
+.aircraft-preview-telemetry
+    .aircraft-preview-stat:last-child
+    .aircraft-preview-stat__unit {
+    color: color-mix(in oklab, var(--atc-signal-accent) 68%, transparent);
+}
+
 .aircraft-preview-stat__label {
     font-family: var(--font-mono);
     font-size: 9px;
@@ -6793,6 +6807,87 @@ body {
 .aircraft-preview-card__track-btn:disabled {
     cursor: not-allowed;
     opacity: 0.4;
+}
+
+/* Action row: primary Track (flex-fills) + square frosted icon buttons
+   (camera = Plane Hunter, raise-hand = suggest route correction). The icons
+   are neutral — the accent stays on the Track button only. */
+.aircraft-preview-card__actions {
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+    margin-top: 14px;
+    pointer-events: auto;
+}
+
+.aircraft-preview-card__actions .aircraft-preview-card__track-btn {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-top: 0;
+}
+
+.aircraft-preview-card__icon-btn {
+    flex: 0 0 auto;
+    display: grid;
+    place-items: center;
+    width: 42px;
+    border-radius: 13px;
+    border: 1px solid var(--app-frost-border);
+    background: var(--atc-control-surface);
+    box-shadow: var(--atc-control-inset-shadow);
+    color: var(--atc-dim);
+    cursor: pointer;
+    pointer-events: auto;
+    transition:
+        background-color 0.15s ease,
+        color 0.15s ease,
+        border-color 0.15s ease,
+        transform 0.15s ease;
+}
+
+.aircraft-preview-card__icon-btn:hover {
+    background: var(--atc-control-surface-hover);
+    color: var(--atc-text);
+}
+
+.aircraft-preview-card__icon-btn:active {
+    transform: scale(0.96);
+}
+
+.aircraft-preview-card__icon-btn:focus-visible {
+    outline: 2px solid var(--atc-signal-accent);
+    outline-offset: 2px;
+}
+
+/* Photo-header "tracking" pill — accent dot + label, top-left of the media.
+   The accent dot is the only orange here; the pill itself is a frosted chip. */
+.aircraft-preview-tracking-pill {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px 4px 9px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--atc-bg) 68%, transparent);
+    -webkit-backdrop-filter: var(--app-frost);
+    backdrop-filter: var(--app-frost);
+    box-shadow: inset 0 0 0 0.5px color-mix(in oklab, var(--atc-text) 14%, transparent);
+    color: var(--atc-dim);
+    font-family: var(--font-sans);
+    font-size: 11px;
+    font-weight: var(--weight-regular);
+    line-height: 1;
+}
+
+.aircraft-preview-tracking-pill__dot {
+    width: 6px;
+    height: 6px;
+    flex: none;
+    border-radius: 999px;
+    background: var(--atc-signal-accent);
 }
 
 .plane-hunter-rainbow-btn {

--- a/src/style.css
+++ b/src/style.css
@@ -6890,61 +6890,45 @@ body {
     background: var(--atc-signal-accent);
 }
 
-.plane-hunter-rainbow-btn {
-    --plane-hunter-surface: oklch(17% 0.018 260);
-    --plane-hunter-surface-strong: oklch(10% 0.014 260);
-    --plane-hunter-ink: oklch(98% 0.006 95);
-    position: relative;
-    isolation: isolate;
-    border: 1px solid transparent !important;
-    background:
-        linear-gradient(
-                180deg,
-                color-mix(in oklab, var(--plane-hunter-surface) 84%, white 16%),
-                var(--plane-hunter-surface-strong)
-            )
-            padding-box,
-        linear-gradient(
-                95deg,
-                oklch(74% 0.19 28),
-                oklch(78% 0.18 78),
-                oklch(82% 0.18 142),
-                oklch(76% 0.18 214),
-                oklch(72% 0.2 286),
-                oklch(74% 0.19 28)
-            )
-            border-box !important;
-    background-size: 100% 100%, 220% 100% !important;
-    box-shadow:
-        0 0 0 1px color-mix(in oklab, var(--atc-text) 8%, transparent),
-        0 10px 24px color-mix(in oklab, oklch(76% 0.18 286) 20%, transparent),
-        inset 0 1px 0 color-mix(in oklab, white 22%, transparent),
-        inset 0 -10px 20px color-mix(in oklab, black 30%, transparent) !important;
-    color: var(--plane-hunter-ink) !important;
-    text-shadow: 0 1px 10px color-mix(in oklab, white 24%, transparent);
-    animation: plane-hunter-rainbow-pan 4.8s linear infinite;
-    filter: saturate(1.08);
+/* Mobile sheet grabber — rides the open edge (bottom in portrait top-sheets,
+   top in landscape bottom-sheets). Drag past the threshold or tap to toggle. */
+.mobile-preview-grabber {
+    align-self: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 72px;
+    height: 18px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: grab;
+    touch-action: none;
 }
 
-.plane-hunter-rainbow-btn:hover {
-    box-shadow:
-        0 0 0 1px color-mix(in oklab, var(--atc-text) 12%, transparent),
-        0 12px 30px color-mix(in oklab, oklch(78% 0.18 214) 28%, transparent),
-        inset 0 1px 0 color-mix(in oklab, white 22%, transparent) !important;
-    filter: brightness(1.05) saturate(1.18);
+.mobile-preview-grabber[data-edge="bottom"] {
+    margin-top: 1px;
 }
 
-.plane-hunter-rainbow-btn:focus-visible {
-    outline: 2px solid oklch(82% 0.18 142);
+.mobile-preview-grabber[data-edge="top"] {
+    margin-bottom: 2px;
 }
 
-@keyframes plane-hunter-rainbow-pan {
-    0% {
-        background-position: 0 0, 0% 50%;
-    }
-    100% {
-        background-position: 0 0, 220% 50%;
-    }
+.mobile-preview-grabber:active {
+    cursor: grabbing;
+}
+
+.mobile-preview-grabber__bar {
+    width: 36px;
+    height: 4px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--atc-text) 22%, transparent);
+    transition: background-color 0.15s ease;
+}
+
+.mobile-preview-grabber:hover .mobile-preview-grabber__bar,
+[data-expanded="true"] .mobile-preview-grabber__bar {
+    background: color-mix(in oklab, var(--atc-text) 34%, transparent);
 }
 
 .aircraft-preview-card__trace-status {
@@ -7640,8 +7624,7 @@ body {
     .aircraft-preview-card--desktop-reveal > *,
     .aircraft-preview-card--desktop-reveal .aircraft-preview-metadata-card,
     .aircraft-preview-card__media-slot,
-    .aircraft-preview-card__trace-status,
-    .plane-hunter-rainbow-btn {
+    .aircraft-preview-card__trace-status {
         transition: none;
         animation: none;
         clip-path: none;

--- a/src/utils/flightRouteDisplay.ts
+++ b/src/utils/flightRouteDisplay.ts
@@ -41,6 +41,17 @@ export const formatFlightRouteMunicipalityLabel = (route) => {
   return `${origin} -> ${destination}${routeAccuracySuffix(route)}`
 }
 
+// Origin / destination codes for the preview-card route line. Empty strings
+// when the route is incomplete or a same-airport (circular) route.
+export const getFlightRouteEndpoints = (route) => {
+  const origin = airportCode(route?.origin)
+  const destination = airportCode(route?.destination)
+  if (!origin || !destination || sameAirport(route?.origin, route?.destination)) {
+    return { origin: '', destination: '' }
+  }
+  return { origin, destination }
+}
+
 export const getFlightRouteAccuracyNotice = (route) =>
   normalizedRouteSource(route) === 'adsbdb'
     ? "This route may be inaccurate: adsbdb uses callsign reference data that may not match today's actual origin and destination."


### PR DESCRIPTION
PR 1 of 2 for the "tap an aircraft" state. Implements the **selected list row**, the **desktop preview card**, and the **mobile drag-to-expand sheet** (portrait + landscape). This is the dark/light frosted-glass world over the map — it reuses the frosted material + the single signal accent (no first-screen serif/chip language). No route/data/map-layer changes. PR 2 (Plane Hunter capture + studio de-dup) follows.

### A. Selected list row
Already in place ([AircraftRow.tsx](src/components/sidebar/AircraftRow.tsx)) and confirmed: orange wash + `inset 2px 0 0` accent rail + accent glyph; other rows quiet; selection differs by color only.

### B. Desktop card
- Photo header with a frosted **"tracking" pill** (accent dot) + `photo @` credit.
- Header = callsign (mono ~21px) + **`B739 / A3`** (TYPE / CATEGORY) — **registration dropped**.
- New **`AircraftPreviewRouteLine`**: `ORIGIN ——✈—— DEST`, hairline + accent plane glyph.
- Telemetry Speed / Altitude / **Vertical (accent)** between hairlines.
- Identity rows **HEX / Track / Distance** (dropped Source).
- Actions = solid **Track** + **camera** (Plane Hunter, device-gated) + **raise-hand** (suggest route correction → feedback modal). Removed the rainbow Plane Hunter button + the inline feedback form.

### C/D. Mobile sheet
- `MobilePreviewCard` is now a **drag-to-expand sheet**: portrait top-anchored with the **grabber at the bottom** (drag down / tap to expand); landscape bottom-anchored with the grabber at the top (expands up).
- Collapsed = callsign / type / route + telemetry line (accent V/S) + actions (Track + camera + raise-hand). Expanded reveals the **photo + HEX / Track / Distance**.
- Replaced the multicolour "rainbow" Plane Hunter button (CSS deleted) with the neutral camera icon button.

### Constraints
Light/regular weight only; one signal accent (tracking pill dot, route glyph, V/S, Track); frosted panels via the existing tokens; both themes via the click-pair only (no `--atc-glass-*` fork). No new color tokens — `--atc-signal-accent` already matches #c2641f / #ff9a45.

### Verification
- **Desktop card**: verified live on `/airport/KBOS` (SWA1053) in **light + dark** — screenshots in the session.
- **Mobile sheet (portrait)**: verified live at 375px in **light + dark** — collapsed + drag-to-expand both confirmed.
- `pnpm build` clean; `pnpm test` 122 files pass.

### Known follow-ups (small)
- **Collapsed thumbnail** (livery thumb left of the callsign) — not yet added; the Plane glyph stands in.
- **Landscape (D)** direction logic is implemented but only device-verifiable (the desktop-mobile-landscape layout is hard to drive in the emulator).
- The **camera/Plane Hunter** action is correctly device-gated, so it appears on real touch devices but not the desktop card / emulated viewport.

`Validation: local browser — /airport/KBOS desktop card + mobile sheet, light + dark; pnpm build + pnpm test (122 pass). Build runs in CI / Railway.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)