### PR TITLE
v2.32.6: Here-mode speed/altitude show the user's own GPS, not aircraft averages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.5",
+  "version": "2.32.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -91,6 +91,8 @@ function normalizeNearMeLocation(location) {
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
   const accuracyMeters = Number(location?.accuracyMeters);
   const headingDeg = Number(location?.headingDeg);
+  const speedMps = Number(location?.speedMps);
+  const altitudeMeters = Number(location?.altitudeMeters);
   return {
     lat,
     lon,
@@ -99,6 +101,8 @@ function normalizeNearMeLocation(location) {
       Number.isFinite(headingDeg) && headingDeg >= 0
         ? ((headingDeg % 360) + 360) % 360
         : null,
+    speedMps: Number.isFinite(speedMps) && speedMps >= 0 ? speedMps : null,
+    altitudeMeters: Number.isFinite(altitudeMeters) ? altitudeMeters : null,
     updatedAt: Number(location?.updatedAt) || Date.now(),
   };
 }
@@ -189,6 +193,13 @@ function AirportExplorerContent({
     if (!nearMe) return null;
     return normalizeNearMeLocation(nearMeSidebarLocation) || nearMeMapUserLocation;
   }, [nearMe, nearMeMapUserLocation, nearMeSidebarLocation]);
+  // The here-mode speed/altitude readout follows the user's own motion, so it
+  // reads from the live position (not the distance-thresholded sidebar one) and
+  // survives hiding the map marker.
+  const nearMeSelfLocation = useMemo(
+    () => (nearMe ? normalizeNearMeLocation(nearMeUserLocation) : null),
+    [nearMe, nearMeUserLocation],
+  );
   const nearbyAirportsFocus = nearMeSidebarUserLocation || airportProfile;
   // Nearby-airports list runs first in near-me mode so we can borrow
   // the closest airport's ICAO for the METAR temperature fetch — the
