### PR TITLE
v2.28.6: Mobile preview card — compact collapsed row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.28.5",
+  "version": "2.28.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -3,7 +3,6 @@ import type { CSSProperties } from "react";
 import { Camera, Hand } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import AircraftPreviewMediaCard from "./AircraftPreviewMediaCard";
-import AircraftPreviewMetadata from "./AircraftPreviewMetadata";
 import AircraftPreviewMetadataCard from "./AircraftPreviewMetadataCard";
 import AircraftPreviewMobileCard from "./AircraftPreviewMobileCard";
 import AirportPreviewMetadataCard from "./AirportPreviewMetadataCard";
@@ -258,24 +257,44 @@ export default function AircraftPreviewCard({
     !isReportingPoint &&
     !isAirspace &&
     !isCandidateWatchingSpot;
-  // Revealed on expand: the photo + the HEX / Track / Distance identity rows
-  // (the same content the desktop card shows inline).
+  // Revealed on expand: the photo (kept modest) plus the secondary actions —
+  // camera (Plane Hunter) and raise-hand (suggest correction). The dense
+  // HEX / Track / Distance rows are intentionally left off the mobile sheet.
   const mobileExpandedContent =
     mobileCompact && isAircraftPreview ? (
-      <div className="pt-1">
+      <div className="flex flex-col gap-2.5 px-[12px] pb-1 pt-2 [[data-density=compact]_&]:px-[10px]">
         {hasPhoto ? (
-          <div className="px-[12px] [[data-density=compact]_&]:px-[10px]">
-            <img
-              src={photo.src}
-              alt=""
-              draggable="false"
-              className="block max-h-[150px] w-full rounded-[12px] object-cover"
-            />
+          <img
+            src={photo.src}
+            alt=""
+            draggable="false"
+            className="block max-h-[160px] w-full rounded-[12px] object-cover"
+          />
+        ) : null}
+        {showMobilePlaneHunterTrigger || showMobileFeedbackTrigger ? (
+          <div className="flex items-center gap-1.5">
+            {showMobilePlaneHunterTrigger ? (
+              <MobilePreviewIconButton
+                className="w-auto px-4"
+                onClick={() => setPlaneHunterOpen(true)}
+                aria-label={t("preview.planeHunter")}
+                title={t("preview.planeHunter")}
+              >
+                <Camera aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+              </MobilePreviewIconButton>
+            ) : null}
+            {showMobileFeedbackTrigger ? (
+              <MobilePreviewIconButton
+                className="w-auto px-4"
+                onClick={() => setFeedbackModalOpen(true)}
+                aria-label={mobileFeedbackLabel}
+                title={mobileFeedbackLabel}
+              >
+                <Hand aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+              </MobilePreviewIconButton>
+            ) : null}
           </div>
         ) : null}
-        <div className="px-[12px] pb-1 pt-2 [[data-density=compact]_&]:px-[10px]">
-          <AircraftPreviewMetadata aircraft={aircraft} />
-        </div>
       </div>
     ) : null;
 
@@ -355,10 +374,11 @@ export default function AircraftPreviewCard({
           }
           style={mobilePreviewSafeAreaStyle}
           actions={
-            (showMobileTrackButton ||
-              showMobilePlaneHunterTrigger ||
-              showMobileFeedbackTrigger ||
-              showMobileSpotNavigationTrigger) ? (
+            // Aircraft: Track lives inline in the collapsed card and the
+            // camera / suggest icons live in the expanded reveal, so the
+            // shared actions row is only for the other (non-compact) previews.
+            !mobileCompact &&
+            (showMobileTrackButton || showMobileSpotNavigationTrigger) ? (
               <MobilePreviewActions>
                 <div className="flex items-stretch gap-1.5">
                   {showMobileTrackButton && (
@@ -377,24 +397,6 @@ export default function AircraftPreviewCard({
                     >
                       {t("preview.goToSpot")}
                     </MobilePreviewTrackButton>
-                  )}
-                  {showMobilePlaneHunterTrigger && (
-                    <MobilePreviewIconButton
-                      onClick={() => setPlaneHunterOpen(true)}
-                      aria-label={t("preview.planeHunter")}
-                      title={t("preview.planeHunter")}
-                    >
-                      <Camera aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
-                    </MobilePreviewIconButton>
-                  )}
-                  {showMobileFeedbackTrigger && (
-                    <MobilePreviewIconButton
-                      onClick={() => setFeedbackModalOpen(true)}
-                      aria-label={mobileFeedbackLabel}
-                      title={mobileFeedbackLabel}
-                    >
-                      <Hand aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
-                    </MobilePreviewIconButton>
                   )}
                 </div>
               </MobilePreviewActions>
@@ -424,7 +426,11 @@ export default function AircraftPreviewCard({
           ) : (
             <AircraftPreviewMobileCard
               aircraft={aircraft}
+              photo={photo}
               traceStatusState={traceStatusVisible ? traceAsyncState : null}
+              trackLabel={mobileTrackLabel}
+              trackDisabled={alreadyTracking}
+              onTrack={showMobileTrackButton ? handleMobileTap : undefined}
             />
           )}
         </MobilePreviewCard>

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -1,197 +1,174 @@
-import { useState } from "react";
-import type { ComponentProps, ReactElement } from "react";
-import NumberFlow from "@number-flow/react";
-import { Plane } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toFiniteNumber } from "@/utils/math";
-import {
-  getFlightRouteAccuracyNotice,
-  getFlightRouteAirlineIconUrl,
-} from "@/utils/flightRouteDisplay";
+import { getFlightRouteEndpoints } from "@/utils/flightRouteDisplay";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
-import { resolveAircraftDisplayModel } from "@/features/aircraft/aircraftTypeDisplayModel";
+import { getAircraftPreviewTypeDisplay } from "@/features/aircraft/preview/aircraftPreviewTypeModel";
 import { formatAltitude } from "@/utils/units";
-import {
-  MobilePreviewContent,
-  MobilePreviewDetailRow,
-  MobilePreviewIdentity,
-  MobilePreviewMetaChip,
-  MobilePreviewMetaChips,
-  MobilePreviewRuleRow,
-} from "./MobilePreviewCard";
+import { MobilePreviewTrackButton } from "./MobilePreviewCard";
 import type { AsyncStatusState } from "@/hooks/useAsyncStatus";
 
-type NumberFlowFormat = ComponentProps<typeof NumberFlow>["format"];
-
-type AircraftPreviewMobileCardAircraft = {
-  callsign?: string | null;
-  icao24?: string | null;
-  type?: string | null;
-  desc?: string | null;
-  category?: string | null;
-  flightRouteLabel?: string | null;
-  flightRoute?: unknown;
-  velocity?: unknown;
-  altitude?: unknown;
-  baroRate?: unknown;
-  onGround?: boolean | null;
-};
-
 type AircraftPreviewMobileCardProps = {
-  aircraft?: AircraftPreviewMobileCardAircraft | null;
+  aircraft?: Record<string, any> | null;
+  photo?: { src?: string | null } | null;
   traceStatusState?: AsyncStatusState | null;
+  trackLabel?: string;
+  trackDisabled?: boolean;
+  onTrack?: () => void;
 };
 
-type AirlineLogoProps = {
-  src?: string | null;
-};
-
-type StatProps = {
-  value?: number;
-  unit?: string;
-  plain?: string;
-  prefix?: string;
-  format?: NumberFlowFormat;
-  accent?: boolean;
-};
-
-// Same self-hiding-on-error pattern as the list row's logo. Keeps the
-// mobile card tidy when an airline isn't covered by the icon CDN.
-function AirlineLogo({ src }: AirlineLogoProps) {
-  const [hidden, setHidden] = useState(false);
-  if (!src || hidden) return null;
-  return (
-    <img
-      src={src}
-      alt=""
-      loading="lazy"
-      decoding="async"
-      onError={() => setHidden(true)}
-      className="h-3.5 w-[22px] flex-none rounded-[2px] bg-[var(--aviation-logo-plate)] object-contain px-[2px] py-[1px]"
-    />
-  );
-}
-
+// Collapsed mobile card: [thumb][callsign + type · route][Track] over a single
+// telemetry line. The photo is a small thumbnail (the full reveal lives in the
+// expanded sheet); the vertical-speed is the one accent in the telemetry line.
 export default function AircraftPreviewMobileCard({
   aircraft,
+  photo,
   traceStatusState = null,
+  trackLabel,
+  trackDisabled = false,
+  onTrack,
 }: AircraftPreviewMobileCardProps) {
   const { t } = useI18n();
   const { preferences: units } = useUnitPreferences();
   const callsign =
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
-  const typeDisplay = resolveAircraftDisplayModel(aircraft || {});
-  const secondary =
-    typeDisplay.displayName === "N/A"
-      ? null
-      : (
-          <span className="inline-flex min-w-0 max-w-full items-center justify-end gap-1.5">
-            <span className="min-w-0 truncate">{typeDisplay.displayName}</span>
-            {typeDisplay.category ? (
-              <span className="flex-none rounded-[3px] border border-atc-line px-1 py-[1px] text-[9px] font-semibold leading-none text-atc-dim">
-                {typeDisplay.category}
-              </span>
-            ) : null}
-          </span>
-        );
-  const route = aircraft?.flightRouteLabel || "";
-  const airlineIconUrl = getFlightRouteAirlineIconUrl(aircraft?.flightRoute);
-  const routeAccuracyNotice = getFlightRouteAccuracyNotice(aircraft?.flightRoute)
-    ? t("aircraft.adsbdbRouteAccuracyNotice")
-    : "";
+  const typeDisplay = getAircraftPreviewTypeDisplay(aircraft);
+  const typeLabel = [typeDisplay.primary, typeDisplay.category]
+    .filter(Boolean)
+    .join(" / ");
+  const { origin, destination } = getFlightRouteEndpoints(aircraft?.flightRoute);
 
   const speed = toFiniteNumber(aircraft?.velocity);
   const altitude = toFiniteNumber(aircraft?.altitude);
   const vs = toFiniteNumber(aircraft?.baroRate);
   const onGround = Boolean(aircraft?.onGround);
-
-  const hasStats = speed != null || altitude != null || vs != null || onGround;
-
-  const stats: ReactElement[] = [];
-  if (speed != null) {
-    stats.push(
-      <Stat key="speed" value={Math.round(speed)} unit="kt" />,
-    );
-  }
-  if (altitude != null || onGround) {
-    const altDisplay =
-      altitude == null
-        ? null
-        : formatAltitude(altitude, units.altitude, { kind: "cruise" });
-    stats.push(
-      onGround ? (
-        <Stat key="alt" plain={t("aircraft.gnd")} />
-      ) : (
-        <Stat
-          key="alt"
-          value={altDisplay?.value ?? 0}
-          unit={altDisplay?.unit ?? "ft"}
-          prefix={altDisplay?.prefix}
-        />
-      ),
-    );
-  }
-  if (vs != null) {
-    stats.push(
-      <Stat
-        key="vs"
-        value={Math.round(vs)}
-        unit="fpm"
-        format={{ signDisplay: "exceptZero" }}
-        accent
-      />,
-    );
-  }
+  const altDisplay =
+    altitude == null
+      ? null
+      : formatAltitude(altitude, units.altitude, { kind: "cruise" });
+  const vsArrow = vs == null || vs === 0 ? "" : vs > 0 ? "↑" : "↓";
 
   return (
-    <MobilePreviewContent>
-      <MobilePreviewIdentity
-        icon={Plane}
-        label={t("preview.aircraftPreview")}
-        primary={
-          <span className="inline-flex min-w-0 max-w-full items-center gap-1.5">
-            <span className="min-w-0 truncate">{callsign}</span>
-            <TraceStatusDot
-              state={traceStatusState}
-              labels={{
-                pending: t("preview.loadingTrace"),
-                success: t("preview.loadedTrace"),
-                error: t("preview.traceLoadError"),
-              }}
-            />
-          </span>
-        }
-        secondary={secondary}
-        secondaryClassName="max-w-[min(47vw,176px)] text-[13px] font-extrabold text-atc-text"
-      />
-      {(route || hasStats) ? (
-        <MobilePreviewRuleRow
-          left={
-            route ? (
+    <div className="flex flex-col gap-[7px] px-[12px] pb-[6px] pt-[10px] [[data-density=compact]_&]:px-[10px]">
+      <div className="flex items-center gap-2.5">
+        {photo?.src ? (
+          <img
+            src={photo.src}
+            alt=""
+            draggable="false"
+            className="size-[42px] flex-none rounded-[11px] object-cover"
+          />
+        ) : (
+          <span className="size-[42px] flex-none rounded-[11px] bg-[color-mix(in_oklab,var(--atc-text)_9%,transparent)]" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-baseline gap-2">
+            <span
+              className="notranslate inline-flex min-w-0 items-center gap-1.5 truncate font-mono text-[19px] leading-none text-atc-text"
+              translate="no"
+              title={callsign}
+            >
+              {callsign}
+              <TraceStatusDot
+                state={traceStatusState}
+                labels={{
+                  pending: t("preview.loadingTrace"),
+                  success: t("preview.loadedTrace"),
+                  error: t("preview.traceLoadError"),
+                }}
+              />
+            </span>
+            {typeLabel ? (
               <span
-                className="inline-flex min-w-0 max-w-full items-center gap-[6px] align-baseline"
-                title={routeAccuracyNotice || route}
+                className="notranslate flex-none whitespace-nowrap font-mono text-[12px] tracking-[0.04em] text-atc-dim"
+                translate="no"
               >
-                <AirlineLogo src={airlineIconUrl} />
-                <span className="min-w-0 truncate whitespace-nowrap">{route}</span>
+                {typeLabel}
               </span>
-            ) : null
-          }
-          right={
-            hasStats ? (
-              <MobilePreviewMetaChips>
-                {stats.map((stat, i) => (
-                  <MobilePreviewMetaChip key={stat.key || i}>
-                    {stat}
-                  </MobilePreviewMetaChip>
-                ))}
-              </MobilePreviewMetaChips>
-            ) : null
-          }
-        />
+            ) : null}
+          </div>
+          <div className="mt-[5px] font-mono text-[11.5px] tracking-[0.04em] text-atc-dim">
+            {origin && destination ? (
+              <span className="notranslate inline-flex items-center gap-1.5" translate="no">
+                {origin}
+                <span aria-hidden="true" className="text-[var(--atc-signal-accent)]">
+                  →
+                </span>
+                {destination}
+              </span>
+            ) : (
+              <span className="italic text-atc-faint">{t("aircraft.noRoute")}</span>
+            )}
+          </div>
+        </div>
+        {onTrack ? (
+          <MobilePreviewTrackButton
+            className="w-auto flex-none self-center px-5 border-[color-mix(in_oklab,var(--atc-signal-accent)_88%,black_8%)] bg-[var(--atc-signal-accent)] text-white"
+            onClick={onTrack}
+            disabled={trackDisabled}
+          >
+            {trackLabel}
+          </MobilePreviewTrackButton>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-baseline gap-x-[7px] gap-y-1 border-t border-atc-line pt-[7px] font-mono text-[13px] tabular-nums text-atc-text">
+        <Metric value={speed != null ? Math.round(speed).toLocaleString() : "—"} unit="kt" />
+        <Separator />
+        {onGround ? (
+          <span className="tabular-nums">{t("aircraft.gnd")}</span>
+        ) : (
+          <Metric
+            prefix={altDisplay?.prefix}
+            value={altDisplay ? altDisplay.value.toLocaleString() : "—"}
+            unit={altDisplay?.unit ?? "ft"}
+          />
+        )}
+        {vs != null ? (
+          <>
+            <Separator />
+            <span className="inline-flex items-baseline gap-[3px] tabular-nums text-[var(--atc-signal-accent)]">
+              {vsArrow ? <span aria-hidden="true">{vsArrow}</span> : null}
+              {Math.abs(Math.round(vs)).toLocaleString()}
+            </span>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Separator() {
+  return (
+    <span aria-hidden="true" className="text-atc-faint">
+      ·
+    </span>
+  );
+}
+
+function Metric({
+  value,
+  unit,
+  prefix,
+}: {
+  value: string;
+  unit?: string;
+  prefix?: string;
+}) {
+  return (
+    <span className="inline-flex items-baseline gap-[2px] tabular-nums">
+      {prefix ? (
+        <span className="notranslate text-atc-dim" translate="no">
+          {prefix}
+        </span>
       ) : null}
-    </MobilePreviewContent>
+      {value}
+      {unit ? (
+        <span translate="no" className="notranslate text-[9px] text-atc-faint">
+          {unit}
+        </span>
+      ) : null}
+    </span>
   );
 }
 
@@ -204,13 +181,13 @@ function TraceStatusDot({
 }) {
   if (!state || state.phase === "idle") return null;
 
-  const isErrorStatus =
-    state.statusCode != null && state.statusCode >= 400;
-  const tone = state.hasError || isErrorStatus
-    ? "error"
-    : state.phase === "pending"
-      ? "loading"
-      : "success";
+  const isErrorStatus = state.statusCode != null && state.statusCode >= 400;
+  const tone =
+    state.hasError || isErrorStatus
+      ? "error"
+      : state.phase === "pending"
+        ? "loading"
+        : "success";
   const label =
     tone === "loading"
       ? labels.pending
@@ -232,44 +209,5 @@ function TraceStatusDot({
       role="status"
       title={label}
     />
-  );
-}
-
-function Stat({ value = 0, unit, plain, prefix, format, accent = false }: StatProps) {
-  return (
-    <>
-      {plain != null ? (
-        <span className="tabular-nums">{plain}</span>
-      ) : (
-        <>
-          {prefix ? (
-            <span className="notranslate text-atc-dim" translate="no">
-              {prefix}
-            </span>
-          ) : null}
-          <NumberFlow
-            value={value}
-            format={format}
-            className={cn(
-              "tabular-nums",
-              accent && "text-[var(--atc-signal-accent)]",
-            )}
-          />
-        </>
-      )}
-      {unit && (
-        <span
-          translate="no"
-          className={cn(
-            "notranslate text-[8px] font-medium lowercase",
-            accent
-              ? "text-[color-mix(in_oklab,var(--atc-signal-accent)_68%,transparent)]"
-              : "text-atc-faint",
-          )}
-        >
-          {unit}
-        </span>
-      )}
-    </>
   );
 }

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -41,32 +41,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 96;
+export const CHANGELOG_TOTAL_COUNT = 97;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.28.5",
+    version: "v2.28.6",
     kind: "patch",
     title: {
-      en: "Aircraft preview card — clearer selection state",
-      zh: "飞机预览卡片——更清晰的选中态",
+      en: "Mobile preview card — compact collapsed row",
+      zh: "移动预览卡片——更紧凑的收起态",
     },
     summary: {
-      en: "Tapping an aircraft now opens a refreshed frosted preview card on desktop and a drag-to-expand sheet on mobile, with one signal accent and no rainbow button.",
-      zh: "点选飞机后，桌面端打开焕新的磨砂预览卡片，移动端为可下拉展开的卡片；统一单一信号强调色，去掉彩虹按钮。",
+      en: "The collapsed mobile aircraft card tightens to a single glance: thumbnail, callsign + type, route, an inline orange Track button, and one telemetry line. The photo and secondary actions move into the expanded sheet.",
+      zh: "移动端飞机卡片的收起态收紧为一眼可读：缩略图、呼号 + 机型、航路、内联橙色 Track 按钮，以及一行参数。照片与次要操作移入展开层。",
     },
     highlights: [
       {
-        en: "Desktop card: a photo header with a 'tracking' pill, callsign + TYPE / CATEGORY (no registration), an ORIGIN ——✈—— DEST route line, accent vertical-speed, HEX / Track / Distance, and a Track button beside camera + suggest-correction icon buttons",
-        zh: "桌面卡片：带「追踪」徽标的照片头、呼号 + 机型 / 类别（不再显示注册号）、ORIGIN ——✈—— DEST 航路线、强调色垂直速度、HEX / 航向 / 距离，以及 Track 按钮搭配相机 + 建议纠正图标按钮",
+        en: "Collapsed row: [thumbnail] [callsign + TYPE / CATEGORY · ORIGIN → DEST] [inline Track], over a 'speed · alt · ↑V/S' line with the vertical-speed in the accent",
+        zh: "收起行：[缩略图] [呼号 + 机型 / 类别 · 起 → 降] [内联 Track]，下方为「速度 · 高度 · ↑垂直速度」一行，垂直速度用强调色",
       },
       {
-        en: "Mobile: a top-anchored drag-to-expand sheet (drag the grabber down) — collapsed shows callsign / type / telemetry / actions; expanded reveals the photo and identity rows. Landscape anchors to the bottom and expands up",
-        zh: "移动端：顶部吸附、可下拉展开的卡片（向下拖动把手）——收起时显示呼号 / 机型 / 参数 / 操作，展开后显示照片与身份信息；横屏改为底部吸附、向上展开",
-      },
-      {
-        en: "The list-row selection (orange wash + accent rail + accent glyph) and the single signal accent are reused throughout; the multicolour Plane Hunter button is gone",
-        zh: "沿用列表行选中态（橙色底色 + 强调导轨 + 强调图标）与单一信号强调色；移除多彩的拍机按钮",
+        en: "Drag the grabber down to reveal a modest photo plus the camera / suggest-correction actions; the dense HEX / Track / Distance rows are left off mobile",
+        zh: "向下拖动把手即可展开适中的照片，以及相机 / 建议纠正操作；移动端不再堆叠 HEX / 航向 / 距离等密集信息",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -277,6 +277,32 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.28.5",
+    kind: "patch",
+    title: {
+      en: "Aircraft preview card — clearer selection state",
+      zh: "飞机预览卡片——更清晰的选中态",
+    },
+    summary: {
+      en: "Tapping an aircraft now opens a refreshed frosted preview card on desktop and a drag-to-expand sheet on mobile, with one signal accent and no rainbow button.",
+      zh: "点选飞机后，桌面端打开焕新的磨砂预览卡片，移动端为可下拉展开的卡片；统一单一信号强调色，去掉彩虹按钮。",
+    },
+    highlights: [
+      {
+        en: "Desktop card: a photo header with a 'tracking' pill, callsign + TYPE / CATEGORY (no registration), an ORIGIN ——✈—— DEST route line, accent vertical-speed, HEX / Track / Distance, and a Track button beside camera + suggest-correction icon buttons",
+        zh: "桌面卡片：带「追踪」徽标的照片头、呼号 + 机型 / 类别（不再显示注册号）、ORIGIN ——✈—— DEST 航路线、强调色垂直速度、HEX / 航向 / 距离，以及 Track 按钮搭配相机 + 建议纠正图标按钮",
+      },
+      {
+        en: "Mobile: a top-anchored drag-to-expand sheet (drag the grabber down) — collapsed shows callsign / type / telemetry / actions; expanded reveals the photo and identity rows. Landscape anchors to the bottom and expands up",
+        zh: "移动端：顶部吸附、可下拉展开的卡片（向下拖动把手）——收起时显示呼号 / 机型 / 参数 / 操作，展开后显示照片与身份信息；横屏改为底部吸附、向上展开",
+      },
+      {
+        en: "The list-row selection (orange wash + accent rail + accent glyph) and the single signal accent are reused throughout; the multicolour Plane Hunter button is gone",
+        zh: "沿用列表行选中态（橙色底色 + 强调导轨 + 强调图标）与单一信号强调色；移除多彩的拍机按钮",
+      },
+    ],
+  },
+  {
     version: "v2.28.4",
     kind: "patch",
     title: {


### PR DESCRIPTION
Follow-up to [#516](https://github.com/orriduck/ADSBao/pull/516) reworking the **collapsed mobile aircraft card** to match the reference you shared.

### What changed
- Collapsed row is now `[thumbnail] [callsign + TYPE / CATEGORY · ORIGIN → DEST] [inline Track]`, over a single `speed · alt · ↑V/S` telemetry line (vertical-speed in the accent, with an ↑/↓ arrow).
- **Track moved inline** into the collapsed row (was a full-width pill below) and is now the **orange accent**, matching the desktop Track button.
- The **photo + camera / suggest-correction** actions move into the **expanded** reveal (drag the grabber down). The dense **HEX / Track / Distance** rows are dropped from the mobile sheet (you noted they're not important).

### Verification
Verified live at 375px (`/airport/KBOS`, AAL1573): collapsed matches the reference (thumb + `B738 / A3` + `CMH → CLT` + orange Track + `↑ 2,880`); expand reveals the photo + suggest button. `pnpm build` clean, `pnpm test` 122 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)