### PR TITLE
v2.30.14: Full-size logo in the landscape sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.13",
+  "version": "2.30.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.14",
+    kind: "patch",
+    title: {
+      en: "Full-size logo in the landscape sidebar",
+      zh: "横屏侧栏 logo 恢复正常大小",
+    },
+    summary: {
+      en: "The ADSBao logo at the top of the mobile landscape sidebar renders at its normal size again instead of a shrunken variant.",
+      zh: "移动端横屏侧栏顶部的 ADSBao logo 恢复正常大小,不再是缩小版。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.13",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -9252,13 +9252,6 @@ body {
     }
 
     .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
-        .sidebar-brand-dock
-        svg {
-        height: 20px;
-        width: auto;
-    }
-
-    .airport-map-kit[data-client-mobile-device="true"][data-client-orientation="landscape"]
         .airport-sidebar-display-mono--hero {
         font-size: calc(14px * var(--sb-title-scale));
     }
@@ -9351,13 +9344,6 @@ body {
         min-height: 32px;
         padding-bottom: 3px;
         padding-top: 3px;
-    }
-
-    .airport-map-kit[data-client-orientation="landscape"]
-        .sidebar-brand-dock
-        svg {
-        height: 20px;
-        width: auto;
     }
 
     .airport-map-kit[data-client-orientation="landscape"]


### PR DESCRIPTION
## What
The ADSBao logo at the top of the mobile landscape sidebar renders at its normal size again.

## Why
Two landscape rules forced the brand-dock SVG to `height: 20px` (the `@media (min-width:640px)` mobile-landscape block and the `(max-height:480px)` block) to save vertical space. Now that the panel is wider and shows the full identity, the shrunken logo looked out of place.

## Fix
Drop both `.sidebar-brand-dock svg { height: 20px }` overrides so the logo renders at its normal 28px component size.

## Validation
Local browser, forced landscape 844×390: logo svg height **28px** (was 20px), dock fits it; screenshot confirms normal size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)