### PR TITLE
v2.30.4: Mobile fixes — sidebar list clearance + instant first screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.3",
+  "version": "2.30.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/animations/usePageEntrance.ts
+++ b/src/animations/usePageEntrance.ts
@@ -75,12 +75,18 @@ export function usePageEntrance(
     ctxRef.current = gsap.context(() => {
       const tl = gsap.timeline({ defaults: { overwrite: "auto" } });
 
+      // Transform-only entrance: never gate visibility behind opacity. The
+      // content paints at full opacity the moment React renders it, and the
+      // animation is a non-blocking settle. If the main thread is busy on
+      // mount (Clerk init, etc.) and the tween is starved, the content is
+      // still fully visible (just briefly offset) instead of being held
+      // invisible at opacity:0 — which is what made the first screen look like
+      // it "waited" half a second to a second before showing content.
       if (header) {
         tl.fromTo(
           header,
-          { opacity: 0, y: 8 },
+          { y: 10 },
           {
-            opacity: 1,
             y: 0,
             duration: MOTION.slow,
             ease: EASE.snap,
@@ -92,9 +98,8 @@ export function usePageEntrance(
       if (body) {
         tl.fromTo(
           body,
-          { opacity: 0, y: 6 },
+          { y: 8 },
           {
-            opacity: 1,
             y: 0,
             duration: MOTION.med,
             ease: EASE.out,
@@ -106,9 +111,9 @@ export function usePageEntrance(
       if (items.length > 0) {
         tl.fromTo(
           items,
-          { opacity: 0 },
+          { y: 6 },
           {
-            opacity: 1,
+            y: 0,
             duration: MOTION.fast,
             ease: EASE.out,
             stagger: { each: 0.025, from: "start" },

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.4",
+    kind: "patch",
+    title: {
+      en: "Fix mobile sidebar list hiding under the toolbar",
+      zh: "修复移动端侧栏列表被工具栏遮挡",
+    },
+    summary: {
+      en: "On mobile, the last row of a sidebar view (e.g. the spotting list) could hide under the floating bottom toolbar; the scroll-end clearance now sits on the view content so the final row always clears the dock.",
+      zh: "移动端侧栏视图(如拍机点列表)的最后一行可能被底部浮动工具栏遮挡;底部留白改到视图内容上,最后一行现在总能清开工具栏。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.3",
     kind: "patch",
     title: {

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -48,12 +48,12 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
     version: "v2.30.4",
     kind: "patch",
     title: {
-      en: "Fix mobile sidebar list hiding under the toolbar",
-      zh: "修复移动端侧栏列表被工具栏遮挡",
+      en: "Mobile fixes — sidebar list clearance + instant first screen",
+      zh: "移动端修复——侧栏列表留白与首屏即时显示",
     },
     summary: {
-      en: "On mobile, the last row of a sidebar view (e.g. the spotting list) could hide under the floating bottom toolbar; the scroll-end clearance now sits on the view content so the final row always clears the dock.",
-      zh: "移动端侧栏视图(如拍机点列表)的最后一行可能被底部浮动工具栏遮挡;底部留白改到视图内容上,最后一行现在总能清开工具栏。",
+      en: "Two mobile fixes: a sidebar view's last row (e.g. the spotting list) no longer hides under the floating toolbar, and the first screen now shows its content the moment it renders instead of being held invisible behind the entrance animation while the page is still busy mounting.",
+      zh: "两个移动端修复:侧栏视图(如拍机点列表)的最后一行不再被底部浮动工具栏遮挡;首屏内容现在一渲染就显示,不再因入场动画在页面挂载繁忙时把内容隐藏起来。",
     },
     highlights: [],
   },

--- a/src/style.css
+++ b/src/style.css
@@ -5776,10 +5776,17 @@ body {
     overflow-y: auto;
     overscroll-behavior-y: contain;
     -webkit-overflow-scrolling: touch;
-    /* Explicit scroll-end placeholder for the bottom-pinned sidebar dock so
-       the last content row can clear the floating toolbar on mobile. */
-    padding-bottom: var(--sidebar-mobile-bottom-placeholder);
     scroll-padding-bottom: var(--sidebar-mobile-bottom-placeholder);
+}
+
+/* Scroll-end clearance for the bottom-pinned floating toolbar. It must live on
+   the content leaf that actually sizes to its own content (the view root),
+   because every wrapper above it is a flex-constrained, overflow:visible box —
+   padding on those sits inside their fixed box, above the overflowing content,
+   so the last row (e.g. the spotting list) stays hidden under the dock. */
+.airport-sidebar-panel--mobile .airport-sidebar-content > *,
+.flight-sidebar-panel--mobile .airport-sidebar-content > * {
+    padding-bottom: var(--sidebar-mobile-bottom-placeholder);
 }
 
 .airport-sidebar-panel--mobile .metar-token-strip {


### PR DESCRIPTION
## What

Two small mobile UX fixes.

**1. Sidebar list hidden under the floating toolbar**
On mobile the bottom-toolbar clearance was a `padding-bottom` on the `.airport-sidebar-panel--mobile` scroll container, but Chrome drops a flex `overflow:auto` container's own bottom padding from the scrollable area, so a view whose content overflows (e.g. the spotting list) had its last row hidden under the dock. Move the clearance onto the content leaf (`.airport-sidebar-content > *`), which sizes to its own content. Applies to every mobile sidebar view (traffic / spotting / ATC / weather).

**2. First screen "waited" before showing content**
The dither-page entrance (`usePageEntrance`) hid header/body/items at `opacity:0` and faded them in via a GSAP rAF tween. On mobile the main thread is busy on mount (Clerk init, etc.), so the tween was starved and content sat invisible for ~0.5–1s after the logo. The entrance is now **transform-only** (a small `translateY` settle): content paints at full opacity the instant React renders it and is never gated behind the animation — a starved tween just leaves content visible (briefly offset) instead of hidden.

## Validation

Mode 2 — local browser, mobile (375px), zh-CN.
- Spotting: mocked 16 locations, scrolled to the end, confirmed the last row clears the floating dock (96px gap); Flights list bottom clears too.
- First screen: after the change the body and rows report `opacity: 1` immediately on load (previously crawled up from ~0.1); content renders in full at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)