### PR TITLE
Mobile preview: small top-right photo, single compact card

### DIFF
--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -257,20 +257,8 @@ export default function AircraftPreviewCard({
     !isReportingPoint &&
     !isAirspace &&
     !isCandidateWatchingSpot;
-  // Revealed on expand: just the larger photo. The collapsed thumbnail hides
-  // while expanded (see AircraftPreviewMobileCard) so it isn't a second copy.
-  // The action buttons stay in the always-visible actions row below.
-  const mobileExpandedContent =
-    mobileCompact && isAircraftPreview && hasPhoto ? (
-      <div className="px-[12px] pb-1 pt-2 [[data-density=compact]_&]:px-[10px]">
-        <img
-          src={photo.src}
-          alt=""
-          draggable="false"
-          className="block max-h-[170px] w-full rounded-[12px] object-cover"
-        />
-      </div>
-    ) : null;
+  // The aircraft mobile card is a single compact card now (small top-right
+  // photo, all actions visible), so there is nothing to reveal on expand.
 
   return (
     <>
@@ -340,9 +328,6 @@ export default function AircraftPreviewCard({
           key={`mobile-${identityKey}`}
           ariaLabel={previewAriaLabel}
           compact={mobileCompact}
-          expandable={Boolean(mobileExpandedContent)}
-          grabberLabel={previewAriaLabel}
-          expandedContent={mobileExpandedContent}
           placement={
             showPreferredMobilePreview ? "bottomRight" : "top"
           }

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -5,7 +5,6 @@ import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { getAircraftPreviewTypeDisplay } from "@/features/aircraft/preview/aircraftPreviewTypeModel";
 import { formatAltitude } from "@/utils/units";
-import { useMobilePreviewExpanded } from "./MobilePreviewCard";
 import type { AsyncStatusState } from "@/hooks/useAsyncStatus";
 
 type AircraftPreviewMobileCardProps = {
@@ -14,17 +13,15 @@ type AircraftPreviewMobileCardProps = {
   traceStatusState?: AsyncStatusState | null;
 };
 
-// Collapsed mobile card: [thumb][callsign + type · route] over a single
-// telemetry line; the action row (Track + camera + suggest) sits below in the
-// shared actions slot. The thumbnail hides when expanded so the larger photo
-// revealed there isn't a second copy. V/S is the one accent in the line.
+// Compact mobile card: [callsign + type · route][small photo, top-right] over a
+// single telemetry line; the action row (Track + camera + suggest) sits below
+// in the shared actions slot. V/S is the one accent in the telemetry line.
 export default function AircraftPreviewMobileCard({
   aircraft,
   photo,
   traceStatusState = null,
 }: AircraftPreviewMobileCardProps) {
   const { t } = useI18n();
-  const expanded = useMobilePreviewExpanded();
   const { preferences: units } = useUnitPreferences();
   const callsign =
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
@@ -46,19 +43,7 @@ export default function AircraftPreviewMobileCard({
 
   return (
     <div className="flex flex-col gap-[7px] px-[12px] pb-[6px] pt-[10px] [[data-density=compact]_&]:px-[10px]">
-      <div className="flex items-center gap-2.5">
-        {/* Hidden when expanded — the larger photo shows in the reveal, so the
-            thumbnail isn't a second copy. */}
-        {expanded ? null : photo?.src ? (
-          <img
-            src={photo.src}
-            alt=""
-            draggable="false"
-            className="size-[42px] flex-none rounded-[11px] object-cover"
-          />
-        ) : (
-          <span className="size-[42px] flex-none rounded-[11px] bg-[color-mix(in_oklab,var(--atc-text)_9%,transparent)]" />
-        )}
+      <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-baseline gap-2">
             <span
@@ -99,6 +84,14 @@ export default function AircraftPreviewMobileCard({
             )}
           </div>
         </div>
+        {photo?.src ? (
+          <img
+            src={photo.src}
+            alt=""
+            draggable="false"
+            className="size-[46px] flex-none rounded-[11px] object-cover"
+          />
+        ) : null}
       </div>
 
       <div className="flex flex-wrap items-baseline gap-x-[7px] gap-y-1 border-t border-atc-line pt-[7px] font-mono text-[13px] tabular-nums text-atc-text">


### PR DESCRIPTION
Per feedback, the aircraft mobile card is a single compact card now: the photo is a small 46px image in the **top-right corner** (was a left thumbnail + a big photo behind the expand). Identity / route / telemetry / Track + camera + suggest are all visible at once, so the drag-to-expand grabber is removed. Verified live at 375px. No version bump (continues v2.28.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)