@@ -474,6 +485,10 @@ function AirportExplorerContent({
     flightAwareResolved: traffic.flightAwareResolved,
     loadingStatus: sourceLoadingStatus,
     nearMe,
+    nearMeSelfSpeedMps: nearMe ? nearMeSelfLocation?.speedMps ?? null : null,
+    nearMeSelfAltitudeMeters: nearMe
+      ? nearMeSelfLocation?.altitudeMeters ?? null
+      : null,
     nearMeRefresh,
     onSelectAircraft: selectAircraft,
     onSelectAirport: selectAirport,

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -43,6 +43,8 @@ export default function AirportSidebar({
   // The identity hero swaps to a "Your location" header and the
   // metric cards collapse to weather + nearby traffic.
   nearMe = false,
+  nearMeSelfSpeedMps = null,
+  nearMeSelfAltitudeMeters = null,
   nearMeRefresh,
   onSelectAircraft,
   onSelectAirport,
@@ -109,6 +111,8 @@ export default function AirportSidebar({
         candidateSpotCount={spottingSpots.length}
         onOpenSpotting={handleSpottingView}
         nearMe={nearMe}
+        nearMeSelfSpeedMps={nearMeSelfSpeedMps}
+        nearMeSelfAltitudeMeters={nearMeSelfAltitudeMeters}
         featureFlagsResolved={flightAwareResolved}
       />
     </>

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import NumberFlow from "@number-flow/react";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
@@ -6,8 +6,10 @@ import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel";
 import { ARRIVAL, DEPARTURE } from "@/utils/aircraftMovement";
 import {
   convertTemperatureFromC,
-  formatAltitude,
+  formatAltitudeFromMeters,
+  formatGroundSpeed,
   temperatureUnitLabel,
+  type GroundSpeedUnit,
 } from "@/utils/units";
 
 // Frosted "hero stats block": one joined rounded glass container with a big
@@ -29,18 +31,22 @@ export default function SidebarViewSwitch({
   candidateSpotCount = 0,
   onOpenSpotting,
   nearMe = false,
+  nearMeSelfSpeedMps = null,
+  nearMeSelfAltitudeMeters = null,
   featureFlagsResolved = true,
 }) {
   const { t } = useI18n();
   const { preferences: units } = useUnitPreferences();
+  // Here-mode ground speed has its own unit, independent of the aviation
+  // distance preference: km/h by default, tap to flip to mph.
+  const [groundSpeedUnit, setGroundSpeedUnit] = useState<GroundSpeedUnit>("kmh");
   const temperature = metarLoading
     ? { value: "—", unit: temperatureUnitLabel(units.temperature) }
     : formatTemperature(metar, units.temperature);
   const temperatureUnit = temperature.value === "—" ? undefined : temperature.unit;
   // In here mode the user's position is not an airport, so departure/arrival
   // classification is meaningless (everything resolves to UNKNOWN). The movement
-  // row is replaced by ambient traffic readouts: the average speed and altitude
-  // of the airborne aircraft around the user.
+  // row is replaced by the user's own GPS speed/altitude readouts instead.
   const showMovementCards =
     !nearMe && featureFlagsResolved && routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
   const atcCount = Array.isArray(frequencies) ? frequencies.length : 0;
@@ -60,40 +66,26 @@ export default function SidebarViewSwitch({
     return { departureCount: dep, arrivalCount: arr };
   }, [aircraft, routeProvider]);
 
-  // Ambient here-mode stats: mean speed/altitude across airborne aircraft only
-  // (on-ground aircraft have no meaningful cruise altitude and drag the speed
-  // mean toward zero). Null when no airborne aircraft carry the field.
-  const { avgSpeed, avgAltitude } = useMemo(() => {
-    if (!nearMe) return { avgSpeed: null, avgAltitude: null };
-    let speedSum = 0;
-    let speedCount = 0;
-    let altSum = 0;
-    let altCount = 0;
-    for (const item of aircraft) {
-      if (item?.onGround) continue;
-      const speed = Number(item?.velocity);
-      if (Number.isFinite(speed)) {
-        speedSum += speed;
-        speedCount += 1;
-      }
-      const altitude = Number(item?.altitude);
-      if (Number.isFinite(altitude)) {
-        altSum += altitude;
-        altCount += 1;
-      }
-    }
-    return {
-      avgSpeed: speedCount ? speedSum / speedCount : null,
-      avgAltitude: altCount ? altSum / altCount : null,
-    };
-  }, [aircraft, nearMe]);
+  // Here mode centers on the user, not an airport, so the movement row reads
+  // out the user's OWN motion from GPS: ground speed (km/h, tap for mph) and
+  // altitude (following the altitude preference, kept ground-relative so it
+  // never reads as a flight level). Null — the common indoor/stationary case
+  // where the device reports no speed/altitude — shows an em dash.
+  const selfSpeedDisplay = nearMe
+    ? formatGroundSpeed(nearMeSelfSpeedMps, groundSpeedUnit)
+    : null;
+  const selfAltitudeDisplay = nearMe
+    ? formatAltitudeFromMeters(nearMeSelfAltitudeMeters, units.altitude, {
+        kind: "ground",
+      })
+    : null;
 
   // Footer stacks into rows under the flight-count hero: first the movement
   // row (departures / arrivals) as the direct breakdown of the count, then
   // the context row (weather / ATC / spotting). Each conditional cell simply
   // drops out of its row when absent. In here mode the movement row carries the
-  // ambient speed/altitude readouts instead — they are pure stats, not views,
-  // so they render as static cells (no view switch, no active rail).
+  // user's own speed/altitude instead: speed is a tap target that toggles its
+  // unit (km/h ⇄ mph), altitude is a static readOnly cell.
   const movementCells = [];
   if (showMovementCards) {
     movementCells.push({
@@ -111,23 +103,29 @@ export default function SidebarViewSwitch({
       onClick: () => onViewChange?.("arrivals"),
     });
   } else if (nearMe) {
-    const altitudeDisplay =
-      avgAltitude == null
-        ? null
-        : formatAltitude(avgAltitude, units.altitude, { kind: "cruise" });
+    // Speed is a tap target (km/h ⇄ mph); altitude is a plain readout.
     movementCells.push({
-      key: "avgSpeed",
-      label: t("sidebar.avgSpeed"),
-      value: avgSpeed == null ? "—" : <NumberFlow value={Math.round(avgSpeed)} />,
-      unit: avgSpeed == null ? undefined : "kt",
-      readOnly: true,
+      key: "selfSpeed",
+      label: t("sidebar.speed"),
+      value: selfSpeedDisplay ? (
+        <NumberFlow value={selfSpeedDisplay.value} />
+      ) : (
+        "—"
+      ),
+      unit: selfSpeedDisplay?.unit || undefined,
+      onClick: () =>
+        setGroundSpeedUnit((current) => (current === "kmh" ? "mph" : "kmh")),
     });
     movementCells.push({
-      key: "avgAltitude",
-      label: t("sidebar.avgAltitude"),
-      value: altitudeDisplay ? <NumberFlow value={altitudeDisplay.value} /> : "—",
-      unit: altitudeDisplay?.unit || undefined,
-      prefix: altitudeDisplay?.prefix,
+      key: "selfAltitude",
+      label: t("sidebar.altitude"),
+      value: selfAltitudeDisplay ? (
+        <NumberFlow value={selfAltitudeDisplay.value} />
+      ) : (
+        "—"
+      ),
+      unit: selfAltitudeDisplay?.unit || undefined,
+      prefix: selfAltitudeDisplay?.prefix,
       readOnly: true,
     });
   }

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.5",
+    version: "v2.32.6",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -83,8 +83,8 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         zh: "实时地图性能:飞机 marker 不再每个位置 tick 都重建剪影 SVG + 标签。portal 内容拆成一个按量化视觉键 memo 的子组件,仅位置变化(最常见的情况)时跳过 React/SVG reconcile,而 marker 仍由运动循环命令式平滑移动——满载机场流量下 marker 与焦点航班详情页都更顺。繁忙机场的主线程卡顿峰值从约 82ms 降到约 59ms。视觉键在亮色主题下还会去掉仅暗色头灯才用的速度/高度输入,这样爬升、加速的飞机不再为地图根本没绘制的状态而重渲染。",
       },
       {
-        en: "Here mode (your location, not an airport) no longer shows the departures/arrivals split — that classification needs an airport anchor, so off-airport it was always 0/0 and opened empty views. Those two cells now read out the ambient traffic instead: the average speed and altitude of the airborne aircraft around you.",
-        zh: "Here 模式(你的位置,不是机场)不再显示起飞/到达拆分——这个分类需要机场作为锚点,离开机场时它永远是 0/0,点进去也是空视图。这两格现在改为读出周围空情:你身边在飞的飞机的平均速度与平均高度。",
+        en: "Here mode (your location, not an airport) no longer shows the departures/arrivals split — that classification needs an airport anchor, so off-airport it was always 0/0 and opened empty views. Those two cells now read out your own motion from GPS instead: ground speed and altitude. Speed is a pedestrian/driver readout — km/h by default, tap to switch to mph, never knots — and altitude follows your altitude unit. When the device reports no speed/altitude (common indoors or while still) the cell shows an em dash.",
+        zh: "Here 模式(你的位置,不是机场)不再显示起飞/到达拆分——这个分类需要机场作为锚点,离开机场时它永远是 0/0,点进去也是空视图。这两格现在改为读出你自己的 GPS 运动数据:地速与海拔。速度是给行人/驾车看的——默认 km/h,点击切换 mph,绝不用航空的节(kt)——海拔则跟随你的海拔单位。当设备没有上报速度/海拔时(室内或静止时常见),该格显示破折号。",
       },
     ],
   },

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -267,8 +267,7 @@ const en = {
     nearMeSubtitle: "Live aircraft around you",
     departures: "Dep",
     arrivals: "Arr",
-    avgSpeed: "Speed",
-    avgAltitude: "Alt.",
+    speed: "Speed",
     atc: "ATC",
     spotting: "Spot",
     metricUnits: {

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -261,8 +261,7 @@ const zhCN = {
     nearMeSubtitle: "查看我周围的飞机",
     departures: "起飞",
     arrivals: "到达",
-    avgSpeed: "速度",
-    avgAltitude: "高度",
+    speed: "速度",
     atc: "ATC",
     spotting: "拍机点",
     metricUnits: {

--- a/src/features/airport/nearby/nearMeLocationModel.test.ts
+++ b/src/features/airport/nearby/nearMeLocationModel.test.ts
@@ -13,6 +13,8 @@ const baseLocation: NearMeLocation = {
   lon: -71.0096,
   accuracyMeters: 12,
   headingDeg: 10,
+  speedMps: null,
+  altitudeMeters: null,
   updatedAt: 1_000,
 };
 
@@ -147,6 +149,38 @@ assert.equal(resolveNearMeDeviceHeading({ absolute: true, alpha: null }), null);
     updatedAt: 2_000,
   };
 
+  assert.equal(shouldUpdateNearMeLocation(previous, next), false);
+}
+
+// Geolocation speed/altitude are captured; a negative speed (no fix) collapses
+// to null so a stationary device never shows a bogus value.
+{
+  const location = buildNearMeLocationFromCoords(
+    { latitude: 42.36, longitude: -71.01, speed: 5.4, altitude: 30 },
+    1_000,
+  );
+  assert.equal(location?.speedMps, 5.4);
+  assert.equal(location?.altitudeMeters, 30);
+}
+{
+  const location = buildNearMeLocationFromCoords(
+    { latitude: 42.36, longitude: -71.01, speed: -1, altitude: null },
+    1_000,
+  );
+  assert.equal(location?.speedMps, null);
+  assert.equal(location?.altitudeMeters, null);
+}
+
+// A whole-unit speed change refreshes the live readout even when the position
+// is unchanged; sub-unit jitter does not.
+{
+  const previous = { ...baseLocation, speedMps: 0 };
+  const next = { ...baseLocation, speedMps: 5, updatedAt: 2_000 };
+  assert.equal(shouldUpdateNearMeLocation(previous, next), true);
+}
+{
+  const previous = { ...baseLocation, speedMps: 5.1 };
+  const next = { ...baseLocation, speedMps: 5.2, updatedAt: 2_000 };
   assert.equal(shouldUpdateNearMeLocation(previous, next), false);
 }
 

--- a/src/features/airport/nearby/nearMeLocationModel.ts
+++ b/src/features/airport/nearby/nearMeLocationModel.ts
@@ -10,6 +10,11 @@ export type NearMeLocation = {
   lon: number;
   accuracyMeters: number | null;
   headingDeg: number | null;
+  // The user's own GPS-reported motion, surfaced by here mode. Speed is in
+  // metres/second and altitude in metres above the ellipsoid; both are null on
+  // devices/fixes that don't report them (common indoors and on desktop).
+  speedMps: number | null;
+  altitudeMeters: number | null;
   updatedAt: number;
 };
 
@@ -18,6 +23,8 @@ type NearMeCoords = {
   longitude?: unknown;
   accuracy?: unknown;
   heading?: unknown;
+  speed?: unknown;
+  altitude?: unknown;
 };
 
 type NearMeDeviceOrientationEvent = {
@@ -81,11 +88,17 @@ export function buildNearMeLocationFromCoords(
   const lon = toFiniteNumber(coords?.longitude);
   if (lat == null || lon == null) return null;
 
+  const speedMps = toFiniteNumber(coords?.speed);
+
   return {
     lat,
     lon,
     accuracyMeters: toFiniteNumber(coords?.accuracy),
     headingDeg: normalizeNearMeHeadingDeg(coords?.heading),
+    // Geolocation speed is non-negative when present; treat a negative reading
+    // as "no fix" so a stationary phone never shows a bogus speed.
+    speedMps: speedMps != null && speedMps >= 0 ? speedMps : null,
+    altitudeMeters: toFiniteNumber(coords?.altitude),
     updatedAt,
   };
 }
@@ -98,6 +111,12 @@ export function shouldUpdateNearMeLocation(
 
   if (previous.lat !== next.lat || previous.lon !== next.lon) return true;
   if (previous.accuracyMeters !== next.accuracyMeters) return true;
+  // Refresh on a whole-unit speed change so the here-mode readout stays live
+  // even when the user is moving in place (e.g. slowing to a stop) without
+  // crossing the position threshold.
+  if (Math.round(previous.speedMps ?? -1) !== Math.round(next.speedMps ?? -1)) {
+    return true;
+  }
 
   if (previous.headingDeg == null) return next.headingDeg != null;
   if (next.headingDeg == null) return false;

--- a/src/utils/units.test.ts
+++ b/src/utils/units.test.ts
@@ -5,7 +5,9 @@ import {
   convertTemperatureFromC,
   convertAltitudeFromFt,
   formatAltitude,
+  formatAltitudeFromMeters,
   formatDistance,
+  formatGroundSpeed,
   formatTemperature,
 } from "./units";
 
@@ -85,6 +87,46 @@ assert.equal(formatDistance("oops", "km"), null);
   assert.ok(meters);
   assert.equal(meters.unit, "m");
   assert.equal(Math.round(meters.value as number), 305);
+}
+
+// --- Here-mode ground speed (km/h default, mph on toggle; never knots)
+{
+  // 10 m/s = 36 km/h, and the same speed in mph.
+  assert.deepEqual(formatGroundSpeed(10, "kmh"), {
+    value: 36,
+    unit: "km/h",
+    text: null,
+  });
+  assert.deepEqual(formatGroundSpeed(10, "mph"), {
+    value: 22,
+    unit: "mph",
+    text: null,
+  });
+  // No fix / negative / non-finite collapses to null (em dash at the call site).
+  assert.equal(formatGroundSpeed(null, "kmh"), null);
+  assert.equal(formatGroundSpeed(-1, "kmh"), null);
+  // A stationary device reporting 0 is a real reading, not "no fix".
+  assert.deepEqual(formatGroundSpeed(0, "kmh"), {
+    value: 0,
+    unit: "km/h",
+    text: null,
+  });
+}
+
+// --- Altitude from metres (Geolocation API reports metres)
+{
+  // ~305 m ≈ 1000 ft.
+  const feet = formatAltitudeFromMeters(304.8, "ft");
+  assert.deepEqual(feet, { value: 1000, unit: "ft", text: null });
+  // Metres preference round-trips back to metres.
+  const meters = formatAltitudeFromMeters(305, "m");
+  assert.ok(meters);
+  assert.equal(meters.unit, "m");
+  assert.equal(Math.round(meters.value as number), 305);
+  // Ground kind keeps a pedestrian off flight levels.
+  const fl = formatAltitudeFromMeters(304.8, "fl", { kind: "ground" });
+  assert.deepEqual(fl, { value: 1000, unit: "ft", text: null });
+  assert.equal(formatAltitudeFromMeters(null, "ft"), null);
 }
 
 console.log("units.test.ts ok");

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -7,6 +7,18 @@ import type {
 const NM_TO_KM = 1.852;
 const NM_TO_MI = 1.15077945;
 const FT_TO_M = 0.3048;
+const MS_TO_KMH = 3.6;
+const MS_TO_MPH = 2.2369362921;
+
+// Here-mode ground speed is a pedestrian/driver readout, deliberately decoupled
+// from the aviation distance unit: it has its own two-state toggle, km/h by
+// default and mph on tap, and never knots.
+export type GroundSpeedUnit = "kmh" | "mph";
+
+const GROUND_SPEED_LABELS: Record<GroundSpeedUnit, string> = {
+  kmh: "km/h",
+  mph: "mph",
+};
 
 const DISTANCE_LABELS: Record<DistanceUnit, string> = {
   nm: "NM",
@@ -165,6 +177,46 @@ export function formatAltitude(
   return {
     value: Math.round(numeric),
     unit: altitudeUnitLabel("ft"),
+    text: null,
+  };
+}
+
+// Altitude as reported by the Geolocation API is in metres above the WGS84
+// ellipsoid; reuse the foot-based formatter (and its unit handling) by
+// converting first. Returns null for the common indoor/desktop case where the
+// device reports no altitude.
+export function formatAltitudeFromMeters(
+  meters: unknown,
+  unit: AltitudeUnit,
+  options: FormatAltitudeOptions = {},
+): FormattedValue | null {
+  if (meters == null || meters === "") return null;
+  const numeric = Number(meters);
+  if (!Number.isFinite(numeric)) return null;
+  return formatAltitude(numeric / FT_TO_M, unit, options);
+}
+
+export function groundSpeedUnitLabel(unit: GroundSpeedUnit) {
+  return GROUND_SPEED_LABELS[unit] ?? GROUND_SPEED_LABELS.kmh;
+}
+
+export function convertSpeedFromMps(mps: number, unit: GroundSpeedUnit) {
+  if (!Number.isFinite(mps)) return mps;
+  return unit === "mph" ? mps * MS_TO_MPH : mps * MS_TO_KMH;
+}
+
+// Formats a ground speed measured in metres per second (Geolocation API) into
+// the here-mode km/h or mph readout. Negative/no-fix speeds collapse to null.
+export function formatGroundSpeed(
+  mps: unknown,
+  unit: GroundSpeedUnit,
+): FormattedValue | null {
+  if (mps == null || mps === "") return null;
+  const numeric = Number(mps);
+  if (!Number.isFinite(numeric) || numeric < 0) return null;
+  return {
+    value: Math.round(convertSpeedFromMps(numeric, unit)),
+    unit: groundSpeedUnitLabel(unit),
     text: null,
   };
 }


### PR DESCRIPTION
## Why

The v2.32.5 here-mode swap showed the **average speed/altitude of nearby aircraft**. That reads as bogus self-telemetry: standing still in a mall, a user saw **140 kt / 5,802 ft** and reasonably read it as their own speed/altitude (screenshot-reported). It also used knots, which is wrong for a person on the ground.

## What

Show the user's **own GPS motion** instead. The Geolocation fix already carries `speed` (m/s) and `altitude` (m); this threads both through `NearMeLocation` → `AirportExplorer` → `AirportSidebar` → `SidebarViewSwitch`.

- **Speed** — pedestrian/driver readout, decoupled from the aviation distance unit: **km/h by default, tap to toggle mph, never knots**.
- **Altitude** — follows the altitude preference, kept `kind: "ground"` so it never renders as a flight level.
- **No fix** (common indoors / stationary / desktop) shows an em dash, not a fabricated number.

New `formatGroundSpeed` / `formatAltitudeFromMeters` helpers in `units.ts`, and a whole-unit speed-change refresh in `shouldUpdateNearMeLocation` so the live readout tracks movement.

## Validation

Local test — `pnpm test` (122 files pass) incl. new `units` + `nearMeLocationModel` cases; `tsc --noEmit` introduces no new errors (the 3 pre-existing loose-JS errors are unchanged). Airport mode dep/arr unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)