### PR TITLE
v2.30.1: Sidebar typography pass — tokenized sizes, sans headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.0",
+  "version": "2.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/about/AboutPanel.tsx
+++ b/src/components/about/AboutPanel.tsx
@@ -101,14 +101,14 @@ export default function AboutPanel() {
       <div className={`flex items-center justify-between gap-3 ${INSET}`}>
         <h2
           className={
-            "flex min-w-0 items-center gap-2 font-serif text-[15px] leading-snug text-atc-dim " +
+            "flex min-w-0 items-center gap-2 [font-weight:600] text-[calc(15px*var(--sb-title-scale))] leading-snug text-atc-dim " +
             "before:block before:h-[1.5px] before:w-[9px] before:shrink-0 before:rounded-full " +
             "before:bg-[var(--atc-signal-accent)] before:content-['']"
           }
         >
           {t("about.dataSources")}
         </h2>
-        <span className="shrink-0 font-code text-[10px] [letter-spacing:0.4px] text-atc-faint">
+        <span className="shrink-0 font-code text-[calc(10px*var(--sb-body-scale))] [letter-spacing:0.4px] text-atc-faint">
           {getDataSourceCountLabel(ABOUT_DATA_SOURCES, locale)}
         </span>
       </div>
@@ -123,9 +123,9 @@ export default function AboutPanel() {
             CATEGORY_LABEL[category][locale === "zh-CN" ? "zh" : "en"];
           return (
             <section key={category} className="flex flex-col gap-1.5">
-              {/* Sub-group label: plain upright serif, no tick. */}
+              {/* Sub-group label: plain upright sans, semibold, no tick. */}
               <h3
-                className={`font-serif text-[12px] leading-snug text-atc-dim ${INSET}`}
+                className={`[font-weight:600] text-[calc(12px*var(--sb-title-scale))] leading-snug text-atc-dim ${INSET}`}
               >
                 {label}
               </h3>
@@ -168,10 +168,10 @@ export default function AboutPanel() {
               <Github className="h-3 w-3" aria-hidden="true" />
             </span>
             <div>
-              <strong className="block text-[11px] font-semibold text-atc-text">
+              <strong className="block text-[calc(11px*var(--sb-body-scale))] font-semibold text-atc-text">
                 {ABOUT_REPOSITORY.name}
               </strong>
-              <small className="mt-0.5 block font-mono text-[9px] tracking-normal uppercase text-atc-dim">
+              <small className="mt-0.5 block font-mono text-[calc(9px*var(--sb-body-scale))] tracking-normal uppercase text-atc-dim">
                 {ABOUT_REPOSITORY.licenseKey
                   ? t(ABOUT_REPOSITORY.licenseKey)
                   : ABOUT_REPOSITORY.license}
@@ -200,10 +200,10 @@ function MetaEntry({
 }) {
   return (
     <div className="flex min-w-0 flex-col gap-1">
-      <span className="text-[10px] uppercase [letter-spacing:1.4px] text-atc-faint">
+      <span className="text-[calc(10px*var(--sb-body-scale))] uppercase [letter-spacing:1.4px] text-atc-faint">
         {label}
       </span>
-      <span className="text-[14px] leading-[1.4] text-atc-text">{value}</span>
+      <span className="text-[calc(14px*var(--sb-body-scale))] leading-[1.4] text-atc-text">{value}</span>
     </div>
   );
 }

--- a/src/components/airport/search/AirportDiscoveryPanel.tsx
+++ b/src/components/airport/search/AirportDiscoveryPanel.tsx
@@ -150,7 +150,7 @@ function DiscoverySectionHeader({
       <h2
         id={id}
         className={
-          "flex min-w-0 items-center gap-2 font-serif text-[15px] leading-snug text-atc-dim " +
+          "flex min-w-0 items-center gap-2 [font-weight:600] text-[calc(15px*var(--sb-title-scale))] leading-snug text-atc-dim " +
           "before:block before:h-[1.5px] before:w-[9px] before:shrink-0 before:rounded-full " +
           "before:bg-[var(--atc-signal-accent)] before:content-['']"
         }

--- a/src/components/airport/search/AirportListRow.tsx
+++ b/src/components/airport/search/AirportListRow.tsx
@@ -53,7 +53,7 @@ export function AirportListRow({
     <span
       className={cn(
         "mt-[2px] inline-flex w-[var(--lr-chip-col,46px)] items-center justify-center self-start rounded-[6px] py-[3px]",
-        "whitespace-nowrap font-code text-[length:var(--lr-chip-fs,10px)] leading-none [letter-spacing:0.6px]",
+        "whitespace-nowrap font-code text-[length:var(--lr-chip-fs,calc(10px*var(--sb-body-scale)))] leading-none [letter-spacing:0.6px]",
         accent
           ? cn(
               "text-[var(--atc-signal-accent-strong)]",
@@ -78,9 +78,9 @@ export function AirportListRow({
   const text = (
     <span className="flex min-w-0 flex-col gap-0.5 self-center">
       {/* Primary line: 15.5px near-black, regular weight, wraps (no ellipsis). */}
-      <span className="text-[15.5px] leading-[1.25] text-atc-text">{title}</span>
+      <span className="text-[calc(15.5px*var(--sb-title-scale))] leading-[1.25] text-atc-text">{title}</span>
       {subtitle ? (
-        <span className="text-[11.5px] leading-[1.3] text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]">
+        <span className="text-[calc(11.5px*var(--sb-body-scale))] leading-[1.3] text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]">
           {subtitle}
         </span>
       ) : null}

--- a/src/components/airport/search/AirportSearchPanel.tsx
+++ b/src/components/airport/search/AirportSearchPanel.tsx
@@ -55,7 +55,7 @@ export default function AirportSearchPanel({
         <Input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          className="h-6 min-w-0 flex-1 p-0 text-[11px] font-semibold tracking-normal text-atc-text"
+          className="h-6 min-w-0 flex-1 p-0 text-[calc(11px*var(--sb-body-scale))] font-semibold tracking-normal text-atc-text"
           placeholder={t("search.placeholder")}
         />
         <kbd className="atc-chip hidden shrink-0 sm:inline-flex">

--- a/src/components/airport/search/AirportSearchResults.tsx
+++ b/src/components/airport/search/AirportSearchResults.tsx
@@ -58,7 +58,7 @@ export function AirportSearchResults({
               pendingLabel={t("search.searchingAirports")}
               successLabel={t("search.searchedAirports")}
               errorLabel={t("search.searchAirportsError")}
-              className="text-[9px]"
+              className="text-[calc(9px*var(--sb-body-scale))]"
             />
             <span className="atc-section-head__count">{countLabel}</span>
           </span>

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -128,7 +128,7 @@ export default function DitherPageShell({
             <div className="dither-page-header dither-page-header--copy-only flex-none px-5 pb-4 pt-1">
               <div className="dither-page-copy">
                 <h1
-                  className="atc-page-title mt-4 text-[26px] font-extrabold leading-[1.12] text-atc-text"
+                  className="atc-page-title mt-4 text-[calc(26px*var(--sb-title-scale))] font-extrabold leading-[1.12] text-atc-text"
                   style={{
                     fontFamily: "var(--font-display)",
                     letterSpacing: "normal",

--- a/src/components/changelog/ChangelogPanel.tsx
+++ b/src/components/changelog/ChangelogPanel.tsx
@@ -153,7 +153,7 @@ function ChangelogEntry({
         <span className="changelog-entry__version">{release.version}</span>
         {release.kind ? (
           // Same mono code chip as the ICAO / category chips; one shared style.
-          <span className="inline-flex w-fit items-center justify-center whitespace-nowrap rounded-[5px] px-[5px] py-[2.5px] font-code text-[8.5px] [letter-spacing:0.4px] text-atc-dim shadow-[inset_0_0_0_0.5px_var(--atc-line-strong)]">
+          <span className="inline-flex w-fit items-center justify-center whitespace-nowrap rounded-[5px] px-[5px] py-[2.5px] font-code text-[calc(8.5px*var(--sb-body-scale))] [letter-spacing:0.4px] text-atc-dim shadow-[inset_0_0_0_0.5px_var(--atc-line-strong)]">
             {release.kind.toUpperCase()}
           </span>
         ) : null}

--- a/src/components/mechanism/MechanismPanel.tsx
+++ b/src/components/mechanism/MechanismPanel.tsx
@@ -33,10 +33,10 @@ export default function MechanismPanel() {
             <Fragment key={item.id}>
               {showGroup ? (
                 <li className={cn("pb-2 pt-[22px] first:pt-1", INSET)}>
-                  {/* Upright serif group label + accent tick — same as Explorer. */}
+                  {/* Upright sans group label (semibold) + accent tick — same as Explorer. */}
                   <h2
                     className={
-                      "flex min-w-0 items-center gap-2 font-serif text-[15px] leading-snug text-atc-dim " +
+                      "flex min-w-0 items-center gap-2 [font-weight:600] text-[calc(15px*var(--sb-title-scale))] leading-snug text-atc-dim " +
                       "before:block before:h-[1.5px] before:w-[9px] before:shrink-0 before:rounded-full " +
                       "before:bg-[var(--atc-signal-accent)] before:content-['']"
                     }
@@ -64,14 +64,14 @@ export default function MechanismPanel() {
                       "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--atc-signal-accent)]",
                     )}
                   >
-                    <span className="mt-[1px] font-code text-[13px] leading-[1.3] text-atc-faint group-data-[expanded=true]:text-atc-text">
+                    <span className="mt-[1px] font-code text-[calc(13px*var(--sb-body-scale))] leading-[1.3] text-atc-faint group-data-[expanded=true]:text-atc-text">
                       {String(index + 1).padStart(2, "0")}
                     </span>
                     <span className="flex min-w-0 flex-col gap-[3px]">
-                      <span className="text-[15px] leading-[1.25] text-atc-text">
+                      <span className="text-[calc(15px*var(--sb-title-scale))] leading-[1.25] text-atc-text">
                         {t(item.titleKey)}
                       </span>
-                      <span className="text-[11.5px] leading-[1.3] text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]">
+                      <span className="text-[calc(11.5px*var(--sb-body-scale))] leading-[1.3] text-[color-mix(in_oklab,var(--atc-text)_46%,transparent)]">
                         {t(item.signalKey)}
                       </span>
                     </span>
@@ -92,7 +92,7 @@ export default function MechanismPanel() {
                   >
                     <div className="min-h-0 overflow-hidden">
                       <div className={cn("pb-3 pr-2.5", DETAIL_INDENT)}>
-                        <p className="text-[12px] leading-[1.55] text-[color-mix(in_oklab,var(--atc-text)_55%,transparent)]">
+                        <p className="text-[calc(12px*var(--sb-body-scale))] leading-[1.55] text-[color-mix(in_oklab,var(--atc-text)_55%,transparent)]">
                           {t(item.bodyKey)}
                         </p>
                         <MechanismFlow
@@ -105,10 +105,10 @@ export default function MechanismPanel() {
                               key={key}
                               className="grid grid-cols-[16px_minmax(0,1fr)] gap-2"
                             >
-                              <span className="font-code text-[10px] leading-[1.5] text-atc-faint">
+                              <span className="font-code text-[calc(10px*var(--sb-body-scale))] leading-[1.5] text-atc-faint">
                                 {String(detailIndex + 1).padStart(2, "0")}
                               </span>
-                              <span className="min-w-0 text-[11.5px] leading-[1.45] text-[color-mix(in_oklab,var(--atc-text)_55%,transparent)]">
+                              <span className="min-w-0 text-[calc(11.5px*var(--sb-body-scale))] leading-[1.45] text-[color-mix(in_oklab,var(--atc-text)_55%,transparent)]">
                                 {t(key)}
                               </span>
                             </li>
@@ -136,7 +136,7 @@ function MechanismFlow({ label, steps }: { label: string; steps: string[] }) {
   return (
     <div className="mt-3.5">
       {/* `uppercase` is globally disabled (modernization override), so cap in JS. */}
-      <span className="block font-code text-[9px] [letter-spacing:1.4px] text-atc-faint">
+      <span className="block font-code text-[calc(9px*var(--sb-body-scale))] [letter-spacing:1.4px] text-atc-faint">
         {label.toUpperCase()}
       </span>
       <ol className="relative mt-2 flex flex-col gap-2.5">
@@ -160,7 +160,7 @@ function MechanismFlow({ label, steps }: { label: string; steps: string[] }) {
                     : "bg-[color-mix(in_oklab,var(--atc-text)_32%,transparent)]",
                 )}
               />
-              <span className="min-w-0 truncate font-code text-[11.5px] leading-none text-atc-text">
+              <span className="min-w-0 truncate font-code text-[calc(11.5px*var(--sb-body-scale))] leading-none text-atc-text">
                 {step}
               </span>
             </li>

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -88,7 +88,7 @@ function AircraftRow({
 
       <div className="flex min-w-0 flex-1 items-baseline gap-2">
         <span
-          className="aircraft-table-callsign airport-sidebar-display-mono notranslate shrink-0 text-[12.5px] text-atc-text"
+          className="aircraft-table-callsign airport-sidebar-display-mono notranslate shrink-0 text-[calc(12.5px*var(--sb-body-scale))] text-atc-text"
           translate="no"
         >
           {callsign}
@@ -96,14 +96,14 @@ function AircraftRow({
         {route ? (
           <span
             title={routeTitle}
-            className="notranslate min-w-0 truncate text-[10.5px] text-atc-faint"
+            className="notranslate min-w-0 truncate text-[calc(10.5px*var(--sb-body-scale))] text-atc-faint"
             translate="no"
           >
             {route}
           </span>
         ) : registration && registration !== callsign ? (
           <span
-            className="notranslate min-w-0 truncate text-[10px] tracking-[0.04em] text-atc-faint"
+            className="notranslate min-w-0 truncate text-[calc(10px*var(--sb-body-scale))] tracking-[0.04em] text-atc-faint"
             translate="no"
           >
             {registration}
@@ -112,19 +112,19 @@ function AircraftRow({
       </div>
 
       <div className="flex flex-none items-baseline gap-2.5 font-mono tabular-nums">
-        <span className="text-[11px] text-atc-faint">
+        <span className="text-[calc(11px*var(--sb-body-scale))] text-atc-faint">
           {distanceMain}
           {distanceUnit ? (
-            <span className="ml-0.5 text-[7.5px] text-atc-faint">
+            <span className="ml-0.5 text-[calc(7.5px*var(--sb-body-scale))] text-atc-faint">
               {distanceUnit}
             </span>
           ) : null}
         </span>
-        <span className="flex items-baseline gap-0.5 text-[11px] text-atc-text">
+        <span className="flex items-baseline gap-0.5 text-[calc(11px*var(--sb-body-scale))] text-atc-text">
           {cue ? (
             <span
               aria-hidden="true"
-              className="text-[8px] leading-none text-atc-faint"
+              className="text-[calc(8px*var(--sb-body-scale))] leading-none text-atc-faint"
             >
               {cue}
             </span>
@@ -141,7 +141,7 @@ function AircraftRow({
                 </span>
               ) : null}
               {altitudeDisplay.value}
-              <span className="ml-0.5 text-[7.5px] text-atc-faint">
+              <span className="ml-0.5 text-[calc(7.5px*var(--sb-body-scale))] text-atc-faint">
                 {String(altitudeDisplay.unit).toUpperCase()}
               </span>
             </>

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -246,7 +246,7 @@ export default function AircraftTable({
           <span className="atc-kicker atc-kicker--lead">
             {entityFilter === "airports" ? t("sidebar.airports") : t("sidebar.flights")}
           </span>
-          <div className="whitespace-nowrap font-mono text-[8px] tracking-normal text-atc-dim tabular-nums">
+          <div className="whitespace-nowrap font-mono text-[calc(8px*var(--sb-body-scale))] tracking-normal text-atc-dim tabular-nums">
             <span>{filteredAircraft.length + filteredAirports.length}</span>
             <span> / </span>
             <span>
@@ -308,10 +308,10 @@ export default function AircraftTable({
                 </FilterCard>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-[220px] text-left">
-                <strong className="block text-[11px] font-semibold uppercase tracking-wide">
+                <strong className="block text-[calc(11px*var(--sb-body-scale))] font-semibold uppercase tracking-wide">
                   {t("sidebar.routed")}
                 </strong>
-                <span className="mt-1 block text-[11px] font-normal leading-snug">
+                <span className="mt-1 block text-[calc(11px*var(--sb-body-scale))] font-normal leading-snug">
                   {t("filters.routedTooltip")}
                 </span>
               </TooltipContent>
@@ -367,7 +367,7 @@ export default function AircraftTable({
           {listRows.length === 0 &&
           filteredAirports.length === 0 &&
           !pinnedAircraft ? (
-            <div className="app-panel-transition px-[var(--airport-sidebar-inset)] py-6 text-center text-[10px] font-semibold uppercase tracking-normal text-atc-faint">
+            <div className="app-panel-transition px-[var(--airport-sidebar-inset)] py-6 text-center text-[calc(10px*var(--sb-body-scale))] font-semibold uppercase tracking-normal text-atc-faint">
               {aircraft.length + airports.length
                 ? t("sidebar.noMatches")
                 : t("sidebar.nothingInRange")}
@@ -624,7 +624,7 @@ function AircraftTypeFilterCard({ groups, selectedTypes, onChange }) {
                       <span className="min-w-0 truncate">{type.label}</span>
                       {type.icaoType && type.icaoType !== type.label ? (
                         <span
-                          className="notranslate min-w-0 truncate font-mono text-[9px] font-medium uppercase tracking-normal text-atc-faint"
+                          className="notranslate min-w-0 truncate font-mono text-[calc(9px*var(--sb-body-scale))] font-medium uppercase tracking-normal text-atc-faint"
                           translate="no"
                         >
                           {type.icaoType}

--- a/src/components/sidebar/AirportIdentity.tsx
+++ b/src/components/sidebar/AirportIdentity.tsx
@@ -87,23 +87,23 @@ export default function AirportIdentity({
       <span className="atc-kicker airport-sidebar-identity__kicker">
         {(nearMe ? t("sidebar.nearMeLabel") : t("sidebar.airport")).toUpperCase()}
       </span>
-      <h1 className="mt-3 text-[22px] font-normal leading-[1.08] text-atc-text">
+      <h1 className="mt-3 text-[calc(22px*var(--sb-title-scale))] font-normal leading-[1.08] text-atc-text">
         <span className="airport-sidebar-display-mono notranslate" translate="no">
           {codeLine || t("sidebar.unknownAirport")}
         </span>
       </h1>
       {nameLine ? (
-        <div className="mt-2 text-[13px] leading-snug text-atc-dim">
+        <div className="mt-2 text-[calc(13px*var(--sb-title-scale))] leading-snug text-atc-dim">
           {nameLine}
         </div>
       ) : null}
       {metaLine ? (
-        <div className="mt-1.5 font-mono text-[11px] leading-snug text-atc-faint">
+        <div className="mt-1.5 font-mono text-[calc(11px*var(--sb-body-scale))] leading-snug text-atc-faint">
           {metaLine}
         </div>
       ) : null}
       {nearMeRefresh && (
-        <div className="mt-1.5 text-[11px] text-atc-faint">
+        <div className="mt-1.5 text-[calc(11px*var(--sb-body-scale))] text-atc-faint">
           {nearMeRefresh.lastTime
             ? t("nearMe.lastUpdated", { time: nearMeRefresh.lastTime })
             : ""}

--- a/src/components/sidebar/AirportRow.tsx
+++ b/src/components/sidebar/AirportRow.tsx
@@ -55,12 +55,12 @@ function AirportRow({
 
       <div className="flex min-w-0 flex-1 items-baseline gap-2">
         <span
-          className="aircraft-table-callsign airport-sidebar-display-mono notranslate shrink-0 text-[12.5px] text-atc-text"
+          className="aircraft-table-callsign airport-sidebar-display-mono notranslate shrink-0 text-[calc(12.5px*var(--sb-body-scale))] text-atc-text"
           translate="no"
         >
           {code}
         </span>
-        <span className="flex min-w-0 items-baseline gap-1 text-[10.5px] text-atc-faint">
+        <span className="flex min-w-0 items-baseline gap-1 text-[calc(10.5px*var(--sb-body-scale))] text-atc-faint">
           {flag ? (
             <span aria-hidden="true" className="flex-none leading-none">
               {flag}
@@ -71,23 +71,23 @@ function AirportRow({
       </div>
 
       <div className="flex flex-none items-baseline gap-2.5 font-mono tabular-nums">
-        <span className="text-[11px] text-atc-faint">
+        <span className="text-[calc(11px*var(--sb-body-scale))] text-atc-faint">
           {distanceDisplay ? (distanceDisplay.text ?? distanceDisplay.value) : "—"}
           {distanceDisplay?.unit ? (
-            <span className="ml-0.5 text-[7.5px] text-atc-faint">
+            <span className="ml-0.5 text-[calc(7.5px*var(--sb-body-scale))] text-atc-faint">
               {distanceDisplay.unit}
             </span>
           ) : null}
         </span>
         {endpointLabel ? (
-          <span className="text-[9px] uppercase tracking-normal text-atc-dim">
+          <span className="text-[calc(9px*var(--sb-body-scale))] uppercase tracking-normal text-atc-dim">
             {endpointLabel}
           </span>
         ) : (
-          <span className="text-[11px] text-atc-text">
+          <span className="text-[calc(11px*var(--sb-body-scale))] text-atc-text">
             {elevationDisplay ? elevationDisplay.value : "—"}
             {elevationDisplay?.unit ? (
-              <span className="ml-0.5 text-[7.5px] text-atc-faint">
+              <span className="ml-0.5 text-[calc(7.5px*var(--sb-body-scale))] text-atc-faint">
                 {elevationDisplay.unit.toUpperCase()}
               </span>
             ) : null}

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -245,10 +245,10 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
   return (
     <div className="flex flex-col gap-3 px-[var(--airport-sidebar-inset)] pb-5 pt-1">
       <div className="flex items-baseline justify-between pb-0.5">
-        <h2 className="text-[11px] uppercase tracking-normal text-atc-text">
+        <h2 className="text-[calc(11px*var(--sb-title-scale))] uppercase tracking-normal text-atc-text">
           ATC Frequencies
         </h2>
-        <span className="font-mono text-[9px] uppercase text-atc-faint">
+        <span className="font-mono text-[calc(9px*var(--sb-body-scale))] uppercase text-atc-faint">
           {frequencies.length} channels
         </span>
       </div>
@@ -257,14 +257,14 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
           href={liveAtcHref}
           target="_blank"
           rel="noopener noreferrer nofollow"
-          className="inline-flex items-center justify-between gap-2 text-[9.5px] uppercase tracking-normal text-atc-dim transition-colors hover:text-atc-text"
+          className="inline-flex items-center justify-between gap-2 text-[calc(9.5px*var(--sb-body-scale))] uppercase tracking-normal text-atc-dim transition-colors hover:text-atc-text"
         >
           <span>Search {normalizedIcao} on LiveATC</span>
           <ExternalLink aria-hidden="true" className="size-3.5" strokeWidth={2} />
         </a>
       ) : null}
       {rows.length === 0 ? (
-        <p className="app-panel-transition rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] bg-[color-mix(in_oklab,var(--app-frost-tint)_22%,transparent)] px-3 py-5 text-center text-[11px] leading-snug text-atc-dim">
+        <p className="app-panel-transition rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] bg-[color-mix(in_oklab,var(--app-frost-tint)_22%,transparent)] px-3 py-5 text-center text-[calc(11px*var(--sb-body-scale))] leading-snug text-atc-dim">
           No published frequencies for this airport.
         </p>
       ) : (
@@ -275,15 +275,15 @@ function AtcFrequencyPanel({ icao = "", frequencies = [] }) {
               className="flex items-baseline justify-between gap-3 border-b border-[color-mix(in_oklab,var(--atc-line)_55%,transparent)] py-2 last:border-b-0"
             >
               <div className="min-w-0">
-                <div className="truncate text-[11.5px] text-atc-text">{row.role}</div>
+                <div className="truncate text-[calc(11.5px*var(--sb-body-scale))] text-atc-text">{row.role}</div>
                 {row.detail ? (
-                  <div className="truncate text-[9px] uppercase tracking-[0.06em] text-atc-faint">
+                  <div className="truncate text-[calc(9px*var(--sb-body-scale))] uppercase tracking-[0.06em] text-atc-faint">
                     {row.detail}
                   </div>
                 ) : null}
               </div>
               <span
-                className="notranslate shrink-0 font-mono text-[12.5px] tabular-nums text-atc-text"
+                className="notranslate shrink-0 font-mono text-[calc(12.5px*var(--sb-body-scale))] tabular-nums text-atc-text"
                 translate="no"
               >
                 {formatFrequencyBadge(row.frequencyMhz)}
@@ -307,15 +307,15 @@ function SpottingPanel({
   return (
     <div className="flex flex-col gap-2 px-[var(--airport-sidebar-inset)] pb-5 pt-1">
       <div className="flex items-baseline justify-between pb-0.5">
-        <h2 className="text-[11px] font-bold uppercase tracking-normal text-atc-text">
+        <h2 className="text-[calc(11px*var(--sb-title-scale))] font-bold uppercase tracking-normal text-atc-text">
           {t("watcherMode.cardsTitle")}
         </h2>
-        <span className="font-mono text-[9px] font-semibold uppercase text-atc-faint">
+        <span className="font-mono text-[calc(9px*var(--sb-body-scale))] font-semibold uppercase text-atc-faint">
           {t(countKey, { count: spots.length })}
         </span>
       </div>
       {spots.length === 0 ? (
-        <p className="app-panel-transition rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] bg-[color-mix(in_oklab,var(--app-frost-tint)_22%,transparent)] px-3 py-5 text-center text-[11px] font-medium leading-snug text-atc-dim">
+        <p className="app-panel-transition rounded-[var(--atc-radius-card)] border border-[var(--app-frost-border)] bg-[color-mix(in_oklab,var(--app-frost-tint)_22%,transparent)] px-3 py-5 text-center text-[calc(11px*var(--sb-body-scale))] font-medium leading-snug text-atc-dim">
           {t("watcherMode.empty")}
         </p>
       ) : null}
@@ -332,21 +332,21 @@ function SpottingPanel({
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <div className="truncate text-[10px] font-bold uppercase tracking-normal text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
+                  <div className="truncate text-[calc(10px*var(--sb-body-scale))] font-bold uppercase tracking-normal text-atc-text group-data-[active=true]:text-[var(--atc-click-fg)]">
                     {spot.name || spot.title || spot.category || "Spotter location"}
                   </div>
-                  <div className="mt-1 text-[10px] font-medium text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
+                  <div className="mt-1 text-[calc(10px*var(--sb-body-scale))] font-medium text-atc-dim group-data-[active=true]:text-[var(--atc-click-muted)]">
                     {spot.what || spot.category || spot.sourceLabel || "Photo guide"}
                   </div>
                 </div>
                 {spot.spotNumber ? (
-                  <span className="shrink-0 font-mono text-[9px] font-semibold text-atc-faint group-data-[active=true]:text-[var(--atc-click-muted)]">
+                  <span className="shrink-0 font-mono text-[calc(9px*var(--sb-body-scale))] font-semibold text-atc-faint group-data-[active=true]:text-[var(--atc-click-muted)]">
                     #{spot.spotNumber}
                   </span>
                 ) : null}
               </div>
               {spot.focalLength || spot.when ? (
-                <div className="mt-1.5 font-mono text-[8px] font-semibold uppercase text-atc-faint group-data-[active=true]:text-[var(--atc-click-muted)]">
+                <div className="mt-1.5 font-mono text-[calc(8px*var(--sb-body-scale))] font-semibold uppercase text-atc-faint group-data-[active=true]:text-[var(--atc-click-muted)]">
                   {[spot.focalLength, spot.when].filter(Boolean).join(" · ")}
                 </div>
               ) : null}

--- a/src/components/sidebar/FlightSidebar.tsx
+++ b/src/components/sidebar/FlightSidebar.tsx
@@ -144,7 +144,7 @@ function FlightIdentity({
       {hasTypeDisplay && (
         <div className="mt-2 flex min-w-0 items-baseline gap-2">
           <span
-            className="notranslate min-w-0 truncate font-mono text-[13px] font-semibold italic text-atc-text"
+            className="notranslate min-w-0 truncate font-mono text-[calc(13px*var(--sb-body-scale))] font-semibold italic text-atc-text"
             translate="no"
             title={typeDisplay.displayName}
           >
@@ -163,7 +163,7 @@ function FlightIdentity({
       )}
       {route ? (
         <div
-          className="notranslate mt-2 flex items-center gap-2 font-mono text-[12px] tracking-[0.04em] text-atc-dim"
+          className="notranslate mt-2 flex items-center gap-2 font-mono text-[calc(12px*var(--sb-body-scale))] tracking-[0.04em] text-atc-dim"
           translate="no"
           title={routeAccuracyNotice || route}
         >
@@ -180,7 +180,7 @@ function FlightIdentity({
         </div>
       ) : null}
       {positionSourceBadge ? (
-        <div className="notranslate mt-2 inline-flex items-center rounded-[3px] border border-atc-line px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-normal text-atc-dim" translate="no">
+        <div className="notranslate mt-2 inline-flex items-center rounded-[3px] border border-atc-line px-1.5 py-0.5 font-mono text-[calc(10px*var(--sb-body-scale))] font-semibold uppercase tracking-normal text-atc-dim" translate="no">
           {positionSourceBadge}
         </div>
       ) : null}
@@ -330,8 +330,8 @@ function TelemetryPrimary({ label, value, active, onClick, divider = false }: Fl
       onClick={onClick}
       className={`px-[15px] pb-[13px] pt-[13px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] ${TELEMETRY_ACTIVE_CLASS} ${divider ? "border-l border-[var(--app-frost-border)]" : ""}`}
     >
-      <div className="text-[12px] font-medium text-atc-dim">{label}</div>
-      <div className="mt-1.5 text-[26px] font-bold leading-none tracking-[-0.5px] tabular-nums text-atc-text">
+      <div className="text-[calc(12px*var(--sb-body-scale))] font-medium text-atc-dim">{label}</div>
+      <div className="mt-1.5 text-[calc(26px*var(--sb-body-scale))] font-bold leading-none tracking-[-0.5px] tabular-nums text-atc-text">
         {value}
       </div>
     </button>
@@ -347,8 +347,8 @@ function TelemetryAux({ label, value, active, onClick, divider = false }: Flight
       onClick={onClick}
       className={`min-w-0 flex-1 px-[13px] py-[9px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_0_2px_0_var(--atc-signal-accent)] ${divider ? "border-l border-[var(--app-frost-border)]" : ""}`}
     >
-      <div className="truncate text-[10px] text-atc-faint">{label}</div>
-      <div className="mt-[3px] truncate text-[15px] font-bold tabular-nums text-atc-text">
+      <div className="truncate text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{label}</div>
+      <div className="mt-[3px] truncate text-[calc(15px*var(--sb-body-scale))] font-bold tabular-nums text-atc-text">
         {value}
       </div>
     </button>

--- a/src/components/sidebar/SidebarIdentityHero.tsx
+++ b/src/components/sidebar/SidebarIdentityHero.tsx
@@ -19,7 +19,7 @@ export default function SidebarIdentityHero({
       <span className="atc-kicker">{label}</span>
       <div className="mt-3 flex items-baseline gap-3">
         <span
-          className={`airport-sidebar-display-mono airport-sidebar-display-mono--hero notranslate text-[28px] font-extrabold text-atc-text ${codeClassName}`}
+          className={`airport-sidebar-display-mono airport-sidebar-display-mono--hero notranslate text-[calc(28px*var(--sb-title-scale))] font-extrabold text-atc-text ${codeClassName}`}
           translate="no"
         >
           {code}

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -118,22 +118,22 @@ export default function SidebarViewSwitch({
           {isTraffic ? (
             <>
               <div className="flex items-center justify-between">
-                <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-atc-faint">
+                <span className="text-[calc(10px*var(--sb-body-scale))] font-semibold uppercase tracking-[0.14em] text-atc-faint">
                   {headlineLabel}
                 </span>
               </div>
               <div className="mt-1.5 flex items-baseline gap-2">
-                <span className="text-[44px] font-normal leading-[0.9] tracking-[-0.02em] tabular-nums text-atc-text">
+                <span className="text-[calc(44px*var(--sb-body-scale))] font-normal leading-[0.9] tracking-[-0.02em] tabular-nums text-atc-text">
                   <NumberFlow value={aircraft.length} />
                 </span>
               </div>
             </>
           ) : (
             <div className="flex items-center justify-between gap-2">
-              <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-atc-faint">
+              <span className="text-[calc(10px*var(--sb-body-scale))] font-semibold uppercase tracking-[0.14em] text-atc-faint">
                 {headlineLabel}
               </span>
-              <span className="text-[16px] font-normal tabular-nums text-atc-text">
+              <span className="text-[calc(16px*var(--sb-body-scale))] font-normal tabular-nums text-atc-text">
                 <NumberFlow value={aircraft.length} />
               </span>
             </div>
@@ -158,13 +158,13 @@ function StatCell({ label, value, unit, active, onClick }) {
       aria-pressed={active}
       className="min-w-0 flex-1 px-[11px] py-[9px] text-left transition-colors [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_0_2px_0_var(--atc-signal-accent)]"
     >
-      <div className="truncate text-[10px] text-atc-faint">{label}</div>
+      <div className="truncate text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{label}</div>
       <div className="mt-[3px]">
-        <span className="text-[16px] font-normal tabular-nums text-atc-text">
+        <span className="text-[calc(16px*var(--sb-body-scale))] font-normal tabular-nums text-atc-text">
           {value}
         </span>
         {unit ? (
-          <span className="ml-0.5 text-[10px] text-atc-faint">{unit}</span>
+          <span className="ml-0.5 text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{unit}</span>
         ) : null}
       </div>
     </button>

--- a/src/components/sidebar/WeatherBriefingStack.tsx
+++ b/src/components/sidebar/WeatherBriefingStack.tsx
@@ -127,7 +127,7 @@ function WeatherSegment({ view, onChange, t }) {
             aria-selected={active}
             data-active={active ? "true" : undefined}
             onClick={() => onChange(item.id)}
-            className="rounded-[calc(var(--atc-radius-pill)_-_4px)] px-3 py-1.5 text-center text-[12px] text-atc-dim transition-[background,color,box-shadow] duration-200 hover:text-atc-text data-[active=true]:bg-[var(--atc-control-surface)] data-[active=true]:text-atc-text data-[active=true]:shadow-[var(--atc-control-inset-shadow)]"
+            className="rounded-[calc(var(--atc-radius-pill)_-_4px)] px-3 py-1.5 text-center text-[calc(12px*var(--sb-body-scale))] text-atc-dim transition-[background,color,box-shadow] duration-200 hover:text-atc-text data-[active=true]:bg-[var(--atc-control-surface)] data-[active=true]:text-atc-text data-[active=true]:shadow-[var(--atc-control-inset-shadow)]"
           >
             {item.label}
           </button>
@@ -158,10 +158,10 @@ function HeroCard({ color, children }) {
 function MetricCell({ label, value }) {
   return (
     <div className="min-w-0">
-      <div className="text-[9.5px] text-atc-faint [letter-spacing:0.08em]">
+      <div className="text-[calc(9.5px*var(--sb-body-scale))] text-atc-faint [letter-spacing:0.08em]">
         {up(label)}
       </div>
-      <div className="notranslate mt-1 font-mono text-[15.5px] tabular-nums text-atc-text">
+      <div className="notranslate mt-1 font-mono text-[calc(15.5px*var(--sb-body-scale))] tabular-nums text-atc-text">
         {value}
       </div>
     </div>
@@ -231,13 +231,13 @@ function MetarView({ metar, metarRaw, metarLoading, t, units }) {
       <HeroCard color={color}>
         <div>
           <div
-            className="text-[40px] font-light leading-none"
+            className="text-[calc(40px*var(--sb-body-scale))] font-light leading-none"
             style={{ color }}
           >
             {category || "—"}
           </div>
           <div
-            className="mt-2 text-[13px] lowercase leading-snug"
+            className="mt-2 text-[calc(13px*var(--sb-body-scale))] lowercase leading-snug"
             style={{ color }}
           >
             {label}
@@ -255,7 +255,7 @@ function MetarView({ metar, metarRaw, metarLoading, t, units }) {
           ))}
         </div>
         {context ? (
-          <p className="mt-3.5 text-[12.5px] leading-snug text-atc-dim">
+          <p className="mt-3.5 text-[calc(12.5px*var(--sb-body-scale))] leading-snug text-atc-dim">
             {context}
           </p>
         ) : null}
@@ -275,16 +275,16 @@ function MetarView({ metar, metarRaw, metarLoading, t, units }) {
 
       <div>
         <div className="flex items-baseline justify-between">
-          <span className="text-[9.5px] text-atc-faint [letter-spacing:0.08em]">
+          <span className="text-[calc(9.5px*var(--sb-body-scale))] text-atc-faint [letter-spacing:0.08em]">
             {up(t("weather.rawReport"))}
           </span>
           {issued ? (
-            <span className="notranslate font-mono text-[10px] text-atc-faint">
+            <span className="notranslate font-mono text-[calc(10px*var(--sb-body-scale))] text-atc-faint">
               {issued}
             </span>
           ) : null}
         </div>
-        <code className="notranslate mt-2 block font-mono text-[11.5px] leading-relaxed text-atc-dim">
+        <code className="notranslate mt-2 block font-mono text-[calc(11.5px*var(--sb-body-scale))] leading-relaxed text-atc-dim">
           {metarRaw || t("weather.metarMissing")}
         </code>
       </div>
@@ -308,7 +308,7 @@ function MetarView({ metar, metarRaw, metarLoading, t, units }) {
             value={visValue}
           />
         </div>
-        <p className="mt-3 text-[12px] leading-snug text-atc-dim">
+        <p className="mt-3 text-[calc(12px*var(--sb-body-scale))] leading-snug text-atc-dim">
           {interpretation}
         </p>
       </div>
@@ -321,9 +321,9 @@ function IconStat({ icon, label, value }) {
     <div className="min-w-0">
       <div className="flex items-center gap-1.5 text-atc-faint">
         <span className="flex-none">{icon}</span>
-        <span className="text-[9px] [letter-spacing:0.08em]">{up(label)}</span>
+        <span className="text-[calc(9px*var(--sb-body-scale))] [letter-spacing:0.08em]">{up(label)}</span>
       </div>
-      <div className="notranslate mt-1 font-mono text-[14px] tabular-nums text-atc-text">
+      <div className="notranslate mt-1 font-mono text-[calc(14px*var(--sb-body-scale))] tabular-nums text-atc-text">
         {value}
       </div>
     </div>
@@ -385,12 +385,12 @@ function LocalView({ local, loading, t, units }) {
         <div className="flex items-start justify-between">
           <div className="flex items-baseline gap-1.5">
             <span
-              className="notranslate text-[44px] font-light leading-none"
+              className="notranslate text-[calc(44px*var(--sb-body-scale))] font-light leading-none"
               style={{ color }}
             >
               {tempValue}
             </span>
-            <span className="text-[14px]" style={{ color }}>
+            <span className="text-[calc(14px*var(--sb-body-scale))]" style={{ color }}>
               {unitLabel}
             </span>
           </div>
@@ -409,7 +409,7 @@ function LocalView({ local, loading, t, units }) {
             />
           ) : null}
         </div>
-        <p className="mt-3.5 text-[12.5px] leading-snug text-atc-dim">
+        <p className="mt-3.5 text-[calc(12.5px*var(--sb-body-scale))] leading-snug text-atc-dim">
           {heroLine}
           {trendKey ? `. ${t(trendKey)}` : heroLine ? "." : null}
         </p>
@@ -426,7 +426,7 @@ function LocalView({ local, loading, t, units }) {
 
       {hours.length > 0 ? (
         <div>
-          <div className="text-[9.5px] text-atc-faint [letter-spacing:0.08em]">
+          <div className="text-[calc(9.5px*var(--sb-body-scale))] text-atc-faint [letter-spacing:0.08em]">
             {up(t("weather.nextHours"))}
           </div>
           <div className="mt-2.5 grid grid-cols-6 gap-1">
@@ -435,7 +435,7 @@ function LocalView({ local, loading, t, units }) {
                 key={index}
                 className="flex flex-col items-center gap-1.5"
               >
-                <span className="text-[10px] text-atc-faint">
+                <span className="text-[calc(10px*var(--sb-body-scale))] text-atc-faint">
                   {index === 0 ? t("weather.now") : String(hour.time).split(":")[0]}
                 </span>
                 <WeatherGlyph
@@ -444,7 +444,7 @@ function LocalView({ local, loading, t, units }) {
                   strokeWidth={1.7}
                   className="text-atc-dim"
                 />
-                <span className="notranslate font-mono text-[12px] tabular-nums text-atc-text">
+                <span className="notranslate font-mono text-[calc(12px*var(--sb-body-scale))] tabular-nums text-atc-text">
                   {hour.temperatureC == null
                     ? "—"
                     : `${Math.round(convertTemperatureFromC(hour.temperatureC, units.temperature))}°`}
@@ -456,7 +456,7 @@ function LocalView({ local, loading, t, units }) {
       ) : null}
 
       {summary ? (
-        <p className="border-t border-[var(--atc-line)] pt-4 text-[12.5px] leading-snug text-atc-dim">
+        <p className="border-t border-[var(--atc-line)] pt-4 text-[calc(12.5px*var(--sb-body-scale))] leading-snug text-atc-dim">
           {summary}
         </p>
       ) : null}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,32 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.1",
+    kind: "patch",
+    title: {
+      en: "Sidebar typography pass — tokenized sizes, sans headers",
+      zh: "侧栏排版微调——字号 token 化、标题改无衬线",
+    },
+    summary: {
+      en: "Every sidebar and dither-panel font size now flows through two scale tokens (titles ×0.8, body ×0.9) so identity names and section headers read tighter while the hierarchy stays fixed. Group headers drop the serif face for the regular sans at a heavier weight, the home airport explorer rail matches the detail sidebar width, and each group gives its first row more breathing room.",
+      zh: "所有侧栏与 dither 面板的字号现在统一走两个缩放 token(标题 ×0.8、正文 ×0.9),机场名与区块标题更紧凑,层级比例保持不变。分组标题去掉花体衬线、改用更重字重的常规无衬线;首页机场探索栏宽度与详情页侧栏对齐;每个分组的标题与首项之间留出更多间距。",
+    },
+    highlights: [
+      {
+        en: "Two sidebar font-scale tokens (--sb-title-scale / --sb-body-scale) replace ad-hoc px sizes across the airport, aircraft, about, mechanism, and changelog panels.",
+        zh: "两个侧栏字号缩放 token(--sb-title-scale / --sb-body-scale)取代散落的 px 字号,覆盖机场、航空器、关于、机制与更新日志面板。",
+      },
+      {
+        en: "Section headers switch from the serif face to the regular sans at a heavier weight.",
+        zh: "区块标题由衬线花体改为更重字重的常规无衬线。",
+      },
+      {
+        en: "Home explorer sidebar width aligns with the detail sidebar, and group header-to-first-row spacing is loosened.",
+        zh: "首页探索侧栏宽度与详情侧栏对齐,分组标题到首项的间距放宽。",
+      },
+    ],
+  },
+  {
     version: "v2.30.0",
     kind: "feat",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -2985,6 +2985,13 @@ body:has(.dither-page-shell) {
 
 :root {
     --app-sidebar-width: 20.75rem;
+    /* Sidebar typography scale — the single knob for sidebar font sizes.
+       Every sidebar font-size is written as calc(<base>px * <scale>) so the
+       hierarchy stays fixed and only these two numbers move it. Title-class
+       text (identity name + section headers) rides --sb-title-scale; all
+       body/content text rides --sb-body-scale. */
+    --sb-title-scale: 0.8;
+    --sb-body-scale: 0.9;
     /* Raycast density pass: keep ADSBao's two glass materials, but tighten
        the shape language into crisp command-panel chrome. */
     /* Frosted geometry — soft, capsule-driven. The redesign uses 13–18px
@@ -4879,7 +4886,7 @@ body {
 
 .aircraft-table-route-cycle {
     color: var(--atc-dim);
-    font-size: 10px;
+    font-size: calc(10px * var(--sb-body-scale));
     font-weight: var(--weight-regular);
     height: 14px;
     line-height: 14px;
@@ -4899,7 +4906,7 @@ body {
     color: var(--atc-dim);
     display: inline-flex;
     flex: 0 1 auto;
-    font-size: 8.5px;
+    font-size: calc(8.5px * var(--sb-body-scale));
     font-weight: var(--weight-regular);
     height: 14px;
     line-height: 1;
@@ -5768,12 +5775,12 @@ body {
 }
 
 .airport-sidebar-panel .metar-token-strip strong {
-    font-size: 17px;
+    font-size: calc(17px * var(--sb-body-scale));
     letter-spacing: normal;
 }
 
 .airport-sidebar-panel--mobile .metar-token-strip strong {
-    font-size: clamp(15px, 4.4vw, 17px);
+    font-size: clamp(calc(15px * var(--sb-body-scale)), 4.4vw, calc(17px * var(--sb-body-scale)));
 }
 
 .sidebar-shell {
@@ -7736,7 +7743,7 @@ body {
 .changelog-entry__version {
     color: var(--fs-rail-color);
     font-family: var(--font-code);
-    font-size: var(--fs-rail-size);
+    font-size: calc(var(--fs-rail-size) * var(--sb-body-scale));
     font-weight: var(--fs-rail-weight);
 }
 
@@ -7746,7 +7753,7 @@ body {
 
 .changelog-entry__current {
     color: var(--atc-faint);
-    font-size: 6.5px;
+    font-size: calc(6.5px * var(--sb-body-scale));
     font-weight: var(--weight-regular);
 }
 
@@ -7757,7 +7764,7 @@ body {
 .changelog-entry__title {
     color: var(--fs-title-color);
     font-family: var(--fs-title-font);
-    font-size: 15px;
+    font-size: calc(15px * var(--sb-title-scale));
     font-weight: var(--fs-title-weight);
     line-height: var(--fs-title-leading);
     margin: 0;
@@ -7765,7 +7772,7 @@ body {
 
 .changelog-entry__summary {
     color: color-mix(in oklab, var(--atc-text) 46%, transparent);
-    font-size: 11.5px;
+    font-size: calc(11.5px * var(--sb-body-scale));
     line-height: 1.45;
     margin-top: 5px;
 }
@@ -7782,7 +7789,7 @@ body {
     align-items: baseline;
     color: var(--fs-body-color);
     display: grid;
-    font-size: var(--fs-body-size);
+    font-size: calc(var(--fs-body-size) * var(--sb-body-scale));
     gap: 5px;
     grid-template-columns: 14px minmax(0, 1fr);
     line-height: var(--fs-body-leading);
@@ -7791,7 +7798,7 @@ body {
 .changelog-entry__highlight-index {
     color: var(--atc-faint);
     font-family: var(--font-mono);
-    font-size: 9px;
+    font-size: calc(9px * var(--sb-body-scale));
     font-weight: var(--weight-regular);
     letter-spacing: 0;
     line-height: 1;
@@ -8018,7 +8025,10 @@ body {
 
 @media (min-width: 768px) {
     .dither-page-shell {
-        --app-sidebar-width: 17.5rem;
+        /* Match the detail page sidebar (.airport-map-kit stays at 18.8rem
+           from min-width:640px) so the rail width doesn't jump between the
+           first screen and airport/aircraft detail. */
+        --app-sidebar-width: 18.8rem;
         --atc-radius-shell: 8px;
         --atc-radius-panel: 6px;
         --atc-radius-card: 6px;
@@ -8049,13 +8059,13 @@ body {
     }
 
     .dither-page-header .atc-page-title {
-        font-size: 22px;
+        font-size: calc(22px * var(--sb-title-scale));
         line-height: 1.16;
         margin-top: 13px;
     }
 
     .dither-page-header .dither-page-description {
-        font-size: 10px;
+        font-size: calc(10px * var(--sb-body-scale));
         line-height: 1.65;
         margin-top: 10px;
     }
@@ -8095,9 +8105,12 @@ body {
         padding-bottom: 8px;
     }
 
-    .dither-page-panel .atc-kicker,
-    .dither-page-panel .atc-section-head__count {
+    .dither-page-panel .atc-kicker {
         font-size: 8px;
+    }
+
+    .dither-page-panel .atc-section-head__count {
+        font-size: calc(8px * var(--sb-body-scale));
     }
 
     .dither-page-panel .atc-kicker {
@@ -8318,6 +8331,13 @@ body {
 .search-screen .dither-content-stack > section + section {
     margin-top: 0;
     padding-top: 22px;
+}
+
+/* Breathing room between a group's header (tick + label) and its first row.
+   .dither-list zeroes margin-block globally, so scope the gap to the home
+   directory rather than fighting it with a utility class. */
+.search-screen .dither-section-flow > .dither-list {
+    margin-top: 12px;
 }
 
 .search-screen .dither-section-flow > .atc-section-head {
@@ -8713,7 +8733,7 @@ body {
 
 .airport-sidebar-panel [data-ui="metric-card"][data-layout="split"] [data-ui="metric-value"],
 .flight-sidebar-panel [data-ui="metric-card"][data-layout="split"] [data-ui="metric-value"] {
-    font-size: 15px;
+    font-size: calc(15px * var(--sb-body-scale));
     line-height: 0.95;
 }
 
@@ -8809,7 +8829,7 @@ body {
     }
 
     .airport-map-kit .airport-sidebar-display-mono--hero {
-        font-size: 20px;
+        font-size: calc(20px * var(--sb-title-scale));
         line-height: 0.95;
     }
 
@@ -8827,18 +8847,18 @@ body {
        (recedes), and .font-mono carries the city/country · coordinates meta
        line. */
     .airport-map-kit .airport-sidebar-identity h1 {
-        font-size: 21px;
+        font-size: calc(21px * var(--sb-title-scale));
         line-height: 1.08;
         margin-top: 12px;
     }
 
     .airport-map-kit .airport-sidebar-identity h1 + div {
-        font-size: 12.5px;
+        font-size: calc(12.5px * var(--sb-title-scale));
         margin-top: 8px;
     }
 
     .airport-map-kit .airport-sidebar-identity .font-mono {
-        font-size: 11px;
+        font-size: calc(11px * var(--sb-body-scale));
     }
 
     .airport-map-kit .aircraft-search {
@@ -8853,7 +8873,7 @@ body {
     }
 
     .airport-map-kit .aircraft-search input {
-        font-size: 13px;
+        font-size: calc(13px * var(--sb-body-scale));
     }
 
     .airport-map-kit .aircraft-table-row-grid {
@@ -8862,7 +8882,7 @@ body {
     }
 
     .airport-map-kit .aircraft-table-header {
-        font-size: 8px;
+        font-size: calc(8px * var(--sb-body-scale));
         min-height: 20px;
         padding-block: 1px;
     }
@@ -8885,11 +8905,11 @@ body {
     }
 
     .airport-map-kit .aircraft-table-callsign {
-        font-size: 10px !important;
+        font-size: calc(10px * var(--sb-body-scale)) !important;
     }
 
     .airport-map-kit .aircraft-table-cell {
-        font-size: 10px;
+        font-size: calc(10px * var(--sb-body-scale));
     }
 
     .airport-map-kit .aircraft-table-cell--distance {
@@ -8905,7 +8925,7 @@ body {
     }
 
     .airport-map-kit .aircraft-table-unit {
-        font-size: 6px;
+        font-size: calc(6px * var(--sb-body-scale));
     }
 
     .airport-map-kit .aircraft-table-route-slot,
@@ -8914,7 +8934,7 @@ body {
     }
 
     .airport-map-kit .aircraft-table-route-cycle {
-        font-size: 8px;
+        font-size: calc(8px * var(--sb-body-scale));
         line-height: 11px;
     }
 
@@ -8922,7 +8942,7 @@ body {
     .airport-map-kit
         .aircraft-table-identity
         > span:not(.aircraft-table-callsign) {
-        font-size: 8px !important;
+        font-size: calc(8px * var(--sb-body-scale)) !important;
     }
 
     .airport-map-kit .aircraft-table-airline-logo {
@@ -8932,7 +8952,7 @@ body {
     }
 
     .airport-map-kit .aircraft-table-route-badge {
-        font-size: 7.5px;
+        font-size: calc(7.5px * var(--sb-body-scale));
         height: 12px;
         max-width: min(70px, 45%);
         padding: 0 4px;
@@ -9020,7 +9040,7 @@ body {
     }
 
     .airport-map-kit .airport-sidebar-display-mono--hero {
-        font-size: 19px;
+        font-size: calc(19px * var(--sb-title-scale));
         line-height: 1;
     }
 
@@ -9038,18 +9058,18 @@ body {
        (recedes), and .font-mono carries the city/country · coordinates meta
        line. */
     .airport-map-kit .airport-sidebar-identity h1 {
-        font-size: 21px;
+        font-size: calc(21px * var(--sb-title-scale));
         line-height: 1.08;
         margin-top: 12px;
     }
 
     .airport-map-kit .airport-sidebar-identity h1 + div {
-        font-size: 12.5px;
+        font-size: calc(12.5px * var(--sb-title-scale));
         margin-top: 8px;
     }
 
     .airport-map-kit .airport-sidebar-identity .font-mono {
-        font-size: 11px;
+        font-size: calc(11px * var(--sb-body-scale));
     }
 
     .airport-map-kit .airport-desktop-sidebar {
@@ -9121,7 +9141,7 @@ body {
 
     .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
         .airport-sidebar-display-mono--hero {
-        font-size: 14px;
+        font-size: calc(14px * var(--sb-title-scale));
     }
 
     .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
@@ -9238,7 +9258,7 @@ body {
 
     .airport-map-kit[data-client-orientation="landscape"]
         .airport-sidebar-display-mono--hero {
-        font-size: 14px;
+        font-size: calc(14px * var(--sb-title-scale));
     }
 
     .airport-map-kit[data-client-orientation="landscape"]


### PR DESCRIPTION
## What

Typography/spacing pass over the sidebar and dither-panel surfaces.

- **Tokenized font sizes.** Every sidebar and dither-panel font size now flows through two scale tokens — `--sb-title-scale` (0.8) for identity names + section headers, `--sb-body-scale` (0.9) for body/content. Sizes are written as `calc(<base>px * var(--sb-…-scale))` so the hierarchy is preserved and future tuning is a two-line change. Covers airport/aircraft detail sidebar, home airport explorer rail, and the About / Mechanism / Changelog panels.
- **Sans section headers.** Group headers drop the serif face for the regular sans at a heavier weight (`[font-weight:600]` — the app flattens all named Tailwind weight utilities to 400, so the arbitrary value is required).
- **Sidebar width alignment.** The home explorer rail now matches the detail sidebar width (18.8rem at ≥768px) so the rail doesn't jump between screens.
- **Group spacing.** Each group's header → first row gets more breathing room on the home explorer (scoped to `.search-screen`, since `.dither-list` zeroes margins globally).

## Validation

Mode 2 — local browser. Checked the home explorer, airport/aircraft detail sidebar, and the About / Mechanism / Changelog panels at desktop width; measured computed font sizes and weights to confirm the token scaling and the 600 weight apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)