### PR TITLE
v2.28.7: Match the other preview cards to the aircraft card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.28.6",
+  "version": "2.28.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -344,11 +344,7 @@ export default function AircraftPreviewCard({
                 <div className="flex items-stretch gap-1.5">
                   {showMobileTrackButton && (
                     <MobilePreviewTrackButton
-                      className={`flex-1 ${
-                        mobileCompact
-                          ? "border-[color-mix(in_oklab,var(--atc-signal-accent)_88%,black_8%)] bg-[var(--atc-signal-accent)] text-white"
-                          : ""
-                      }`}
+                      className="flex-1 border-[color-mix(in_oklab,var(--atc-signal-accent)_88%,black_8%)] bg-[var(--atc-signal-accent)] text-white"
                       onClick={handleMobileTap}
                       disabled={alreadyTracking}
                     >
@@ -357,7 +353,7 @@ export default function AircraftPreviewCard({
                   )}
                   {showMobileSpotNavigationTrigger && (
                     <MobilePreviewTrackButton
-                      className="flex-1"
+                      className="flex-1 border-[color-mix(in_oklab,var(--atc-signal-accent)_88%,black_8%)] bg-[var(--atc-signal-accent)] text-white"
                       onClick={onOpenCandidateWatchingSpotNavigation}
                     >
                       {t("preview.goToSpot")}

--- a/src/components/aircraft/preview/AirportPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/AirportPreviewMetadataCard.tsx
@@ -1,6 +1,6 @@
+import type { ReactNode } from "react";
 import { Link, useLocation } from "react-router-dom";
 import NumberFlow from "@number-flow/react";
-import { TowerControl } from "lucide-react";
 import { countryName, flagEmoji } from "@/utils/flag";
 import {
   airportCityName,
@@ -17,9 +17,9 @@ import {
   formatAltitude,
 } from "@/utils/units";
 
-// Airport variant of the bottom-right preview card. Mirrors the aircraft
-// card's chrome (same container class so the slide-in / blur / sizing
-// match) and exposes a Track link that lands on /airport/[icao].
+// Airport variant of the preview card. Mirrors the aircraft card's chrome and
+// typography: a mono identity (ICAO + IATA) over name / place, the shared
+// metadata rows, and the Track button in the actions row.
 export default function AirportPreviewMetadataCard({ airport }) {
   const { locale, t } = useI18n();
   const { preferences: units } = useUnitPreferences();
@@ -27,6 +27,7 @@ export default function AirportPreviewMetadataCard({ airport }) {
   const icao = cleanAirportCode(airport?.icao || airport?.code);
   const iata = cleanAirportCode(airport?.iata);
   const codeLine = airportDisplayCodeLine(airport);
+  const primaryCode = icao || codeLine;
   const name = airportDisplayName(airport, locale) || t("sidebar.unknownAirport");
   const flag = flagEmoji(airport?.country);
   const country = countryName(airport?.country, locale) || airport?.country || "";
@@ -41,136 +42,114 @@ export default function AirportPreviewMetadataCard({ airport }) {
     elevation == null
       ? null
       : formatAltitude(elevation, units.altitude, { kind: "ground" });
-  const detailRows = [
-    { label: t("metrics.iata"), value: iata },
-    { label: t("metrics.icao"), value: icao },
-    { label: t("metrics.city"), value: city },
-    { label: t("metrics.country"), value: country },
-  ].filter((row) => row.value);
 
   const alreadyTracking = icao && pathname === `/airport/${icao}`;
   const trackHref = icao ? `/airport/${icao}` : null;
 
   return (
     <div className="aircraft-preview-metadata-card">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <span className="atc-kicker">{t("sidebar.airport")}</span>
-          <div className="mt-1 flex min-w-0 items-baseline gap-2">
+      <div className="mb-2.5 flex flex-col gap-[7px]">
+        <div className="flex min-w-0 items-baseline justify-between gap-3">
+          <span
+            className="notranslate min-w-0 truncate font-mono text-[21px] leading-none tracking-[0.02em] text-atc-text"
+            translate="no"
+            title={primaryCode}
+          >
+            {primaryCode}
+          </span>
+          {iata && iata !== primaryCode ? (
             <span
-              className="airport-sidebar-display-mono airport-sidebar-display-mono--hero notranslate text-[28px] font-extrabold leading-none text-atc-text"
+              className="notranslate flex-none whitespace-nowrap font-mono text-[12.5px] tracking-[0.04em] text-atc-dim"
               translate="no"
             >
-              {codeLine}
+              {iata}
             </span>
-          </div>
-          <dl className="mt-2 grid min-w-0 gap-2">
-            <div className="min-w-0">
-              <dt className="font-[var(--font-mono)] text-[7px] font-semibold uppercase leading-none tracking-normal text-atc-faint">
-                {t("preview.airportName")}
-              </dt>
-              <dd className="mt-1 text-[14px] font-semibold leading-snug whitespace-normal break-words text-atc-text">
-                {name}
-              </dd>
-            </div>
-            {placeLine ? (
-              <div className="min-w-0">
-                <dt className="font-[var(--font-mono)] text-[7px] font-semibold uppercase leading-none tracking-normal text-atc-faint">
-                  {t("preview.airportPlace")}
-                </dt>
-                <dd className="mt-1 text-[11px] leading-snug whitespace-normal break-words text-atc-dim">
-                  {placeLine}
-                </dd>
-              </div>
-            ) : null}
-          </dl>
+          ) : null}
         </div>
-        <TowerControl
-          aria-hidden="true"
-          className="mt-1 size-5 flex-none text-atc-dim"
-          strokeWidth={1.8}
-        />
+        {name ? (
+          <div className="min-w-0 truncate text-[13px] leading-snug text-atc-dim">
+            {name}
+          </div>
+        ) : null}
+        {placeLine ? (
+          <div className="min-w-0 truncate text-[11.5px] leading-snug text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]">
+            {placeLine}
+          </div>
+        ) : null}
       </div>
 
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
 
-      <dl className="grid grid-cols-2 gap-y-1.5 gap-x-3 font-mono text-[11px]">
-        <dt className="text-atc-faint uppercase tracking-[0.12em]">
-          {t("metrics.distance")}
-        </dt>
-        <dd className="text-right text-atc-text">
-          {distanceConverted == null ? (
-            "—"
-          ) : (
-            <>
-              <NumberFlow
-                value={distanceConverted}
-                format={{
-                  maximumFractionDigits: 1,
-                  minimumFractionDigits: 1,
-                }}
-              />
-              <span className="notranslate ml-1 text-atc-dim" translate="no">
-                {distanceUnitLabel(units.distance)}
-              </span>
-            </>
-          )}
-        </dd>
-        <dt className="text-atc-faint uppercase tracking-[0.12em]">
-          {t("metrics.elevation")}
-        </dt>
-        <dd className="text-right text-atc-text">
-          {!elevationDisplay ? (
-            "—"
-          ) : (
-            <>
-              <NumberFlow value={elevationDisplay.value ?? 0} />
-              <span className="notranslate ml-1 text-atc-dim" translate="no">
-                {elevationDisplay.unit.toUpperCase()}
-              </span>
-            </>
-          )}
-        </dd>
+      <dl className="aircraft-preview-metadata">
+        <MetaRow
+          label={t("metrics.distance")}
+          value={
+            distanceConverted == null ? (
+              "—"
+            ) : (
+              <>
+                <NumberFlow
+                  value={distanceConverted}
+                  format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
+                />
+                <span className="notranslate" translate="no">
+                  {" "}
+                  {distanceUnitLabel(units.distance)}
+                </span>
+              </>
+            )
+          }
+        />
+        <MetaRow
+          label={t("metrics.elevation")}
+          value={
+            !elevationDisplay ? (
+              "—"
+            ) : (
+              <>
+                <NumberFlow value={elevationDisplay.value ?? 0} />
+                <span className="notranslate" translate="no">
+                  {" "}
+                  {elevationDisplay.unit.toUpperCase()}
+                </span>
+              </>
+            )
+          }
+        />
       </dl>
 
-      {detailRows.length ? (
-        <>
-          <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
-          <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
-            {detailRows.map((row) => (
-              <div className="contents" key={row.label}>
-                <dt className="text-atc-faint uppercase tracking-[0.1em]">
-                  {row.label}
-                </dt>
-                <dd
-                  className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
-                  translate="no"
-                >
-                  {row.value}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </>
-      ) : null}
+      <div className="aircraft-preview-card__actions">
+        {trackHref && !alreadyTracking ? (
+          <Link
+            to={trackHref}
+            className="aircraft-preview-card__track-btn"
+            aria-label={`${t("preview.openAirport")} ${primaryCode}`}
+          >
+            {t("preview.openAirport")}
+          </Link>
+        ) : (
+          <button
+            type="button"
+            className="aircraft-preview-card__track-btn"
+            disabled
+          >
+            {alreadyTracking
+              ? t("preview.viewingAirport")
+              : t("preview.openAirport")}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
 
-      {trackHref && !alreadyTracking ? (
-        <Link
-          to={trackHref}
-          className="aircraft-preview-card__track-btn"
-          aria-label={`${t("preview.openAirport")} ${codeLine}`}
-        >
-          {t("preview.openAirport")}
-        </Link>
-      ) : (
-        <button
-          type="button"
-          className="aircraft-preview-card__track-btn"
-          disabled
-        >
-          {alreadyTracking ? t("preview.viewingAirport") : t("preview.openAirport")}
-        </button>
-      )}
+function MetaRow({ label, value }: { label: ReactNode; value: ReactNode }) {
+  return (
+    <div className="aircraft-preview-meta-row">
+      <dt className="aircraft-preview-meta-row__label">{label}</dt>
+      <dd className="aircraft-preview-meta-row__value notranslate" translate="no">
+        {value}
+      </dd>
     </div>
   );
 }

--- a/src/components/aircraft/preview/AirportPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AirportPreviewMobileCard.tsx
@@ -1,10 +1,8 @@
-import type { ComponentProps } from "react";
-import NumberFlow from "@number-flow/react";
-import { TowerControl } from "lucide-react";
 import {
   airportCityName,
   airportDisplayCodeLine,
   airportDisplayName,
+  cleanAirportCode,
 } from "@/utils/airport";
 import { countryName, flagEmoji } from "@/utils/flag";
 import { toFiniteNumber } from "@/utils/math";
@@ -15,42 +13,23 @@ import {
   distanceUnitLabel,
   formatAltitude,
 } from "@/utils/units";
-import {
-  MobilePreviewContent,
-  MobilePreviewDetailRow,
-  MobilePreviewIdentity,
-} from "./MobilePreviewCard";
-
-type NumberFlowFormat = ComponentProps<typeof NumberFlow>["format"];
-
-type AirportPreviewMobileCardAirport = {
-  icao?: string | null;
-  iata?: string | null;
-  country?: string | null;
-  city?: unknown;
-  distanceNm?: unknown;
-  elevationFt?: unknown;
-  name?: unknown;
-  localizedName?: unknown;
-};
 
 type AirportPreviewMobileCardProps = {
-  airport?: AirportPreviewMobileCardAirport | null;
+  airport?: Record<string, any> | null;
 };
 
-type StatProps = {
-  value: number;
-  unit: string;
-  format?: NumberFlowFormat;
-};
-
-// Airport variant of the bottom-of-screen mobile preview card. The airport
-// type marker, code, long name, and location share the same mobile preview
-// structure used by aircraft and navaids.
-export default function AirportPreviewMobileCard({ airport }: AirportPreviewMobileCardProps) {
+// Compact mobile airport card — mirrors the aircraft card: a mono identity
+// (ICAO + IATA) over the airport name, with a single dot-separated detail line
+// (distance · elevation). The Track action lives in the shared actions slot.
+export default function AirportPreviewMobileCard({
+  airport,
+}: AirportPreviewMobileCardProps) {
   const { locale, t } = useI18n();
   const { preferences: units } = useUnitPreferences();
   const codeLine = airportDisplayCodeLine(airport);
+  const icao = cleanAirportCode(airport?.icao || airport?.code);
+  const iata = cleanAirportCode(airport?.iata);
+  const primaryCode = icao || codeLine;
   const name = airportDisplayName(airport, locale);
   const flag = flagEmoji(airport?.country);
   const country = countryName(airport?.country, locale) || airport?.country || "";
@@ -65,62 +44,77 @@ export default function AirportPreviewMobileCard({ airport }: AirportPreviewMobi
     elevation == null
       ? null
       : formatAltitude(elevation, units.altitude, { kind: "ground" });
-  const hasStats = distance != null || elevation != null;
+  const hasStats = distanceConverted != null || elevationDisplay != null;
 
   return (
-    <MobilePreviewContent>
-      <MobilePreviewIdentity
-        icon={TowerControl}
-        label={t("preview.airportPreview")}
-        primary={codeLine}
-        secondary={
-          hasStats ? (
-            <span className="flex items-baseline justify-end gap-[10px]">
-              {distanceConverted != null ? (
-                <Stat
-                  value={distanceConverted}
-                  unit={distanceUnitLabel(units.distance)}
-                  format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
-                />
-              ) : null}
-              {elevationDisplay && elevationDisplay.value != null ? (
-                <Stat
-                  value={elevationDisplay.value}
-                  unit={elevationDisplay.unit}
-                />
-              ) : null}
+    <div className="flex flex-col gap-[7px] px-[12px] pb-[6px] pt-[10px] [[data-density=compact]_&]:px-[10px]">
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-baseline gap-2">
+          <span
+            className="notranslate min-w-0 truncate font-mono text-[19px] leading-none text-atc-text"
+            translate="no"
+            title={primaryCode}
+          >
+            {primaryCode}
+          </span>
+          {iata && iata !== primaryCode ? (
+            <span
+              className="notranslate flex-none whitespace-nowrap font-mono text-[12px] tracking-[0.04em] text-atc-dim"
+              translate="no"
+            >
+              {iata}
             </span>
-          ) : null
-        }
-      />
-      {name ? (
-        <MobilePreviewDetailRow wrap>
-          {name}
-        </MobilePreviewDetailRow>
-      ) : null}
-      {placeLine ? (
-        <MobilePreviewDetailRow wrap>
+          ) : null}
+        </div>
+        {name ? (
+          <div className="mt-[5px] min-w-0 truncate text-[11.5px] leading-snug text-atc-dim">
+            {name}
+          </div>
+        ) : null}
+      </div>
+
+      {hasStats ? (
+        <div className="flex flex-wrap items-baseline gap-x-[7px] gap-y-1 border-t border-atc-line pt-[7px] font-mono text-[13px] tabular-nums text-atc-text">
+          {distanceConverted != null ? (
+            <Metric
+              value={distanceConverted.toFixed(1)}
+              unit={distanceUnitLabel(units.distance)}
+            />
+          ) : null}
+          {distanceConverted != null && elevationDisplay ? <Separator /> : null}
+          {elevationDisplay ? (
+            <Metric
+              value={(elevationDisplay.value ?? 0).toLocaleString()}
+              unit={elevationDisplay.unit}
+            />
+          ) : null}
+        </div>
+      ) : placeLine ? (
+        <div className="min-w-0 truncate border-t border-atc-line pt-[7px] text-[11px] text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]">
           {placeLine}
-        </MobilePreviewDetailRow>
+        </div>
       ) : null}
-    </MobilePreviewContent>
+    </div>
   );
 }
 
-function Stat({ value, unit, format }: StatProps) {
+function Separator() {
   return (
-    <>
-      <NumberFlow
-        value={value}
-        format={format}
-        className="tabular-nums"
-      />
-      <span
-        translate="no"
-        className="notranslate text-[8px] font-medium uppercase text-atc-faint"
-      >
-        {unit}
-      </span>
-    </>
+    <span aria-hidden="true" className="text-atc-faint">
+      ·
+    </span>
+  );
+}
+
+function Metric({ value, unit }: { value: string; unit?: string }) {
+  return (
+    <span className="inline-flex items-baseline gap-[2px] tabular-nums">
+      {value}
+      {unit ? (
+        <span translate="no" className="notranslate text-[9px] text-atc-faint">
+          {unit}
+        </span>
+      ) : null}
+    </span>
   );
 }

--- a/src/components/aircraft/preview/AirspacePreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/AirspacePreviewMetadataCard.tsx
@@ -1,9 +1,9 @@
-import { ShieldAlert } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { resolveAirspacePreviewDisplay } from "@/features/airport/openaip/airspacePreviewDisplayModel";
 import AirspacePreviewSelector, {
   useAirspaceCarouselSwipe,
 } from "./AirspacePreviewSelector";
+import { PreviewCardHeader, PreviewMetaRows } from "./previewCardChrome";
 
 type AirspacePreviewMetadataCardProps = {
   airspace?: Record<string, any> | null;
@@ -21,15 +21,15 @@ export default function AirspacePreviewMetadataCard({
   const { locale, t } = useI18n();
   const name = String(airspace?.name || "Airspace").trim();
   const display = resolveAirspacePreviewDisplay(airspace, locale);
-  const source = airspace?.source === "openaip" ? "OpenAIP" : String(airspace?.source || "");
+  const source =
+    airspace?.source === "openaip" ? "OpenAIP" : String(airspace?.source || "");
   const carouselSwipeHandlers = useAirspaceCarouselSwipe({
     airspaces,
     selectedAirspaceId,
     onSelectAirspace,
   });
 
-  const detailRows = [
-    { label: t("preview.airspaceType"), value: display.type },
+  const rows = [
     { label: t("preview.airspaceAccess"), value: display.access },
     { label: t("preview.airspaceClass"), value: display.classLabel },
     { label: t("preview.airspaceLowerLimit"), value: display.lowerLimit },
@@ -42,43 +42,13 @@ export default function AirspacePreviewMetadataCard({
       className="aircraft-preview-metadata-card pointer-events-auto touch-pan-y"
       {...carouselSwipeHandlers}
     >
-      <div className="relative">
-        <div className="min-w-0 pr-8">
-          <span className="atc-kicker">{t("preview.airspacePreview")}</span>
-          <div className="mt-1 min-w-0">
-            <span
-              className="notranslate block min-w-0 whitespace-normal break-words font-sans text-[14px] font-bold leading-tight text-atc-text"
-              translate="no"
-            >
-              {name}
-            </span>
-          </div>
-        </div>
-        <ShieldAlert
-          aria-hidden="true"
-          className="absolute right-0 top-0 size-5 text-atc-dim"
-          strokeWidth={1.8}
-        />
-      </div>
-
+      <PreviewCardHeader
+        primary={name}
+        primaryMono={false}
+        secondary={display.type || undefined}
+      />
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
-
-      <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
-        {detailRows.map((row) => (
-          <div className="contents" key={row.label}>
-            <dt className="text-atc-faint uppercase tracking-[0.1em]">
-              {row.label}
-            </dt>
-            <dd
-              className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
-              translate="no"
-            >
-              {row.value}
-            </dd>
-          </div>
-        ))}
-      </dl>
-
+      <PreviewMetaRows rows={rows} />
       {display.description ? (
         <>
           <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
@@ -87,7 +57,6 @@ export default function AirspacePreviewMetadataCard({
           </p>
         </>
       ) : null}
-
       <AirspacePreviewSelector
         airspaces={airspaces}
         selectedAirspaceId={selectedAirspaceId}

--- a/src/components/aircraft/preview/AirspacePreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AirspacePreviewMobileCard.tsx
@@ -1,13 +1,9 @@
-import { ShieldAlert } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { resolveAirspacePreviewDisplay } from "@/features/airport/openaip/airspacePreviewDisplayModel";
-import {
-  MobilePreviewContent,
-  MobilePreviewDetailRow,
-} from "./MobilePreviewCard";
 import AirspacePreviewSelector, {
   useAirspaceCarouselSwipe,
 } from "./AirspacePreviewSelector";
+import { MobilePreviewHeader, MobilePreviewMetaLine } from "./previewCardChrome";
 
 type AirspacePreviewMobileCardProps = {
   airspace?: Record<string, any> | null;
@@ -34,49 +30,28 @@ export default function AirspacePreviewMobileCard({
     onSelectAirspace,
   });
 
+  const items = [
+    display.access ? <span key="access">{display.access}</span> : null,
+    display.vertical ? <span key="vertical">{display.vertical}</span> : null,
+  ].filter(Boolean);
+
   return (
-    <MobilePreviewContent
-      className="pointer-events-auto touch-pan-y gap-[3px] pb-[4px]"
+    <div
+      className="pointer-events-auto touch-pan-y flex flex-col gap-[6px] px-[12px] pb-[5px] pt-[10px] [[data-density=compact]_&]:px-[10px]"
       {...carouselSwipeHandlers}
     >
-      <div className="flex min-w-0 items-start gap-[6px]">
-        <span
-          aria-label={t("preview.airspacePreview")}
-          title={t("preview.airspacePreview")}
-          className="mt-[1px] grid size-[18px] flex-none place-items-center text-atc-dim"
-        >
-          <ShieldAlert aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
-        </span>
-        <div className="min-w-0 flex-1">
-          <span
-            translate="no"
-            className="notranslate block min-w-0 whitespace-normal break-words font-[var(--font-mono)] text-[18px] font-extrabold leading-[1.05] tracking-normal text-atc-text"
-          >
-            {name}
-          </span>
-        </div>
-      </div>
-      {display.access ? (
-        <MobilePreviewDetailRow wrap>
-          {display.access}
-        </MobilePreviewDetailRow>
-      ) : null}
-      {typeAndClass ? (
-        <MobilePreviewDetailRow wrap>
-          {typeAndClass}
-        </MobilePreviewDetailRow>
-      ) : null}
-      {display.vertical ? (
-        <MobilePreviewDetailRow wrap>
-          {display.vertical}
-        </MobilePreviewDetailRow>
-      ) : null}
+      <MobilePreviewHeader
+        primary={name}
+        primaryMono={false}
+        secondary={typeAndClass || undefined}
+      />
+      <MobilePreviewMetaLine items={items} />
       <AirspacePreviewSelector
         airspaces={airspaces}
         selectedAirspaceId={selectedAirspaceId}
         onSelectAirspace={onSelectAirspace}
         compact
       />
-    </MobilePreviewContent>
+    </div>
   );
 }

--- a/src/components/aircraft/preview/AirspacePreviewSelector.tsx
+++ b/src/components/aircraft/preview/AirspacePreviewSelector.tsx
@@ -25,12 +25,9 @@ const AIRSPACE_CAROUSEL_SWIPE_MAX_VERTICAL_RATIO = 0.72;
 const AIRSPACE_CAROUSEL_SWIPE_MAX_DURATION_MS = 900;
 const AIRSPACE_CAROUSEL_WHEEL_MIN_DISTANCE_PX = 36;
 const AIRSPACE_CAROUSEL_WHEEL_MAX_VERTICAL_RATIO = 0.86;
+// A continuous trackpad swipe fires once; it only re-arms after this pause (or
+// a direction change) — so one swipe moves exactly one card.
 const AIRSPACE_CAROUSEL_WHEEL_RESET_MS = 180;
-const AIRSPACE_CAROUSEL_WHEEL_RESTART_GAP_MS = 140;
-const AIRSPACE_CAROUSEL_WHEEL_DECAY_DELTA_PX = 12;
-const AIRSPACE_CAROUSEL_WHEEL_REARM_MS = 120;
-const AIRSPACE_CAROUSEL_WHEEL_REACCELERATION_MIN_DELTA_PX = 20;
-const AIRSPACE_CAROUSEL_WHEEL_REACCELERATION_RATIO = 1.55;
 
 export default function AirspacePreviewSelector({
   airspaces = [],
@@ -120,10 +117,7 @@ export function useAirspaceCarouselSwipe({
     dy: 0,
     time: 0,
     triggered: false,
-    triggerTime: 0,
     direction: 0,
-    lastAbsDx: 0,
-    decayed: false,
   });
 
   const selectByDelta = (dx: number) => {
@@ -221,50 +215,24 @@ export function useAirspaceCarouselSwipe({
       const wheel = wheelRef.current;
       const direction = dx < 0 ? -1 : 1;
       const gap = event.timeStamp - wheel.time;
-      const timeSinceTrigger = event.timeStamp - wheel.triggerTime;
       const directionChanged =
         wheel.direction !== 0 && direction !== wheel.direction;
-      const secondSwipeAfterGap =
-        wheel.triggered &&
-        gap >= AIRSPACE_CAROUSEL_WHEEL_RESTART_GAP_MS &&
-        absDx >= AIRSPACE_CAROUSEL_WHEEL_REACCELERATION_MIN_DELTA_PX;
-      const secondSwipeByAcceleration =
-        wheel.triggered &&
-        wheel.decayed &&
-        timeSinceTrigger >= AIRSPACE_CAROUSEL_WHEEL_REARM_MS &&
-        absDx >= AIRSPACE_CAROUSEL_WHEEL_REACCELERATION_MIN_DELTA_PX &&
-        wheel.lastAbsDx > 0 &&
-        absDx >=
-          wheel.lastAbsDx * AIRSPACE_CAROUSEL_WHEEL_REACCELERATION_RATIO;
 
-      if (
-        gap > AIRSPACE_CAROUSEL_WHEEL_RESET_MS ||
-        directionChanged ||
-        secondSwipeAfterGap ||
-        secondSwipeByAcceleration
-      ) {
+      // Re-arm only after a clear pause or a direction change. A single
+      // continuous swipe therefore advances exactly one card; to move again
+      // the user lifts/pauses (gap > reset) and swipes once more.
+      if (gap > AIRSPACE_CAROUSEL_WHEEL_RESET_MS || directionChanged) {
         wheel.dx = 0;
         wheel.dy = 0;
         wheel.triggered = false;
-        wheel.triggerTime = 0;
-        wheel.decayed = false;
       }
 
-      if (wheel.triggered) {
-        if (absDx <= AIRSPACE_CAROUSEL_WHEEL_DECAY_DELTA_PX) {
-          wheel.decayed = true;
-        }
-        wheel.time = event.timeStamp;
-        wheel.direction = direction;
-        wheel.lastAbsDx = absDx;
-        return;
-      }
+      wheel.time = event.timeStamp;
+      wheel.direction = direction;
+      if (wheel.triggered) return;
 
       wheel.dx += dx;
       wheel.dy += dy;
-      wheel.time = event.timeStamp;
-      wheel.direction = direction;
-      wheel.lastAbsDx = absDx;
 
       const accumulatedAbsDx = Math.abs(wheel.dx);
       const accumulatedAbsDy = Math.abs(wheel.dy);
@@ -280,10 +248,7 @@ export function useAirspaceCarouselSwipe({
       selectByDelta(-wheel.dx);
       wheel.dx = 0;
       wheel.dy = 0;
-      wheel.time = event.timeStamp;
       wheel.triggered = true;
-      wheel.triggerTime = event.timeStamp;
-      wheel.decayed = false;
     },
   };
 }

--- a/src/components/aircraft/preview/CandidateWatchingSpotPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/CandidateWatchingSpotPreviewMetadataCard.tsx
@@ -1,10 +1,10 @@
-import { Camera } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import {
   formatCandidateWatchingSpotCategory,
   formatCandidateWatchingSpotDistance,
   formatCandidateWatchingSpotName,
 } from "./candidateWatchingSpotPreviewFormat";
+import { PreviewCardHeader, PreviewMetaRows } from "./previewCardChrome";
 
 type CandidateWatchingSpotPreviewMetadataCardProps = {
   spot?: Record<string, any> | null;
@@ -27,8 +27,7 @@ export default function CandidateWatchingSpotPreviewMetadataCard({
   const disclaimer = String(spot?.disclaimer || t("watcherMode.disclaimer")).trim();
   const sourceLabel = String(spot?.sourceLabel || spot?.source || "").trim();
   const attribution = String(sourceAttribution || "").trim();
-  const detailRows = [
-    { label: t("preview.candidateWatchingSpotType"), value: category },
+  const rows = [
     { label: t("metrics.distance"), value: distance },
     { label: t("preview.airspaceSource"), value: sourceLabel },
   ].filter((row) => row.value);
@@ -36,66 +35,31 @@ export default function CandidateWatchingSpotPreviewMetadataCard({
   return (
     <div className="aircraft-preview-metadata-card">
       <div className="candidate-watching-spot-preview-motion">
-        <div className="relative">
-          <div className="min-w-0 pr-8">
-            <span className="atc-kicker">
-              {t("preview.candidateWatchingSpotPreview")}
-            </span>
-            <div className="mt-1 min-w-0">
-              <span
-                className="notranslate block min-w-0 whitespace-normal break-words font-sans text-[14px] font-bold leading-tight text-atc-text"
-                translate="no"
-              >
-                {name}
-              </span>
-            </div>
-          </div>
-          <Camera
-            aria-hidden="true"
-            className="absolute right-0 top-0 size-5 text-atc-dim"
-            strokeWidth={1.8}
-          />
-        </div>
-
-        {detailRows.length ? (
-          <>
-            <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
-            <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
-              {detailRows.map((row) => (
-                <div className="contents" key={row.label}>
-                  <dt className="text-atc-faint uppercase tracking-[0.1em]">
-                    {row.label}
-                  </dt>
-                  <dd
-                    className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
-                    translate="no"
-                  >
-                    {row.value}
-                  </dd>
-                </div>
-              ))}
-            </dl>
-          </>
-        ) : null}
-
+        <PreviewCardHeader
+          primary={name}
+          primaryMono={false}
+          secondary={category || undefined}
+        />
         <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
-        <p className="text-[11px] leading-snug text-atc-dim">
-          {disclaimer}
-        </p>
+        <PreviewMetaRows rows={rows} />
+        <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
+        <p className="text-[11px] leading-snug text-atc-dim">{disclaimer}</p>
         {attribution ? (
           <p className="mt-2 text-[9px] leading-tight text-atc-faint">
             {attribution}
           </p>
         ) : null}
         {typeof onOpenNavigation === "function" ? (
-          <button
-            type="button"
-            className="aircraft-preview-card__track-btn mt-3"
-            onClick={onOpenNavigation}
-            aria-label={`${t("preview.goToSpot")} ${name}`}
-          >
-            {t("preview.goToSpot")}
-          </button>
+          <div className="aircraft-preview-card__actions">
+            <button
+              type="button"
+              className="aircraft-preview-card__track-btn"
+              onClick={onOpenNavigation}
+              aria-label={`${t("preview.goToSpot")} ${name}`}
+            >
+              {t("preview.goToSpot")}
+            </button>
+          </div>
         ) : null}
       </div>
     </div>

--- a/src/components/aircraft/preview/CandidateWatchingSpotPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/CandidateWatchingSpotPreviewMobileCard.tsx
@@ -1,14 +1,10 @@
-import { Camera } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
-import {
-  MobilePreviewContent,
-  MobilePreviewIdentity,
-} from "./MobilePreviewCard";
 import {
   formatCandidateWatchingSpotCategory,
   formatCandidateWatchingSpotDistance,
   formatCandidateWatchingSpotName,
 } from "./candidateWatchingSpotPreviewFormat";
+import { MobilePreviewHeader, MobilePreviewMetaLine } from "./previewCardChrome";
 
 type CandidateWatchingSpotPreviewMobileCardProps = {
   spot?: Record<string, any> | null;
@@ -27,32 +23,24 @@ export default function CandidateWatchingSpotPreviewMobileCard({
   const category = formatCandidateWatchingSpotCategory(spot);
   const distance = formatCandidateWatchingSpotDistance(spot, t);
   const attribution = String(sourceAttribution || "").trim();
-  const summaryLabel = distance || category || null;
+
+  const items = [
+    distance ? <span key="distance">{distance}</span> : null,
+    attribution ? (
+      <span key="attribution" className="text-atc-faint">
+        {attribution}
+      </span>
+    ) : null,
+  ].filter(Boolean);
 
   return (
-    <MobilePreviewContent>
-      <div className="candidate-watching-spot-preview-motion flex min-w-0 flex-col items-stretch gap-[6px]">
-        <MobilePreviewIdentity
-          icon={Camera}
-          label={t("preview.candidateWatchingSpotPreview")}
-          primary={name}
-          primaryClassName="whitespace-normal break-words text-[18px] leading-[1.05]"
-          secondary={null}
-        />
-        <div className="flex min-w-0 items-baseline justify-between gap-3 font-[var(--font-mono)]">
-          <span
-            translate="no"
-            className="notranslate min-w-0 shrink-0 truncate whitespace-nowrap text-left text-[10px] font-semibold leading-tight tracking-normal text-atc-dim"
-          >
-            {summaryLabel}
-          </span>
-          {attribution ? (
-            <span className="min-w-0 truncate whitespace-nowrap text-right text-[10px] font-medium leading-tight tracking-normal text-atc-dim">
-              {attribution}
-            </span>
-          ) : null}
-        </div>
-      </div>
-    </MobilePreviewContent>
+    <div className="candidate-watching-spot-preview-motion flex flex-col gap-[7px] px-[12px] pb-[6px] pt-[10px] [[data-density=compact]_&]:px-[10px]">
+      <MobilePreviewHeader
+        primary={name}
+        primaryMono={false}
+        secondary={category || undefined}
+      />
+      <MobilePreviewMetaLine items={items} />
+    </div>
   );
 }

--- a/src/components/aircraft/preview/NavaidPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/NavaidPreviewMetadataCard.tsx
@@ -1,11 +1,11 @@
 import NumberFlow from "@number-flow/react";
-import { RadioTower } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { toFiniteNumber } from "@/utils/math";
 import {
   formatNavaidFrequency,
   formatNavaidVariation,
 } from "./navaidPreviewFormat";
+import { PreviewCardHeader, PreviewMetaRows } from "./previewCardChrome";
 
 type NavaidPreviewMetadataCardProps = {
   navaid?: Record<string, any> | null;
@@ -17,7 +17,7 @@ export default function NavaidPreviewMetadataCard({
   const { t } = useI18n();
   const ident = String(navaid?.ident || "").trim().toUpperCase() || "—";
   const type = String(navaid?.type || "").trim().toUpperCase();
-  const name = String(navaid?.name || ident).trim();
+  const name = String(navaid?.name || "").trim();
   const distance = toFiniteNumber(navaid?.distanceNm);
   const elevation = toFiniteNumber(navaid?.elevationFt);
   const frequency = formatNavaidFrequency(navaid?.frequencyKhz);
@@ -25,16 +25,47 @@ export default function NavaidPreviewMetadataCard({
   const dmeChannel = String(navaid?.dme?.channel || "").trim();
   const usage = String(navaid?.usageType || "").trim();
   const power = String(navaid?.power || "").trim();
-  const associatedAirport = String(navaid?.associatedAirport || "").trim().toUpperCase();
+  const associatedAirport = String(navaid?.associatedAirport || "")
+    .trim()
+    .toUpperCase();
   const variation =
     formatNavaidVariation(navaid?.magneticVariationDeg) ||
     formatNavaidVariation(navaid?.slavedVariationDeg);
 
-  const identityRows = [
-    { label: t("preview.navaidName"), value: name },
-    { label: t("preview.navaidType"), value: type },
-  ].filter((row) => row.value);
-  const detailRows = [
+  const rows = [
+    {
+      label: t("metrics.distance"),
+      value:
+        distance == null ? (
+          "—"
+        ) : (
+          <>
+            <NumberFlow
+              value={distance}
+              format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
+            />
+            <span className="notranslate" translate="no">
+              {" "}
+              NM
+            </span>
+          </>
+        ),
+    },
+    {
+      label: t("metrics.elevation"),
+      value:
+        elevation == null ? (
+          "—"
+        ) : (
+          <>
+            <NumberFlow value={Math.round(elevation)} />
+            <span className="notranslate" translate="no">
+              {" "}
+              FT
+            </span>
+          </>
+        ),
+    },
     { label: t("metrics.frequency"), value: frequency },
     {
       label: t("metrics.dme"),
@@ -48,103 +79,13 @@ export default function NavaidPreviewMetadataCard({
 
   return (
     <div className="aircraft-preview-metadata-card">
-      <div className="relative">
-        <div className="min-w-0 pr-8">
-          <span className="atc-kicker">{t("preview.navaidPreview")}</span>
-          <div className="mt-1 flex min-w-0 items-baseline gap-2">
-            <span
-              className="notranslate airport-sidebar-display-mono airport-sidebar-display-mono--hero text-[28px] font-extrabold leading-none text-atc-text"
-              translate="no"
-            >
-              {ident}
-            </span>
-          </div>
-        </div>
-        <RadioTower
-          aria-hidden="true"
-          className="absolute right-0 top-0 size-5 text-atc-dim"
-          strokeWidth={1.8}
-        />
-        {identityRows.length ? (
-          <dl className="mt-2 grid w-full grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
-            {identityRows.map((row) => (
-              <div className="contents" key={row.label}>
-                <dt className="text-atc-faint uppercase tracking-[0.1em]">
-                  {row.label}
-                </dt>
-                <dd
-                  className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
-                  translate="no"
-                >
-                  {row.value}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        ) : null}
-      </div>
-
+      <PreviewCardHeader
+        primary={ident}
+        secondary={type || undefined}
+        sublines={[name]}
+      />
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
-
-      <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 font-mono text-[11px]">
-        <dt className="text-atc-faint uppercase tracking-[0.12em]">
-          {t("metrics.distance")}
-        </dt>
-        <dd className="text-right text-atc-text">
-          {distance == null ? (
-            "—"
-          ) : (
-            <>
-              <NumberFlow
-                value={distance}
-                format={{
-                  maximumFractionDigits: 1,
-                  minimumFractionDigits: 1,
-                }}
-              />
-              <span className="notranslate ml-1 text-atc-dim" translate="no">
-                NM
-              </span>
-            </>
-          )}
-        </dd>
-        <dt className="text-atc-faint uppercase tracking-[0.12em]">
-          {t("metrics.elevation")}
-        </dt>
-        <dd className="text-right text-atc-text">
-          {elevation == null ? (
-            "—"
-          ) : (
-            <>
-              <NumberFlow value={Math.round(elevation)} />
-              <span className="notranslate ml-1 text-atc-dim" translate="no">
-                FT
-              </span>
-            </>
-          )}
-        </dd>
-      </dl>
-
-      {detailRows.length ? (
-        <>
-          <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
-          <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
-            {detailRows.map((row) => (
-              <div className="contents" key={row.label}>
-                <dt className="text-atc-faint uppercase tracking-[0.1em]">
-                  {row.label}
-                </dt>
-                <dd
-                  className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
-                  translate="no"
-                >
-                  {row.value}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </>
-      ) : null}
+      <PreviewMetaRows rows={rows} />
     </div>
   );
 }

--- a/src/components/aircraft/preview/NavaidPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/NavaidPreviewMobileCard.tsx
@@ -1,15 +1,7 @@
-import NumberFlow from "@number-flow/react";
-import { RadioTower } from "lucide-react";
 import { toFiniteNumber } from "@/utils/math";
 import { formatNavaidFrequency } from "./navaidPreviewFormat";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
-import {
-  MobilePreviewContent,
-  MobilePreviewIdentity,
-  MobilePreviewMetaChip,
-  MobilePreviewMetaChips,
-  MobilePreviewRuleRow,
-} from "./MobilePreviewCard";
+import { MobilePreviewHeader, MobilePreviewMetaLine } from "./previewCardChrome";
 
 type NavaidPreviewMobileCardProps = {
   navaid?: Record<string, any> | null;
@@ -21,79 +13,32 @@ export default function NavaidPreviewMobileCard({
   const { t } = useI18n();
   const ident = String(navaid?.ident || "").trim().toUpperCase() || "—";
   const type = String(navaid?.type || "").trim().toUpperCase();
-  const name = String(navaid?.name || ident).trim();
+  const name = String(navaid?.name || "").trim();
   const distance = toFiniteNumber(navaid?.distanceNm);
   const frequency = formatNavaidFrequency(navaid?.frequencyKhz);
   const dmeChannel = String(navaid?.dme?.channel || "").trim();
-  const hasStats = Boolean(distance != null || frequency || dmeChannel);
+
+  const items = [
+    frequency ? <span key="freq">{frequency}</span> : null,
+    distance != null ? (
+      <span key="dist" className="inline-flex items-baseline gap-[2px]">
+        {distance.toFixed(1)}
+        <span translate="no" className="notranslate text-[9px] text-atc-faint">
+          NM
+        </span>
+      </span>
+    ) : null,
+    dmeChannel ? <span key="dme">{dmeChannel}</span> : null,
+  ].filter(Boolean);
 
   return (
-    <MobilePreviewContent>
-      <MobilePreviewIdentity
-        icon={RadioTower}
-        label={t("preview.navaidPreview")}
+    <div className="flex flex-col gap-[7px] px-[12px] pb-[6px] pt-[10px] [[data-density=compact]_&]:px-[10px]">
+      <MobilePreviewHeader
         primary={ident}
-        secondary={type}
+        secondary={type || undefined}
+        subline={name || undefined}
       />
-      {(name || hasStats) ? (
-        <MobilePreviewRuleRow
-          left={name ? <span className="block min-w-0 truncate whitespace-nowrap">{name}</span> : null}
-          right={
-            <MobilePreviewMetaChips>
-              {frequency ? (
-                <MobilePreviewMetaChip>
-                  <Stat plain={frequency} />
-                </MobilePreviewMetaChip>
-              ) : null}
-              {distance != null ? (
-                <MobilePreviewMetaChip>
-                  <Stat
-                    value={distance}
-                    unit="NM"
-                    format={{ maximumFractionDigits: 1, minimumFractionDigits: 1 }}
-                  />
-                </MobilePreviewMetaChip>
-              ) : null}
-              {dmeChannel ? (
-                <MobilePreviewMetaChip>
-                  <Stat plain={dmeChannel} />
-                </MobilePreviewMetaChip>
-              ) : null}
-            </MobilePreviewMetaChips>
-          }
-        />
-      ) : null}
-    </MobilePreviewContent>
-  );
-}
-
-function Stat({
-  value = 0,
-  unit = "",
-  plain = "",
-  format,
-}: Record<string, any>) {
-  if (plain) {
-    return (
-      <span className="notranslate tabular-nums">
-        {plain}
-      </span>
-    );
-  }
-
-  return (
-    <>
-      <NumberFlow
-        value={value}
-        format={format}
-        className="tabular-nums"
-      />
-      <span
-        translate="no"
-        className="notranslate text-[8px] font-medium uppercase text-atc-faint"
-      >
-        {unit}
-      </span>
-    </>
+      <MobilePreviewMetaLine items={items} />
+    </div>
   );
 }

--- a/src/components/aircraft/preview/ReportingPointPreviewMetadataCard.tsx
+++ b/src/components/aircraft/preview/ReportingPointPreviewMetadataCard.tsx
@@ -1,5 +1,5 @@
-import { Signpost } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { PreviewCardHeader, PreviewMetaRows } from "./previewCardChrome";
 
 type ReportingPointPreviewMetadataCardProps = {
   point?: Record<string, any> | null;
@@ -15,51 +15,16 @@ export default function ReportingPointPreviewMetadataCard({
     : t("preview.reportingPointOptional");
   const source =
     point?.source === "openaip" ? "OpenAIP" : String(point?.source || "");
-  const detailRows = [
-    { label: t("preview.reportingPointName"), value: name },
-    { label: t("preview.reportingPointType"), value: kind },
+  const rows = [
     { label: t("preview.reportingPointCountry"), value: String(point?.country || "") },
     { label: t("preview.airspaceSource"), value: source },
   ].filter((row) => row.value);
 
   return (
     <div className="aircraft-preview-metadata-card">
-      <div className="relative">
-        <div className="min-w-0 pr-8">
-          <span className="atc-kicker">{t("preview.reportingPointPreview")}</span>
-          <div className="mt-1 min-w-0">
-            <span
-              className="notranslate block min-w-0 whitespace-normal break-words font-sans text-[18px] font-bold leading-tight text-atc-text"
-              translate="no"
-            >
-              {name}
-            </span>
-          </div>
-        </div>
-        <Signpost
-          aria-hidden="true"
-          className="absolute right-0 top-0 size-5 text-atc-dim"
-          strokeWidth={1.8}
-        />
-      </div>
-
+      <PreviewCardHeader primary={name} primaryMono={false} secondary={kind} />
       <div className="aircraft-preview-card__divider aircraft-preview-card__divider--soft" />
-
-      <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[10px]">
-        {detailRows.map((row) => (
-          <div className="contents" key={row.label}>
-            <dt className="text-atc-faint uppercase tracking-[0.1em]">
-              {row.label}
-            </dt>
-            <dd
-              className="notranslate min-w-0 truncate text-right font-semibold text-atc-text"
-              translate="no"
-            >
-              {row.value}
-            </dd>
-          </div>
-        ))}
-      </dl>
+      <PreviewMetaRows rows={rows} />
     </div>
   );
 }

--- a/src/components/aircraft/preview/ReportingPointPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/ReportingPointPreviewMobileCard.tsx
@@ -1,12 +1,5 @@
-import { Signpost } from "lucide-react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
-import {
-  MobilePreviewContent,
-  MobilePreviewIdentity,
-  MobilePreviewMetaChip,
-  MobilePreviewMetaChips,
-  MobilePreviewRuleRow,
-} from "./MobilePreviewCard";
+import { MobilePreviewHeader, MobilePreviewMetaLine } from "./previewCardChrome";
 
 type ReportingPointPreviewMobileCardProps = {
   point?: Record<string, any> | null;
@@ -24,29 +17,15 @@ export default function ReportingPointPreviewMobileCard({
     point?.source === "openaip" ? "OpenAIP" : String(point?.source || "");
   const country = String(point?.country || "");
 
+  const items = [
+    country ? <span key="country">{country}</span> : null,
+    source ? <span key="source">{source}</span> : null,
+  ].filter(Boolean);
+
   return (
-    <MobilePreviewContent>
-      <MobilePreviewIdentity
-        icon={Signpost}
-        label={t("preview.reportingPointPreview")}
-        primary={name}
-        primaryClassName="whitespace-normal break-words text-[18px] leading-[1.05]"
-        secondary={kind}
-      />
-      {(country || source) ? (
-        <MobilePreviewRuleRow
-          right={
-            <MobilePreviewMetaChips>
-              {country ? (
-                <MobilePreviewMetaChip>{country}</MobilePreviewMetaChip>
-              ) : null}
-              {source ? (
-                <MobilePreviewMetaChip>{source}</MobilePreviewMetaChip>
-              ) : null}
-            </MobilePreviewMetaChips>
-          }
-        />
-      ) : null}
-    </MobilePreviewContent>
+    <div className="flex flex-col gap-[7px] px-[12px] pb-[6px] pt-[10px] [[data-density=compact]_&]:px-[10px]">
+      <MobilePreviewHeader primary={name} primaryMono={false} secondary={kind} />
+      <MobilePreviewMetaLine items={items} />
+    </div>
   );
 }

--- a/src/components/aircraft/preview/previewCardChrome.tsx
+++ b/src/components/aircraft/preview/previewCardChrome.tsx
@@ -1,0 +1,144 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type MetaRow = { label: ReactNode; value: ReactNode };
+
+// Shared chrome for the non-aircraft preview cards so they match the aircraft
+// card: a primary identity (mono for codes, sans for names) with an optional
+// secondary on the right, quiet sublines, and the shared metadata rows.
+
+export function PreviewCardHeader({
+  primary,
+  primaryMono = true,
+  secondary,
+  sublines = [],
+}: {
+  primary: ReactNode;
+  primaryMono?: boolean;
+  secondary?: ReactNode;
+  sublines?: ReactNode[];
+}) {
+  return (
+    <div className="mb-2.5 flex flex-col gap-[7px]">
+      <div className="flex min-w-0 items-baseline justify-between gap-3">
+        <span
+          className={cn(
+            "notranslate min-w-0 truncate leading-none text-atc-text",
+            primaryMono
+              ? "font-mono text-[21px] tracking-[0.02em]"
+              : "text-[16px] leading-snug",
+          )}
+          translate="no"
+          title={typeof primary === "string" ? primary : undefined}
+        >
+          {primary}
+        </span>
+        {secondary ? (
+          <span
+            className="notranslate flex-none whitespace-nowrap font-mono text-[12.5px] tracking-[0.04em] text-atc-dim"
+            translate="no"
+          >
+            {secondary}
+          </span>
+        ) : null}
+      </div>
+      {sublines.filter(Boolean).map((line, index) => (
+        <div
+          key={index}
+          className={cn(
+            "min-w-0 truncate leading-snug",
+            index === 0
+              ? "text-[13px] text-atc-dim"
+              : "text-[11.5px] text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]",
+          )}
+        >
+          {line}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function PreviewMetaRows({ rows }: { rows: MetaRow[] }) {
+  if (!rows.length) return null;
+  return (
+    <dl className="aircraft-preview-metadata">
+      {rows.map((row, index) => (
+        <div className="aircraft-preview-meta-row" key={index}>
+          <dt className="aircraft-preview-meta-row__label">{row.label}</dt>
+          <dd
+            className="aircraft-preview-meta-row__value notranslate min-w-0 truncate"
+            translate="no"
+          >
+            {row.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+// Compact mobile header: primary (+ optional secondary on the right) over a
+// quiet subline — same look as the aircraft mobile card.
+export function MobilePreviewHeader({
+  primary,
+  primaryMono = true,
+  secondary,
+  subline,
+}: {
+  primary: ReactNode;
+  primaryMono?: boolean;
+  secondary?: ReactNode;
+  subline?: ReactNode;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <span
+          className={cn(
+            "notranslate min-w-0 truncate leading-none text-atc-text",
+            primaryMono ? "font-mono text-[19px]" : "text-[15.5px] leading-snug",
+          )}
+          translate="no"
+          title={typeof primary === "string" ? primary : undefined}
+        >
+          {primary}
+        </span>
+        {secondary ? (
+          <span
+            className="notranslate flex-none whitespace-nowrap font-mono text-[12px] tracking-[0.04em] text-atc-dim"
+            translate="no"
+          >
+            {secondary}
+          </span>
+        ) : null}
+      </div>
+      {subline ? (
+        <div className="mt-[5px] min-w-0 truncate text-[11.5px] leading-snug text-atc-dim">
+          {subline}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// Dot-separated mobile detail line (e.g. "12.8 NM · 49 ft"), matching the
+// aircraft telemetry line.
+export function MobilePreviewMetaLine({ items }: { items: ReactNode[] }) {
+  const shown = items.filter(Boolean);
+  if (!shown.length) return null;
+  return (
+    <div className="flex flex-wrap items-baseline gap-x-[7px] gap-y-1 border-t border-atc-line pt-[7px] font-mono text-[12.5px] tabular-nums text-atc-text">
+      {shown.map((item, index) => (
+        <span key={index} className="inline-flex items-baseline gap-[7px]">
+          {index > 0 ? (
+            <span aria-hidden="true" className="text-atc-faint">
+              ·
+            </span>
+          ) : null}
+          {item}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -41,28 +41,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 97;
+export const CHANGELOG_TOTAL_COUNT = 98;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.28.6",
+    version: "v2.28.7",
     kind: "patch",
     title: {
-      en: "Mobile preview card — compact collapsed row",
-      zh: "移动预览卡片——更紧凑的收起态",
+      en: "Preview cards — airport / navaid / airspace match the aircraft card",
+      zh: "预览卡片——机场 / 导航台 / 空域与飞机卡片统一",
     },
     summary: {
-      en: "The collapsed mobile aircraft card tightens to a single glance: thumbnail, callsign + type, route, an inline orange Track button, and one telemetry line. The photo and secondary actions move into the expanded sheet.",
-      zh: "移动端飞机卡片的收起态收紧为一眼可读：缩略图、呼号 + 机型、航路、内联橙色 Track 按钮，以及一行参数。照片与次要操作移入展开层。",
+      en: "The airport, navaid, reporting-point, airspace, and watching-spot preview cards adopt the aircraft card's typography on both desktop and mobile — a mono identity with a secondary on the right, the shared metadata rows, and an orange Track button.",
+      zh: "机场、导航台、报告点、空域、拍机点预览卡片在桌面和移动端都沿用飞机卡片的排版——等宽标识 + 右侧次级、共享的元数据行、橙色 Track 按钮。",
     },
     highlights: [
       {
-        en: "Collapsed row: [thumbnail] [callsign + TYPE / CATEGORY · ORIGIN → DEST] [inline Track], over a 'speed · alt · ↑V/S' line with the vertical-speed in the accent",
-        zh: "收起行：[缩略图] [呼号 + 机型 / 类别 · 起 → 降] [内联 Track]，下方为「速度 · 高度 · ↑垂直速度」一行，垂直速度用强调色",
+        en: "All preview cards share one chrome — a primary identity (mono for codes, sans for names) over quiet sublines, the same label-left / value-right metadata rows, and a single dot-separated detail line on mobile; the kicker eyebrow, 28px bold heads, and entity icons are dropped",
+        zh: "所有预览卡片共用一套外观——主标识（代号用等宽、名称用无衬线）+ 安静的副行、同样的左标签 / 右值元数据行，移动端用一行点分隔参数；去掉了 kicker eyebrow、28px 粗标题与实体图标",
       },
       {
-        en: "Drag the grabber down to reveal a modest photo plus the camera / suggest-correction actions; the dense HEX / Track / Distance rows are left off mobile",
-        zh: "向下拖动把手即可展开适中的照片，以及相机 / 建议纠正操作；移动端不再堆叠 HEX / 航向 / 距离等密集信息",
+        en: "The mobile Track button is the orange accent everywhere (matching desktop); the multi-airspace selector now advances exactly one card per swipe",
+        zh: "移动端 Track 按钮统一为橙色强调色（与桌面一致）；多空域选择器现在每次滑动只前进一张",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -277,6 +277,28 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.28.6",
+    kind: "patch",
+    title: {
+      en: "Mobile preview card — compact collapsed row",
+      zh: "移动预览卡片——更紧凑的收起态",
+    },
+    summary: {
+      en: "The collapsed mobile aircraft card tightens to a single glance: thumbnail, callsign + type, route, an inline orange Track button, and one telemetry line. The photo and secondary actions move into the expanded sheet.",
+      zh: "移动端飞机卡片的收起态收紧为一眼可读：缩略图、呼号 + 机型、航路、内联橙色 Track 按钮，以及一行参数。照片与次要操作移入展开层。",
+    },
+    highlights: [
+      {
+        en: "Collapsed row: [thumbnail] [callsign + TYPE / CATEGORY · ORIGIN → DEST] [inline Track], over a 'speed · alt · ↑V/S' line with the vertical-speed in the accent",
+        zh: "收起行：[缩略图] [呼号 + 机型 / 类别 · 起 → 降] [内联 Track]，下方为「速度 · 高度 · ↑垂直速度」一行，垂直速度用强调色",
+      },
+      {
+        en: "Drag the grabber down to reveal a modest photo plus the camera / suggest-correction actions; the dense HEX / Track / Distance rows are left off mobile",
+        zh: "向下拖动把手即可展开适中的照片，以及相机 / 建议纠正操作；移动端不再堆叠 HEX / 航向 / 距离等密集信息",
+      },
+    ],
+  },
+  {
     version: "v2.28.5",
     kind: "patch",
     title: {


### PR DESCRIPTION
PR 2 of the preview-card work: the **airport / navaid / reporting-point / airspace / watching-spot** cards now match the redesigned aircraft card on **both desktop and mobile**.

### What changed
A small shared chrome (`previewCardChrome.tsx`) is reused across all of them:
- **PreviewCardHeader** — a primary identity (mono for codes like `KBOS` / `BOS`, sans for names like "Boston Class B Area A") with a secondary on the right, over quiet sublines. Drops the `atc-kicker` eyebrow, the 28px-bold heads, and the entity icons.
- **PreviewMetaRows** — the shared label-left / value-right metadata rows (same as the aircraft card).
- **MobilePreviewHeader + MobilePreviewMetaLine** — the compact mobile identity over one dot-separated detail line, matching the aircraft telemetry line.
- The **mobile Track button is the orange accent everywhere** (matching desktop).

### Airspace — one card per swipe
The multi-airspace carousel now advances **exactly one card per swipe**: the wheel handler re-arms only after a pause or a direction change (removed the re-acceleration paths that let one continuous trackpad swipe skip several cards). The touch swipe was already one-per-gesture.

### Verification
Verified live on `/airport/KBOS` (light):
- **Airport** — desktop + mobile (mono `KOWD · OWD`, Distance/Elevation rows, orange Track).
- **Navaid** — desktop (`BOS` + name + Distance/Elevation/Frequency rows).
- **Airspace** — desktop with the 3-dot multi-airspace selector ("Boston Class B Area A", Access/Class/Limits rows + description).
- Reporting-point / watching-spot use the same chrome (consistent by construction).

`pnpm build` clean; `pnpm test` 122 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)