### PR TITLE
ux(sidebar): select an aircraft in place instead of pinning to the header

### DIFF
--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -46,7 +46,6 @@ import {
 import { formatFlightRouteMunicipalityLabel } from "../../utils/flightRouteDisplay";
 import { getDistanceNm } from "../../utils/aircraftTrafficIntent";
 import AircraftList from "./AircraftList";
-import AircraftSlot from "./AircraftSlot";
 import AirportSlot from "./AirportSlot";
 import VirtualNearbyList from "./VirtualNearbyList";
 
@@ -164,26 +163,10 @@ export default function AircraftTable({
     [filteredAirports],
   );
   const endpointAirportRows = hasRouteEndpointAirports ? filteredAirports : [];
-  // Pinned aircraft sits above the scrolling list and stays visible even
-  // when filters would otherwise exclude it. Look in the full nearby set,
-  // not the filtered rows, so a user can keep watching a selection without
-  // losing it to a stray filter toggle.
-  const pinnedAircraft = useMemo(() => {
-    if (!selectedAircraftId) return null;
-    return (
-      aircraftWithDist.find(
-        (item) => getAircraftIdentity(item) === selectedAircraftId,
-      ) ||
-      null
-    );
-  }, [aircraftWithDist, selectedAircraftId]);
-  // Don't duplicate the pinned aircraft inside the scroll list.
-  const listRows = useMemo(() => {
-    if (!pinnedAircraft) return filteredAircraft;
-    return filteredAircraft.filter(
-      (item) => getAircraftIdentity(item) !== selectedAircraftId,
-    );
-  }, [pinnedAircraft, filteredAircraft, selectedAircraftId]);
+  // Selecting an aircraft highlights its row in place (data-selected styling).
+  // It is no longer hoisted into a pinned header slot — that reorder cost a
+  // list reflow on every selection, and the in-place focus reads clearly enough.
+  const listRows = filteredAircraft;
   const combinedRows = useMemo(() => {
     const out = [];
     for (const aircraftItem of listRows) {
@@ -237,10 +220,7 @@ export default function AircraftTable({
   });
 
   return (
-    <div
-      data-has-pinned-aircraft={pinnedAircraft ? "true" : undefined}
-      className="aircraft-table-shell flex flex-col"
-    >
+    <div className="aircraft-table-shell flex flex-col">
       <div className="aircraft-table-controls flex-none">
         <div className="flex items-baseline justify-between px-[var(--airport-sidebar-inset)] pb-1.5 pt-4">
           <span className="atc-kicker atc-kicker--lead">
@@ -333,17 +313,6 @@ export default function AircraftTable({
       </div>
 
       <div className="aircraft-table-list-card flex flex-col">
-        {pinnedAircraft && (
-          <div className="aircraft-table-pin">
-            <AircraftSlot
-              aircraft={pinnedAircraft}
-              cascadeOrder={0}
-              flipStaggerStep={0}
-              selectedAircraftId={selectedAircraftId}
-              onSelectAircraft={onSelectAircraft}
-            />
-          </div>
-        )}
         {endpointAirportRows.length > 0 ? (
           <ul>
             {endpointAirportRows.map((airport, index) => (
@@ -364,9 +333,7 @@ export default function AircraftTable({
         ) : null}
 
         <div className="aircraft-table-scroll-shell overflow-visible">
-          {listRows.length === 0 &&
-          filteredAirports.length === 0 &&
-          !pinnedAircraft ? (
+          {listRows.length === 0 && filteredAirports.length === 0 ? (
             <div className="app-panel-transition px-[var(--airport-sidebar-inset)] py-6 text-center text-[calc(10px*var(--sb-body-scale))] font-semibold uppercase tracking-normal text-atc-faint">
               {aircraft.length + airports.length
                 ? t("sidebar.noMatches")


### PR DESCRIPTION
Per the user's call (they asked to confirm interaction-simplifying changes first, and chose this): selecting an aircraft no longer pins it to the list header.

## Before
Selecting an aircraft hoisted it out of the scroll list into a pinned `.aircraft-table-pin` slot above the list (filtered out of `listRows`, re-rendered on top). That reorder cost a **list reflow on every selection**, and kept the selection visible even when scrolled/filtered away.

## After
The selected aircraft stays in the list; its row highlights **in place** via the existing `data-selected` styling — `VirtualNearbyList` already marks the matching row selected → `AircraftRow` sets `data-selected="true"` → the frosted selected-row style applies. No reorder, no reflow on selection.

Tradeoff (user-accepted): a selected aircraft scrolled or filtered out of view is no longer force-pinned.

Removes `pinnedAircraft`, the pin slot, the `data-has-pinned-aircraft` attribute, and the now-unused `AircraftSlot` import. The `.aircraft-table-pin` CSS is now dead but **left in place** (its selectors match nothing) to keep this diff off the shared, concurrently-edited `style.css`; a follow-up will remove it.

## Coordination
Developed in an isolated `git worktree` off `origin/main` (a concurrent session holds the shared dir on its StatTile branch). Touches only `AircraftTable.tsx`. **No version bump** to avoid colliding with that session's here-mode/StatTile versioning on the rolling changelog.

Validation: relies on Railway CI build (the isolated worktree has no node_modules and the shared dev server is on the other session's branch, so local test/browser verification wasn't available here). The change is a pure simplification with verified selected-row wiring; please eyeball the in-place focus once it's on a deployed/main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)