### PR TITLE
v2.32.0: Animated flight-rule glyph + progress bar in the weather METAR hero

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.31.8",
+  "version": "2.32.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/WeatherBriefingStack.tsx
+++ b/src/components/sidebar/WeatherBriefingStack.tsx
@@ -13,6 +13,7 @@ import {
   Sun,
 } from "lucide-react";
 import { useLocalWeather } from "@/hooks/useLocalWeather";
+import FlightRuleGlyph, { type FlightRule } from "@/components/weather/FlightRuleGlyph";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import {
@@ -182,6 +183,9 @@ function MetarView({ metar, metarRaw, metarLoading, t, units }) {
   const category = metar?.flightCategory || null;
   const rules = category ? FLIGHT_RULES[category] : null;
   const color = flightRuleColor(category);
+  // Index of the current category in the VFR→LIFR scale; -1 when unknown.
+  // Drives how far the progress bar fills.
+  const level = FLIGHT_RULE_SEQUENCE.findIndex((item) => item === category);
   const label = rules
     ? t(rules.labelKey)
     : metarLoading
@@ -229,30 +233,57 @@ function MetarView({ metar, metarRaw, metarLoading, t, units }) {
   return (
     <>
       <HeroCard color={color}>
-        <div>
-          <div
-            className="text-[calc(40px*var(--sb-body-scale))] font-light leading-none"
-            style={{ color }}
-          >
-            {category || "—"}
+        {/* Abbreviation + subtitle, with the category glyph drawing on to the right */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div
+              className="text-[calc(40px*var(--sb-body-scale))] font-light leading-none"
+              style={{ color }}
+            >
+              {category || "—"}
+            </div>
+            <div
+              className="mt-2 text-[calc(13px*var(--sb-body-scale))] lowercase leading-snug"
+              style={{ color }}
+            >
+              {label}
+            </div>
           </div>
-          <div
-            className="mt-2 text-[calc(13px*var(--sb-body-scale))] lowercase leading-snug"
-            style={{ color }}
-          >
-            {label}
-          </div>
+          {category && level >= 0 ? (
+            <span className="shrink-0" style={{ color }}>
+              <FlightRuleGlyph key={category} rule={category as FlightRule} />
+            </span>
+          ) : null}
         </div>
+        {/* Progress bar — fills to the current category's level after the glyph draws */}
         <div className="mt-3.5 flex gap-1.5" aria-hidden="true">
-          {FLIGHT_RULE_SEQUENCE.map((item) => (
-            <span
-              key={item}
-              className="h-1 flex-1 rounded-full"
-              style={{
-                background: item === category ? color : "var(--atc-line)",
-              }}
-            />
-          ))}
+          {FLIGHT_RULE_SEQUENCE.map((item, i) => {
+            const on = level >= 0 && i <= level;
+            return (
+              <span
+                key={item}
+                className={`frule-seg${on ? " frule-seg--on" : ""}`}
+                style={on ? { "--c": color, "--dl": `${0.5 + i * 0.08}s` } : undefined}
+              />
+            );
+          })}
+        </div>
+        <div
+          className="mt-[7px] flex justify-between text-[calc(9px*var(--sb-body-scale))] [letter-spacing:0.04em]"
+          aria-hidden="true"
+        >
+          {FLIGHT_RULE_SEQUENCE.map((item) => {
+            const active = item === category;
+            return (
+              <span
+                key={item}
+                className={active ? "" : "opacity-30"}
+                style={active ? { color } : undefined}
+              >
+                {item}
+              </span>
+            );
+          })}
         </div>
         {context ? (
           <p className="mt-3.5 text-[calc(12.5px*var(--sb-body-scale))] leading-snug text-atc-dim">

--- a/src/components/weather/FlightRuleGlyph.tsx
+++ b/src/components/weather/FlightRuleGlyph.tsx
@@ -1,0 +1,129 @@
+import type { ReactElement } from "react";
+import { cn } from "@/lib/utils";
+
+// Flight-rule category glyph. Ported faithfully from the design reference
+// (flight-rules-glyph-preview.html) — same viewBox, paths, stroke weight, and
+// draw-on timing. The motif is a shared runway + the *means of seeing it*:
+// eyes for the visual rules (VFR / MVFR) graduating to an attitude instrument
+// for the instrument rules (IFR / LIFR), with obscuring / ground bands added
+// as conditions deteriorate.
+//
+// Entrance draws on once via stroke-dashoffset (the `.dr` / `.d2` / `.d3` /
+// `.pop` classes + keyframes live scoped under `.flight-rule-glyph` in
+// style.css, which also honors prefers-reduced-motion by jumping to the final
+// state). The component plays on mount; re-key it by `rule` at the call site so
+// it redraws when the flight category changes.
+//
+// Color is inherited: the glyph strokes/fills with `currentColor`, so the
+// caller sets the per-rule category color (e.g. `flightRuleColor(category)`)
+// on the wrapper — the glyph stays decoupled from any color token.
+
+export type FlightRule = "VFR" | "MVFR" | "IFR" | "LIFR";
+
+function VfrGlyph() {
+  return (
+    <>
+      <g className="dr" style={{ "--len": 120 }}>
+        <path d="M33,46 L37,30 M47,46 L43,30" />
+        <path d="M40,46 L40,42 M40,38 L40,34" />
+        <path d="M35,30 L45,30" />
+      </g>
+      <path className="dr d2" style={{ "--len": 46 }} d="M28,16 Q40,7 52,16 Q40,25 28,16" />
+      <circle className="pop" cx="40" cy="16" r="3.4" fill="currentColor" stroke="none" />
+    </>
+  );
+}
+
+function MvfrGlyph() {
+  return (
+    <>
+      <g className="dr" style={{ "--len": 120 }}>
+        <path d="M33,46 L37,30 M47,46 L43,30" />
+        <path d="M40,46 L40,42 M40,38 L40,34" />
+        <path d="M35,30 L45,30" />
+      </g>
+      <path className="dr d2" style={{ "--len": 46 }} d="M28,15 Q40,6 52,15 Q40,24 28,15" />
+      <circle className="pop" cx="40" cy="15" r="3.4" fill="currentColor" stroke="none" />
+      <path
+        className="dr d3"
+        style={{ "--len": 34 }}
+        d="M26,33 q6,-5 13,-1 q7,-4 15,1"
+        strokeDasharray="3.5 4"
+      />
+    </>
+  );
+}
+
+function IfrGlyph() {
+  return (
+    <>
+      <g className="dr" style={{ "--len": 120 }}>
+        <path d="M33,46 L37,32 M47,46 L43,32" />
+        <path d="M40,46 L40,42 M40,38 L40,36" />
+        <path d="M35,32 L45,32" />
+      </g>
+      <circle className="dr d2" style={{ "--len": 82 }} cx="40" cy="16" r="12" />
+      <path className="dr d3" style={{ "--len": 22 }} d="M29,16 h22" />
+      <path className="pop" d="M40,16 L47,10" />
+      <circle className="pop" cx="40" cy="16" r="1.6" fill="currentColor" stroke="none" />
+    </>
+  );
+}
+
+function LifrGlyph() {
+  return (
+    <>
+      <g className="dr" style={{ "--len": 120 }}>
+        <path d="M34,46 L37,34 M46,46 L43,34" />
+        <path d="M40,46 L40,43 M40,40 L40,38" />
+        <path d="M37,34 L43,34" />
+      </g>
+      <circle className="dr d2" style={{ "--len": 82 }} cx="40" cy="15" r="12" />
+      <path className="dr d3" style={{ "--len": 22 }} d="M29,15 h22" />
+      <path className="pop" d="M40,15 L40,7" />
+      <circle className="pop" cx="40" cy="15" r="1.6" fill="currentColor" stroke="none" />
+      <path
+        className="dr d3"
+        style={{ "--len": 26 }}
+        d="M30,40 h20"
+        strokeDasharray="2.5 3.5"
+      />
+    </>
+  );
+}
+
+const GLYPHS: Record<FlightRule, () => ReactElement> = {
+  VFR: VfrGlyph,
+  MVFR: MvfrGlyph,
+  IFR: IfrGlyph,
+  LIFR: LifrGlyph,
+};
+
+export default function FlightRuleGlyph({
+  rule,
+  className,
+}: {
+  rule: FlightRule;
+  className?: string;
+}) {
+  const Glyph = GLYPHS[rule];
+  if (!Glyph) return null;
+
+  return (
+    <svg
+      className={cn("flight-rule-glyph", className)}
+      width={84}
+      height={50}
+      viewBox="0 0 80 48"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label={`${rule} flight rule`}
+    >
+      <Glyph />
+    </svg>
+  );
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -47,28 +47,28 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 55;
+export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.31.8",
+    version: "v2.32.0",
     kind: "feat",
     title: {
-      en: "Flight route badges in the nearby list",
-      zh: "邻近列表加入航路徽章",
+      en: "Animated flight-rule glyph in the weather briefing",
+      zh: "天气简报中加入飞行规则动效图标",
     },
     summary: {
-      en: "Routed aircraft in the nearby list now carry a compact route badge — origin → destination in a frosted pill, with the airline's logo fading in at the left when one is available. Aircraft with no known route show no subline (the registration is no longer shown there).",
-      zh: "邻近列表中有航路的飞机现在带一枚紧凑的航路徽章——磨砂胶囊里显示起点 → 终点,有航司 logo 时在左侧淡入。没有已知航路的飞机不显示副标题(不再显示注册号)。",
+      en: "The METAR weather view's flight-rules hero now draws a little category glyph on the right of the VFR/MVFR/IFR/LIFR badge — eyes over a runway for the visual rules, graduating to a cockpit instrument for the instrument rules — and the level bar fills in to the current category right after it draws. Each category keeps its own color (mint → blue → red → magenta), and the whole entrance plays once and respects reduced-motion.",
+      zh: "METAR 天气视图的飞行规则主卡现在会在 VFR/MVFR/IFR/LIFR 标识右侧绘制一枚分类图标——目视规则是跑道上方的眼睛,逐级过渡到仪表规则的座舱仪表——图标绘制完成后,等级条随即填充到当前分类。每个分类保留自己的颜色(薄荷绿 → 蓝 → 红 → 品红),整段入场动画只播放一次,并遵循减弱动效设置。",
     },
     highlights: [
       {
-        en: "Nearby-list motion: when the list re-sorts, each row stays in place and its content cross-fades to the new aircraft (instead of rows sliding around), and a route badge eases in when its route resolves. Light, scroll-safe, and keeps the list's real-time feel.",
-        zh: "邻近列表动效:列表重新排序时每一行位置不动、内容就地交叉淡入切到新飞机(而非整行滑动),航路解析出来时徽章淡入登场。轻量、滚动安全,保持列表的实时手感。",
+        en: "New <FlightRuleGlyph> component: inline SVG with a stroke-dashoffset draw-on, sitting on the same row as the category abbreviation. Color is inherited, so it tracks the existing data-driven flight-rule color (never the orange signal accent).",
+        zh: "新增 <FlightRuleGlyph> 组件:内联 SVG,采用 stroke-dashoffset 描边绘制动画,与分类缩写同行排布。颜色继承自父级,因此沿用既有的数据驱动飞行规则配色(绝不使用橙色信号强调色)。",
       },
       {
-        en: "Airport sidebar polish: the Flights metric now eases open and closed (height + count) instead of snapping, the logo row blends into the frosted panel — now on mobile and the home panel too, where it had read as a separate band — and the Flights tile gets the same orange active state as the others.",
-        zh: "机场侧边栏细节:Flights 指标现在平滑展开/收起(高度与数字)而非生硬切换;logo 行融入磨砂面板——现在移动端和首页面板也一样(之前那里会显出一条分隔的色带);Flights 磁贴也获得与其它磁贴一致的橙色激活态。",
+        en: "The flat category rail became a progress bar that fills segment-by-segment up to the current rule, with a VFR/MVFR/IFR/LIFR label row beneath it and the active label lit.",
+        zh: "原本扁平的分类轨道升级为进度条,逐段填充至当前规则,下方配有 VFR/MVFR/IFR/LIFR 标签行,并点亮当前分类标签。",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -170,6 +170,19 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.31.8",
+    kind: "feat",
+    title: {
+      en: "Flight route badges in the nearby list",
+      zh: "邻近列表加入航路徽章",
+    },
+    summary: {
+      en: "Routed aircraft in the nearby list now carry a compact route badge — origin → destination in a frosted pill, with the airline's logo fading in at the left when one is available. When the list re-sorts, each row stays in place and its content cross-fades to the new aircraft instead of sliding around, and the Flights metric and logo row in the airport sidebar got matching motion and blend polish.",
+      zh: "邻近列表中有航路的飞机现在带一枚紧凑的航路徽章——磨砂胶囊里显示起点 → 终点,有航司 logo 时在左侧淡入。列表重新排序时每一行位置不动、内容就地交叉淡入切到新飞机(而非整行滑动);机场侧边栏的 Flights 指标与 logo 行也获得了配套的动效与融合打磨。",
+    },
+    highlights: [],
+  },
+  {
     version: "v2.30.17",
     kind: "feat",
     title: {

--- a/src/style.css
+++ b/src/style.css
@@ -3015,6 +3015,89 @@ body:has(.dither-page-shell) {
     opacity: 1;
 }
 
+/* Flight-rules hero (sidebar METAR view) — category glyph draw-on +
+   progress-bar fill. Layout/colors live inline on the components
+   (FlightRuleGlyph.tsx / WeatherBriefingStack.tsx); only the keyframes and
+   reduced-motion fallback live here, per the styling decision order. The
+   per-category color is data-driven (flightRuleColor in weatherDisplayModel),
+   never the orange signal accent. Glyph classes are scoped under
+   .flight-rule-glyph so the short .dr/.d2/.d3/.pop names don't leak. */
+.flight-rule-glyph .dr {
+    stroke-dasharray: var(--len);
+    stroke-dashoffset: var(--len);
+    animation: flight-rule-draw 0.85s ease forwards;
+}
+
+.flight-rule-glyph .d2 {
+    animation-delay: 0.3s;
+}
+
+.flight-rule-glyph .d3 {
+    animation-delay: 0.55s;
+}
+
+.flight-rule-glyph .pop {
+    opacity: 0;
+    animation: flight-rule-pop 0.4s ease forwards;
+    animation-delay: 0.68s;
+}
+
+@keyframes flight-rule-draw {
+    to {
+        stroke-dashoffset: 0;
+    }
+}
+
+@keyframes flight-rule-pop {
+    to {
+        opacity: 1;
+    }
+}
+
+.frule-seg {
+    position: relative;
+    flex: 1;
+    height: 3px;
+    overflow: hidden;
+    border-radius: 2px;
+    background: color-mix(in oklab, var(--atc-text) 14%, transparent);
+}
+
+.frule-seg--on::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 2px;
+    background: var(--c);
+    transform: scaleX(0);
+    transform-origin: left;
+    animation: flight-rule-fill 0.7s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+    animation-delay: var(--dl);
+}
+
+@keyframes flight-rule-fill {
+    to {
+        transform: scaleX(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .flight-rule-glyph .dr {
+        animation: none;
+        stroke-dashoffset: 0;
+    }
+
+    .flight-rule-glyph .pop {
+        animation: none;
+        opacity: 1;
+    }
+
+    .frule-seg--on::after {
+        animation: none;
+        transform: scaleX(1);
+    }
+}
+
 .local-weather-glyph {
     align-items: center;
     background: color-mix(in oklab, var(--atc-accent) 9%, transparent);


### PR DESCRIPTION
## What

Adds a `<FlightRuleGlyph>` component and upgrades the sidebar **METAR weather view's flight-rules hero** with an animated category glyph + a filling progress bar — ported faithfully from the attached design reference (`flight-rules-glyph-preview.html`).

- **`src/components/weather/FlightRuleGlyph.tsx`** — inline SVG, draw-on entrance via `stroke-dashoffset` (paths, viewBox, stroke weight, and timing ported verbatim). Motif = a shared runway + the means of seeing it: **eyes** for the visual rules (VFR/MVFR) graduating to an **attitude instrument** for the instrument rules (IFR/LIFR), with obscuring/ground bands as conditions worsen. Color is inherited via `currentColor`, so the caller owns the per-category color.
- **`WeatherBriefingStack.MetarView`** (the live hero) — the glyph now sits to the right of the abbreviation on the same row; the flat category rail became a **progress bar** that fills segment-by-segment up to the current rule after the glyph draws, with a `VFR/MVFR/IFR/LIFR` label row beneath (active label lit).
- Per-category color reuses the existing data-driven `flightRuleColor` (mint → blue → red → magenta) — **never** the orange signal accent (per `DESIGN.md`). Kept the frosted-glass hero surface; only the content is colored.
- Plays **once on mount**; re-keyed by category so it redraws on change. Honors `prefers-reduced-motion` by jumping to the final state. Light/regular weight only.

Only the keyframes + reduced-motion fallback live in `style.css`; layout/colors stay inline on the components.

## Release

User-visible feature → minor bump **v2.31.8 → v2.32.0** (`package.json` + changelog; the previous entry rolled into `changelogHistory.ts`, keeping one entry in `CHANGELOG_RECENT`).

## Validation

Mode 2 (local browser) + Mode 3 (tests):
- Verified the live hero at `/airport/KBOS` (VFR — eyes glyph, 1 filled segment) in **light and dark** themes, and `/airport/KSFO` (IFR — instrument glyph, red, 3 filled segments). Draw-on, fill, labels, and per-category color all render correctly.
- `pnpm test` — 122 test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)