### PR TITLE
v2.32.2: Unify the sticky sidebar logo row into one token-driven rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.1",
+  "version": "2.32.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/CollapsibleSidebarChrome.tsx
+++ b/src/components/sidebar/CollapsibleSidebarChrome.tsx
@@ -236,11 +236,12 @@ export function SidebarBrandDock({
     <div
       className={cn(
         "sidebar-brand-dock sticky top-0 z-[calc(var(--z-index-sticky)+1)] flex items-center justify-between gap-2 px-[var(--airport-sidebar-inset)] transition-[padding] duration-200 ease-out",
-        // The brand row is an OPAQUE strip (no backdrop-filter — that blur was
-        // a per-scroll cost). A gradient scrim rendered just below it (see
-        // .sidebar-brand-dock::after in style.css) fades scrolling content out
-        // before it reaches the logo, so content disappears naturally without
-        // any live blur.
+        // The sticky brand row's resting surface (near-opaque panel tint +
+        // fade scrim, no backdrop-filter) is owned by a single token-driven
+        // rule — .sidebar-brand-dock.sticky in style.css, keyed off
+        // --app-frost-tint so every glass sidebar shares one appearance. A
+        // gradient scrim just below it fades scrolling content out before it
+        // reaches the logo, so content disappears naturally without a live blur.
         compact ? "pb-2 pt-3" : "pb-3 pt-5",
         "[[data-mobile-overlay=true]_&]:pb-1 [[data-mobile-overlay=true]_&]:pt-[calc(12px+env(safe-area-inset-top))]",
         className,

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.1",
+    version: "v2.32.2",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -73,6 +73,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Preview polish: aircraft photos that 404 or fail to decode now hide cleanly instead of leaving a broken-image frame, and the realtime feed's reconnecting state shows a tiny spinner in place of the wide RECONNECTING/CONNECTING label that used to flicker and crowd the status row.",
         zh: "预览细节优化:飞机照片在 404 或解码失败时直接隐藏,不再留下破图占位;实时数据流重连状态改用一个极小的旋转图标,取代过去那段会闪烁、又挤占状态行排版的 RECONNECTING/CONNECTING 文字。",
+      },
+      {
+        en: "Unified the sticky sidebar logo row across every glass sidebar (home, desktop explorer, mobile detail). Its resting surface now comes from one token-driven rule instead of three per-panel overrides that had drifted apart — the live backdrop-blur that smeared scrolling rows into a band is gone, replaced by the panel's own tint plus a clean fade-out scrim, so content disappears under the wordmark without a seam or bleed-through.",
+        zh: "统一了各个玻璃侧边栏(首页、桌面浏览、移动详情)顶部吸附的 Logo 行。它的静止态外观改由单一 token 规则驱动,取代此前已各自漂移的三份按面板覆盖样式——会把滚动行糊成一条带子的实时背景模糊被移除,改用面板自身的色调加一层干净的渐隐遮罩,内容滚到 Logo 下方自然消失,不再有接缝或透字。",
       },
     ],
   },

--- a/src/style.css
+++ b/src/style.css
@@ -6422,13 +6422,24 @@ body {
     box-shadow: inset 0 -1px 0 color-mix(in oklab, var(--atc-text) 28%, transparent);
 }
 
-/* The sticky brand row (every sidebar) is an OPAQUE strip — no backdrop-filter,
-   so there is no per-scroll blur to compute. A gradient scrim rendered just
-   below it (::after) fades scrolling content out before it reaches the logo, so
-   content disappears naturally as it scrolls up. The collapsed pill variant
-   (.static, a glass Toolbar) is intentionally excluded. */
+/* SINGLE source of truth for the sticky brand/logo row, shared by every glass
+   sidebar (desktop explorer .airport-map-kit, mobile detail shell
+   .app-detail-shell, home panel .dither-page-panel). They all standardise on
+   --app-frost-tint, so the row derives its resting surface from that ONE token
+   rather than each panel re-specifying it per ancestor (which is exactly what
+   let the surfaces drift apart).
+
+   - Back the logo with the panel's OWN tint (theme-aware via --app-frost-tint),
+     near-opaque so scrolling rows are hidden behind the wordmark.
+   - NO backdrop-filter: a live blur on a sticky row smeared the scrolling
+     rows/search into a frosted band under the logo.
+   - A matching tinted scrim (::after) just below fades content out cleanly as
+     it scrolls up — no smear, no foreign-colour seam.
+
+   The collapsed/static pill (.static) is a glass Toolbar and owns its own
+   surface, so it is intentionally untouched here. */
 .sidebar-brand-dock.sticky {
-    background: var(--atc-bg);
+    background: color-mix(in oklab, var(--app-frost-tint) 96%, transparent);
     box-shadow: none;
 }
 
@@ -6439,36 +6450,12 @@ body {
     left: 0;
     right: 0;
     height: 28px;
-    background: linear-gradient(to bottom, var(--atc-bg), transparent);
+    background: linear-gradient(
+        to bottom,
+        color-mix(in oklab, var(--app-frost-tint) 96%, transparent),
+        transparent
+    );
     pointer-events: none;
-}
-
-/* On the frosted panels (translucent glass + warm bottom-wash) the solid
-   --atc-bg logo strip + its fade-to-transparent scrim read as a separate band,
-   and the flat scrim colour can't track the panel's tint per theme. Give the
-   logo row the panel's OWN frosted material instead — transparent tint + the
-   same blur — so it melts into the panel, and drop the scrim band. Covers the
-   desktop explorer (.airport-map-kit), the mobile detail shell
-   (.app-detail-shell — airport + flight), and the home panel
-   (.dither-page-panel, which uses the stronger --app-frost-strong). Only the
-   collapsed/static pill keeps the opaque strip. */
-.airport-map-kit .sidebar-brand-dock.sticky,
-.app-detail-shell .sidebar-brand-dock.sticky {
-    background: transparent;
-    -webkit-backdrop-filter: saturate(1.4) blur(8px);
-    backdrop-filter: saturate(1.4) blur(8px);
-}
-
-.dither-page-panel .sidebar-brand-dock.sticky {
-    background: transparent;
-    -webkit-backdrop-filter: var(--app-frost-strong);
-    backdrop-filter: var(--app-frost-strong);
-}
-
-.airport-map-kit .sidebar-brand-dock.sticky::after,
-.app-detail-shell .sidebar-brand-dock.sticky::after,
-.dither-page-panel .sidebar-brand-dock.sticky::after {
-    content: none;
 }
 
 .aircraft-search:focus-within {


### PR DESCRIPTION
## Why
The sticky logo row (`SidebarBrandDock`) is a shared component, but its resting surface (background + fade scrim) was pulled out into **three ancestor-keyed CSS overrides** — `.airport-map-kit`, `.app-detail-shell`, `.dither-page-panel`. Three independent definitions drift apart; that's the root cause of the inconsistency, and exactly the ancestor-keyed anti-pattern CLAUDE.md calls out.

## What
All three glass sidebars already standardise on `--app-frost-tint`, so the row now derives its surface from that **one token** in a single base rule. Net `-25` lines of per-surface override.

- Logo backed by the panel's own tint (`color-mix(--app-frost-tint 96%)`), theme-aware, near-opaque so scrolling rows are hidden behind the wordmark (fixes the content bleed-through visible at the previous 92%).
- Removed the live `backdrop-filter` — on a sticky row it smeared the scrolling rows/search into a frosted band under the logo.
- Matching tinted `::after` scrim fades content out cleanly on scroll, no foreign-colour seam.
- Component comment now points to the single rule instead of describing an opaque `--atc-bg` strip.

Folded into the rolling v2.32.2 changelog entry; `package.json` bumped to match.

Validation: local browser — CSS-only logo-row change, hot-reloaded; verified the row no longer shows a blur band or content bleed-through and content fades cleanly under the wordmark (light + dark, home / desktop explorer / mobile detail share the one rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)