### PR TITLE
v2.32.5: Swap here-mode dep/arr cells for ambient speed/altitude

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.4",
+  "version": "2.32.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -6,6 +6,7 @@ import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel";
 import { ARRIVAL, DEPARTURE } from "@/utils/aircraftMovement";
 import {
   convertTemperatureFromC,
+  formatAltitude,
   temperatureUnitLabel,
 } from "@/utils/units";
 
@@ -36,8 +37,12 @@ export default function SidebarViewSwitch({
     ? { value: "—", unit: temperatureUnitLabel(units.temperature) }
     : formatTemperature(metar, units.temperature);
   const temperatureUnit = temperature.value === "—" ? undefined : temperature.unit;
+  // In here mode the user's position is not an airport, so departure/arrival
+  // classification is meaningless (everything resolves to UNKNOWN). The movement
+  // row is replaced by ambient traffic readouts: the average speed and altitude
+  // of the airborne aircraft around the user.
   const showMovementCards =
-    featureFlagsResolved && routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
+    !nearMe && featureFlagsResolved && routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
   const atcCount = Array.isArray(frequencies) ? frequencies.length : 0;
   const spottingCount = Number(candidateSpotCount) || 0;
   const showAtcCard = atcCount > 0;
@@ -55,10 +60,40 @@ export default function SidebarViewSwitch({
     return { departureCount: dep, arrivalCount: arr };
   }, [aircraft, routeProvider]);
 
+  // Ambient here-mode stats: mean speed/altitude across airborne aircraft only
+  // (on-ground aircraft have no meaningful cruise altitude and drag the speed
+  // mean toward zero). Null when no airborne aircraft carry the field.
+  const { avgSpeed, avgAltitude } = useMemo(() => {
+    if (!nearMe) return { avgSpeed: null, avgAltitude: null };
+    let speedSum = 0;
+    let speedCount = 0;
+    let altSum = 0;
+    let altCount = 0;
+    for (const item of aircraft) {
+      if (item?.onGround) continue;
+      const speed = Number(item?.velocity);
+      if (Number.isFinite(speed)) {
+        speedSum += speed;
+        speedCount += 1;
+      }
+      const altitude = Number(item?.altitude);
+      if (Number.isFinite(altitude)) {
+        altSum += altitude;
+        altCount += 1;
+      }
+    }
+    return {
+      avgSpeed: speedCount ? speedSum / speedCount : null,
+      avgAltitude: altCount ? altSum / altCount : null,
+    };
+  }, [aircraft, nearMe]);
+
   // Footer stacks into rows under the flight-count hero: first the movement
   // row (departures / arrivals) as the direct breakdown of the count, then
   // the context row (weather / ATC / spotting). Each conditional cell simply
-  // drops out of its row when absent.
+  // drops out of its row when absent. In here mode the movement row carries the
+  // ambient speed/altitude readouts instead — they are pure stats, not views,
+  // so they render as static cells (no view switch, no active rail).
   const movementCells = [];
   if (showMovementCards) {
     movementCells.push({
@@ -74,6 +109,26 @@ export default function SidebarViewSwitch({
       value: <NumberFlow value={arrivalCount} />,
       active: activeView === "arrivals",
       onClick: () => onViewChange?.("arrivals"),
+    });
+  } else if (nearMe) {
+    const altitudeDisplay =
+      avgAltitude == null
+        ? null
+        : formatAltitude(avgAltitude, units.altitude, { kind: "cruise" });
+    movementCells.push({
+      key: "avgSpeed",
+      label: t("sidebar.avgSpeed"),
+      value: avgSpeed == null ? "—" : <NumberFlow value={Math.round(avgSpeed)} />,
+      unit: avgSpeed == null ? undefined : "kt",
+      readOnly: true,
+    });
+    movementCells.push({
+      key: "avgAltitude",
+      label: t("sidebar.avgAltitude"),
+      value: altitudeDisplay ? <NumberFlow value={altitudeDisplay.value} /> : "—",
+      unit: altitudeDisplay?.unit || undefined,
+      prefix: altitudeDisplay?.prefix,
+      readOnly: true,
     });
   }
   const restCells = [];
@@ -166,7 +221,39 @@ export default function SidebarViewSwitch({
   );
 }
 
-function StatCell({ label, value, unit, active, onClick }) {
+function StatCell({ label, value, unit, prefix, active, onClick, readOnly = false }) {
+  const body = (
+    <>
+      <div className="truncate text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{label}</div>
+      <div className="mt-[3px]">
+        {prefix ? (
+          <span
+            className="notranslate text-[calc(10px*var(--sb-body-scale))] text-atc-faint"
+            translate="no"
+          >
+            {prefix}
+          </span>
+        ) : null}
+        <span className="text-[calc(16px*var(--sb-body-scale))] font-normal tabular-nums text-atc-text">
+          {value}
+        </span>
+        {unit ? (
+          <span className="ml-0.5 text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{unit}</span>
+        ) : null}
+      </div>
+    </>
+  );
+
+  // Read-only stats (here-mode speed/altitude) are not view switches: render a
+  // plain cell with no hover/active affordance so they don't read as tappable.
+  if (readOnly) {
+    return (
+      <div className="relative min-w-0 flex-1 px-[11px] py-[9px] text-left [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)]">
+        {body}
+      </div>
+    );
+  }
+
   return (
     <button
       type="button"
@@ -175,15 +262,7 @@ function StatCell({ label, value, unit, active, onClick }) {
       aria-pressed={active}
       className="relative min-w-0 flex-1 px-[11px] py-[9px] text-left transition-[background-color] duration-200 ease-out [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-[2px] before:origin-center before:scale-x-0 before:bg-[var(--atc-signal-accent)] before:transition-transform before:duration-300 before:ease-[cubic-bezier(0.34,1.3,0.64,1)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:before:scale-x-100"
     >
-      <div className="truncate text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{label}</div>
-      <div className="mt-[3px]">
-        <span className="text-[calc(16px*var(--sb-body-scale))] font-normal tabular-nums text-atc-text">
-          {value}
-        </span>
-        {unit ? (
-          <span className="ml-0.5 text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{unit}</span>
-        ) : null}
-      </div>
+      {body}
     </button>
   );
 }

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.4",
+    version: "v2.32.5",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -81,6 +81,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Live-map performance: aircraft markers no longer rebuild their silhouette SVG + label on every position tick. The portal content is split into a content component memoized on a quantized visual key, so a position-only update (the common case) skips the React/SVG reconcile while the marker keeps animating imperatively — markers and the focal-flight detail page stay smooth under a full airport's worth of traffic. Peak main-thread hitch on a busy airport dropped from ~82ms to ~59ms. The visual key also drops the dark-only headlight inputs (speed/altitude) in light theme, so climbing and accelerating traffic stop re-rendering for state the map isn't even drawing.",
         zh: "实时地图性能:飞机 marker 不再每个位置 tick 都重建剪影 SVG + 标签。portal 内容拆成一个按量化视觉键 memo 的子组件,仅位置变化(最常见的情况)时跳过 React/SVG reconcile,而 marker 仍由运动循环命令式平滑移动——满载机场流量下 marker 与焦点航班详情页都更顺。繁忙机场的主线程卡顿峰值从约 82ms 降到约 59ms。视觉键在亮色主题下还会去掉仅暗色头灯才用的速度/高度输入,这样爬升、加速的飞机不再为地图根本没绘制的状态而重渲染。",
+      },
+      {
+        en: "Here mode (your location, not an airport) no longer shows the departures/arrivals split — that classification needs an airport anchor, so off-airport it was always 0/0 and opened empty views. Those two cells now read out the ambient traffic instead: the average speed and altitude of the airborne aircraft around you.",
+        zh: "Here 模式(你的位置,不是机场)不再显示起飞/到达拆分——这个分类需要机场作为锚点,离开机场时它永远是 0/0,点进去也是空视图。这两格现在改为读出周围空情:你身边在飞的飞机的平均速度与平均高度。",
       },
     ],
   },

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -267,6 +267,8 @@ const en = {
     nearMeSubtitle: "Live aircraft around you",
     departures: "Dep",
     arrivals: "Arr",
+    avgSpeed: "Speed",
+    avgAltitude: "Alt.",
     atc: "ATC",
     spotting: "Spot",
     metricUnits: {

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -261,6 +261,8 @@ const zhCN = {
     nearMeSubtitle: "查看我周围的飞机",
     departures: "起飞",
     arrivals: "到达",
+    avgSpeed: "速度",
+    avgAltitude: "高度",
     atc: "ATC",
     spotting: "拍机点",
     metricUnits: {


### PR DESCRIPTION
## What

In `here` mode the explorer centers on the user's position, not an airport, so the **departures / arrivals** movement split has no anchor to classify against: every aircraft resolves to `UNKNOWN`, the two cells read **0/0**, and tapping them opened empty filtered views.

This gates the movement row off when `nearMe`, and in its place shows two **read-only** stat cells — the **mean speed** and **mean altitude** of the airborne aircraft around the user (on-ground aircraft excluded; `—` when no airborne aircraft carry the field). Airport mode is unchanged.

## Changes
- `SidebarViewSwitch.tsx` — `showMovementCards` now also requires `!nearMe`; new averages memo; new `readOnly` `StatCell` variant (renders a plain cell, no hover/active rail) with optional `prefix` support for FL-style altitude.
- `i18n/en.ts`, `i18n/zh-CN.ts` — `sidebar.avgSpeed` / `sidebar.avgAltitude`.
- Version bump folded into the rolling v2.32 entry (`package.json` + `changelog.ts`).

## Validation
Local browser — checked the `/here` sidebar stats row replaces dep/arr with speed/altitude; airport sidebar dep/arr unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)