### PR TITLE
v2.30.11: Map range scale clears the sidebar on desktop/tablet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.10",
+  "version": "2.30.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.11",
+    kind: "patch",
+    title: {
+      en: "Map scale clears the sidebar on desktop too",
+      zh: "桌面端比例尺也避开侧栏",
+    },
+    summary: {
+      en: "The map's range scale is now offset clear of the sidebar on desktop and tablet as well — previously it sat hidden behind the panel except in mobile landscape.",
+      zh: "地图比例尺在桌面和平板上也移到侧栏右侧,之前只在移动横屏避让、其它情况被面板挡住。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.10",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -8527,11 +8527,27 @@ body {
     left: calc(var(--map-kit-inset) + var(--app-safe-area-left, 0px));
 }
 
-/* In mobile landscape the sidebar spans the full height down the left, so the
-   bottom-left range scale would hide behind it. Offset it clear of the panel
-   (width + Dynamic-Island inset). Scoped to mobile landscape only — desktop and
-   portrait keep the default left-4 placement. */
-.airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
+/* The bottom-left range scale is positioned against the full-bleed map, so it
+   hides behind the sidebar wherever the panel is shown down the left edge —
+   desktop/tablet (≥768) and mobile landscape. Offset it clear of the panel
+   (width + Dynamic-Island inset, which is 0 without an island). A collapsed
+   sidebar is a small pill that doesn't occlude the scale, so :has() keeps the
+   default left-4 placement in that case. Portrait (<768) uses a bottom-sheet
+   sidebar that never covers the bottom-left, so it is excluded. */
+@media (min-width: 768px) {
+    .airport-map-kit:has(.airport-desktop-sidebar:not([data-collapsed="true"]))
+        .z-map-legend {
+        left: calc(
+            var(--app-sidebar-width) + var(--app-safe-area-left, 0px) + 16px
+        );
+    }
+}
+
+/* Landscape phones below 768px still show the desktop sidebar via the mobile
+   landscape exception, so offset there too. */
+.airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]:has(
+        .airport-desktop-sidebar:not([data-collapsed="true"])
+    )
     .z-map-legend {
     left: calc(
         var(--app-sidebar-width) + var(--app-safe-area-left, 0px) + 16px


### PR DESCRIPTION
## What
Extends the landscape scale-clearance fix (v2.30.10) to desktop and tablet — the map's range scale (比例尺) was hidden behind the sidebar there too.

## How
```css
@media (min-width: 768px) {
  .airport-map-kit:has(.airport-desktop-sidebar:not([data-collapsed="true"])) .z-map-legend {
    left: calc(var(--app-sidebar-width) + var(--app-safe-area-left, 0px) + 16px);
  }
}
```
- `:has` guard so a **collapsed** sidebar (a small pill that doesn't occlude) keeps the default `left-4`.
- Landscape phones <768 keep the dedicated rule (now also `:has`-guarded).
- Safe-area term is 0 without a Dynamic Island; portrait (<768 bottom sheet) is unaffected.

## Validation — all modes
- **Desktop 1280:** legend left 318 ≥ sidebar 301 → "5 NM" visible at the map's bottom-left.
- **Landscape 844 (forced island):** 384 ≥ 367 → clears.
- **Collapsed sidebar:** legend falls back to `left-4` (`:has` excludes it).
- **Portrait 375:** stays `left-4` over the full map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)