### PR TITLE
v2.30.17: Drop the top-left glow on the dark sidebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.16",
+  "version": "2.30.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,15 +51,15 @@ export const CHANGELOG_TOTAL_COUNT = 87;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.30.16",
+    version: "v2.30.17",
     kind: "feat",
     title: {
       en: "v2.30 — sidebar, landscape and performance polish",
       zh: "v2.30——侧栏、横屏与性能打磨",
     },
     summary: {
-      en: "A run of refinements on top of the weather redesign. The frosted sidebar is quieter and lighter — an opaque logo bar with a fade scrim (no scroll blur), tightened typography, a smoother first-screen entrance and a shorter nearby list. Mobile landscape got a full pass: the panel runs edge-to-edge clear of the Dynamic Island, shows the full place identity at a width matched to the home screen, keeps the map scale clear of the sidebar, and the logo reliably returns home.",
-      zh: "在天气改版基础上的一系列打磨。磨砂侧栏更安静更轻——不透明 logo 条配渐变淡出（滚动无模糊）、排版收紧、首屏入场更顺滑、邻近列表更短。移动端横屏也过了一遍：面板铺到边缘并避开灵动岛、完整显示地点信息且宽度与首屏对齐、地图比例尺避开侧栏、logo 稳定回主页。",
+      en: "A run of refinements on top of the weather redesign. The frosted sidebar is quieter and lighter — an opaque logo bar with a fade scrim (no scroll blur), tightened typography, a smoother first-screen entrance and a shorter nearby list; the dark sidebar also drops a stray top-left glow for a cleaner black. Mobile landscape got a full pass: the panel runs edge-to-edge clear of the Dynamic Island, shows the full place identity at a width matched to the home screen, keeps the map scale clear of the sidebar, and the logo reliably returns home.",
+      zh: "在天气改版基础上的一系列打磨。磨砂侧栏更安静更轻——不透明 logo 条配渐变淡出（滚动无模糊）、排版收紧、首屏入场更顺滑、邻近列表更短；暗色侧栏也去掉了左上角多余的渐变光,更纯净的黑。移动端横屏也过了一遍：面板铺到边缘并避开灵动岛、完整显示地点信息且宽度与首屏对齐、地图比例尺避开侧栏、logo 稳定回主页。",
     },
     highlights: [],
   },

--- a/src/style.css
+++ b/src/style.css
@@ -3478,17 +3478,11 @@ body {
         inset 0 1px 0 color-mix(in oklab, var(--atc-click-fg) 24%, transparent),
         inset 0 0 0 1px color-mix(in oklab, var(--atc-click-fg) 10%, transparent),
         0 8px 18px color-mix(in oklab, oklch(0.08 0.003 100) 28%, transparent);
-    background:
-        radial-gradient(
-            120% 70% at 16% 0%,
-            color-mix(in oklab, oklch(0.72 0.003 100) 13%, transparent),
-            transparent 48%
-        ),
-        linear-gradient(
-            180deg,
-            color-mix(in oklab, oklch(0.215 0.003 100) 88%, transparent),
-            color-mix(in oklab, oklch(0.145 0.003 100) 90%, transparent)
-        );
+    background: linear-gradient(
+        180deg,
+        color-mix(in oklab, oklch(0.215 0.003 100) 88%, transparent),
+        color-mix(in oklab, oklch(0.145 0.003 100) 90%, transparent)
+    );
     border-right: 1px solid color-mix(in oklab, var(--atc-text) 10%, transparent);
     box-shadow:
         inset -1px 0 0 color-mix(in oklab, var(--atc-text) 6%, transparent),
@@ -3777,17 +3771,11 @@ body {
         inset 0 0 0 1px color-mix(in oklab, var(--atc-text) 7%, transparent);
     /* Translucent frosted glass (dark) over the full-bleed map — small blur(8px)
        shows the live map diffused through the deep-gray panel. */
-    background:
-        radial-gradient(
-            120% 70% at 18% 0%,
-            color-mix(in oklab, oklch(0.72 0.003 100) 14%, transparent),
-            transparent 46%
-        ),
-        linear-gradient(
-            180deg,
-            color-mix(in oklab, oklch(0.215 0.003 100) 92%, transparent),
-            color-mix(in oklab, oklch(0.135 0.003 100) 96%, transparent)
-        );
+    background: linear-gradient(
+        180deg,
+        color-mix(in oklab, oklch(0.215 0.003 100) 92%, transparent),
+        color-mix(in oklab, oklch(0.135 0.003 100) 96%, transparent)
+    );
     -webkit-backdrop-filter: saturate(1.5) blur(8px);
     backdrop-filter: saturate(1.5) blur(8px);
     border-right: 1px solid color-mix(in oklab, var(--atc-text) 9%, transparent);


### PR DESCRIPTION
## What
The dark sidebars had a faint light glow in the top-left corner — the user wants it fully black.

## Cause
Both the dark `.dither-page-panel` (home) and the dark airport sidebar shell layered a `radial-gradient(120% 70% at 16-18% 0%, oklch(0.72) ~13%, transparent)` over their base, lifting the top-left off black.

## Fix
Removed both radial glows, keeping the dark linear base gradient. The sidebar now reads as a clean uniform black. Light theme and the `.map-settings-sheet` (a different surface) are unchanged.

## Changelog
Folded into the rolling v2.30 entry per the one-entry-per-minor convention; version bumped **v2.30.16 → v2.30.17** so the update toast still fires.

## Validation
Local browser, dark theme: home + explorer sidebar backgrounds have no `radial-gradient`; top-left matches the rest of the panel (screenshot confirms uniform black).

🤖 Generated with [Claude Code](https://claude.com/claude-code)