### PR TITLE
v2.31.1: Shrink the route badge ~15%

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.31.0",
+  "version": "2.31.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/RouteBadge.tsx
+++ b/src/components/ui/RouteBadge.tsx
@@ -47,10 +47,10 @@ export default function RouteBadge({
   return (
     <span
       className={cn(
-        "relative inline-flex h-4 select-none items-center overflow-hidden rounded-full font-sans",
+        "relative inline-flex h-[13.6px] select-none items-center overflow-hidden rounded-full font-sans",
         "bg-[color-mix(in_oklab,var(--atc-text)_5%,transparent)]",
         "shadow-[inset_0_0_0_0.5px_color-mix(in_oklab,var(--atc-text)_12%,transparent)]",
-        hasLogo ? "pl-[18px] pr-2" : "px-2",
+        hasLogo ? "pl-[15.3px] pr-[6.8px]" : "px-[6.8px]",
         className,
       )}
     >
@@ -65,13 +65,13 @@ export default function RouteBadge({
             markAirlineLogoUnavailable(airlineLogoUrl);
             setLogoFailed(true);
           }}
-          className="pointer-events-none absolute left-0 top-0 z-[1] h-full w-[24px] object-cover object-left opacity-90 [-webkit-mask-image:var(--route-badge-logo-mask)] [mask-image:var(--route-badge-logo-mask)]"
+          className="pointer-events-none absolute left-0 top-0 z-[1] h-full w-[20.4px] object-cover object-left opacity-90 [-webkit-mask-image:var(--route-badge-logo-mask)] [mask-image:var(--route-badge-logo-mask)]"
           style={{ ["--route-badge-logo-mask" as string]: LOGO_MASK }}
         />
       ) : null}
 
       <span
-        className="notranslate relative z-[2] inline-flex items-baseline gap-1 text-[calc(9.5px*var(--sb-body-scale,1))] font-normal leading-none tracking-[0.2px] text-atc-text"
+        className="notranslate relative z-[2] inline-flex items-baseline gap-1 text-[calc(8.1px*var(--sb-body-scale,1))] font-normal leading-none tracking-[0.2px] text-atc-text"
         translate="no"
       >
         {from}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 55;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.31.0",
+    version: "v2.31.1",
     kind: "feat",
     title: {
       en: "Flight route badges in the nearby list",


### PR DESCRIPTION
Scales the RouteBadge down by 0.85: height 16 → 13.6px, codes 9.5 → 8.1px base (7.29px rendered), logo width 24 → 20.4px, paddings ×0.85. Arrow + uncertain marker are em-relative and follow automatically. Folded into the rolling v2.31 changelog entry (version bumped to v2.31.1). Verified in the dark explorer — badges render smaller and still legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)