### PR TITLE
v2.30.7: Fix photo-locations horizontal overflow on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.6",
+  "version": "2.30.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -319,7 +319,7 @@ function SpottingPanel({
           {t("watcherMode.empty")}
         </p>
       ) : null}
-      <div className="app-list-motion grid gap-1">
+      <div className="app-list-motion grid grid-cols-1 gap-1">
         {spots.map((spot) => {
           const active = Boolean(selectedSpotId && selectedSpotId === spot.id);
           return (

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.7",
+    kind: "patch",
+    title: {
+      en: "Fix photo-locations overflow on mobile",
+      zh: "修复移动端拍机点横向溢出",
+    },
+    summary: {
+      en: "The airport photo-locations list no longer runs off the right edge on mobile — long spot descriptions now wrap inside the sidebar instead of pushing the list wider than the screen.",
+      zh: "机场拍机点列表在移动端不再冲出右边缘——长描述会在侧栏内换行,不再把列表撑得比屏幕还宽。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.6",
     kind: "patch",
     title: {


### PR DESCRIPTION
## What
Mobile airport photo-locations (spotting) list ran off the right edge.

## Root cause
The list container was `app-list-motion grid gap-1` — a CSS grid with **no explicit columns**, so the implicit column sized to `auto` (= max-content). A spot description's max-content is the entire paragraph on one line, which blew the column ~76px past a 375px viewport. The inner `min-w-0` couldn't help because the grid *track itself* was the overflow source.

## Fix
Add `grid-cols-1` (Tailwind `minmax(0, 1fr)`) so the track clamps to the container width and the inner `min-w-0` wrapping/truncation takes effect.

## Validation
Local browser against the **real spotter DB** (KBOS, 15 locations): panel horizontal overflow **76px → 0**, descriptions wrap inside the sidebar, titles truncate, last row clears the bottom dock.

> Note: this is the primary mobile overflow bug. The v2.30.5 bottom-clearance change addressed a secondary axis; this is the horizontal one seen in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)