### PR TITLE
v2.32.3: Memoize aircraft marker content to cut per-tick re-renders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.2",
+  "version": "2.32.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -272,54 +272,167 @@ function AircraftPosition({
     matchesFilters: selectionActive ? selected : matchesFilters,
     selected,
   });
-  const rot = Math.round(aircraft.track || 0);
+  // Quantize the continuously-drifting visual inputs so straight-and-level
+  // traffic produces a STABLE visualKey across position ticks: heading snaps
+  // to 2°, bank/pitch to 1° (sub-pixel on a 20px glyph), light state to coarse
+  // speed/altitude bands. Position is deliberately NOT part of the key — it is
+  // animated imperatively by the motion-frame loop (marker.setLatLng), outside
+  // React. That lets <AircraftMarkerContent> below skip the SVG/portal rebuild
+  // on the ~per-second WS ticks where only the position moved.
+  const rot = Math.round((Number(aircraft.track) || 0) / 2) * 2;
+  const roll = Math.round(attitude.roll);
+  const pitch = Math.round(attitude.pitch);
   const label = (aircraft.callsign || aircraft.icao24 || "").trim();
   const labelColor = color;
   const sourceBadge = getAircraftPositionSourceBadge(aircraft.positionQuality);
+  const showLabel = Boolean(
+    selected ||
+      forceSilhouette ||
+      (showCallsigns && !traceActive && emphasis.showLabel),
+  );
   const labelLeft = showArrow
     ? silhouette
       ? SILHOUETTE_SIZE_PX + 4
       : 22
     : SILHOUETTE_SIZE_PX;
+  const iconName = silhouette?.name ?? "";
+  const onGround = Boolean(aircraft.onGround);
+  const velocity = Number(aircraft.velocity ?? 0);
+  const baroAltitude = Number(aircraft.baroAltitude ?? 0);
+  const visualKey = [
+    selected ? 1 : 0,
+    showArrow ? 1 : 0,
+    color,
+    iconName,
+    sizeScale,
+    rot,
+    roll,
+    pitch,
+    theme,
+    showLabel ? 1 : 0,
+    label,
+    labelColor,
+    sourceBadge,
+    emphasis.opacity,
+    labelLeft,
+    onGround ? 1 : 0,
+    Math.round(velocity / 10),
+    Math.round(baroAltitude / 200),
+  ].join("|");
 
-  return createPortal(
-    <div
-      className={`aircraft-marker ${
-        selected ? "aircraft-marker--selected" : ""
-      }`}
-      style={{ opacity: emphasis.opacity }}
-    >
-      <span className="aircraft-marker-hit-target" aria-hidden="true" />
-      <Pointer
-        color={color}
-        rot={rot}
-        roll={attitude.roll}
-        pitch={attitude.pitch}
-        showArrow={showArrow}
-        silhouette={silhouette}
-        sizeScale={sizeScale}
-        theme={theme}
-        iconName={silhouette?.name ?? undefined}
-        aircraftState={{
-          onGround: aircraft.onGround,
-          velocity: Number(aircraft.velocity ?? 0),
-          baroAltitude: Number(aircraft.baroAltitude ?? 0),
-        }}
-      />
-      {(selected ||
-        forceSilhouette ||
-        (showCallsigns && !traceActive && emphasis.showLabel)) && (
-        <AircraftLabel
-          color={labelColor}
-          label={label}
-          sourceBadge={sourceBadge}
-          left={labelLeft}
-        />
-      )}
-    </div>,
-    container,
+  return (
+    <AircraftMarkerContent
+      container={container}
+      visualKey={visualKey}
+      color={color}
+      rot={rot}
+      roll={roll}
+      pitch={pitch}
+      showArrow={showArrow}
+      silhouette={silhouette}
+      sizeScale={sizeScale}
+      theme={theme}
+      iconName={iconName || undefined}
+      onGround={onGround}
+      velocity={velocity}
+      baroAltitude={baroAltitude}
+      selected={selected}
+      opacity={emphasis.opacity}
+      showLabel={showLabel}
+      label={label}
+      labelColor={labelColor}
+      sourceBadge={sourceBadge}
+      labelLeft={labelLeft}
+    />
   );
 }
