### PR TITLE
v2.31.0: RouteBadge in the nearby list + local FlightAware dev gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.30.17",
+  "version": "2.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { Plane } from "lucide-react";
-import { getFlightRouteAccuracyNotice } from "../../utils/flightRouteDisplay";
+import { routeBadgePropsFromRoute } from "../../utils/flightRouteDisplay";
+import RouteBadge from "@/components/ui/RouteBadge";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import { formatFlightTelemetryMetric } from "@/features/aircraft/tracking/flightTelemetryDisplayModel";
@@ -42,12 +43,9 @@ function AircraftRow({
   });
   const { preferences: units } = useUnitPreferences();
   const callsign = aircraft.callsign?.trim() || aircraft.icao24 || "-";
-  const route = aircraft.flightRouteLabel || "";
-  const registration = String(aircraft.registration || "").trim();
-  const routeAccuracyNotice = getFlightRouteAccuracyNotice(aircraft.flightRoute)
-    ? t("aircraft.adsbdbRouteAccuracyNotice")
-    : "";
-  const routeTitle = routeAccuracyNotice || route;
+  // The subline is the route badge when a route exists, and nothing otherwise —
+  // the registration / N-number is never shown here.
+  const routeBadge = routeBadgePropsFromRoute(aircraft.flightRoute);
 
   const distValue = toNumber(aircraft.distanceNm);
   const distanceDisplay = formatNearbyDistanceDisplay(distValue, units.distance);
