### PR TITLE
v2.28.8: Restore nearby-list virtualization on the desktop sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.28.7",
+  "version": "2.28.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -59,7 +59,6 @@ export default function AirportSidebar({
   fillAircraftList = true,
 }) {
   const { t } = useI18n();
-  const isMobileOverlay = Boolean(onClose);
   const [activeView, setActiveView] = useState("traffic");
   const atcFrequencies = Array.isArray(frequencies) ? frequencies : [];
   const spottingSpots = Array.isArray(candidateWatchingSpots)
@@ -176,14 +175,13 @@ export default function AirportSidebar({
       <div
         key={`${activeView}:${movementFilter}`}
         className={
-          isMobileOverlay
-            ? // The traffic list owns its own (virtualized) scroll, so the
-              // overlay content area clips; every other view (weather / ATC /
-              // spotting) scrolls normally so its content is never cut off.
-              `airport-sidebar-content app-panel-transition flex min-h-0 flex-1 flex-col ${
-                activeView === "traffic" ? "overflow-hidden" : "overflow-y-auto"
-              }`
-            : "airport-sidebar-content app-panel-transition flex min-h-0 flex-col"
+          // The traffic list owns its own (virtualized) scroll, so the content
+          // area clips and the list windows internally; every other view
+          // (weather / ATC / spotting) scrolls normally so its content is
+          // never cut off. Same on desktop and the mobile overlay.
+          `airport-sidebar-content app-panel-transition flex min-h-0 flex-1 flex-col ${
+            activeView === "traffic" ? "overflow-hidden" : "overflow-y-auto"
+          }`
         }
       >
         {activeViewContent}

--- a/src/components/sidebar/SidebarShell.tsx
+++ b/src/components/sidebar/SidebarShell.tsx
@@ -88,10 +88,10 @@ export default function SidebarShell({
         ? "airport-sidebar-panel--mobile"
         : "flight-sidebar-panel--mobile"
       : "",
-    // On the mobile overlay the panel becomes a fixed-height flex column:
-    // the brand/identity/filters stay put and ONLY the list scrolls (so it
-    // can virtualize instead of rendering 100+ rows at once).
-    isMobileOverlay ? "min-h-0 overflow-hidden" : "",
+    // The panel is a fixed-height flex column on BOTH desktop and the mobile
+    // overlay: the brand/identity/filters stay put and ONLY the list scrolls,
+    // so the virtualizer can window instead of rendering 100+ rows at once.
+    "min-h-0 overflow-hidden",
   ]
     .filter(Boolean)
     .join(" ");
@@ -177,21 +177,9 @@ export default function SidebarShell({
             </div>
           ) : null}
 
-          <div
-            className={
-              isMobileOverlay
-                ? "sidebar-shell-body flex min-h-0 flex-1 flex-col overflow-visible"
-                : "sidebar-shell-body flex flex-none flex-col overflow-visible"
-            }
-          >
+          <div className="sidebar-shell-body flex min-h-0 flex-1 flex-col overflow-visible">
             {header ? <div className="flex-none">{header}</div> : null}
-            <div
-              className={
-                isMobileOverlay
-                  ? "sidebar-shell-main flex min-h-0 flex-1 flex-col overflow-visible"
-                  : "sidebar-shell-main flex-none overflow-visible"
-              }
-            >
+            <div className="sidebar-shell-main flex min-h-0 flex-1 flex-col overflow-visible">
               {children}
             </div>
           </div>

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import AircraftRow from "./AircraftRow";
@@ -67,15 +67,12 @@ export default function VirtualNearbyList({
     parentRef.current?.scrollTo({ top: 0 });
   }, [resetSignal]);
 
+  // Re-measure only when the list itself changes — NOT on selection. Selecting
+  // a row only swaps its background/rail colour (no height change), so forcing
+  // a full re-measure on every click was pure layout thrash.
   useEffect(() => {
     virtualizer.measure();
-  }, [
-    items.length,
-    resetSignal,
-    selectedAircraftId,
-    selectedAirportIcao,
-    virtualizer,
-  ]);
+  }, [items.length, resetSignal, virtualizer]);
 
   const virtualRows = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
@@ -88,6 +85,13 @@ export default function VirtualNearbyList({
         {virtualRows.map((virtualRow) => {
           const item = items[virtualRow.index];
           if (!item) return null;
+          // Resolve selection to a per-row boolean here so the memoized row
+          // only re-renders when ITS own selection flips — selecting a
+          // different row no longer re-renders every visible row.
+          const selected =
+            item.type === "aircraft"
+              ? item.id === selectedAircraftId
+              : item.data?.icao === selectedAirportIcao;
           return (
             <NearbyVirtualRow
               ref={virtualizer.measureElement}
@@ -96,8 +100,7 @@ export default function VirtualNearbyList({
               start={virtualRow.start}
               shouldAnimateEnter={enterFlags.get(item.id) === true}
               item={item}
-              selectedAircraftId={selectedAircraftId}
-              selectedAirportIcao={selectedAirportIcao}
+              selected={selected}
               onSelectAircraft={onSelectAircraft}
               onSelectAirport={onSelectAirport}
             />
@@ -108,14 +111,13 @@ export default function VirtualNearbyList({
   );
 }
 
-function NearbyVirtualRow({
+const NearbyVirtualRow = memo(function NearbyVirtualRow({
   ref,
   index,
   start,
   shouldAnimateEnter,
   item,
-  selectedAircraftId,
-  selectedAirportIcao,
+  selected,
   onSelectAircraft,
   onSelectAirport,
 }) {
@@ -164,17 +166,14 @@ function NearbyVirtualRow({
               <AircraftRow
                 aircraft={displayed.data}
                 aircraftId={displayed.id}
-                selected={
-                  swapState.phase !== "erasing" &&
-                  displayed.id === selectedAircraftId
-                }
+                selected={swapState.phase !== "erasing" && selected}
                 onSelectAircraft={onSelectAircraft}
               />
             ) : (
               <AirportRow
                 airport={displayed.data}
                 airportId={displayed.data?.icao}
-                selected={displayed.data?.icao === selectedAirportIcao}
+                selected={selected}
                 onSelectAirport={onSelectAirport}
               />
             )}
@@ -183,4 +182,4 @@ function NearbyVirtualRow({
       </CardFlipSlot>
     </div>
   );
-}
+});

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -41,28 +41,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 98;
+export const CHANGELOG_TOTAL_COUNT = 99;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.28.7",
+    version: "v2.28.8",
     kind: "patch",
     title: {
-      en: "Preview cards — airport / navaid / airspace match the aircraft card",
-      zh: "预览卡片——机场 / 导航台 / 空域与飞机卡片统一",
+      en: "Nearby list performance — desktop sidebar virtualizes again",
+      zh: "邻近列表性能——桌面侧栏恢复虚拟化",
     },
     summary: {
-      en: "The airport, navaid, reporting-point, airspace, and watching-spot preview cards adopt the aircraft card's typography on both desktop and mobile — a mono identity with a secondary on the right, the shared metadata rows, and an orange Track button.",
-      zh: "机场、导航台、报告点、空域、拍机点预览卡片在桌面和移动端都沿用飞机卡片的排版——等宽标识 + 右侧次级、共享的元数据行、橙色 Track 按钮。",
+      en: "On desktop the whole sidebar used to scroll, which left the nearby traffic list unbounded and defeated its virtualizer — every airport/flight page mounted all 80–100+ rows at once. Now the brand, identity, and filters stay fixed and only the list scrolls internally (matching the mobile layout), so it windows ~20 rows. Selecting a row no longer re-renders or re-measures the whole list.",
+      zh: "桌面端此前是整条侧栏一起滚动,导致邻近列表高度不受限、虚拟化被架空——每个机场/航班页都会一次性挂载全部 80–100+ 行。现在品牌、标识、筛选固定不动,只有列表内部滚动(与移动端一致),因此只渲染约 20 行。选中某行也不再重渲染或重新测量整张列表。",
     },
     highlights: [
       {
-        en: "All preview cards share one chrome — a primary identity (mono for codes, sans for names) over quiet sublines, the same label-left / value-right metadata rows, and a single dot-separated detail line on mobile; the kicker eyebrow, 28px bold heads, and entity icons are dropped",
-        zh: "所有预览卡片共用一套外观——主标识（代号用等宽、名称用无衬线）+ 安静的副行、同样的左标签 / 右值元数据行，移动端用一行点分隔参数；去掉了 kicker eyebrow、28px 粗标题与实体图标",
+        en: "Desktop airport + flight sidebars now have a fixed header with an internally-scrolling nearby list, so the virtualizer windows ~20 rows instead of mounting the full ~87",
+        zh: "桌面机场 + 航班侧栏改为固定表头 + 列表内部滚动,虚拟化只渲染约 20 行,而不是挂载全部约 87 行",
       },
       {
-        en: "The mobile Track button is the orange accent everywhere (matching desktop); the multi-airspace selector now advances exactly one card per swipe",
-        zh: "移动端 Track 按钮统一为橙色强调色（与桌面一致）；多空域选择器现在每次滑动只前进一张",
+        en: "Selecting an aircraft/airport only re-renders the affected rows (memoized) and skips the per-click full re-measure — clicking a row is noticeably snappier",
+        zh: "选中飞机/机场只重渲染受影响的行(memo 化),并跳过每次点击的整表重测量——点击明显更跟手",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -277,6 +277,28 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.28.7",
+    kind: "patch",
+    title: {
+      en: "Preview cards — airport / navaid / airspace match the aircraft card",
+      zh: "预览卡片——机场 / 导航台 / 空域与飞机卡片统一",
+    },
+    summary: {
+      en: "The airport, navaid, reporting-point, airspace, and watching-spot preview cards adopt the aircraft card's typography on both desktop and mobile — a mono identity with a secondary on the right, the shared metadata rows, and an orange Track button.",
+      zh: "机场、导航台、报告点、空域、拍机点预览卡片在桌面和移动端都沿用飞机卡片的排版——等宽标识 + 右侧次级、共享的元数据行、橙色 Track 按钮。",
+    },
+    highlights: [
+      {
+        en: "All preview cards share one chrome — a primary identity (mono for codes, sans for names) over quiet sublines, the same label-left / value-right metadata rows, and a single dot-separated detail line on mobile; the kicker eyebrow, 28px bold heads, and entity icons are dropped",
+        zh: "所有预览卡片共用一套外观——主标识（代号用等宽、名称用无衬线）+ 安静的副行、同样的左标签 / 右值元数据行，移动端用一行点分隔参数；去掉了 kicker eyebrow、28px 粗标题与实体图标",
+      },
+      {
+        en: "The mobile Track button is the orange accent everywhere (matching desktop); the multi-airspace selector now advances exactly one card per swipe",
+        zh: "移动端 Track 按钮统一为橙色强调色（与桌面一致）；多空域选择器现在每次滑动只前进一张",
+      },
+    ],
+  },
+  {
     version: "v2.28.6",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -3797,8 +3797,11 @@ body {
 .airport-desktop-sidebar > .h-full,
 .airport-desktop-sidebar .sidebar-shell {
     border-radius: var(--atc-radius-shell);
-    overflow-x: hidden;
-    overflow-y: auto;
+    /* The panel itself clips; the brand + identity + filters stay fixed and
+       only the nearby list scrolls internally, so the virtualizer can window
+       (render ~20 rows) instead of mounting the whole 100+ row list. Matches
+       the mobile-overlay layout. */
+    overflow: hidden;
     overscroll-behavior-y: contain;
     -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
The nearby traffic list was rendering **all ~87 rows** on desktop (airport + flight pages), which is the lag the user reported — and it was on **desktop too**, not just mobile.

### Root cause
The desktop sidebar scrolled as one block: `.airport-desktop-sidebar .sidebar-shell` was `overflow-y: auto`, and `sidebar-shell-body` / `-main` were `flex-none overflow-visible`. So the list's own `overflow-y-auto` container grew to the full ~4600px content height and never bounded → the `@tanstack/react-virtual` virtualizer saw a 4600px viewport and windowed nothing. The **mobile overlay already did the right thing** (fixed header + internally-scrolling list); desktop was just left on the old whole-panel-scroll model.

### Fix (make desktop bound the list like mobile already does)
- `.airport-desktop-sidebar .sidebar-shell` → `overflow: hidden` (panel clips; list scrolls internally).
- `SidebarShell`: the panel + `sidebar-shell-body` + `-main` are always a bounded flex column (`min-h-0 flex-1`), not only on the mobile overlay.
- `AirportSidebar`: `airport-sidebar-content` is always `flex-1 min-h-0`, traffic view clips so the list windows.

The brand / identity / filters now stay fixed; only the list scrolls — consistent with mobile.

### Plus the per-click cost (the first thing reported)
- `VirtualNearbyList` no longer calls `virtualizer.measure()` on selection (selection changes colour, not row height — the re-measure was pure layout thrash across all rendered rows).
- `NearbyVirtualRow` is memoized and selection is resolved to a per-row boolean, so selecting a row re-renders only the **2 affected rows**, not every visible row.

### Verification (local browser, desktop)
- `/airport/KBOS`: rendered rows **87 → 19**, list scroll container bounded (528px vs 4550px content), windows on scroll (rows recycle to index 20+), selection + preview intact, layout visually unchanged.
- `/aircraft/SWA4736`: same — 19 rows, 262px fixed header, nothing clipped.
- Mobile overlay untouched (different class scope `.airport-sidebar-panel--mobile`; SidebarShell classes unchanged for it).

`pnpm build` clean; `pnpm test` 122 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)