### PR TITLE
v2.30.2: Airport flight-count card — stacked rows + tile transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.1",
+  "version": "2.30.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -55,8 +55,29 @@ export default function SidebarViewSwitch({
     return { departureCount: dep, arrivalCount: arr };
   }, [aircraft, routeProvider]);
 
-  const footerCells = [];
-  footerCells.push({
+  // Footer stacks into rows under the flight-count hero: first the movement
+  // row (departures / arrivals) as the direct breakdown of the count, then
+  // the context row (weather / ATC / spotting). Each conditional cell simply
+  // drops out of its row when absent.
+  const movementCells = [];
+  if (showMovementCards) {
+    movementCells.push({
+      key: "departures",
+      label: t("sidebar.departures"),
+      value: <NumberFlow value={departureCount} />,
+      active: activeView === "departures",
+      onClick: () => onViewChange?.("departures"),
+    });
+    movementCells.push({
+      key: "arrivals",
+      label: t("sidebar.arrivals"),
+      value: <NumberFlow value={arrivalCount} />,
+      active: activeView === "arrivals",
+      onClick: () => onViewChange?.("arrivals"),
+    });
+  }
+  const restCells = [];
+  restCells.push({
     key: "briefing",
     label: t("sidebar.weather"),
     value: temperature.value,
@@ -65,7 +86,7 @@ export default function SidebarViewSwitch({
     onClick: () => onViewChange?.("briefing"),
   });
   if (showAtcCard) {
-    footerCells.push({
+    restCells.push({
       key: "atc",
       label: t("sidebar.atc"),
       value: <NumberFlow value={atcCount} />,
@@ -73,29 +94,13 @@ export default function SidebarViewSwitch({
       onClick: () => onViewChange?.("atc"),
     });
   }
-  footerCells.push({
+  restCells.push({
     key: "spotting",
     label: t("sidebar.spotting"),
     value: <NumberFlow value={spottingCount} />,
     active: activeView === "spotting",
     onClick: onOpenSpotting,
   });
-  if (showMovementCards) {
-    footerCells.push({
-      key: "departures",
-      label: t("sidebar.departures"),
-      value: <NumberFlow value={departureCount} />,
-      active: activeView === "departures",
-      onClick: () => onViewChange?.("departures"),
-    });
-    footerCells.push({
-      key: "arrivals",
-      label: t("sidebar.arrivals"),
-      value: <NumberFlow value={arrivalCount} />,
-      active: activeView === "arrivals",
-      onClick: () => onViewChange?.("arrivals"),
-    });
-  }
 
   const headlineLabel = nearMe ? t("sidebar.nearby") : t("sidebar.flights");
   // The flight-count is the hero only on the traffic view. On the other
@@ -112,7 +117,7 @@ export default function SidebarViewSwitch({
           onClick={() => onViewChange?.("traffic")}
           aria-pressed={isTraffic}
           className={`block w-full px-[16px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] ${
-            isTraffic ? "pb-3 pt-[15px]" : "py-[9px]"
+            isTraffic ? "pb-3 pt-[15px]" : "py-[14px]"
           }`}
         >
           {isTraffic ? (
@@ -139,8 +144,15 @@ export default function SidebarViewSwitch({
             </div>
           )}
         </button>
+        {movementCells.length > 0 ? (
+          <div className="flex border-t border-[var(--app-frost-border)]">
+            {movementCells.map(({ key, ...cell }) => (
+              <StatCell key={key} {...cell} />
+            ))}
+          </div>
+        ) : null}
         <div className="flex border-t border-[var(--app-frost-border)]">
-          {footerCells.map(({ key, ...cell }) => (
+          {restCells.map(({ key, ...cell }) => (
             <StatCell key={key} {...cell} />
           ))}
         </div>
@@ -156,7 +168,7 @@ function StatCell({ label, value, unit, active, onClick }) {
       data-active={active ? "true" : undefined}
       onClick={onClick}
       aria-pressed={active}
-      className="min-w-0 flex-1 px-[11px] py-[9px] text-left transition-colors [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_0_2px_0_var(--atc-signal-accent)]"
+      className="relative min-w-0 flex-1 px-[11px] py-[9px] text-left transition-[background-color] duration-200 ease-out [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-[2px] before:origin-center before:scale-x-0 before:bg-[var(--atc-signal-accent)] before:transition-transform before:duration-300 before:ease-[cubic-bezier(0.34,1.3,0.64,1)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:before:scale-x-100"
     >
       <div className="truncate text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{label}</div>
       <div className="mt-[3px]">

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,28 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.2",
+    kind: "patch",
+    title: {
+      en: "Airport flight-count card — stacked rows + tile transitions",
+      zh: "机场航班卡——分行排列与切换动效",
+    },
+    summary: {
+      en: "The airport flight-count card restacks into rows under the count hero: departures / arrivals sit directly beneath the total as its breakdown, then weather / ATC / spotting form the context row. The demoted count keeps more height when another tile is selected, and selecting a tile now plays a designed transition — an accent bar that grows from the tile's centre with a soft spring, plus a tint that fades in — so focus lands on the chosen metric.",
+      zh: "机场航班卡改为分行排列:起飞 / 到达直接位于航班总数下方作为进出明细,天气 / ATC / 拍机点构成第三行的上下文。选中其他 tile 时航班数仍保留更舒展的行高;切换 tile 现在带有设计过的过渡——强调条从 tile 中心带轻微回弹地展开,底色淡入,使焦点落到所选指标上。",
+    },
+    highlights: [
+      {
+        en: "Flight count, departures/arrivals, and weather/ATC/spotting now stack as three rows instead of one dense strip.",
+        zh: "航班数、起飞/到达、天气/ATC/拍机点改为三行堆叠,取代原来的单行密排。",
+      },
+      {
+        en: "Selecting a tile animates an accent bar growing from centre with a soft spring and a fading tint.",
+        zh: "选中 tile 时强调条从中心带轻微回弹地展开,并伴随底色淡入。",
+      },
+    ],
+  },
+  {
     version: "v2.30.1",
     kind: "patch",
     title: {


### PR DESCRIPTION
## What

UX pass on the airport sidebar flight-count card.

- **Stacked rows.** The footer restacks under the count hero into rows: **departures / arrivals** sit directly beneath the total as its breakdown, then **weather / ATC / spotting** form the context row. Conditional cells (ATC, movements) drop out of their row when absent, so a no-movement airport simply shows hero + context row.
- **Taller demoted count.** When another tile is selected the count demotes to a compact row; its height bumps (`py-[9px]` → `py-[14px]`, ~50px) so it no longer reads as cramped next to the metric tiles.
- **Designed tile transition.** Selecting a tile animates an accent bar growing from the tile's centre (`scaleX` 0→1, 300ms, soft spring `cubic-bezier(0.34,1.3,0.64,1)`) plus a tint fading in (200ms), so focus lands on the chosen metric instead of snapping.

## Validation

Mode 2 — local browser. Checked the KBOS sidebar card at desktop width; measured the demoted hero height (50px) and the active tile's computed tint + accent-bar `scale` transition (0→1). Cleared `node_modules/.vite` to drop a stale Tailwind bundle before verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)