@@ -93,22 +91,7 @@ function AircraftRow({
         >
           {callsign}
         </span>
-        {route ? (
-          <span
-            title={routeTitle}
-            className="notranslate min-w-0 truncate text-[calc(10.5px*var(--sb-body-scale))] text-atc-faint"
-            translate="no"
-          >
-            {route}
-          </span>
-        ) : registration && registration !== callsign ? (
-          <span
-            className="notranslate min-w-0 truncate text-[calc(10px*var(--sb-body-scale))] tracking-[0.04em] text-atc-faint"
-            translate="no"
-          >
-            {registration}
-          </span>
-        ) : null}
+        {routeBadge ? <RouteBadge {...routeBadge} className="shrink-0" /> : null}
       </div>
 
       <div className="flex flex-none items-baseline gap-2.5 font-mono tabular-nums">
@@ -162,8 +145,6 @@ export default memo(AircraftRow, (prev, next) =>
     nestedFields: [
       "callsign",
       "icao24",
-      "registration",
-      "flightRouteLabel",
       "flightRoute",
       "distanceNm",
       "altitude",

--- a/src/components/ui/RouteBadge.tsx
+++ b/src/components/ui/RouteBadge.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { markAirlineLogoUnavailable } from "@/features/aviation/airlineLogoModel";
+import { cn } from "@/lib/utils";
+
+/**
+ * RouteBadge — a compact frosted pill showing an origin→destination route.
+ *
+ * Two variants only:
+ *   • WITH IMAGE — an airline logo sits at the left end and radial-fades into
+ *     the frost (U-shaped fade opening toward the left edge); the codes sit in
+ *     the clear middle, always above the image. No airline name/text.
+ *   • NO IMAGE — a plain frosted pill with just the codes.
+ *
+ * There is no country-flag variant. Renders NOTHING when from/to are missing.
+ * Neutral frost only — no signal accent. Shell tint + hairline derive from
+ * --atc-text so light/dark retune without forking the glass tokens.
+ */
+export interface RouteBadgeProps {
+  /** Origin airport code (ICAO, e.g. "KBOS"). */
+  from: string;
+  /** Destination airport code (ICAO, e.g. "KATL"). */
+  to: string;
+  /** Airline logo URL (e.g. /api/proxy/airlines/DAL). Omit/empty → no-image. */
+  airlineLogoUrl?: string;
+  /** Lower-confidence (adsbdb) route — shows a faint trailing marker. */
+  uncertain?: boolean;
+  className?: string;
+}
+
+// U-shaped radial mask: solid at the left edge, fading inward so only the
+// logo's edge-anchored center shows and it never sits under the codes.
+const LOGO_MASK =
+  "radial-gradient(ellipse 140% 120% at 0% 50%, #000 0%, #000 32%, transparent 82%)";
+
+export default function RouteBadge({
+  from,
+  to,
+  airlineLogoUrl,
+  uncertain = false,
+  className,
+}: RouteBadgeProps) {
+  const [logoFailed, setLogoFailed] = useState(false);
+  if (!from || !to) return null;
+
+  const hasLogo = Boolean(airlineLogoUrl) && !logoFailed;
+
+  return (
+    <span
+      className={cn(
+        "relative inline-flex h-4 select-none items-center overflow-hidden rounded-full font-sans",
+        "bg-[color-mix(in_oklab,var(--atc-text)_5%,transparent)]",
+        "shadow-[inset_0_0_0_0.5px_color-mix(in_oklab,var(--atc-text)_12%,transparent)]",
+        hasLogo ? "pl-[18px] pr-2" : "px-2",
+        className,
+      )}
+    >
+      {hasLogo ? (
+        <img
+          src={airlineLogoUrl}
+          alt=""
+          aria-hidden="true"
+          loading="lazy"
+          decoding="async"
+          onError={() => {
+            markAirlineLogoUnavailable(airlineLogoUrl);
+            setLogoFailed(true);
+          }}
+          className="pointer-events-none absolute left-0 top-0 z-[1] h-full w-[24px] object-cover object-left opacity-90 [-webkit-mask-image:var(--route-badge-logo-mask)] [mask-image:var(--route-badge-logo-mask)]"
+          style={{ ["--route-badge-logo-mask" as string]: LOGO_MASK }}
+        />
+      ) : null}
+
+      <span
+        className="notranslate relative z-[2] inline-flex items-baseline gap-1 text-[calc(9.5px*var(--sb-body-scale,1))] font-normal leading-none tracking-[0.2px] text-atc-text"
+        translate="no"
+      >
+        {from}
+        <span aria-hidden="true" className="text-[0.82em] text-atc-dim">
+          →
+        </span>
+        {to}
+        {uncertain ? (
+          <span
+            aria-hidden="true"
+            title="Approximate route (callsign reference data)"
+            className="ml-px text-[0.74em] leading-none text-atc-faint"
+          >
+            *
+          </span>
+        ) : null}
+      </span>
+    </span>
+  );
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,28 +51,15 @@ export const CHANGELOG_TOTAL_COUNT = 55;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.30.17",
+    version: "v2.31.0",
     kind: "feat",
     title: {
-      en: "v2.30 — sidebar, landscape and performance polish",
-      zh: "v2.30——侧栏、横屏与性能打磨",
+      en: "Flight route badges in the nearby list",
+      zh: "邻近列表加入航路徽章",
     },
     summary: {
-      en: "A run of refinements on top of the weather redesign. The frosted sidebar is quieter and lighter — an opaque logo bar with a fade scrim (no scroll blur), tightened typography, a smoother first-screen entrance and a shorter nearby list; the dark sidebar also drops a stray top-left glow for a cleaner black. Mobile landscape got a full pass: the panel runs edge-to-edge clear of the Dynamic Island, shows the full place identity at a width matched to the home screen, keeps the map scale clear of the sidebar, and the logo reliably returns home.",
-      zh: "在天气改版基础上的一系列打磨。磨砂侧栏更安静更轻——不透明 logo 条配渐变淡出（滚动无模糊）、排版收紧、首屏入场更顺滑、邻近列表更短；暗色侧栏也去掉了左上角多余的渐变光,更纯净的黑。移动端横屏也过了一遍：面板铺到边缘并避开灵动岛、完整显示地点信息且宽度与首屏对齐、地图比例尺避开侧栏、logo 稳定回主页。",
-    },
-    highlights: [],
-  },
-  {
-    version: "v2.30.0",
-    kind: "feat",
-    title: {
-      en: "Airport weather redesign — METAR + Local views",
-      zh: "机场天气改版——METAR 与实况两视图",
-    },
-    summary: {
-      en: "Airport weather is rebuilt around one colour-coded hero card per view, switched by a METAR / Local control: flight-rules category colours for METAR, temperature-mapped colour for Local (now with UV index and visibility).",
-      zh: "机场天气以每视图一张颜色编码主卡片重做,由 METAR / 实况控件切换:METAR 按飞行规则类别着色,实况随温度映射(新增紫外线与能见度)。",
+      en: "Routed aircraft in the nearby list now carry a compact route badge — origin → destination in a frosted pill, with the airline's logo fading in at the left when one is available. Aircraft with no known route show no subline (the registration is no longer shown there).",
+      zh: "邻近列表中有航路的飞机现在带一枚紧凑的航路徽章——磨砂胶囊里显示起点 → 终点,有航司 logo 时在左侧淡入。没有已知航路的飞机不显示副标题(不再显示注册号)。",
     },
     highlights: [],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -170,6 +170,19 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.30.17",
+    kind: "feat",
+    title: {
+      en: "Airport weather redesign + sidebar & landscape polish",
+      zh: "机场天气改版 + 侧栏与横屏打磨",
+    },
+    summary: {
+      en: "Airport weather is rebuilt around one colour-coded hero card per view (METAR / Local, now with UV index and visibility). On top of that, a long polish run: a quieter frosted sidebar with an opaque logo bar (no scroll blur), tighter typography, a smoother first screen, and a full mobile-landscape pass — an edge-to-edge panel clear of the Dynamic Island, the full place identity at a home-matched width, and the map scale kept clear of the sidebar.",
+      zh: "机场天气以每视图一张颜色编码主卡片重做(METAR / 实况,新增紫外线与能见度)。在此基础上一轮长打磨:更安静的磨砂侧栏与不透明 logo 条(滚动无模糊)、排版更紧、首屏更顺滑,以及一整轮移动端横屏修整——面板铺到边缘并避开灵动岛、完整地点信息且宽度与首屏对齐、地图比例尺避开侧栏。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.29.0",
     kind: "feat",
     title: {

--- a/src/features/app-shell/auth/useFlightAwareEnabled.ts
+++ b/src/features/app-shell/auth/useFlightAwareEnabled.ts
@@ -7,6 +7,14 @@ import {
   normalizeFeatureFlags,
 } from "../feature-flags/userFeatureFlagsModel";
 
+// Local-dev gate: force the FlightAware path ON in `vite dev` so the feature can
+// be exercised without a Clerk login + grant. `import.meta.env.DEV` is false in
+// production builds, so this compiles out and the real Clerk-grant gate is the
+// only thing that runs in prod (the product guardrail is untouched). Committed
+// on purpose — local dev needs zero per-run setup. Flip to `false` to exercise
+// the adsbdb path locally.
+const DEV_FORCE_FLIGHTAWARE = Boolean(import.meta.env?.DEV);
+
 // Module-scoped dedupe key for the dev log. Every consumer of the hook
 // would otherwise re-emit the same line on every render and the
 // console gets buried. Keyed on the full signature so a *change* in
@@ -99,10 +107,11 @@ export function usePlaneHunterCameraStudioEnabled() {
 
 export function useFlightAwareEnabled() {
   const { email, flags, hasUser, user, resolved } = useUserFeatureFlags();
-  const enabled = isFeatureFlagEnabled(
+  const granted = isFeatureFlagEnabled(
     flags,
     FEATURE_FLAGS.FLIGHTAWARE_ENABLED,
   );
+  const enabled = DEV_FORCE_FLIGHTAWARE || granted;
 
   // Dev-only trace, deduped across the whole app: each consumer of the
   // hook re-renders independently, and several of them re-run on every
@@ -122,5 +131,5 @@ export function useFlightAwareEnabled() {
     }
   }, [email, enabled, flags, hasUser, user]);
 
-  return { enabled, resolved };
+  return { enabled, resolved: DEV_FORCE_FLIGHTAWARE || resolved };
 }

--- a/src/utils/flightRouteDisplay.ts
+++ b/src/utils/flightRouteDisplay.ts
@@ -1,4 +1,6 @@
-export { getFlightRouteAirlineIconUrl } from '../features/aviation/airlineLogoModel'
+import { getFlightRouteAirlineIconUrl } from '../features/aviation/airlineLogoModel'
+
+export { getFlightRouteAirlineIconUrl }
 
 const airportCode = (airport) =>
   String(airport?.iata || airport?.icao || '').trim().toUpperCase()
@@ -56,3 +58,23 @@ export const getFlightRouteAccuracyNotice = (route) =>
   normalizedRouteSource(route) === 'adsbdb'
     ? "This route may be inaccurate: adsbdb uses callsign reference data that may not match today's actual origin and destination."
     : ''
+
+// ICAO-first airport code (KBOS), falling back to IATA. RouteBadge renders the
+// 4-letter ICAO identifiers to match the rest of the app's airport language.
+const airportIcaoCode = (airport) =>
+  String(airport?.icao || airport?.iata || '').trim().toUpperCase()
+
+// Resolve <RouteBadge> props from a flight route. Returns null when the route
+// is incomplete or circular (same airport) — the badge should render nothing.
+// `uncertain` flags adsbdb-sourced routes so the badge can show a faint marker.
+export const routeBadgePropsFromRoute = (route) => {
+  const from = airportIcaoCode(route?.origin)
+  const to = airportIcaoCode(route?.destination)
+  if (!from || !to || sameAirport(route?.origin, route?.destination)) return null
+  return {
+    from,
+    to,
+    airlineLogoUrl: getFlightRouteAirlineIconUrl(route) || undefined,
+    uncertain: normalizedRouteSource(route) === 'adsbdb',
+  }
+}


### PR DESCRIPTION
## RouteBadge
New reusable `src/components/ui/RouteBadge.tsx` — a compact frosted pill showing **origin → destination** (ICAO codes).
- **WITH IMAGE**: airline logo at the left, radial-masked (U-fade opening toward the edge), codes always above. Logo URL from the existing `getFlightRouteAirlineIconUrl` (FlightAware proxy); falls back to no-image on error.
- **NO IMAGE**: plain frosted pill, codes only.
- Renders **nothing** with no route. Neutral frost, no orange accent; shell tint + hairline from `--atc-text` (light/dark retune, no glass-token fork). Codes one step below the callsign, scaled by `--sb-body-scale`. `uncertain` (adsbdb) shows a faint trailing marker.

`routeBadgePropsFromRoute(route)` resolves `from`/`to` (ICAO-first), the logo URL, and `uncertain`. **AircraftRow**: the callsign subline is the RouteBadge when a route exists and nothing otherwise — the **registration is no longer shown there**.

## Local FlightAware dev gate
`useFlightAwareEnabled` now force-enables the FlightAware path in `vite dev` (`import.meta.env.DEV`) so it can be exercised without a Clerk login + grant. Compiles out of production (DEV is false there) — the prod Clerk-grant guardrail is untouched. Committed so local dev needs zero per-run setup (flip the constant to exercise adsbdb).

## Changelog
`CHANGELOG_RECENT` holds only the current release (`CHANGELOG_INITIAL_LIMIT = 1`). Rolled the v2.30 series into a single history entry; v2.31.0 is the recent entry.

## Validation
- `pnpm test` — 122 files pass; typecheck clean.
- Local browser against the wired FlightAware service: with-logo (CPA / FDX / THY) and no-image variants render; badge codes **8.55px < 9px** callsign; no-route rows show no subline. Light + dark verified earlier in the badge work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