+
+// The portal content is the expensive half of each marker — a masked
+// silhouette SVG (or fallback glyph) plus the callsign label. It is split out
+// and memoized on `visualKey` so that a position-only WS tick (the common
+// case) skips re-rendering all of it; only a genuine visual change (heading
+// step, colour band, selection, label, light state) re-renders. The parent
+// keeps re-rendering each tick to re-seed motionRef — that is cheap and is
+// what keeps the inferred/extrapolated position live.
+type AircraftMarkerContentProps = {
+  container: HTMLElement;
+  visualKey: string;
+  color: string;
+  rot: number;
+  roll: number;
+  pitch: number;
+  showArrow: boolean;
+  silhouette: any;
+  sizeScale: number;
+  theme: string;
+  iconName?: string;
+  onGround: boolean;
+  velocity: number;
+  baroAltitude: number;
+  selected: boolean;
+  opacity: number;
+  showLabel: boolean;
+  label: string;
+  labelColor: string;
+  sourceBadge: string;
+  labelLeft: number;
+};
+
+const AircraftMarkerContent = memo(
+  function AircraftMarkerContent({
+    container,
+    color,
+    rot,
+    roll,
+    pitch,
+    showArrow,
+    silhouette,
+    sizeScale,
+    theme,
+    iconName,
+    onGround,
+    velocity,
+    baroAltitude,
+    selected,
+    opacity,
+    showLabel,
+    label,
+    labelColor,
+    sourceBadge,
+    labelLeft,
+  }: AircraftMarkerContentProps) {
+    return createPortal(
+      <div
+        className={`aircraft-marker ${selected ? "aircraft-marker--selected" : ""}`}
+        style={{ opacity }}
+      >
+        <span className="aircraft-marker-hit-target" aria-hidden="true" />
+        <Pointer
+          color={color}
+          rot={rot}
+          roll={roll}
+          pitch={pitch}
+          showArrow={showArrow}
+          silhouette={silhouette}
+          sizeScale={sizeScale}
+          theme={theme}
+          iconName={iconName}
+          aircraftState={{ onGround, velocity, baroAltitude }}
+        />
+        {showLabel && (
+          <AircraftLabel
+            color={labelColor}
+            label={label}
+            sourceBadge={sourceBadge}
+            left={labelLeft}
+          />
+        )}
+      </div>,
+      container,
+    );
+  },
+  (prev, next) => prev.visualKey === next.visualKey && prev.container === next.container,
+);
 
 // Memoized: unchanged aircraft skip React/portal rebuilds. Moving aircraft
 // update motionRef from fresh snapshots, but only aircraft near the current

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.2",
+    version: "v2.32.3",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -77,6 +77,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Unified the sticky sidebar logo row across every glass sidebar (home, desktop explorer, mobile detail). Its resting surface now comes from one token-driven rule instead of three per-panel overrides that had drifted apart — the live backdrop-blur that smeared scrolling rows into a band is gone, replaced by the panel's own tint plus a clean fade-out scrim, so content disappears under the wordmark without a seam or bleed-through.",
         zh: "统一了各个玻璃侧边栏(首页、桌面浏览、移动详情)顶部吸附的 Logo 行。它的静止态外观改由单一 token 规则驱动,取代此前已各自漂移的三份按面板覆盖样式——会把滚动行糊成一条带子的实时背景模糊被移除,改用面板自身的色调加一层干净的渐隐遮罩,内容滚到 Logo 下方自然消失,不再有接缝或透字。",
+      },
+      {
+        en: "Live-map performance: aircraft markers no longer rebuild their silhouette SVG + label on every position tick. The portal content is split into a content component memoized on a quantized visual key, so a position-only update (the common case) skips the React/SVG reconcile while the marker keeps animating imperatively — markers and the focal-flight detail page stay smooth under a full airport's worth of traffic. Peak main-thread hitch on a busy airport dropped from ~82ms to ~59ms.",
+        zh: "实时地图性能:飞机 marker 不再每个位置 tick 都重建剪影 SVG + 标签。portal 内容拆成一个按量化视觉键 memo 的子组件,仅位置变化(最常见的情况)时跳过 React/SVG reconcile,而 marker 仍由运动循环命令式平滑移动——满载机场流量下 marker 与焦点航班详情页都更顺。繁忙机场的主线程卡顿峰值从约 82ms 降到约 59ms。",
       },
     ],
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -264,7 +264,7 @@ export default defineConfig(({ mode }) => {
     ],
     server: {
       host: "0.0.0.0",
-      port: 3000,
+      port: Number(process.env.PORT) || 3000,
       strictPort: true,
       proxy: {
         "/api": {


### PR DESCRIPTION
## Bottleneck (frontend re-render, not the data fetch)
All viewport aircraft legitimately need WS position updates. The problem is how the frontend digested them: every tick `normalizeAircraftSnapshot` rebuilds the whole aircraft array with **fresh object refs** (incl. a new `receiveTime`), so `React.memo` on each `<AircraftPosition>` was always broken → every viewport marker re-rendered its masked silhouette SVG + label. But the position is already animated **imperatively** by the motion-frame loop (`marker.setLatLng`), outside React — so that SVG/portal reconcile was wasted work. On a full KLAX (~90 markers) it showed up as periodic ~70–82ms main-thread longtasks.

## Why not just add a comparator
The effect that re-seeds `motionRef` from each fresh snapshot runs on re-render. Skipping the re-render would freeze the inferred/extrapolated position re-seed — a product guardrail. So the outer component must keep re-rendering.

## Fix
Split the portal content into `<AircraftMarkerContent>`, memoized on a quantized `visualKey` (heading→2°, bank/pitch→1°, light state→coarse speed/alt bands; **position deliberately excluded**). The outer keeps re-rendering each tick (motion effect still re-seeds `motionRef`, `setLatLng` still animates, `positionTime`/staleness unchanged), but the expensive SVG/portal reconcile is skipped on the common position-only tick. The inferred-position path is untouched.

## Measured (full KLAX, 90+ targets, ~10–12s steady state)
| | peak longtask | longtask time |
|---|---|---|
| before | ~82 ms | ~29 ms/s |
| after | **~59 ms** | **~14.5 ms/s** |

Helps both the airport explorer and the focal-flight detail page's nearby traffic.

## Scope note — detail page (`/aircraft/:callsign`)
This is part 1. Measured steady-state on the flight detail page is ~62ms every ~3s (ADS-B tick). With markers now memoized, the remaining detail-page-specific cost is the **focal-flight trace** recomputing geometry + tearing down/rebuilding ~28 Leaflet layers every poll (plus a ~113ms hitch on open from the full-trace load). That needs an incremental-render change to a guardrail-adjacent component and is intentionally left for a focused follow-up rather than bundled here.

Also bumps vite.config server port to read `PORT` env (defaults to 3000) so the preview/autoPort can bind a free port — dev-tooling only.

Validation: local — `pnpm test` (122 files pass); preview on a live KLAX confirmed markers render correctly (silhouettes, headings, labels, route badges) and the longtask drop above. Foreground 60fps smooth-motion was not measurable under the headless preview's rAF throttling; the motion/extrapolation code path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)