### PR TITLE
v2.32.7: Here-mode speed default follows the user's metric/imperial units

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.6",
+  "version": "2.32.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -7,6 +7,7 @@ import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel";
 import { ARRIVAL, DEPARTURE } from "@/utils/aircraftMovement";
 import {
   convertTemperatureFromC,
+  defaultGroundSpeedUnit,
   formatAltitudeFromMeters,
   formatGroundSpeed,
   temperatureUnitLabel,
@@ -38,9 +39,11 @@ export default function SidebarViewSwitch({
 }) {
   const { t } = useI18n();
   const { preferences: units } = useUnitPreferences();
-  // Here-mode ground speed has its own unit, independent of the aviation
-  // distance preference: km/h by default, tap to flip to mph.
-  const [groundSpeedUnit, setGroundSpeedUnit] = useState<GroundSpeedUnit>("kmh");
+  // Here-mode ground speed is km/h or mph (never knots). Its default follows the
+  // user's metric/imperial setting; a tap overrides it for the session.
+  const [speedUnitOverride, setSpeedUnitOverride] =
+    useState<GroundSpeedUnit | null>(null);
+  const groundSpeedUnit = speedUnitOverride ?? defaultGroundSpeedUnit(units);
   const temperature = metarLoading
     ? { value: "—", unit: temperatureUnitLabel(units.temperature) }
     : formatTemperature(metar, units.temperature);
@@ -68,10 +71,11 @@ export default function SidebarViewSwitch({
   }, [aircraft, routeProvider]);
 
   // Here mode centers on the user, not an airport, so the movement row reads
-  // out the user's OWN motion from GPS: ground speed (km/h, tap for mph) and
-  // altitude (following the altitude preference, kept ground-relative so it
-  // never reads as a flight level). Null — the common indoor/stationary case
-  // where the device reports no speed/altitude — shows an em dash.
+  // out the user's OWN motion from GPS: ground speed (defaults to the user's
+  // metric/imperial system — km/h or mph — tap to flip) and altitude (following
+  // the altitude preference, kept ground-relative so it never reads as a flight
+  // level). Null — the common indoor/stationary case where the device reports
+  // no speed/altitude — shows an em dash.
   const selfSpeedDisplay = nearMe
     ? formatGroundSpeed(nearMeSelfSpeedMps, groundSpeedUnit)
     : null;
@@ -115,7 +119,7 @@ export default function SidebarViewSwitch({
       ),
       unit: selfSpeedDisplay?.unit || undefined,
       onClick: () =>
-        setGroundSpeedUnit((current) => (current === "kmh" ? "mph" : "kmh")),
+        setSpeedUnitOverride(groundSpeedUnit === "kmh" ? "mph" : "kmh"),
     });
     movementCells.push({
       key: "selfAltitude",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.6",
+    version: "v2.32.7",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -83,8 +83,8 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         zh: "实时地图性能:飞机 marker 不再每个位置 tick 都重建剪影 SVG + 标签。portal 内容拆成一个按量化视觉键 memo 的子组件,仅位置变化(最常见的情况)时跳过 React/SVG reconcile,而 marker 仍由运动循环命令式平滑移动——满载机场流量下 marker 与焦点航班详情页都更顺。繁忙机场的主线程卡顿峰值从约 82ms 降到约 59ms。视觉键在亮色主题下还会去掉仅暗色头灯才用的速度/高度输入,这样爬升、加速的飞机不再为地图根本没绘制的状态而重渲染。",
       },
       {
-        en: "Here mode (your location, not an airport) no longer shows the departures/arrivals split — that classification needs an airport anchor, so off-airport it was always 0/0 and opened empty views. Those two cells now read out your own motion from GPS instead: ground speed and altitude. Speed is a pedestrian/driver readout — km/h by default, tap to switch to mph, never knots — and altitude follows your altitude unit. When the device reports no speed/altitude (common indoors or while still) the cell shows an em dash.",
-        zh: "Here 模式(你的位置,不是机场)不再显示起飞/到达拆分——这个分类需要机场作为锚点,离开机场时它永远是 0/0,点进去也是空视图。这两格现在改为读出你自己的 GPS 运动数据:地速与海拔。速度是给行人/驾车看的——默认 km/h,点击切换 mph,绝不用航空的节(kt)——海拔则跟随你的海拔单位。当设备没有上报速度/海拔时(室内或静止时常见),该格显示破折号。",
+        en: "Here mode (your location, not an airport) no longer shows the departures/arrivals split — that classification needs an airport anchor, so off-airport it was always 0/0 and opened empty views. Those two cells now read out your own motion from GPS instead: ground speed and altitude. Speed is a pedestrian/driver readout — never knots — that defaults to your own metric/imperial setting (km/h or mph) and flips to the other on tap; altitude follows your altitude unit. When the device reports no speed/altitude (common indoors or while still) the cell shows an em dash.",
+        zh: "Here 模式(你的位置,不是机场)不再显示起飞/到达拆分——这个分类需要机场作为锚点,离开机场时它永远是 0/0,点进去也是空视图。这两格现在改为读出你自己的 GPS 运动数据:地速与海拔。速度是给行人/驾车看的——绝不用航空的节(kt)——默认跟随你自己的米制/英制设置(km/h 或 mph),点击切换到另一种;海拔则跟随你的海拔单位。当设备没有上报速度/海拔时(室内或静止时常见),该格显示破折号。",
       },
     ],
   },

