### PR TITLE
v2.32.1: Hide unloadable aircraft photos + tiny reconnect spinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.0",
+  "version": "2.32.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -61,7 +61,9 @@ export default function AircraftPreviewCard({
   const selectedTrace = useSelectedAircraftTrace();
   const photoState = useAircraftPhoto(aircraft);
   const photo = photoState.photo;
-  const hasPhoto = Boolean(photo?.src);
+  const photoSrc = photo?.src || "";
+  const [failedPhotoSrc, setFailedPhotoSrc] = useState("");
+  const hasPhoto = Boolean(photoSrc) && photoSrc !== failedPhotoSrc;
   const photoTone = usePhotoTone(photo?.src);
   const airspaceOptions = Array.isArray(airspaces)
     ? airspaces.filter(Boolean)
@@ -278,7 +280,10 @@ export default function AircraftPreviewCard({
                 className="aircraft-preview-card__media-slot"
                 key={`photo-${photo.src}`}
               >
-                <AircraftPreviewMediaCard photo={photo} />
+                <AircraftPreviewMediaCard
+                  photo={photo}
+                  onError={() => setFailedPhotoSrc(photoSrc)}
+                />
               </div>
             )
           )}

--- a/src/components/aircraft/preview/AircraftPreviewMediaCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMediaCard.tsx
@@ -15,7 +15,7 @@ function resolveVisiblePhotoHeight(photo) {
   return Math.round(CARD_WIDTH_PX * heightRatio * PHOTO_VISIBLE_HEIGHT_RATIO);
 }
 
-export default function AircraftPreviewMediaCard({ photo }) {
+export default function AircraftPreviewMediaCard({ photo, onError }) {
   const { t } = useI18n();
   const credit = photo?.photographer || photo?.source || "";
   const style = {
@@ -35,6 +35,7 @@ export default function AircraftPreviewMediaCard({ photo }) {
           height={photo.height || Math.round(CARD_WIDTH_PX * DEFAULT_PHOTO_ASPECT_HEIGHT_RATIO)}
           alt=""
           draggable="false"
+          onError={onError}
         />
       </div>
       <span className="aircraft-preview-tracking-pill" aria-hidden="true">

--- a/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewMobileCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { toFiniteNumber } from "@/utils/math";
 import { getFlightRouteEndpoints } from "@/utils/flightRouteDisplay";
@@ -23,6 +24,9 @@ export default function AircraftPreviewMobileCard({
 }: AircraftPreviewMobileCardProps) {
   const { t } = useI18n();
   const { preferences: units } = useUnitPreferences();
+  const [failedPhotoSrc, setFailedPhotoSrc] = useState("");
+  const photoSrc = photo?.src || "";
+  const showPhoto = Boolean(photoSrc) && photoSrc !== failedPhotoSrc;
   const callsign =
     (aircraft?.callsign || "").trim() || aircraft?.icao24?.toUpperCase() || "—";
   const typeDisplay = getAircraftPreviewTypeDisplay(aircraft);
@@ -84,12 +88,13 @@ export default function AircraftPreviewMobileCard({
             )}
           </div>
         </div>
-        {photo?.src ? (
+        {showPhoto ? (
           <img
-            src={photo.src}
+            src={photoSrc}
             alt=""
             draggable="false"
             className="size-[46px] flex-none rounded-[11px] object-cover"
+            onError={() => setFailedPhotoSrc(photoSrc)}
           />
         ) : null}
       </div>

--- a/src/components/map/MapSourceStatusDisplay.tsx
+++ b/src/components/map/MapSourceStatusDisplay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
 import gsap from "gsap";
 import { MOTION, EASE } from "@/animations/gsap";
 import { usePrefersReducedMotion } from "@/components/effects/usePrefersReducedMotion";
@@ -427,12 +428,13 @@ export default function MapSourceStatusDisplay({
         <span className={lineClassName}>
           {realtimeStatusLabel ? (
             <>
-              <StatusSpan className="inline-flex flex-none items-center gap-1.5 font-mono text-atc-dim">
-                <span
-                  aria-hidden="true"
-                  className="size-1.5 rounded-full bg-[var(--atc-dim)] opacity-80 motion-safe:animate-pulse [.airport-map-kit_&]:size-1"
+              <StatusSpan className="inline-flex flex-none items-center text-atc-dim">
+                <Loader2
+                  role="img"
+                  aria-label={realtimeStatusLabel}
+                  className="size-2.5 opacity-80 motion-safe:animate-spin [.airport-map-kit_&]:size-2"
+                  strokeWidth={2.5}
                 />
-                <span>{realtimeStatusLabel}</span>
               </StatusSpan>
               {(wakeLockActive || feedSource || updatedLabel) ? (
                 <span

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.0",
+    version: "v2.32.1",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -69,6 +69,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "The flat category rail became a progress bar that fills segment-by-segment up to the current rule, with a VFR/MVFR/IFR/LIFR label row beneath it and the active label lit.",
         zh: "原本扁平的分类轨道升级为进度条,逐段填充至当前规则,下方配有 VFR/MVFR/IFR/LIFR 标签行,并点亮当前分类标签。",
+      },
+      {
+        en: "Preview polish: aircraft photos that 404 or fail to decode now hide cleanly instead of leaving a broken-image frame, and the realtime feed's reconnecting state shows a tiny spinner in place of the wide RECONNECTING/CONNECTING label that used to flicker and crowd the status row.",
+        zh: "预览细节优化:飞机照片在 404 或解码失败时直接隐藏,不再留下破图占位;实时数据流重连状态改用一个极小的旋转图标,取代过去那段会闪烁、又挤占状态行排版的 RECONNECTING/CONNECTING 文字。",
       },
     ],
   },


### PR DESCRIPTION
Two small preview/status fixes.

## Aircraft photo — hide when it can't display
Fetch failures (404 / errors) already returned `null` and rendered nothing. The gap was when a photo URL resolves but the browser can't decode it — that showed a broken-image frame. Added an `<img>` `onError` handler that records the failed `src` and treats it as "no photo":
- Desktop preview card removes the whole media slot and the `aircraft-preview-card--has-photo` layout class (no empty gap).
- Mobile thumbnail hides in place.

## Reconnecting indicator — tiny spinner instead of wide text
The realtime feed status showed a pulsing dot plus the `RECONNECTING` / `CONNECTING` label, which flickered on every (re)connect and crowded the status row. Replaced it with a small `Loader2` spinner (`size-2.5`, `size-2` inside the map kit); the state text is kept as the spinner's `aria-label`. The `realtimeStatusModel` logic is unchanged.

Folded into the v2.32.1 rolling changelog entry; `package.json` bumped to match.

Validation: local browser — both states are edge-triggered (broken image / disconnect); changes are small and low-risk, relying on the Railway CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)