### PR TITLE
Mobile preview: visible Track + camera + suggest button row

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -257,37 +257,20 @@ export default function AircraftPreviewCard({
     !isReportingPoint &&
     !isAirspace &&
     !isCandidateWatchingSpot;
-  // Revealed on expand: the secondary actions only — camera (Plane Hunter) and
-  // raise-hand (suggest correction). The photo already shows as the collapsed
-  // thumbnail (no second copy), and HEX / Track / Distance are left off mobile.
-  const mobileExtraActions =
-    mobileCompact &&
-    isAircraftPreview &&
-    (showMobilePlaneHunterTrigger || showMobileFeedbackTrigger);
-  const mobileExpandedContent = mobileExtraActions ? (
-    <div className="flex items-center gap-1.5 px-[12px] pb-1 pt-2 [[data-density=compact]_&]:px-[10px]">
-      {showMobilePlaneHunterTrigger ? (
-        <MobilePreviewIconButton
-          className="w-auto px-4"
-          onClick={() => setPlaneHunterOpen(true)}
-          aria-label={t("preview.planeHunter")}
-          title={t("preview.planeHunter")}
-        >
-          <Camera aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
-        </MobilePreviewIconButton>
-      ) : null}
-      {showMobileFeedbackTrigger ? (
-        <MobilePreviewIconButton
-          className="w-auto px-4"
-          onClick={() => setFeedbackModalOpen(true)}
-          aria-label={mobileFeedbackLabel}
-          title={mobileFeedbackLabel}
-        >
-          <Hand aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
-        </MobilePreviewIconButton>
-      ) : null}
-    </div>
-  ) : null;
+  // Revealed on expand: just the larger photo. The collapsed thumbnail hides
+  // while expanded (see AircraftPreviewMobileCard) so it isn't a second copy.
+  // The action buttons stay in the always-visible actions row below.
+  const mobileExpandedContent =
+    mobileCompact && isAircraftPreview && hasPhoto ? (
+      <div className="px-[12px] pb-1 pt-2 [[data-density=compact]_&]:px-[10px]">
+        <img
+          src={photo.src}
+          alt=""
+          draggable="false"
+          className="block max-h-[170px] w-full rounded-[12px] object-cover"
+        />
+      </div>
+    ) : null;
 
   return (
     <>
@@ -365,16 +348,22 @@ export default function AircraftPreviewCard({
           }
           style={mobilePreviewSafeAreaStyle}
           actions={
-            // Aircraft: Track lives inline in the collapsed card and the
-            // camera / suggest icons live in the expanded reveal, so the
-            // shared actions row is only for the other (non-compact) previews.
-            !mobileCompact &&
-            (showMobileTrackButton || showMobileSpotNavigationTrigger) ? (
+            // One always-visible action row. For an aircraft the Track button
+            // is the orange accent, beside the camera (Plane Hunter) and
+            // raise-hand (suggest correction) icon buttons.
+            (showMobileTrackButton ||
+              showMobileSpotNavigationTrigger ||
+              showMobilePlaneHunterTrigger ||
+              showMobileFeedbackTrigger) ? (
               <MobilePreviewActions>
                 <div className="flex items-stretch gap-1.5">
                   {showMobileTrackButton && (
                     <MobilePreviewTrackButton
-                      className="flex-1"
+                      className={`flex-1 ${
+                        mobileCompact
+                          ? "border-[color-mix(in_oklab,var(--atc-signal-accent)_88%,black_8%)] bg-[var(--atc-signal-accent)] text-white"
+                          : ""
+                      }`}
                       onClick={handleMobileTap}
                       disabled={alreadyTracking}
                     >
@@ -388,6 +377,24 @@ export default function AircraftPreviewCard({
                     >
                       {t("preview.goToSpot")}
                     </MobilePreviewTrackButton>
+                  )}
+                  {showMobilePlaneHunterTrigger && (
+                    <MobilePreviewIconButton
+                      onClick={() => setPlaneHunterOpen(true)}
+                      aria-label={t("preview.planeHunter")}
+                      title={t("preview.planeHunter")}
+                    >
+                      <Camera aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+                    </MobilePreviewIconButton>
+                  )}
+                  {showMobileFeedbackTrigger && (
+                    <MobilePreviewIconButton
+                      onClick={() => setFeedbackModalOpen(true)}
+                      aria-label={mobileFeedbackLabel}
+                      title={mobileFeedbackLabel}
+                    >
+                      <Hand aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
+                    </MobilePreviewIconButton>
                   )}
                 </div>
               </MobilePreviewActions>
@@ -419,9 +426,6 @@ export default function AircraftPreviewCard({
               aircraft={aircraft}
               photo={photo}
               traceStatusState={traceStatusVisible ? traceAsyncState : null}
-              trackLabel={mobileTrackLabel}
-              trackDisabled={alreadyTracking}
-              onTrack={showMobileTrackButton ? handleMobileTap : undefined}
             />
           )}
         </MobilePreviewCard>

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -5,30 +5,26 @@ import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { getAircraftPreviewTypeDisplay } from "@/features/aircraft/preview/aircraftPreviewTypeModel";
 import { formatAltitude } from "@/utils/units";
-import { MobilePreviewTrackButton } from "./MobilePreviewCard";
+import { useMobilePreviewExpanded } from "./MobilePreviewCard";
 import type { AsyncStatusState } from "@/hooks/useAsyncStatus";
 
 type AircraftPreviewMobileCardProps = {
   aircraft?: Record<string, any> | null;
   photo?: { src?: string | null } | null;
   traceStatusState?: AsyncStatusState | null;
-  trackLabel?: string;
-  trackDisabled?: boolean;
-  onTrack?: () => void;
 };
 
-// Collapsed mobile card: [thumb][callsign + type · route][Track] over a single
-// telemetry line. The photo is a small thumbnail (the full reveal lives in the
-// expanded sheet); the vertical-speed is the one accent in the telemetry line.
+// Collapsed mobile card: [thumb][callsign + type · route] over a single
+// telemetry line; the action row (Track + camera + suggest) sits below in the
+// shared actions slot. The thumbnail hides when expanded so the larger photo
+// revealed there isn't a second copy. V/S is the one accent in the line.
 export default function AircraftPreviewMobileCard({
   aircraft,
   photo,
   traceStatusState = null,
-  trackLabel,
-  trackDisabled = false,
-  onTrack,
 }: AircraftPreviewMobileCardProps) {
   const { t } = useI18n();
+  const expanded = useMobilePreviewExpanded();
   const { preferences: units } = useUnitPreferences();
   const callsign =
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
@@ -51,7 +47,9 @@ export default function AircraftPreviewMobileCard({
   return (
     <div className="flex flex-col gap-[7px] px-[12px] pb-[6px] pt-[10px] [[data-density=compact]_&]:px-[10px]">
       <div className="flex items-center gap-2.5">
-        {photo?.src ? (
+        {/* Hidden when expanded — the larger photo shows in the reveal, so the
+            thumbnail isn't a second copy. */}
+        {expanded ? null : photo?.src ? (
           <img
             src={photo.src}
             alt=""
@@ -101,15 +99,6 @@ export default function AircraftPreviewMobileCard({
             )}
           </div>
         </div>
-        {onTrack ? (
-          <MobilePreviewTrackButton
-            className="w-auto flex-none self-center px-5 border-[color-mix(in_oklab,var(--atc-signal-accent)_88%,black_8%)] bg-[var(--atc-signal-accent)] text-white"
-            onClick={onTrack}
-            disabled={trackDisabled}
-          >
-            {trackLabel}
-          </MobilePreviewTrackButton>
-        ) : null}
       </div>
 
       <div className="flex flex-wrap items-baseline gap-x-[7px] gap-y-1 border-t border-atc-line pt-[7px] font-mono text-[13px] tabular-nums text-atc-text">


### PR DESCRIPTION
Follow-up: the action buttons (Track accent pill + camera Plane Hunter + raise-hand suggest) are now a single always-visible row matching the reference, instead of hiding the secondary actions in the expand. Expanding reveals the larger photo (the collapsed thumbnail hides while expanded, so only one photo shows at a time). Verified live at 375px: collapsed = thumb + identity + telemetry + button row; expanded = identity + telemetry + photo + button row. No version bump (continues v2.28.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)