### PR TITLE
devtools: in-app perf probe (frame timing + motion loop + React commits)

### DIFF
--- a/src/components/devtools/PerfBoundary.tsx
+++ b/src/components/devtools/PerfBoundary.tsx
@@ -1,0 +1,14 @@
+import { Profiler, type ReactNode } from "react";
+import { perfProbeEnabled, recordCommit } from "@/features/devtools/perfProbe";
+
+// Wraps a subtree in a React Profiler that reports commit cost to the dev perf
+// probe — but ONLY when the probe is enabled (?perf=1). When off it returns the
+// children untouched, so production and normal dev pay nothing.
+export function PerfBoundary({ id, children }: { id: string; children: ReactNode }) {
+  if (!perfProbeEnabled()) return <>{children}</>;
+  return (
+    <Profiler id={id} onRender={(profilerId, _phase, actualDuration) => recordCommit(profilerId, actualDuration)}>
+      {children}
+    </Profiler>
+  );
+}

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import { useNavigate } from "react-router-dom";
 import FlightSidebar from "@/components/sidebar/FlightSidebar";
 import ExplorerMapMenu from "@/components/explorer/ExplorerMapMenu";
+import { PerfBoundary } from "@/components/devtools/PerfBoundary";
 import {
   MapLoadingFallback,
   useMapLoadingOverlayText,
@@ -73,7 +74,9 @@ const TRACE_VIEW_ALL = "all";
 export default function FlightExplorer({ callsign = "" }) {
   return (
     <ExplorerUiProvider>
-      <FlightExplorerContent callsign={callsign} />
+      <PerfBoundary id="FlightExplorer">
+        <FlightExplorerContent callsign={callsign} />
+      </PerfBoundary>
     </ExplorerUiProvider>
   );
 }

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import L from "leaflet";
 import { MapContext } from "./MapContext";
+import { PerfBoundary } from "@/components/devtools/PerfBoundary";
 import MapTileLayers from "./MapTileLayers";
 import AirportMarker from "./AirportMarker";
 import MapRangeLegend from "./MapRangeLegend";
@@ -67,7 +68,7 @@ const WEB_MERCATOR_BOUNDS = [
   [WEB_MERCATOR_MAX_LAT, 180],
 ] as any;
 
-export default function AirportMap({
+function AirportMapInner({
   icao = "",
   lat = null,
   lon = null,
@@ -750,4 +751,15 @@ function mapClickTargetsAirspace(event: any) {
   return document
     .elementsFromPoint(x, y)
     .some((element) => element.getAttribute?.("data-airspace-feature-id"));
+}
+
+// Default export wraps the map subtree in a dev-only Profiler (no-op unless
+// ?perf=1). The shared map is the heaviest per-tick subtree on both the
+// airport and flight-detail pages, so this is where commit cost is measured.
+export default function AirportMap(props: Parameters<typeof AirportMapInner>[0]) {
+  return (
+    <PerfBoundary id="AirportMap">
+      <AirportMapInner {...props} />
+    </PerfBoundary>
+  );
 }

--- a/src/components/map/aircraftMotionFrameLoop.ts
+++ b/src/components/map/aircraftMotionFrameLoop.ts
@@ -1,3 +1,5 @@
+import { perfProbeEnabled, recordMotionFrame } from "@/features/devtools/perfProbe";
+
 type MotionFrameCallback = (now: number) => boolean | void;
 
 const callbacks = new Set<MotionFrameCallback>();
@@ -29,10 +31,15 @@ function cancelCurrentFrameIfIdle() {
 function runFrame() {
   frameId = null;
   const now = Date.now();
+  const probe = perfProbeEnabled();
+  const startedAt = probe ? performance.now() : 0;
+  let invoked = 0;
   for (const callback of Array.from(callbacks)) {
     if (!callbacks.has(callback)) continue;
+    invoked += 1;
     if (callback(now) === false) callbacks.delete(callback);
   }
+  if (probe) recordMotionFrame(invoked, performance.now() - startedAt);
   requestNextFrame();
 }
 

--- a/src/features/devtools/perfProbe.ts
+++ b/src/features/devtools/perfProbe.ts
@@ -1,0 +1,184 @@
+// Dev-only in-app performance probe. Establishes a real foreground baseline
+// the headless preview can't (its rAF is throttled): it measures the actual
+// frame cadence, the imperative aircraft motion-loop cost, and React commit
+// durations, and paints a small HUD plus a `window.__adsbaoPerf` snapshot.
+//
+// Zero-cost in production (gated on import.meta.env.DEV) and when the flag is
+// off. Enable with `?perf=1` in the URL (persists to localStorage so it
+// survives SPA navigation) or `localStorage.adsbaoPerf = "1"`. Disable with
+// `?perf=0` or by clearing the key.
+
+let enabled = false;
+try {
+  if (import.meta.env?.DEV && typeof window !== "undefined") {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("perf")) {
+      const value = params.get("perf");
+      window.localStorage.setItem("adsbaoPerf", value === "0" ? "0" : "1");
+    }
+    enabled = window.localStorage.getItem("adsbaoPerf") === "1";
+  }
+} catch {
+  enabled = false;
+}
+
+export function perfProbeEnabled() {
+  return enabled;
+}
+
+type CommitAgg = { count: number; total: number; max: number };
+
+const win = {
+  start: 0,
+  frames: [] as number[],
+  motionFrames: 0,
+  motionCallbacks: 0,
+  motionTime: 0,
+  motionMaxCallbacks: 0,
+  commits: new Map<string, CommitAgg>(),
+};
+
+let lastFrameTs = 0;
+let rafId = 0;
+let hud: HTMLDivElement | null = null;
+let lastSnapshot: unknown = null;
+
+export function recordMotionFrame(callbackCount: number, durationMs: number) {
+  if (!enabled) return;
+  win.motionFrames += 1;
+  win.motionCallbacks += callbackCount;
+  win.motionTime += durationMs;
+  if (callbackCount > win.motionMaxCallbacks) win.motionMaxCallbacks = callbackCount;
+}
+
+export function recordCommit(id: string, actualDuration: number) {
+  if (!enabled) return;
+  let agg = win.commits.get(id);
+  if (!agg) {
+    agg = { count: 0, total: 0, max: 0 };
+    win.commits.set(id, agg);
+  }
+  agg.count += 1;
+  agg.total += actualDuration;
+  if (actualDuration > agg.max) agg.max = actualDuration;
+}
+
+export function perfSnapshot() {
+  return lastSnapshot;
+}
+
+function resetWindow(now: number) {
+  win.start = now;
+  win.frames = [];
+  win.motionFrames = 0;
+  win.motionCallbacks = 0;
+  win.motionTime = 0;
+  win.motionMaxCallbacks = 0;
+  win.commits = new Map();
+}
+
+function round(value: number, digits = 0) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function buildSnapshot(now: number) {
+  const frames = win.frames.slice().sort((a, b) => a - b);
+  const fc = frames.length;
+  const elapsedSec = (now - win.start) / 1000 || 1;
+  const pct = (p: number) =>
+    fc ? round(frames[Math.min(fc - 1, Math.floor(fc * p))], 1) : 0;
+  const commits = [...win.commits.entries()]
+    .map(([id, a]) => ({
+      id,
+      count: a.count,
+      avg: round(a.total / a.count, 1),
+      max: round(a.max, 1),
+      total: round(a.total),
+    }))
+    .sort((a, b) => b.total - a.total);
+  return {
+    fps: round(fc / elapsedSec),
+    frameMs: {
+      p50: pct(0.5),
+      p95: pct(0.95),
+      p99: pct(0.99),
+      max: fc ? round(frames[fc - 1], 1) : 0,
+    },
+    longFrames: {
+      gt16: frames.filter((x) => x > 16.7).length,
+      gt32: frames.filter((x) => x > 32).length,
+      gt50: frames.filter((x) => x > 50).length,
+    },
+    motion: {
+      framesPerSec: round(win.motionFrames / elapsedSec),
+      avgMarkers: win.motionFrames ? round(win.motionCallbacks / win.motionFrames) : 0,
+      maxMarkers: win.motionMaxCallbacks,
+      msPerFrame: win.motionFrames ? round(win.motionTime / win.motionFrames, 2) : 0,
+      msPerSec: round(win.motionTime / elapsedSec),
+    },
+    commits,
+  };
+}
+
+function ensureHud() {
+  if (hud || typeof document === "undefined") return;
+  hud = document.createElement("div");
+  hud.id = "adsbao-perf-hud";
+  hud.style.cssText = [
+    "position:fixed",
+    "left:8px",
+    "bottom:8px",
+    "z-index:2147483647",
+    "pointer-events:none",
+    "font:11px/1.35 ui-monospace,SFMono-Regular,Menlo,monospace",
+    "white-space:pre",
+    "color:#d8ffd8",
+    "background:rgba(8,12,10,0.82)",
+    "padding:7px 9px",
+    "border-radius:8px",
+    "border:1px solid rgba(120,255,160,0.25)",
+    "box-shadow:0 6px 24px rgba(0,0,0,0.4)",
+    "max-width:46ch",
+  ].join(";");
+  document.body.appendChild(hud);
+}
+
+function paintHud(s: ReturnType<typeof buildSnapshot>) {
+  if (!hud) return;
+  const top = s.commits
+    .slice(0, 4)
+    .map((c) => `  ${c.id}: ${c.count}× avg${c.avg} max${c.max} Σ${c.total}`)
+    .join("\n");
+  const fpsColor = s.fps >= 55 ? "#9dffb0" : s.fps >= 40 ? "#ffe08a" : "#ff9a9a";
+  hud.style.color = fpsColor;
+  hud.textContent =
+    `FPS ${s.fps}  frame p50 ${s.frameMs.p50} p95 ${s.frameMs.p95} p99 ${s.frameMs.p99} max ${s.frameMs.max}\n` +
+    `long >16:${s.longFrames.gt16} >32:${s.longFrames.gt32} >50:${s.longFrames.gt50}\n` +
+    `motion ${s.motion.framesPerSec}fps  mk avg${s.motion.avgMarkers} max${s.motion.maxMarkers}  ${s.motion.msPerFrame}ms/f  ${s.motion.msPerSec}ms/s\n` +
+    `react commits/s:\n${top || "  (none)"}`;
+}
+
+function tick(ts: number) {
+  if (lastFrameTs) win.frames.push(ts - lastFrameTs);
+  lastFrameTs = ts;
+  if (ts - win.start >= 1000) {
+    const snapshot = buildSnapshot(ts);
+    lastSnapshot = snapshot;
+    (window as any).__adsbaoPerf = { snapshot: () => lastSnapshot };
+    paintHud(snapshot);
+    resetWindow(ts);
+  }
+  rafId = requestAnimationFrame(tick);
+}
+
+export function startPerfProbe() {
+  if (!enabled || rafId || typeof window === "undefined") return;
+  ensureHud();
+  win.start = performance.now();
+  lastFrameTs = 0;
+  (window as any).__adsbaoPerf = { snapshot: () => lastSnapshot };
+  rafId = requestAnimationFrame(tick);
+
+  console.info("[adsbaoPerf] probe on — HUD bottom-left, window.__adsbaoPerf.snapshot()");
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/features/app-shell/i18n/i18nModel";
 import { UnitPreferencesProvider } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
 import WebMcpProvider from "@/features/webmcp/WebMcpProvider";
+import { startPerfProbe } from "@/features/devtools/perfProbe";
 import { runtimeEnvValue } from "@/platform/env/runtimeEnv";
 import { isConcreteTheme } from "@/utils/theme";
 import App from "./App";
@@ -70,6 +71,7 @@ if (!root) {
 
 const { initialTheme } = applyDocumentShell();
 registerAdsbaoServiceWorker();
+startPerfProbe();
 
 createRoot(root).render(
   <React.StrictMode>


### PR DESCRIPTION
The headless preview throttles rAF, so my earlier longtask-based measurements missed the **foreground** cost of the 60fps aircraft motion loop. This adds a dev-only, flag-gated probe to establish a real baseline before chasing the remaining detail-page/airport jank.

## What it measures
- **Frame cadence** — fps, frame p50/p95/p99/max, long-frame counts (>16/32/50ms) via its own rAF loop.
- **Motion loop** — markers animated per frame, ms/frame, ms/s, instrumented in `aircraftMotionFrameLoop`.
- **React commits** — commit durations via `<Profiler>`, wrapping `AirportMap` (the shared heavy map subtree) and `FlightExplorer` (the detail page).

Paints a small HUD (bottom-left) and exposes `window.__adsbaoPerf.snapshot()`.

## How to use
Open any page with `?perf=1` (persists to localStorage across SPA nav), or set `localStorage.adsbaoPerf = "1"`. Disable with `?perf=0`.

## Cost
Gated on `import.meta.env.DEV` **and** the flag. Production and normal dev pay nothing — one boolean check per motion frame, `PerfBoundary` passes children through untouched when off. No product-visible change, **no version bump**.

## Early signal (throttled preview, KLAX ~90 markers)
Even throttled to 18fps the breakdown is telling: motion loop runs **80 markers/frame at ~1.08ms/frame** (→ ~65ms/s at 60fps) and `AirportMap` commits ~6×/s, ~10ms avg. The motion loop scales with fps and is the cost the throttled longtask numbers hid. Real foreground numbers to be read from the HUD.

Validation: local — `pnpm test` (122 files pass); preview confirmed the HUD renders and `window.__adsbaoPerf.snapshot()` populates with frame/motion/commit data on a live KLAX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)