### PR TITLE
v2.30.15: Solid sidebar logo bar + gradient scrim (no backdrop blur)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.14",
+  "version": "2.30.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/CollapsibleSidebarChrome.tsx
+++ b/src/components/sidebar/CollapsibleSidebarChrome.tsx
@@ -235,13 +235,12 @@ export function SidebarBrandDock({
   return (
     <div
       className={cn(
-        "sidebar-brand-dock sticky top-0 z-[calc(var(--z-index-sticky)+1)] flex items-center justify-between gap-2 px-[var(--airport-sidebar-inset)] transition-[padding,background,box-shadow] duration-200 ease-out",
-        // At rest the brand row floats transparently on the frosted sidebar
-        // (no separate opaque strip / hard divider). Only once content
-        // scrolls under it does a faint frost + hairline fade in to mask it.
-        compact
-          ? "bg-[color-mix(in_oklab,var(--app-frost-tint)_52%,transparent)] [backdrop-filter:var(--app-frost)] [-webkit-backdrop-filter:var(--app-frost)] shadow-[0_1px_0_color-mix(in_oklab,var(--app-frost-border)_70%,transparent)]"
-          : "bg-transparent shadow-none",
+        "sidebar-brand-dock sticky top-0 z-[calc(var(--z-index-sticky)+1)] flex items-center justify-between gap-2 px-[var(--airport-sidebar-inset)] transition-[padding] duration-200 ease-out",
+        // The brand row is an OPAQUE strip (no backdrop-filter — that blur was
+        // a per-scroll cost). A gradient scrim rendered just below it (see
+        // .sidebar-brand-dock::after in style.css) fades scrolling content out
+        // before it reaches the logo, so content disappears naturally without
+        // any live blur.
         compact ? "pb-2 pt-3" : "pb-3 pt-5",
         "[[data-mobile-overlay=true]_&]:pb-1 [[data-mobile-overlay=true]_&]:pt-[calc(12px+env(safe-area-inset-top))]",
         className,

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -45,6 +45,19 @@ export const CHANGELOG_TOTAL_COUNT = 101;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
+    version: "v2.30.15",
+    kind: "patch",
+    title: {
+      en: "Solid sidebar logo bar with a fade scrim",
+      zh: "侧栏 logo 改为实色 + 渐变淡出",
+    },
+    summary: {
+      en: "The sidebar logo row is now a solid strip with a soft gradient beneath it instead of a live backdrop blur — scrolling content fades out naturally under the logo, and there's no per-scroll blur to compute.",
+      zh: "侧栏 logo 那一条改为实色,下方加一道柔和渐变取代实时背景模糊——滚动内容在 logo 下自然淡出,也省去了每次滚动的模糊计算。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.14",
     kind: "patch",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -6329,16 +6329,25 @@ body {
     box-shadow: inset 0 -1px 0 color-mix(in oklab, var(--atc-text) 28%, transparent);
 }
 
-.airport-map-kit .sidebar-brand-dock {
-    /* The brand row's tone (--atc-bg) softly fades into the frosted sidebar
-       below — no hard strip, no hairline divider — so the logo melts into the
-       panel instead of sitting on a separate header bar. */
-    background: linear-gradient(
-        to bottom,
-        color-mix(in oklab, var(--atc-bg) 92%, transparent),
-        transparent
-    ) !important;
-    box-shadow: none !important;
+/* The sticky brand row (every sidebar) is an OPAQUE strip — no backdrop-filter,
+   so there is no per-scroll blur to compute. A gradient scrim rendered just
+   below it (::after) fades scrolling content out before it reaches the logo, so
+   content disappears naturally as it scrolls up. The collapsed pill variant
+   (.static, a glass Toolbar) is intentionally excluded. */
+.sidebar-brand-dock.sticky {
+    background: var(--atc-bg);
+    box-shadow: none;
+}
+
+.sidebar-brand-dock.sticky::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    height: 28px;
+    background: linear-gradient(to bottom, var(--atc-bg), transparent);
+    pointer-events: none;
 }
 
 .aircraft-search:focus-within {


### PR DESCRIPTION
## What
Replace the sidebar logo row's live backdrop blur with an **opaque strip + gradient fade scrim**, across all sidebars.

## Why
The sticky brand row used `backdrop-filter` (a per-scroll blur cost) over a semi-transparent tint. The ask: make the logo bar opaque, fade scrolling content out beneath it with a gradient, and cut the blur computation.

## How
- **Component** (`CollapsibleSidebarChrome`): drop the compact frosted-bg + `backdrop-filter` classes; background comes from CSS now.
- **CSS**: `.sidebar-brand-dock.sticky` is opaque `var(--atc-bg)` with an `::after` gradient scrim (`atc-bg → transparent`, 28px) just below it. Scoped to `.sticky` so the collapsed glass-pill variant is untouched. Replaces the old `.airport-map-kit` semi-transparent gradient override.

## Validation
Local browser — explorer + home screen, light + dark themes: dock opaque, `backdrop-filter: none`, 28px scrim; scrolling content fades out naturally under the logo in both themes. Collapsed pill unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)