### PR TITLE
v2.30.13: Landscape sidebar — full identity, matched width, working logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.12",
+  "version": "2.30.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/SidebarBrandMark.tsx
+++ b/src/components/sidebar/SidebarBrandMark.tsx
@@ -25,14 +25,18 @@ export default function SidebarBrandMark({ className = "", compact = false }) {
         to={homeHref}
         aria-label={t("nav.homePage")}
         title={t("nav.homePage")}
-        className="inline-flex items-center rounded-[2px] text-atc-text outline-none focus-visible:ring-2 focus-visible:ring-atc-accent"
+        className="inline-flex touch-manipulation items-center rounded-[2px] text-atc-text outline-none focus-visible:ring-2 focus-visible:ring-atc-accent"
       >
         <BrandLogo
           height={logoHeight}
           wordmark={wordmark}
           ariaLabel={wordmark}
+          // The mark animates; without this, a tap landing on a moving SVG
+          // sub-element can fail to resolve to a click on touch (notably in the
+          // landscape sidebar's sticky, scrollable header). Routing all pointer
+          // events to the anchor keeps the tap target stable.
           className={cn(
-            "block w-auto transition-[height] duration-200 ease-out",
+            "pointer-events-none block w-auto transition-[height] duration-200 ease-out",
             compact ? "h-[22px]" : "h-[28px]",
           )}
           animated

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.13",
+    kind: "patch",
+    title: {
+      en: "Landscape sidebar — full identity, matched width, working logo",
+      zh: "横屏侧栏——完整信息、宽度对齐、logo 可点",
+    },
+    summary: {
+      en: "Three mobile-landscape fixes: the sidebar shows the full place identity again (name, region and coordinates, kept clear of the Dynamic Island), the first screen and detail page now use the same sidebar width, and tapping the logo reliably returns to the home screen.",
+      zh: "三个移动端横屏修复:侧栏重新完整显示地点信息(名称、地区与坐标,并避开灵动岛);首屏与详情页的侧栏宽度对齐;点击 logo 能稳定回到主页。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.12",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -3570,6 +3570,11 @@ body {
 
 .dither-page-shell[data-client-horizontal-obstruction="true"][data-client-orientation="landscape"]
     .dither-page-panel {
+    /* Mirror the detail sidebar: widen the panel by the Dynamic-Island inset
+       and push the content clear of the island, so the first screen and detail
+       page render at the same width and inset. */
+    box-sizing: border-box;
+    width: calc(var(--app-sidebar-width) + var(--app-safe-area-left, 0px));
     padding-left: var(--app-safe-area-left, 0px);
 }
 
@@ -3579,7 +3584,9 @@ body {
     }
 
     .dither-page-shell[data-client-mobile-device="true"][data-client-orientation="landscape"] {
-        --app-sidebar-width: 18rem;
+        /* Match the airport detail sidebar width in landscape (.airport-map-kit
+           uses 20rem) so the first screen and detail page line up. */
+        --app-sidebar-width: 20rem;
     }
 }
 
@@ -9263,18 +9270,6 @@ body {
         margin-top: 3px;
     }
 
-    /* Keep the airport-name title (h1) visible in landscape now that the panel
-       is wider — only the secondary subtitle + coordinate line are dropped to
-       save vertical space. */
-    .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
-        .airport-sidebar-identity
-        h1
-        ~ div,
-    .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
-        .airport-sidebar-identity
-        .font-mono {
-        display: none;
-    }
 
     .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
         [data-ui="metric-grid"] {
@@ -9377,17 +9372,6 @@ body {
         margin-top: 3px;
     }
 
-    /* Keep the airport-name title (h1) visible in short landscape too; only the
-       secondary subtitle + coordinate line drop out to save vertical space. */
-    .airport-map-kit[data-client-orientation="landscape"]
-        .airport-sidebar-identity
-        h1
-        ~ div,
-    .airport-map-kit[data-client-orientation="landscape"]
-        .airport-sidebar-identity
-        .font-mono {
-        display: none;
-    }
 
     .airport-map-kit[data-client-orientation="landscape"]
         [data-ui="metric-grid"] {


### PR DESCRIPTION
Three mobile-landscape fixes.

## 1. Full place identity
Show the place name title **and** the secondary subtitle (region) + coordinate line again — they were hidden to save vertical space (in both the `@media (min-width:640px)` and `(max-height:480px)` blocks). Content lives inside the frosted shell whose `padding-left = --app-safe-area-left`, so every line stays clear of the **Dynamic Island** (verified left 61 ≥ 47 inset).

## 2. Matched sidebar width
First screen (`.dither-page-shell`) landscape width was 18rem vs the detail page (`.airport-map-kit`) 20rem. Aligned the first screen to 20rem and widened its panel by the island inset — both now render **367px** at a 47px inset.

## 3. Logo tap returns home
The brand mark is an animated SVG inside the home `<Link>`; on touch a tap on a moving sub-element could fail to resolve to a click (notably in the landscape sticky/scrollable header). Set the SVG `pointer-events:none` (anchor becomes the stable tap target) + `touch-manipulation`. Verified `elementFromPoint` resolves to the anchor and the click navigates to `/`.

## Validation
Local browser, forced landscape 844×390 + 47px island inset: identity all four lines visible and island-clear; home panel 367px = detail 367px; logo anchor resolves taps and navigates home. Needs real-device confirmation for the touch tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)