--- a/src/utils/units.test.ts
+++ b/src/utils/units.test.ts
@@ -4,6 +4,7 @@ import {
   convertDistanceFromNm,
   convertTemperatureFromC,
   convertAltitudeFromFt,
+  defaultGroundSpeedUnit,
   formatAltitude,
   formatAltitudeFromMeters,
   formatDistance,
@@ -111,6 +112,18 @@ assert.equal(formatDistance("oops", "km"), null);
     unit: "km/h",
     text: null,
   });
+}
+
+// --- Here-mode speed default follows the user's metric/imperial system
+{
+  // Distance is the primary signal.
+  assert.equal(defaultGroundSpeedUnit({ distance: "km", altitude: "ft" }), "kmh");
+  assert.equal(defaultGroundSpeedUnit({ distance: "mi", altitude: "m" }), "mph");
+  // Nautical miles (neither system) falls back to the altitude unit.
+  assert.equal(defaultGroundSpeedUnit({ distance: "nm", altitude: "ft" }), "mph");
+  assert.equal(defaultGroundSpeedUnit({ distance: "nm", altitude: "m" }), "kmh");
+  // Fully aviation prefs (nm + fl) default to metric.
+  assert.equal(defaultGroundSpeedUnit({ distance: "nm", altitude: "fl" }), "kmh");
 }
 
 // --- Altitude from metres (Geolocation API reports metres)

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -200,6 +200,23 @@ export function groundSpeedUnitLabel(unit: GroundSpeedUnit) {
   return GROUND_SPEED_LABELS[unit] ?? GROUND_SPEED_LABELS.kmh;
 }
 
+// Here-mode speed has no preference of its own, so its *default* follows the
+// user's broader metric/imperial choice rather than being forced to km/h:
+// km/h when their units read metric, mph when imperial. Distance is the primary
+// signal (speed is distance over time); nautical miles — the aviation default,
+// which is neither system — falls back to the altitude unit. The here-mode tap
+// toggle still overrides this per session.
+export function defaultGroundSpeedUnit(units: {
+  distance: DistanceUnit;
+  altitude: AltitudeUnit;
+}): GroundSpeedUnit {
+  if (units.distance === "km") return "kmh";
+  if (units.distance === "mi") return "mph";
+  if (units.altitude === "m") return "kmh";
+  if (units.altitude === "ft") return "mph";
+  return "kmh";
+}
+
 export function convertSpeedFromMps(mps: number, unit: GroundSpeedUnit) {
   if (!Number.isFinite(mps)) return mps;
   return unit === "mph" ? mps * MS_TO_MPH : mps * MS_TO_KMH;


### PR DESCRIPTION
## Why

Here-mode ground speed defaulted to **km/h**, hardcoded. But this readout only has two systems — metric and imperial — and the user's existing **distance/altitude preferences already encode which they want**. Forcing metric is wrong for an imperial user.

## What

Derive the default from prefs via `defaultGroundSpeedUnit(units)`:
- distance `km` → km/h, `mi` → mph (distance is the primary signal — speed is distance/time)
- distance `nm` (nautical, neither system) → falls back to the altitude unit (`ft` → mph, `m` → kmh)

The here-mode tap toggle still overrides it for the session (now via a `speedUnitOverride` that falls back to the derived default, so it also tracks a pref change until the user taps). Altitude already followed the altitude preference — unchanged.

## Validation

Local test — `pnpm test` incl. new `defaultGroundSpeedUnit` cases; `tsc --noEmit` no new errors. Patch bump folded into the rolling v2.32 changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)