### PR TITLE
v2.30.12: Restore airport-name title in the landscape sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.11",
+  "version": "2.30.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.12",
+    kind: "patch",
+    title: {
+      en: "Restore the airport name in the landscape sidebar",
+      zh: "横屏侧栏恢复机场名字标题",
+    },
+    summary: {
+      en: "The airport name title is shown again in the mobile landscape sidebar — it had been dropped to save space when the panel was narrower, but now that it's wider there's room for it.",
+      zh: "移动端横屏侧栏重新显示机场名字标题——之前面板较窄时为省空间隐藏了,现在加宽后有空间放回来。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.11",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -9263,12 +9263,9 @@ body {
         margin-top: 3px;
     }
 
-    .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
-        .airport-sidebar-identity
-        h1 {
-        display: none;
-    }
-
+    /* Keep the airport-name title (h1) visible in landscape now that the panel
+       is wider — only the secondary subtitle + coordinate line are dropped to
+       save vertical space. */
     .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
         .airport-sidebar-identity
         h1
@@ -9380,9 +9377,8 @@ body {
         margin-top: 3px;
     }
 
-    .airport-map-kit[data-client-orientation="landscape"]
-        .airport-sidebar-identity
-        h1,
+    /* Keep the airport-name title (h1) visible in short landscape too; only the
+       secondary subtitle + coordinate line drop out to save vertical space. */
     .airport-map-kit[data-client-orientation="landscape"]
         .airport-sidebar-identity
         h1


### PR DESCRIPTION
## What
Show the airport-name title (`h1`, e.g. "BOS · KBOS") again in the mobile landscape sidebar. It had been hidden.

## Why
Landscape hid the identity `h1` to save vertical space back when the panel was narrow (18rem). Now that v2.30.9 widened it (edge-to-edge + 20rem), there's room for the title — but it stayed hidden.

## Fix
Two rules hid it — un-hide `h1` in both:
- `@media (min-width: 640px)` mobile-landscape block
- `@media (min-width: 640px) and (max-height: 480px)` short-landscape block (the binding one on phones)

Only the secondary subtitle (full airport name) and the coordinate line stay hidden for vertical economy.

## Validation
Local browser, forced landscape 844×390 with Dynamic-Island inset: `h1` "BOS · KBOS" display block, left 61 (inset clear of the island), subtitle/coords still hidden. Title visible in screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)