### PR TITLE
perf(map): cache motion viewport bounds per frame (stop layout thrashing)

### DIFF
--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -43,17 +43,36 @@ function resolveAircraftLatLng(latValue, lonValue) {
   return Number.isFinite(lat) && Number.isFinite(lon) ? { lat, lon } : null;
 }
 
-function resolveMotionBounds(map) {
+// The padded viewport bounds are identical for every marker within a single
+// animation frame, but computing them reads the map (getBounds) and the
+// container `clientWidth` — a forced layout. Doing that per-marker interleaves
+// reads with each marker's setLatLng write, so the browser re-runs layout for
+// every aircraft: classic thrashing (~N forced reflows per frame on a busy
+// map). Cache by frame key — the shared `now` the motion-frame loop hands every
+// marker that frame — so the read happens once, before the batch of writes.
+let cachedBoundsMap: any = null;
+let cachedBoundsFrameKey = Number.NaN;
+let cachedBounds: any = null;
+
+function resolveMotionBounds(map, frameKey: number) {
+  if (map === cachedBoundsMap && Object.is(frameKey, cachedBoundsFrameKey)) {
+    return cachedBounds;
+  }
   const bounds = safeGetMapBounds(map, {
     label: "AircraftPosition",
     logger: silentLeafletLogger,
   });
-  if (!bounds) return null;
-  const width = Number(map?.getContainer?.()?.clientWidth);
-  const padRatio = Number.isFinite(width) && width <= MOBILE_VIEWPORT_WIDTH_PX
-    ? 0.06
-    : 0.18;
-  return typeof bounds.pad === "function" ? bounds.pad(padRatio) : bounds;
+  let padded = null;
+  if (bounds) {
+    const width = Number(map?.getContainer?.()?.clientWidth);
+    const padRatio =
+      Number.isFinite(width) && width <= MOBILE_VIEWPORT_WIDTH_PX ? 0.06 : 0.18;
+    padded = typeof bounds.pad === "function" ? bounds.pad(padRatio) : bounds;
+  }
+  cachedBoundsMap = map;
+  cachedBoundsFrameKey = frameKey;
+  cachedBounds = padded;
+  return padded;
 }
 
 function positionInBounds(bounds, position) {
@@ -106,7 +125,7 @@ function AircraftPosition({
   });
   const shouldAnimateInCurrentViewport = useCallback((motion, now) => {
     if (!map || !shouldAnimateAircraftVisualPosition(motion, now)) return false;
-    const bounds = resolveMotionBounds(map);
+    const bounds = resolveMotionBounds(map, now);
     if (!bounds) return true;
 
     const visual = calculateAircraftVisualPosition(motion, now);


### PR DESCRIPTION
## Bottleneck (foreground, found via the new `?perf=1` probe)
The 60fps aircraft motion loop is the dominant main-thread cost on a busy map — ~90 markers/frame. The probe (motion ms/f) plus a code read pinned the cause: per marker, per frame, `resolveMotionBounds(map)` reads `map.getBounds()` **and** the container `clientWidth` (a forced layout), and then `marker.setLatLng()` **writes** (dirties layout). Interleaving read→write per marker forces the browser to re-run layout for every aircraft — classic thrashing, ~N forced reflows/frame (5000+/s at 60fps on KLAX).

## Fix
The padded bounds are identical for every marker within one frame. Cache them by frame key — the shared `now` the motion-frame loop passes every marker that frame — so the read happens **once per frame, before** the batch of `setLatLng` writes. No interleaved read-after-write.

Marker positions are byte-identical; this is a pure thrashing fix, so the inferred/extrapolated-position path and visuals are unchanged.

## Coordination / no version bump
A concurrent session is shipping the here-mode/StatTile work (v2.32.5–.7) and we share a working dir, so this PR **deliberately skips the package.json/changelog bump** to avoid colliding on the rolling version. It's a pure internal optimization (no product-visible behavior change). Developed in an isolated `git worktree` off `origin/main` so it never touched the other session's checkout.

Validation: local — `pnpm test` (122 files pass); preview on live KLAX (94 markers) confirmed markers still render/animate correctly and `motion ms/frame` trended down. Headless preview throttles paint, so it understates the reflow win; real foreground gain is larger — read it with `?perf=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)