### PR TITLE
v2.31.2: Route badge logo fades to transparent earlier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.31.1",
+  "version": "2.31.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/RouteBadge.tsx
+++ b/src/components/ui/RouteBadge.tsx
@@ -30,7 +30,7 @@ export interface RouteBadgeProps {
 // U-shaped radial mask: solid at the left edge, fading inward so only the
 // logo's edge-anchored center shows and it never sits under the codes.
 const LOGO_MASK =
-  "radial-gradient(ellipse 140% 120% at 0% 50%, #000 0%, #000 32%, transparent 82%)";
+  "radial-gradient(ellipse 140% 120% at 0% 50%, #000 0%, #000 24%, transparent 68%)";
 
 export default function RouteBadge({
   from,

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 55;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.31.1",
+    version: "v2.31.2",
     kind: "feat",
     title: {
       en: "Flight route badges in the nearby list",


### PR DESCRIPTION
Pulls the RouteBadge logo mask stops inward so the U-fade reaches transparent sooner (closer to the left edge): solid 0→32% / transparent 82% → 0→24% / transparent 68%. Verified in the dark explorer. Folded into the rolling v2.31 changelog entry (→ v2.31.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)