### PR TITLE
v2.30.10: Keep map range scale clear of the landscape sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.9",
+  "version": "2.30.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.10",
+    kind: "patch",
+    title: {
+      en: "Keep the map scale clear of the landscape sidebar",
+      zh: "横屏下比例尺避开侧栏",
+    },
+    summary: {
+      en: "In mobile landscape the map's range scale is offset clear of the sidebar instead of hiding behind it.",
+      zh: "移动端横屏下,地图比例尺移到侧栏右侧,不再被侧栏遮住。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.9",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -8527,6 +8527,17 @@ body {
     left: calc(var(--map-kit-inset) + var(--app-safe-area-left, 0px));
 }
 
+/* In mobile landscape the sidebar spans the full height down the left, so the
+   bottom-left range scale would hide behind it. Offset it clear of the panel
+   (width + Dynamic-Island inset). Scoped to mobile landscape only — desktop and
+   portrait keep the default left-4 placement. */
+.airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
+    .z-map-legend {
+    left: calc(
+        var(--app-sidebar-width) + var(--app-safe-area-left, 0px) + 16px
+    );
+}
+
 .airport-map-kit--sidebar-open .airport-desktop-sidebar {
     box-shadow: var(--app-map-sidebar-shadow);
 }


### PR DESCRIPTION
## What
In mobile landscape, offset the map's range scale (比例尺) so it clears the sidebar instead of hiding behind it.

## Why
The landscape sidebar spans the full height down the left edge. The range scale (`z-map-legend`) is positioned `bottom-left / left-4` against the full-bleed map, so it sat under the panel.

## How
```css
.airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
  .z-map-legend {
  left: calc(var(--app-sidebar-width) + var(--app-safe-area-left, 0px) + 16px);
}
```
Scoped to mobile landscape only — desktop and portrait keep the default `left-4`. Map centering already follows the wider sidebar (occlusion measures the panel via `getBoundingClientRect`).

## Validation — all three modes
- **Landscape (changed):** visible legend left 384 ≥ sidebar right 367 → clears. Map center: KBOS marker sits right of the panel.
- **Desktop (unchanged):** rule doesn't apply (`mobile=false`); legend stays `left-4`.
- **Portrait (unchanged):** rule doesn't apply (needs `landscape`); legend stays `left-4` over the full map.

> Pre-existing note (not changed here): on desktop the scale already sits under the frosted sidebar. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)