### PR TITLE
v2.30.9: Landscape sidebar — edge-to-edge glass, island-safe content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.8",
+  "version": "2.30.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.9",
+    kind: "patch",
+    title: {
+      en: "Landscape sidebar — edge-to-edge glass, island-safe content",
+      zh: "横屏侧栏——玻璃铺到边缘、内容避让灵动岛",
+    },
+    summary: {
+      en: "In mobile landscape the sidebar's frosted background now runs to the screen edge while its content stays inset clear of the Dynamic Island, and the panel is a bit wider for more room.",
+      zh: "移动端横屏下,侧栏的磨砂背景铺到屏幕边缘,内容则内缩避开灵动岛;面板也加宽了一些,内容区更充裕。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.8",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -9097,7 +9097,7 @@ body {
     }
 
     .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"] {
-        --app-sidebar-width: 18rem;
+        --app-sidebar-width: 20rem;
     }
 
     .airport-map-kit .airport-sidebar-identity {
@@ -9178,13 +9178,29 @@ body {
         .airport-desktop-sidebar {
         box-sizing: border-box;
         left: auto;
-        padding-left: var(--app-safe-area-left, 0px);
+        /* Widen the panel by the Dynamic-Island inset so insetting the content
+           past the island below does not steal room from the content area. */
+        flex-basis: calc(
+            var(--app-sidebar-width) + var(--app-safe-area-left, 0px)
+        );
+        padding-left: 0;
     }
 
     .airport-map-kit[data-client-horizontal-obstruction="true"][data-client-orientation="landscape"]
         .airport-desktop-sidebar
         > .h-full {
         width: 100% !important;
+    }
+
+    /* The frosted shell bleeds to the screen edge; only the content inside is
+       inset past the Dynamic Island. Padding on the frosted element keeps the
+       blur filling the safe-area strip while the logo/cards/text clear the
+       island. */
+    .airport-map-kit[data-client-horizontal-obstruction="true"][data-client-orientation="landscape"]
+        .airport-desktop-sidebar
+        .sidebar-shell {
+        box-sizing: border-box;
+        padding-left: var(--app-safe-area-left, 0px);
     }
 
     .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]


### PR DESCRIPTION
## What
Mobile-landscape airport sidebar: extend the frosted background to the screen edge, keep content clear of the Dynamic Island, and widen the panel.

## Before
The landscape sidebar is the floating desktop panel. With a Dynamic-Island obstruction the whole panel was inset (`left = --map-kit-inset + --app-safe-area-left`) and the safe-area padding sat on the **outer** box — so the frosted shell was pushed in with the content, leaving a strip of map down the left and the logo under the island.

## Change
- Move the safe-area inset onto the frosted `.sidebar-shell` (border-box `padding-left`), so the blur fills to the edge while only the content insets past the island.
- Widen the panel: `flex-basis: calc(--app-sidebar-width + --app-safe-area-left)` so the inset doesn't steal room, plus landscape base width `18rem → 20rem`.

Occlusion compensation measures `.airport-desktop-sidebar` via `getBoundingClientRect`, so map centering follows the new width automatically.

## Validation
Local browser, forced `landscape + horizontal-obstruction` state at 844px: frosted shell `left = 0` (edge), content `left = safe-area inset` (island-clear), panel width `= base + inset`. Left corners are square against the edge. Needs real-device confirmation (desktop preview can't emulate the device UA/safe-area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)