### PR TITLE
v2.30.8: Skip brand background video on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.7",
+  "version": "2.30.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/app-shell/DitherPageShell.tsx
+++ b/src/components/app-shell/DitherPageShell.tsx
@@ -152,7 +152,11 @@ export default function DitherPageShell({
       </div>
 
       <div className="dither-page-background relative isolate flex-1 overflow-hidden">
-        <BrandingVideoBackground />
+        {/* Skip the looping brand video on mobile devices: decoding it during a
+            cold first-screen boot competes for the main thread and is the kind
+            of work that dragged the mobile entrance. The background area is
+            mostly behind the full-width panel on mobile anyway. */}
+        {clientDeviceLayout.isMobileDevice ? null : <BrandingVideoBackground />}
       </div>
     </div>
   );

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.8",
+    kind: "patch",
+    title: {
+      en: "Skip the brand background video on mobile",
+      zh: "移动端不再加载品牌背景视频",
+    },
+    summary: {
+      en: "Mobile devices no longer load and decode the looping brand background video — it was decorative behind the full-width panel but competed for the main thread during a cold first-screen boot.",
+      zh: "移动端不再加载和解码循环播放的品牌背景视频——它本来就藏在全宽面板后面只作装饰,却会在冷启动首屏时抢占主线程。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.7",
     kind: "patch",
     title: {


### PR DESCRIPTION
## What
Mobile devices no longer mount the looping brand background video (`BrandingVideoBackground`).

## Why
The `.mp4` is fetched, decoded, and looped on every dither shell screen (home / about / mechanism / changelog). On a cold mobile boot that decode competes for the main thread — the work that dragged the first-screen entrance. The video is decorative and mostly sits behind the full-width panel on mobile.

## How
Gate the render on `clientDeviceLayout.isMobileDevice` (phone/tablet, via UA/touch — already used elsewhere in this component). Desktop is unchanged.

## Validation
Logic-only render gate. Verify on a real phone (the desktop preview can't emulate a mobile device UA): the home first screen should no longer carry the looping background video, and the cold-boot entrance should settle faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)