### PR TITLE
v2.31.3: Make route-badge airline logos resilient to transient 404s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.31.2",
+  "version": "2.31.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/api/webapi/proxy.go
+++ b/services/data-service/internal/api/webapi/proxy.go
@@ -357,8 +357,11 @@ func (h *Handler) handleAirlineLogo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if h.flightAwareServiceBaseURL == "" {
+		// Not a genuine "this airline has no logo" — the service just isn't
+		// configured. Never cache this, or a misconfigured window poisons
+		// client caches for an hour.
 		writeJSONWithHeaders(w, http.StatusNotFound, map[string]any{"error": "Airline logo not found"}, map[string]string{
-			"Cache-Control": "public, max-age=3600",
+			"Cache-Control": "no-store",
 			"X-Data-Source": "flightaware",
 		})
 		return
@@ -370,8 +373,15 @@ func (h *Handler) handleAirlineLogo(w http.ResponseWriter, r *http.Request) {
 	}
 	body, contentType, status, err := h.fetchImageWithHeaders(r.Context(), upstream, headers)
 	if err != nil || status < 200 || status >= 300 {
+		// Only a genuine upstream 404 (the airline truly has no logo) is worth
+		// caching. A transport error or a 5xx is transient — serve it
+		// no-store so a blip doesn't hide the logo until the cache expires.
+		cacheControl := "public, max-age=3600"
+		if err != nil || status == 0 || status >= 500 {
+			cacheControl = "no-store"
+		}
 		writeJSONWithHeaders(w, statusOr(status, http.StatusNotFound), map[string]any{"error": "Airline logo not found"}, map[string]string{
-			"Cache-Control": "public, max-age=3600",
+			"Cache-Control": cacheControl,
 			"X-Data-Source": "flightaware",
 		})
 		return

--- a/src/components/ui/RouteBadge.tsx
+++ b/src/components/ui/RouteBadge.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { markAirlineLogoUnavailable } from "@/features/aviation/airlineLogoModel";
 import { cn } from "@/lib/utils";
 
 /**
@@ -61,10 +60,12 @@ export default function RouteBadge({
           aria-hidden="true"
           loading="lazy"
           decoding="async"
-          onError={() => {
-            markAirlineLogoUnavailable(airlineLogoUrl);
-            setLogoFailed(true);
-          }}
+          // Hide only THIS row's logo on error. Don't globally mark the airline
+          // unavailable — a single transient 404 (e.g. a backend blip) would
+          // otherwise permanently suppress that airline's logo across every row
+          // for the whole session. Other rows retry independently, and a fresh
+          // mount tries again.
+          onError={() => setLogoFailed(true)}
           className="pointer-events-none absolute left-0 top-0 z-[1] h-full w-[20.4px] object-cover object-left opacity-90 [-webkit-mask-image:var(--route-badge-logo-mask)] [mask-image:var(--route-badge-logo-mask)]"
           style={{ ["--route-badge-logo-mask" as string]: LOGO_MASK }}
         />

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 55;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.31.2",
+    version: "v2.31.3",
     kind: "feat",
     title: {
       en: "Flight route badges in the nearby list",

--- a/src/utils/flightRouteDisplay.ts
+++ b/src/utils/flightRouteDisplay.ts
@@ -64,6 +64,18 @@ export const getFlightRouteAccuracyNotice = (route) =>
 const airportIcaoCode = (airport) =>
   String(airport?.icao || airport?.iata || '').trim().toUpperCase()
 
+// Airline-logo URL for the badge, built straight from the route's airline code.
+// Deliberately does NOT consult the shared `unavailable` set (unlike
+// getFlightRouteAirlineIconUrl): one transient 404 elsewhere must not suppress
+// the logo across every nearby-list row. The <RouteBadge> hides its own image
+// on error instead, and retries on the next mount.
+const airlineLogoUrlForBadge = (route) => {
+  const code = String(route?.airlineIcao || route?.airline?.icao || '')
+    .trim()
+    .toUpperCase()
+  return /^[A-Z]{2,3}$/.test(code) ? `/api/proxy/airlines/${code}` : undefined
+}
+
 // Resolve <RouteBadge> props from a flight route. Returns null when the route
 // is incomplete or circular (same airport) — the badge should render nothing.
 // `uncertain` flags adsbdb-sourced routes so the badge can show a faint marker.
@@ -74,7 +86,7 @@ export const routeBadgePropsFromRoute = (route) => {
   return {
     from,
     to,
-    airlineLogoUrl: getFlightRouteAirlineIconUrl(route) || undefined,
+    airlineLogoUrl: airlineLogoUrlForBadge(route),
     uncertain: normalizedRouteSource(route) === 'adsbdb',
   }
 }


### PR DESCRIPTION
## Symptom
Some airline logos (Delta, JetBlue, American, Southwest, Republic) never appeared in the route badge, while others (United, Copa, Cathay) did.

## Root cause
A single transient 404 on `/api/proxy/airlines/{code}` got latched in two places:
1. **Frontend** — `getFlightRouteAirlineIconUrl` records a failed URL in a module-global "unavailable" set on the first error and never retries it for the session. One blip (e.g. my local data-service restart) suppressed that airline's logo across every nearby-list row.
2. **Backend** — the "Airline logo not found" 404 was sent with `Cache-Control: public, max-age=3600`, so the browser cached the transient 404 for an hour. Proven: a `cache:'reload'` fetch returns **200** for JBU/DAL/AAL/SWA/RPA while the cached request returns 404.

## Fix
- `routeBadgePropsFromRoute` builds the logo URL directly (no global "unavailable" set); the badge hides only its own image on error and retries on the next mount.
- The data-service only caches a **genuine** upstream 404 (airline truly has no logo). An unconfigured service or a transport error / 5xx is served `no-store`, so a blip self-heals instead of poisoning client caches for an hour.

## Validation
`go test ./internal/api/webapi/...` and `pnpm test` (122 files) pass. Backend serves all logos 200 (incl. a 14-way parallel burst); badges load logos on fresh mounts.

> Note: backend change — deploys to Railway with the next push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
