### PR TITLE
v2.31.4: Fix big gap at top of the nearby list when scrolled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.31.3",
+  "version": "2.31.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -94,10 +94,23 @@ export default function VirtualNearbyList({
     // recompute where the list starts.
     const body = scrollEl.querySelector(".sidebar-shell-body");
     if (body) observer.observe(body);
+    // The mobile panel has no .sidebar-shell-body — its header (identity + hero
+    // + filters) lives beside the list, so observe the list's own container too:
+    // when the header grows it pushes the list down, which must recompute where
+    // the list begins.
+    if (listEl.parentElement) observer.observe(listEl.parentElement);
+    // Safety net: scrollMargin is scroll-invariant, but it can be measured
+    // stale when the header grows asynchronously after mount (e.g. the Flights
+    // card / airport name resolving) without resizing an observed element — the
+    // virtualizer would then window the wrong rows and leave a gap at the top.
+    // Re-validate on scroll; the >0.5px diff guard keeps it from re-rendering
+    // once it settles.
+    scrollEl.addEventListener("scroll", schedule, { passive: true });
     window.addEventListener("resize", measure);
     return () => {
       window.cancelAnimationFrame(raf);
       observer.disconnect();
+      scrollEl.removeEventListener("scroll", schedule);
       window.removeEventListener("resize", measure);
     };
   }, [scrollRef, visibleItems.length]);

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 55;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.31.3",
+    version: "v2.31.4",
     kind: "feat",
     title: {
       en: "Flight route badges in the nearby list",


### PR DESCRIPTION
## Bug
On the mobile airport detail panel, scrolling the nearby list left a large empty gap at the top — the rows rendered far down the page (see report video).

## Cause
`VirtualNearbyList` windows against the shared panel scroll via a measured `scrollMargin` (the list's offset from the scroll-content top). The mobile header (identity + Flights card + filters) grows asynchronously after mount, pushing the list down — but the ResizeObserver only watched `.sidebar-shell-body` (desktop-only). So `scrollMargin` stayed stale (~275 vs the real ~570), the virtualizer windowed the wrong rows, and they rendered ~300px too low.

## Fix
- Also observe the list's own container, so header growth beside the list re-measures.
- Re-measure `scrollMargin` on scroll as a safety net (it's scroll-invariant; the >0.5px diff guard prevents re-render churn once settled).

## Validation
`pnpm test` (122 files). Mobile detail panel: scrolled past the header the top visible row sits ~32px in (one row height), not the ~296px gap before; rows fill directly under the sticky logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)