### PR TITLE
v2.31.5: Blend explorer logo row + orange active state on the Flights tile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.31.4",
+  "version": "2.31.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -114,9 +114,10 @@ export default function SidebarViewSwitch({
       <div className="overflow-hidden rounded-[var(--atc-radius-panel)] border border-[color-mix(in_oklab,var(--atc-text)_8%,transparent)] bg-[color-mix(in_oklab,var(--atc-text)_3.5%,transparent)]">
         <button
           type="button"
+          data-active={isTraffic ? "true" : undefined}
           onClick={() => onViewChange?.("traffic")}
           aria-pressed={isTraffic}
-          className={`block w-full px-[16px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] ${
+          className={`relative block w-full px-[16px] text-left transition-[background-color] duration-200 ease-out before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-[2px] before:origin-center before:scale-x-0 before:bg-[var(--atc-signal-accent)] before:transition-transform before:duration-300 before:ease-[cubic-bezier(0.34,1.3,0.64,1)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:before:scale-x-100 ${
             isTraffic ? "pb-3 pt-[15px]" : "py-[14px]"
           }`}
         >

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 55;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.31.4",
+    version: "v2.31.5",
     kind: "feat",
     title: {
       en: "Flight route badges in the nearby list",

--- a/src/style.css
+++ b/src/style.css
@@ -6338,6 +6338,21 @@ body {
     pointer-events: none;
 }
 
+/* On the frosted explorer sidebar (translucent glass over the map) the solid
+   --atc-bg logo strip + scrim read as a separate, darker band. Give the logo
+   row the panel's OWN frosted material instead — transparent tint + the same
+   blur — so it melts into the panel, and drop the scrim band. The home/static
+   sidebars keep the opaque strip above (their panel is opaque, so it matches). */
+.airport-map-kit .sidebar-brand-dock.sticky {
+    background: transparent;
+    -webkit-backdrop-filter: saturate(1.4) blur(8px);
+    backdrop-filter: saturate(1.4) blur(8px);
+}
+
+.airport-map-kit .sidebar-brand-dock.sticky::after {
+    content: none;
+}
+
 .aircraft-search:focus-within {
     color: var(--atc-text);
     box-shadow:


### PR DESCRIPTION
Two small detail-sidebar fixes.

## 1. Logo row blends into the frosted panel
On the explorer the logo row was a solid `--atc-bg` strip + a scrim, which read as a separate darker band over the translucent glass panel. Now the logo row uses the panel's own frosted material (transparent tint + the same `saturate(1.4) blur(8px)`) and the scrim band is dropped, so it melts into the panel. Scoped to `.airport-map-kit`; home/static sidebars keep the opaque strip (their panel matches it).

## 2. Orange active state on the Flights tile
The Flights hero switched to the traffic view but showed no active highlight, unlike the Wx/ATC/Spot/Dep/Arr cells. It now gets the same `data-active` orange background + animated accent bar when the traffic view is active.

## Validation
`pnpm test` (122 files). Explorer dark: logo row blends into the panel; tapping Flights shows the orange active background + accent bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)