### PR TITLE
v2.31.7: Cross-fade nearby-list rows in place on re-sort; reveal route badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.31.6",
+  "version": "2.31.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/AircraftRow.tsx
+++ b/src/components/sidebar/AircraftRow.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Plane } from "lucide-react";
 import { routeBadgePropsFromRoute } from "../../utils/flightRouteDisplay";
 import RouteBadge from "@/components/ui/RouteBadge";
@@ -46,6 +46,29 @@ function AircraftRow({
   // The subline is the route badge when a route exists, and nothing otherwise —
   // the registration / N-number is never shown here.
   const routeBadge = routeBadgePropsFromRoute(aircraft.flightRoute);
+  const hasRoute = Boolean(routeBadge);
+
+  // Play the badge reveal ONLY when a route resolves while the SAME aircraft is
+  // already mounted and on screen — the route lookup lands well after the row
+  // paints. prevRoute.mounted gates out the first render; the id check gates out
+  // a slot's occupant changing on a re-sort (rows are position-keyed, so the
+  // slot's aircraft swaps in place — that's CardFlipSlot's cross-fade, not a
+  // route appearing). Only a genuine same-aircraft no-route -> route fires it.
+  const [revealRoute, setRevealRoute] = useState(false);
+  const prevRouteRef = useRef({ id: aircraftId, mounted: false, had: hasRoute });
+  useEffect(() => {
+    const prev = prevRouteRef.current;
+    const sameAircraft = prev.id === aircraftId;
+    if (prev.mounted && sameAircraft && hasRoute && !prev.had) {
+      setRevealRoute(true);
+    }
+    prevRouteRef.current = { id: aircraftId, mounted: true, had: hasRoute };
+  }, [aircraftId, hasRoute]);
+  useEffect(() => {
+    if (!revealRoute) return undefined;
+    const timer = window.setTimeout(() => setRevealRoute(false), 320);
+    return () => window.clearTimeout(timer);
+  }, [revealRoute]);
 
   const distValue = toNumber(aircraft.distanceNm);
   const distanceDisplay = formatNearbyDistanceDisplay(distValue, units.distance);
@@ -91,7 +114,12 @@ function AircraftRow({
         >
           {callsign}
         </span>
-        {routeBadge ? <RouteBadge {...routeBadge} className="shrink-0" /> : null}
+        {routeBadge ? (
+          <RouteBadge
+            {...routeBadge}
+            className={`shrink-0 ${revealRoute ? "route-badge-reveal" : ""}`}
+          />
+        ) : null}
       </div>
 
       <div className="flex flex-none items-baseline gap-2.5 font-mono tabular-nums">

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -34,9 +34,11 @@ const GROW_THRESHOLD_ROWS = 8;
 
 // Windowed render for the nearby list. Both aircraft and airport rows live in
 // a single scroll container so the virtualizer can manage them as one stream.
-// Stable per-item keys (icao for airports, callsign/icao24 for aircraft) let
-// React preserve component identity across scrolls so rows do not remount while
-// the user scrolls dense airport lists.
+// Rows are keyed by POSITION (index), not identity: each slot stays fixed at
+// its index and, when the list re-sorts, its occupant (CardFlipSlot's swapKey =
+// item.id) changes and the content cross-fades in place — rows never physically
+// slide. Scrolling only shifts which indices render, so a persisting slot keeps
+// its occupant and never spuriously swaps.
 export default function VirtualNearbyList({
   items,
   selectedAircraftId = "",
@@ -120,7 +122,10 @@ export default function VirtualNearbyList({
     getScrollElement: () => scrollRef?.current ?? null,
     estimateSize: () => ROW_HEIGHT_ESTIMATE_PX,
     overscan: OVERSCAN_ROWS,
-    getItemKey: (index) => visibleItems[index]?.id ?? index,
+    // Key by POSITION, not identity: a slot stays put at its index and its
+    // occupant changes when the list re-sorts (see CardFlipSlot), so rows never
+    // physically slide — the content cross-fades in place instead.
+    getItemKey: (index) => index,
     scrollMargin,
   });
 
@@ -206,7 +211,7 @@ export default function VirtualNearbyList({
           return (
             <NearbyVirtualRow
               ref={virtualizer.measureElement}
-              key={item.id}
+              key={virtualRow.index}
               index={virtualRow.index}
               start={virtualRow.start - scrollMargin}
               shouldAnimateEnter={enterFlags.get(item.id) === true}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 55;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.31.6",
+    version: "v2.31.7",
     kind: "feat",
     title: {
       en: "Flight route badges in the nearby list",
@@ -62,6 +62,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       zh: "邻近列表中有航路的飞机现在带一枚紧凑的航路徽章——磨砂胶囊里显示起点 → 终点,有航司 logo 时在左侧淡入。没有已知航路的飞机不显示副标题(不再显示注册号)。",
     },
     highlights: [
+      {
+        en: "Nearby-list motion: when the list re-sorts, each row stays in place and its content cross-fades to the new aircraft (instead of rows sliding around), and a route badge eases in when its route resolves. Light, scroll-safe, and keeps the list's real-time feel.",
+        zh: "邻近列表动效:列表重新排序时每一行位置不动、内容就地交叉淡入切到新飞机(而非整行滑动),航路解析出来时徽章淡入登场。轻量、滚动安全,保持列表的实时手感。",
+      },
       {
         en: "Airport sidebar polish: the Flights metric now eases open and closed (height + count) instead of snapping, the logo row blends into the frosted panel, and the Flights tile gets the same orange active state as the others.",
         zh: "机场侧边栏细节:Flights 指标现在平滑展开/收起(高度与数字)而非生硬切换,logo 行融入磨砂面板,Flights 磁贴也获得与其它磁贴一致的橙色激活态。",

--- a/src/style.css
+++ b/src/style.css
@@ -174,6 +174,26 @@
     }
 }
 
+/* Route badge reveal. A route resolves once per aircraft, well after the row is
+   already painted, so this one-shot can lean into effect: the pill scales up
+   from the callsign edge and fades in. */
+@keyframes route-badge-reveal {
+    from {
+        opacity: 0;
+        transform: translateX(-3px) scale(0.86);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.route-badge-reveal {
+    transform-origin: left center;
+    animation: route-badge-reveal var(--motion-ui-slow) var(--motion-ease-snap)
+        both;
+}
+
 @keyframes app-route-enter {
     from {
         opacity: 0;
@@ -569,6 +589,7 @@
 
 @media (prefers-reduced-motion: reduce) {
     .nearby-row-enter,
+    .route-badge-reveal,
     .app-route-transition,
     .app-panel-transition,
     .app-preview-transition,
@@ -589,6 +610,7 @@
 
     .app-preview-transition:not(.mobile-preview-card-enter),
     .nearby-row-enter,
+    .route-badge-reveal,
     .app-route-transition,
     .app-panel-transition,
     .app-list-motion > *,


### PR DESCRIPTION
Lightweight nearby-list motion that balances effect against the list's real-time feel — split by the priorities requested: position/re-sort changes stay snappy, the one-shot route reveal can lean into effect.

## Position changes / re-sort — content cross-fade in place (real-time)
Rows no longer slide to a new position when the list re-sorts. Instead each row is **keyed by position (index)**: the slot stays fixed at its index and, when the list re-sorts, its occupant (`CardFlipSlot`'s `swapKey = item.id`) changes and the content **cross-fades in place**. This re-activates the existing `CardFlipSlot` / `useContentSwap` machinery, which was inert under the old `item.id` keying. Scrolling only shifts which indices render, so a persisting slot keeps its occupant and never spuriously swaps.

## Route badge — reveal once (effect)
When a route resolves for an already-mounted aircraft, the badge scales up from the callsign edge and fades in. Gated (`mounted` + `aircraftId` checks) to the genuine same-aircraft no-route → route transition, so it never fires on first paint, scroll-in, or a slot occupant swap.

Both honor `prefers-reduced-motion`.

## Validation
`pnpm test` (122 files). Explorer dark: slot `translateY` stays fixed (0/42/84/126/168) while occupants change in place; content-swap cross-fade fires on re-sort; badge reveal plays once; **0 console errors over 7s of live re-sorting**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
