### PR TITLE
refactor(ui): tracking-page telemetry adopts the StatTile skin (Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.7",
+  "version": "2.32.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/FlightSidebar.tsx
+++ b/src/components/sidebar/FlightSidebar.tsx
@@ -3,6 +3,7 @@ import NumberFlow from "@number-flow/react";
 import AircraftTable from "./AircraftTable";
 import SidebarIdentityHero from "./SidebarIdentityHero";
 import SidebarShell from "./SidebarShell";
+import StatTile from "@/components/ui/StatTile";
 import {
   formatFlightRouteLabel,
   getFlightRouteAccuracyNotice,
@@ -258,7 +259,8 @@ function FlightTelemetryGrid({
     <div className="px-[var(--airport-sidebar-inset)] pt-3.5">
       <div className="overflow-hidden rounded-[var(--atc-radius-panel)] border border-[var(--app-frost-border)] bg-[var(--atc-control-surface-muted)] shadow-[var(--atc-control-inset-shadow-subtle)]">
         <div className="grid grid-cols-2">
-          <TelemetryPrimary
+          <StatTile
+            size="lg"
             label={t("metrics.speed")}
             active={activeMetric === "speed"}
             onClick={() => toggle("speed")}
@@ -273,8 +275,8 @@ function FlightTelemetryGrid({
               )
             }
           />
-          <TelemetryPrimary
-            divider
+          <StatTile
+            size="lg"
             label={t("metrics.altitude")}
             active={activeMetric === "altitude"}
             onClick={() => toggle("altitude")}
@@ -282,7 +284,7 @@ function FlightTelemetryGrid({
           />
         </div>
         <div className="flex border-t border-[var(--app-frost-border)]">
-          <TelemetryAux
+          <StatTile
             label={t("metrics.verticalSpeed")}
             active={activeMetric === "vs"}
             onClick={() => toggle("vs")}
@@ -298,15 +300,13 @@ function FlightTelemetryGrid({
               )
             }
           />
-          <TelemetryAux
-            divider
+          <StatTile
             label={t("metrics.track")}
             active={activeMetric === "track"}
             onClick={() => toggle("track")}
             value={trackValue}
           />
-          <TelemetryAux
-            divider
+          <StatTile
             label={t("metrics.flightPhase")}
             active={activeMetric === "status"}
             onClick={() => toggle("status")}
@@ -315,43 +315,6 @@ function FlightTelemetryGrid({
         </div>
       </div>
     </div>
-  );
-}
-
-const TELEMETRY_ACTIVE_CLASS =
-  "data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_2px_0_0_var(--atc-signal-accent)]";
-
-function TelemetryPrimary({ label, value, active, onClick, divider = false }: FlightSidebarRecord) {
-  return (
-    <button
-      type="button"
-      aria-pressed={active}
-      data-active={active ? "true" : undefined}
-      onClick={onClick}
-      className={`px-[15px] pb-[13px] pt-[13px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] ${TELEMETRY_ACTIVE_CLASS} ${divider ? "border-l border-[var(--app-frost-border)]" : ""}`}
-    >
-      <div className="text-[calc(12px*var(--sb-body-scale))] font-medium text-atc-dim">{label}</div>
-      <div className="mt-1.5 text-[calc(26px*var(--sb-body-scale))] font-bold leading-none tracking-[-0.5px] tabular-nums text-atc-text">
-        {value}
-      </div>
-    </button>
-  );
-}
-
-function TelemetryAux({ label, value, active, onClick, divider = false }: FlightSidebarRecord) {
-  return (
-    <button
-      type="button"
-      aria-pressed={active}
-      data-active={active ? "true" : undefined}
-      onClick={onClick}
-      className={`min-w-0 flex-1 px-[13px] py-[9px] text-left transition-colors hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:shadow-[inset_0_2px_0_var(--atc-signal-accent)] ${divider ? "border-l border-[var(--app-frost-border)]" : ""}`}
-    >
-      <div className="truncate text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{label}</div>
-      <div className="mt-[3px] truncate text-[calc(15px*var(--sb-body-scale))] font-bold tabular-nums text-atc-text">
-        {value}
-      </div>
-    </button>
   );
 }
 

--- a/src/components/ui/StatTile.tsx
+++ b/src/components/ui/StatTile.tsx
@@ -1,23 +1,29 @@
 import type { ReactNode } from "react";
 
 // Presentational stat tile for the sidebar's joined "hero stats" blocks — the
-// label-over-value cell that fills the bordered footer rows under the flight
-// count (airport + here mode) and, going forward, the flight-tracking
-// telemetry grid. It is intentionally dumb: callers pass an already-formatted
-// value (NumberFlow, an em dash, plain text) plus the label/unit/prefix; the
-// per-context "what is this number" logic lives in the screen models/hooks, not
-// here.
+// label-over-value cell that fills the bordered rows under a headline metric.
+// Used by the airport / here-mode hero stats (`md`) and the flight-tracking
+// telemetry grid (`lg` for the two big speed/altitude metrics, `md` for the
+// auxiliary V/S / track / phase row). Values stay regular weight at every size —
+// hierarchy comes from size + luminance, never weight (DESIGN.md). It is
+// intentionally dumb: callers pass an
+// already-formatted value (NumberFlow, an em dash, plain text) plus the
+// label/unit/prefix; the per-context "what is this number" logic lives in the
+// screen models/hooks, not here.
 //
 // Two modes share one skin:
 //   - interactive (default, has `onClick`): a tab-like button with the orange
-//     top-rail on `active` and a hover wash — used for view switches and the
-//     here-mode km/h⇄mph speed toggle.
+//     top-rail on `active` and a hover wash — view switches, the here-mode
+//     km/h⇄mph speed toggle, and the tracking-page metric selection all use it.
 //   - readOnly: a plain cell with no hover/active affordance, so pure readouts
 //     (here-mode altitude) don't read as tappable.
 //
-// This supersedes the old ui/MetricCard tile primitive (which carried the glass
-// capsule but was never rendered); the live glass-capsule reference now lives in
-// SelectableCard / FilterCard / Toolbar.
+// One active treatment (the orange top-rail) is shared across every size so the
+// whole app reads the selected stat the same way. This supersedes the old
+// ui/MetricCard tile primitive (which carried an unused glass capsule); the live
+// glass-capsule reference now lives in SelectableCard / FilterCard / Toolbar.
+type StatTileSize = "md" | "lg";
+
 type StatTileProps = {
   label: ReactNode;
   value: ReactNode;
@@ -26,6 +32,26 @@ type StatTileProps = {
   active?: boolean;
   onClick?: () => void;
   readOnly?: boolean;
+  size?: StatTileSize;
+};
+
+const SIZE_CLASSES: Record<
+  StatTileSize,
+  { pad: string; label: string; value: string; gap: string }
+> = {
+  md: {
+    pad: "px-[11px] py-[9px]",
+    label: "text-[calc(10px*var(--sb-body-scale))] text-atc-faint",
+    value: "text-[calc(16px*var(--sb-body-scale))] font-normal tabular-nums text-atc-text",
+    gap: "mt-[3px]",
+  },
+  lg: {
+    pad: "px-[15px] py-[13px]",
+    label: "text-[calc(12px*var(--sb-body-scale))] text-atc-dim",
+    value:
+      "text-[calc(26px*var(--sb-body-scale))] font-normal leading-none tracking-[-0.5px] tabular-nums text-atc-text",
+    gap: "mt-1.5",
+  },
 };
 
 export default function StatTile({
@@ -36,11 +62,13 @@ export default function StatTile({
   active,
   onClick,
   readOnly = false,
+  size = "md",
 }: StatTileProps) {
+  const sizing = SIZE_CLASSES[size];
   const body = (
     <>
-      <div className="truncate text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{label}</div>
-      <div className="mt-[3px]">
+      <div className={`truncate ${sizing.label}`}>{label}</div>
+      <div className={sizing.gap}>
         {prefix ? (
           <span
             className="notranslate text-[calc(10px*var(--sb-body-scale))] text-atc-faint"
@@ -49,9 +77,7 @@ export default function StatTile({
             {prefix}
           </span>
         ) : null}
-        <span className="text-[calc(16px*var(--sb-body-scale))] font-normal tabular-nums text-atc-text">
-          {value}
-        </span>
+        <span className={sizing.value}>{value}</span>
         {unit ? (
           <span className="ml-0.5 text-[calc(10px*var(--sb-body-scale))] text-atc-faint">{unit}</span>
         ) : null}
@@ -63,7 +89,9 @@ export default function StatTile({
   // cell with no hover/active affordance so they don't read as tappable.
   if (readOnly) {
     return (
-      <div className="relative min-w-0 flex-1 px-[11px] py-[9px] text-left [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)]">
+      <div
+        className={`relative min-w-0 flex-1 text-left [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] ${sizing.pad}`}
+      >
         {body}
       </div>
     );
@@ -75,7 +103,7 @@ export default function StatTile({
       data-active={active ? "true" : undefined}
       onClick={onClick}
       aria-pressed={active}
-      className="relative min-w-0 flex-1 px-[11px] py-[9px] text-left transition-[background-color] duration-200 ease-out [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-[2px] before:origin-center before:scale-x-0 before:bg-[var(--atc-signal-accent)] before:transition-transform before:duration-300 before:ease-[cubic-bezier(0.34,1.3,0.64,1)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:before:scale-x-100"
+      className={`relative min-w-0 flex-1 text-left transition-[background-color] duration-200 ease-out [&:not(:last-child)]:border-r [&:not(:last-child)]:border-[var(--app-frost-border)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-[2px] before:origin-center before:scale-x-0 before:bg-[var(--atc-signal-accent)] before:transition-transform before:duration-300 before:ease-[cubic-bezier(0.34,1.3,0.64,1)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:before:scale-x-100 ${sizing.pad}`}
     >
       {body}
     </button>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.7",
+    version: "v2.32.8",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -85,6 +85,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Here mode (your location, not an airport) no longer shows the departures/arrivals split — that classification needs an airport anchor, so off-airport it was always 0/0 and opened empty views. Those two cells now read out your own motion from GPS instead: ground speed and altitude. Speed is a pedestrian/driver readout — never knots — that defaults to your own metric/imperial setting (km/h or mph) and flips to the other on tap; altitude follows your altitude unit. When the device reports no speed/altitude (common indoors or while still) the cell shows an em dash.",
         zh: "Here 模式(你的位置,不是机场)不再显示起飞/到达拆分——这个分类需要机场作为锚点,离开机场时它永远是 0/0,点进去也是空视图。这两格现在改为读出你自己的 GPS 运动数据:地速与海拔。速度是给行人/驾车看的——绝不用航空的节(kt)——默认跟随你自己的米制/英制设置(km/h 或 mph),点击切换到另一种;海拔则跟随你的海拔单位。当设备没有上报速度/海拔时(室内或静止时常见),该格显示破折号。",
+      },
+      {
+        en: "The tracked-flight telemetry grid (speed / altitude / vertical speed / track / phase) now shares one stat-tile primitive with the airport and here-mode hero stats. Its numbers drop to regular weight like everywhere else in the frosted UI — hierarchy comes from size and luminance, not bold — and the selected metric now shows the same orange top-rail used across the app instead of a one-off inset bar.",
+        zh: "被追踪航班的遥测面板(速度 / 高度 / 升降率 / 航向 / 阶段)现在与机场、here 模式的 hero 统计共用同一个 stat-tile 原语。数字改为与 frosted 界面其余部分一致的常规字重——层级靠字号与明度,而非加粗——选中的指标也改用全 app 统一的橙色顶条,取代原先一次性的 inset 边条。",
       },
     ],
   },


### PR DESCRIPTION
**Draft — pending visual sign-off (intentional visual change, not pixel-identical).**

## What
Migrates the aircraft tracking page's `FlightTelemetryGrid` onto the shared `StatTile` primitive. `StatTile` gains one `size` variant (`lg` for the two big speed/altitude metrics, `md` for the V/S / track / phase aux row); the active indicator unifies to the app-wide **orange top-rail**.

## Intentional visual deltas (vs main)
1. Active indicator: inset-left (primary) / inset-top (aux) bars → **orange top-rail** — consistent with the airport/here hero stats and every other stat tile.
2. Aux value: 15px **bold** → 16px **regular** — one weight/scale across tiles.
3. Aux horizontal padding 13px → 11px.

The 26px speed/altitude hero hierarchy is preserved (`lg` variant). Deletes the now-dead `TelemetryPrimary` / `TelemetryAux` / `TELEMETRY_ACTIVE_CLASS`.

## Perf
No regression: `StatTile` has **no backdrop-filter** (unlike the retired glass capsule), same `NumberFlow` usage, and swaps an inset box-shadow for a transform-animated top-rail that only animates on metric selection.

## Validation
`tsc --noEmit` no new errors; `pnpm test` (122 files) passes. **Visual sign-off pending** before un-drafting + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)