### PR TITLE
v2.31.8: Blend the logo row on mobile + home panels (kill the band/scrim seam)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.31.7",
+  "version": "2.31.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 55;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.31.7",
+    version: "v2.31.8",
     kind: "feat",
     title: {
       en: "Flight route badges in the nearby list",
@@ -67,8 +67,8 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         zh: "邻近列表动效:列表重新排序时每一行位置不动、内容就地交叉淡入切到新飞机(而非整行滑动),航路解析出来时徽章淡入登场。轻量、滚动安全,保持列表的实时手感。",
       },
       {
-        en: "Airport sidebar polish: the Flights metric now eases open and closed (height + count) instead of snapping, the logo row blends into the frosted panel, and the Flights tile gets the same orange active state as the others.",
-        zh: "机场侧边栏细节:Flights 指标现在平滑展开/收起(高度与数字)而非生硬切换,logo 行融入磨砂面板,Flights 磁贴也获得与其它磁贴一致的橙色激活态。",
+        en: "Airport sidebar polish: the Flights metric now eases open and closed (height + count) instead of snapping, the logo row blends into the frosted panel — now on mobile and the home panel too, where it had read as a separate band — and the Flights tile gets the same orange active state as the others.",
+        zh: "机场侧边栏细节:Flights 指标现在平滑展开/收起(高度与数字)而非生硬切换;logo 行融入磨砂面板——现在移动端和首页面板也一样(之前那里会显出一条分隔的色带);Flights 磁贴也获得与其它磁贴一致的橙色激活态。",
       },
     ],
   },

--- a/src/style.css
+++ b/src/style.css
@@ -6360,18 +6360,31 @@ body {
     pointer-events: none;
 }
 
-/* On the frosted explorer sidebar (translucent glass over the map) the solid
-   --atc-bg logo strip + scrim read as a separate, darker band. Give the logo
-   row the panel's OWN frosted material instead — transparent tint + the same
-   blur — so it melts into the panel, and drop the scrim band. The home/static
-   sidebars keep the opaque strip above (their panel is opaque, so it matches). */
-.airport-map-kit .sidebar-brand-dock.sticky {
+/* On the frosted panels (translucent glass + warm bottom-wash) the solid
+   --atc-bg logo strip + its fade-to-transparent scrim read as a separate band,
+   and the flat scrim colour can't track the panel's tint per theme. Give the
+   logo row the panel's OWN frosted material instead — transparent tint + the
+   same blur — so it melts into the panel, and drop the scrim band. Covers the
+   desktop explorer (.airport-map-kit), the mobile detail shell
+   (.app-detail-shell — airport + flight), and the home panel
+   (.dither-page-panel, which uses the stronger --app-frost-strong). Only the
+   collapsed/static pill keeps the opaque strip. */
+.airport-map-kit .sidebar-brand-dock.sticky,
+.app-detail-shell .sidebar-brand-dock.sticky {
     background: transparent;
     -webkit-backdrop-filter: saturate(1.4) blur(8px);
     backdrop-filter: saturate(1.4) blur(8px);
 }
 
-.airport-map-kit .sidebar-brand-dock.sticky::after {
+.dither-page-panel .sidebar-brand-dock.sticky {
+    background: transparent;
+    -webkit-backdrop-filter: var(--app-frost-strong);
+    backdrop-filter: var(--app-frost-strong);
+}
+
+.airport-map-kit .sidebar-brand-dock.sticky::after,
+.app-detail-shell .sidebar-brand-dock.sticky::after,
+.dither-page-panel .sidebar-brand-dock.sticky::after {
     content: none;
 }
 


### PR DESCRIPTION
On a real device (mobile portrait) the sticky logo strip read as a separate band under the logo — the dock + its fade-to-transparent scrim use a flat opaque `var(--atc-bg)`, while the panel is frosted/translucent with a warm bottom-wash, so the flat scrim couldn't track the panel's per-theme tint.

v2.31.5 already fixed this for the **desktop explorer** (`.airport-map-kit`) by giving the logo row the panel's own frosted material and dropping the scrim — but that rule was scoped to `.airport-map-kit`, so the **mobile detail shell** (`.app-detail-shell`) and the **home panel** (`.dither-page-panel`) never got it.

This extends the same blend to both: transparent tint + backdrop blur (home uses its stronger `--app-frost-strong`) and no scrim. The logo row now melts into the panel and adapts to the theme. Only the collapsed/static pill keeps the opaque strip.

## Validation
`pnpm test` (122 files). Mobile portrait airport detail, light + dark: dock computed as transparent + `saturate(1.4) blur(8px)`, scrim `content: none`, content blurs cleanly under the logo with no band (verified visually in light; dark confirmed via computed styles — the fix is the panel's themed frosted material).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
