### PR TITLE
refactor(sidebar): extract sidebar hero-stats into a pure, tested model

### DIFF
--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -3,16 +3,11 @@ import NumberFlow from "@number-flow/react";
 import StatTile from "@/components/ui/StatTile";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
-import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel";
-import { ARRIVAL, DEPARTURE } from "@/utils/aircraftMovement";
 import {
-  convertTemperatureFromC,
-  defaultGroundSpeedUnit,
-  formatAltitudeFromMeters,
-  formatGroundSpeed,
-  temperatureUnitLabel,
-  type GroundSpeedUnit,
-} from "@/utils/units";
+  buildSidebarStats,
+  type SidebarStat,
+} from "@/features/airport/explorer/sidebarStatsModel";
+import { defaultGroundSpeedUnit, type GroundSpeedUnit } from "@/utils/units";
 
 // Frosted "hero stats block": one joined rounded glass container with a big
 // headline metric (nearby flights) over a row of small footer cells
@@ -44,121 +39,84 @@ export default function SidebarViewSwitch({
   const [speedUnitOverride, setSpeedUnitOverride] =
     useState<GroundSpeedUnit | null>(null);
   const groundSpeedUnit = speedUnitOverride ?? defaultGroundSpeedUnit(units);
-  const temperature = metarLoading
-    ? { value: "—", unit: temperatureUnitLabel(units.temperature) }
-    : formatTemperature(metar, units.temperature);
-  const temperatureUnit = temperature.value === "—" ? undefined : temperature.unit;
-  // In here mode the user's position is not an airport, so departure/arrival
-  // classification is meaningless (everything resolves to UNKNOWN). The movement
-  // row is replaced by the user's own GPS speed/altitude readouts instead.
-  const showMovementCards =
-    !nearMe && featureFlagsResolved && routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
   const atcCount = Array.isArray(frequencies) ? frequencies.length : 0;
   const spottingCount = Number(candidateSpotCount) || 0;
-  const showAtcCard = atcCount > 0;
 
-  const { departureCount, arrivalCount } = useMemo(() => {
-    if (routeProvider !== ROUTE_PROVIDER.FLIGHTAWARE) {
-      return { departureCount: 0, arrivalCount: 0 };
+  // The footer's product rules — which cells show, what they read, and how they
+  // behave (here mode swaps departures/arrivals for the user's own GPS
+  // speed/altitude, the movement row only exists on FlightAware, ATC only when
+  // there are frequencies) — live in a pure, tested model. This component only
+  // maps each descriptor to a <StatTile>.
+  const stats = useMemo(
+    () =>
+      buildSidebarStats({
+        nearMe,
+        routeProvider,
+        featureFlagsResolved,
+        aircraft,
+        selfSpeedMps: nearMeSelfSpeedMps,
+        selfAltitudeMeters: nearMeSelfAltitudeMeters,
+        groundSpeedUnit,
+        metar,
+        metarLoading,
+        units,
+        atcCount,
+        spottingCount,
+      }),
+    [
+      nearMe,
+      routeProvider,
+      featureFlagsResolved,
+      aircraft,
+      nearMeSelfSpeedMps,
+      nearMeSelfAltitudeMeters,
+      groundSpeedUnit,
+      metar,
+      metarLoading,
+      units,
+      atcCount,
+      spottingCount,
+    ],
+  );
+
+  const renderStat = (stat: SidebarStat) => {
+    const { id, labelKey, value, display, unit, prefix, interaction } = stat;
+    let active: boolean | undefined;
+    let onClick: (() => void) | undefined;
+    let readOnly = false;
+    if (interaction.kind === "view") {
+      active = activeView === interaction.view;
+      onClick = () => onViewChange?.(interaction.view);
+    } else if (interaction.kind === "spotting") {
+      active = activeView === "spotting";
+      onClick = onOpenSpotting;
+    } else if (interaction.kind === "groundSpeedToggle") {
+      onClick = () =>
+        setSpeedUnitOverride(groundSpeedUnit === "kmh" ? "mph" : "kmh");
+    } else {
+      readOnly = true;
     }
-    let dep = 0;
-    let arr = 0;
-    for (const item of aircraft) {
-      if (item?.movement === DEPARTURE) dep += 1;
-      else if (item?.movement === ARRIVAL) arr += 1;
-    }
-    return { departureCount: dep, arrivalCount: arr };
-  }, [aircraft, routeProvider]);
-
-  // Here mode centers on the user, not an airport, so the movement row reads
-  // out the user's OWN motion from GPS: ground speed (defaults to the user's
-  // metric/imperial system — km/h or mph — tap to flip) and altitude (following
-  // the altitude preference, kept ground-relative so it never reads as a flight
-  // level). Null — the common indoor/stationary case where the device reports
-  // no speed/altitude — shows an em dash.
-  const selfSpeedDisplay = nearMe
-    ? formatGroundSpeed(nearMeSelfSpeedMps, groundSpeedUnit)
-    : null;
-  const selfAltitudeDisplay = nearMe
-    ? formatAltitudeFromMeters(nearMeSelfAltitudeMeters, units.altitude, {
-        kind: "ground",
-      })
-    : null;
-
-  // Footer stacks into rows under the flight-count hero: first the movement
-  // row (departures / arrivals) as the direct breakdown of the count, then
-  // the context row (weather / ATC / spotting). Each conditional cell simply
-  // drops out of its row when absent. In here mode the movement row carries the
-  // user's own speed/altitude instead: speed is a tap target that toggles its
-  // unit (km/h ⇄ mph), altitude is a static readOnly cell.
-  const movementCells = [];
-  if (showMovementCards) {
-    movementCells.push({
-      key: "departures",
-      label: t("sidebar.departures"),
-      value: <NumberFlow value={departureCount} />,
-      active: activeView === "departures",
-      onClick: () => onViewChange?.("departures"),
-    });
-    movementCells.push({
-      key: "arrivals",
-      label: t("sidebar.arrivals"),
-      value: <NumberFlow value={arrivalCount} />,
-      active: activeView === "arrivals",
-      onClick: () => onViewChange?.("arrivals"),
-    });
-  } else if (nearMe) {
-    // Speed is a tap target (km/h ⇄ mph); altitude is a plain readout.
-    movementCells.push({
-      key: "selfSpeed",
-      label: t("sidebar.speed"),
-      value: selfSpeedDisplay ? (
-        <NumberFlow value={selfSpeedDisplay.value} />
-      ) : (
+    const rendered =
+      value == null ? (
         "—"
-      ),
-      unit: selfSpeedDisplay?.unit || undefined,
-      onClick: () =>
-        setSpeedUnitOverride(groundSpeedUnit === "kmh" ? "mph" : "kmh"),
-    });
-    movementCells.push({
-      key: "selfAltitude",
-      label: t("sidebar.altitude"),
-      value: selfAltitudeDisplay ? (
-        <NumberFlow value={selfAltitudeDisplay.value} />
+      ) : display === "numberFlow" ? (
+        <NumberFlow value={value as number} />
       ) : (
-        "—"
-      ),
-      unit: selfAltitudeDisplay?.unit || undefined,
-      prefix: selfAltitudeDisplay?.prefix,
-      readOnly: true,
-    });
-  }
-  const restCells = [];
-  restCells.push({
-    key: "briefing",
-    label: t("sidebar.weather"),
-    value: temperature.value,
-    unit: temperatureUnit,
-    active: activeView === "briefing",
-    onClick: () => onViewChange?.("briefing"),
-  });
-  if (showAtcCard) {
-    restCells.push({
-      key: "atc",
-      label: t("sidebar.atc"),
-      value: <NumberFlow value={atcCount} />,
-      active: activeView === "atc",
-      onClick: () => onViewChange?.("atc"),
-    });
-  }
-  restCells.push({
-    key: "spotting",
-    label: t("sidebar.spotting"),
-    value: <NumberFlow value={spottingCount} />,
-    active: activeView === "spotting",
-    onClick: onOpenSpotting,
-  });
+        value
+      );
+    return (
+      <StatTile
+        key={id}
+        label={t(labelKey)}
+        value={rendered}
+        unit={unit || undefined}
+        prefix={prefix}
+        active={active}
+        onClick={onClick}
+        readOnly={readOnly}
+      />
+    );
+  };
 
   const headlineLabel = nearMe ? t("sidebar.nearby") : t("sidebar.flights");
   // The flight-count is the hero only on the traffic view. On the other
@@ -207,26 +165,15 @@ export default function SidebarViewSwitch({
             </span>
           </div>
         </button>
-        {movementCells.length > 0 ? (
+        {stats.movementRow.length > 0 ? (
           <div className="flex border-t border-[var(--app-frost-border)]">
-            {movementCells.map(({ key, ...cell }) => (
-              <StatTile key={key} {...cell} />
-            ))}
+            {stats.movementRow.map(renderStat)}
           </div>
         ) : null}
         <div className="flex border-t border-[var(--app-frost-border)]">
-          {restCells.map(({ key, ...cell }) => (
-            <StatTile key={key} {...cell} />
-          ))}
+          {stats.contextRow.map(renderStat)}
         </div>
       </div>
     </div>
   );
-}
-
-function formatTemperature(metar, unit) {
-  const temp = Number(metar?.rawTemp);
-  const label = temperatureUnitLabel(unit);
-  if (!Number.isFinite(temp)) return { value: "—", unit: label };
-  return { value: Math.round(convertTemperatureFromC(temp, unit)), unit: label };
 }

--- a/src/features/airport/explorer/sidebarStatsModel.test.ts
+++ b/src/features/airport/explorer/sidebarStatsModel.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import {
+  buildSidebarStats,
+  countAircraftMovements,
+  type BuildSidebarStatsInput,
+} from "./sidebarStatsModel";
+
+const baseUnits = { distance: "nm", temperature: "c", altitude: "ft" } as const;
+
+function makeInput(
+  overrides: Partial<BuildSidebarStatsInput> = {},
+): BuildSidebarStatsInput {
+  return {
+    nearMe: false,
+    routeProvider: "flightaware",
+    featureFlagsResolved: true,
+    aircraft: [],
+    selfSpeedMps: null,
+    selfAltitudeMeters: null,
+    groundSpeedUnit: "kmh",
+    metar: null,
+    metarLoading: false,
+    units: { ...baseUnits },
+    atcCount: 0,
+    spottingCount: 0,
+    ...overrides,
+  };
+}
+
+const ids = (row: { id: string }[]) => row.map((item) => item.id);
+
+// Movement counting only applies to the FlightAware provider.
+{
+  const aircraft = [
+    { movement: "DEPARTURE" },
+    { movement: "DEPARTURE" },
+    { movement: "ARRIVAL" },
+    { movement: "UNKNOWN" },
+  ];
+  assert.deepEqual(countAircraftMovements(aircraft, "flightaware"), {
+    departureCount: 2,
+    arrivalCount: 1,
+  });
+  assert.deepEqual(countAircraftMovements(aircraft, "adsbdb"), {
+    departureCount: 0,
+    arrivalCount: 0,
+  });
+}
+
+// Airport + FlightAware → departures / arrivals movement row.
+{
+  const stats = buildSidebarStats(
+    makeInput({
+      aircraft: [{ movement: "DEPARTURE" }, { movement: "ARRIVAL" }],
+    }),
+  );
+  assert.deepEqual(ids(stats.movementRow), ["departures", "arrivals"]);
+  assert.equal(stats.movementRow[0].value, 1);
+  assert.equal(stats.movementRow[1].value, 1);
+}
+
+// Non-FlightAware provider → no movement row at all.
+{
+  const stats = buildSidebarStats(makeInput({ routeProvider: "adsbdb" }));
+  assert.deepEqual(stats.movementRow, []);
+}
+
+// FlightAware grant not resolved → no movement row.
+{
+  const stats = buildSidebarStats(makeInput({ featureFlagsResolved: false }));
+  assert.deepEqual(stats.movementRow, []);
+}
+
+// Here mode → the movement row is the user's OWN speed/altitude, never
+// departures/arrivals (the off-airport 0/0 bug this guards). Speed toggles its
+// unit; altitude is a static readout.
+{
+  const stats = buildSidebarStats(
+    makeInput({
+      nearMe: true,
+      aircraft: [{ movement: "DEPARTURE" }],
+      selfSpeedMps: 10,
+      selfAltitudeMeters: 304.8,
+    }),
+  );
+  assert.deepEqual(ids(stats.movementRow), ["selfSpeed", "selfAltitude"]);
+  assert.equal(stats.movementRow[0].interaction.kind, "groundSpeedToggle");
+  assert.equal(stats.movementRow[1].interaction.kind, "readonly");
+  // 10 m/s = 36 km/h by default; ~304.8 m ≈ 1000 ft.
+  assert.equal(stats.movementRow[0].value, 36);
+  assert.equal(stats.movementRow[0].unit, "km/h");
+  assert.equal(stats.movementRow[1].value, 1000);
+}
+
+// Here mode speed follows the toggle unit, and a missing GPS fix collapses to
+// null (rendered as an em dash).
+{
+  const mph = buildSidebarStats(
+    makeInput({ nearMe: true, selfSpeedMps: 10, groundSpeedUnit: "mph" }),
+  );
+  assert.equal(mph.movementRow[0].value, 22);
+  assert.equal(mph.movementRow[0].unit, "mph");
+
+  const noFix = buildSidebarStats(
+    makeInput({ nearMe: true, selfSpeedMps: null, selfAltitudeMeters: null }),
+  );
+  assert.equal(noFix.movementRow[0].value, null);
+  assert.equal(noFix.movementRow[1].value, null);
+}
+
+// Context row: briefing always present; ATC only with frequencies; spotting
+// always present and routed to the dedicated open handler.
+{
+  const noAtc = buildSidebarStats(makeInput());
+  assert.deepEqual(ids(noAtc.contextRow), ["briefing", "spotting"]);
+
+  const withAtc = buildSidebarStats(makeInput({ atcCount: 3 }));
+  assert.deepEqual(ids(withAtc.contextRow), ["briefing", "atc", "spotting"]);
+  const spotting = withAtc.contextRow.find((item) => item.id === "spotting");
+  assert.equal(spotting?.interaction.kind, "spotting");
+}
+
+// Briefing temperature comes from the METAR raw temp; loading shows an em dash
+// with no unit.
+{
+  const warm = buildSidebarStats(makeInput({ metar: { rawTemp: 21.4 } }));
+  const briefing = warm.contextRow[0];
+  assert.equal(briefing.value, 21);
+  assert.equal(briefing.unit, "°C");
+
+  const loading = buildSidebarStats(makeInput({ metarLoading: true }));
+  assert.equal(loading.contextRow[0].value, "—");
+  assert.equal(loading.contextRow[0].unit, undefined);
+}
+
+console.log("sidebarStatsModel.test.ts ok");

--- a/src/features/airport/explorer/sidebarStatsModel.ts
+++ b/src/features/airport/explorer/sidebarStatsModel.ts
@@ -1,0 +1,187 @@
+import type { UnitPreferences } from "@/features/app-shell/unitPreferences/unitPreferencesModel";
+import { ROUTE_PROVIDER } from "@/features/aviation/sourceDisplayModel";
+import { ARRIVAL, DEPARTURE } from "@/utils/aircraftMovement";
+import {
+  convertTemperatureFromC,
+  formatAltitudeFromMeters,
+  formatGroundSpeed,
+  temperatureUnitLabel,
+  type GroundSpeedUnit,
+} from "@/utils/units";
+
+// Pure view-model for the sidebar's joined hero-stats footer. It owns the
+// product rules — which cells show, what they read, and how they behave — so
+// they can be tested without rendering: here mode swaps departures/arrivals for
+// the user's own GPS speed/altitude (the off-airport classification is always
+// 0/0, the bug this guards), the movement row only exists on the FlightAware
+// route provider, ATC only appears when there are frequencies, etc. The
+// component stays dumb: it maps each item to a <StatTile>, resolving the i18n
+// label, NumberFlow wrapping, and click handler from these descriptors.
+
+export type SidebarStatInteraction =
+  // A view switch (active when activeView === view); the component wires it to
+  // onViewChange.
+  | { kind: "view"; view: string }
+  // The spotting cell switches view but runs a dedicated open handler.
+  | { kind: "spotting" }
+  // The here-mode speed cell toggles its km/h ⇄ mph unit.
+  | { kind: "groundSpeedToggle" }
+  // A static readout (here-mode altitude) — no hover/active affordance.
+  | { kind: "readonly" };
+
+export type SidebarStat = {
+  id: string;
+  labelKey: string;
+  // Already-resolved display value. `null` renders as an em dash (no GPS fix);
+  // a number renders through NumberFlow when `display` is "numberFlow".
+  value: number | string | null;
+  display: "numberFlow" | "text";
+  unit?: string;
+  prefix?: string;
+  interaction: SidebarStatInteraction;
+};
+
+export type SidebarStats = {
+  movementRow: SidebarStat[];
+  contextRow: SidebarStat[];
+};
+
+export type BuildSidebarStatsInput = {
+  nearMe: boolean;
+  routeProvider: string;
+  featureFlagsResolved: boolean;
+  aircraft: Array<{ movement?: string }>;
+  selfSpeedMps: number | null;
+  selfAltitudeMeters: number | null;
+  groundSpeedUnit: GroundSpeedUnit;
+  metar: { rawTemp?: unknown } | null;
+  metarLoading: boolean;
+  units: UnitPreferences;
+  atcCount: number;
+  spottingCount: number;
+};
+
+export function countAircraftMovements(
+  aircraft: Array<{ movement?: string }>,
+  routeProvider: string,
+): { departureCount: number; arrivalCount: number } {
+  if (routeProvider !== ROUTE_PROVIDER.FLIGHTAWARE) {
+    return { departureCount: 0, arrivalCount: 0 };
+  }
+  let departureCount = 0;
+  let arrivalCount = 0;
+  for (const item of aircraft) {
+    if (item?.movement === DEPARTURE) departureCount += 1;
+    else if (item?.movement === ARRIVAL) arrivalCount += 1;
+  }
+  return { departureCount, arrivalCount };
+}
+
+function metarTemperature(
+  metar: { rawTemp?: unknown } | null,
+  unit: UnitPreferences["temperature"],
+): { value: number | string; unit: string } {
+  const label = temperatureUnitLabel(unit);
+  const temp = Number(metar?.rawTemp);
+  if (!Number.isFinite(temp)) return { value: "—", unit: label };
+  return { value: Math.round(convertTemperatureFromC(temp, unit)), unit: label };
+}
+
+export function buildSidebarStats(input: BuildSidebarStatsInput): SidebarStats {
+  const {
+    nearMe,
+    routeProvider,
+    featureFlagsResolved,
+    aircraft,
+    selfSpeedMps,
+    selfAltitudeMeters,
+    groundSpeedUnit,
+    metar,
+    metarLoading,
+    units,
+    atcCount,
+    spottingCount,
+  } = input;
+
+  const showMovement =
+    !nearMe &&
+    featureFlagsResolved &&
+    routeProvider === ROUTE_PROVIDER.FLIGHTAWARE;
+
+  const movementRow: SidebarStat[] = [];
+  if (showMovement) {
+    const { departureCount, arrivalCount } = countAircraftMovements(
+      aircraft,
+      routeProvider,
+    );
+    movementRow.push({
+      id: "departures",
+      labelKey: "sidebar.departures",
+      value: departureCount,
+      display: "numberFlow",
+      interaction: { kind: "view", view: "departures" },
+    });
+    movementRow.push({
+      id: "arrivals",
+      labelKey: "sidebar.arrivals",
+      value: arrivalCount,
+      display: "numberFlow",
+      interaction: { kind: "view", view: "arrivals" },
+    });
+  } else if (nearMe) {
+    const speed = formatGroundSpeed(selfSpeedMps, groundSpeedUnit);
+    const altitude = formatAltitudeFromMeters(selfAltitudeMeters, units.altitude, {
+      kind: "ground",
+    });
+    movementRow.push({
+      id: "selfSpeed",
+      labelKey: "sidebar.speed",
+      value: speed ? speed.value : null,
+      display: "numberFlow",
+      unit: speed?.unit,
+      interaction: { kind: "groundSpeedToggle" },
+    });
+    movementRow.push({
+      id: "selfAltitude",
+      labelKey: "sidebar.altitude",
+      value: altitude ? altitude.value : null,
+      display: "numberFlow",
+      unit: altitude?.unit,
+      prefix: altitude?.prefix,
+      interaction: { kind: "readonly" },
+    });
+  }
+
+  const temperature = metarLoading
+    ? { value: "—" as const, unit: temperatureUnitLabel(units.temperature) }
+    : metarTemperature(metar, units.temperature);
+
+  const contextRow: SidebarStat[] = [
+    {
+      id: "briefing",
+      labelKey: "sidebar.weather",
+      value: temperature.value,
+      display: "text",
+      unit: temperature.value === "—" ? undefined : temperature.unit,
+      interaction: { kind: "view", view: "briefing" },
+    },
+  ];
+  if (atcCount > 0) {
+    contextRow.push({
+      id: "atc",
+      labelKey: "sidebar.atc",
+      value: atcCount,
+      display: "numberFlow",
+      interaction: { kind: "view", view: "atc" },
+    });
+  }
+  contextRow.push({
+    id: "spotting",
+    labelKey: "sidebar.spotting",
+    value: spottingCount,
+    display: "numberFlow",
+    interaction: { kind: "spotting" },
+  });
+
+  return { movementRow, contextRow };
+}


### PR DESCRIPTION
## What
Moves the sidebar hero-stats footer's product rules — which cells show, what they read, how they behave — out of `SidebarViewSwitch` into a pure `buildSidebarStats()` model (`src/features/airport/explorer/sidebarStatsModel.ts`). The component is now a thin mapper: descriptor → `<StatTile>`, resolving the i18n label, NumberFlow wrapping, and click handler.

This is the 'data side' of the StatTile direction: **hooks/models produce the values, StatTile renders them.** The component no longer owns the branching.

## Why it's worth it
The rules are now testable without rendering. The new test locks down the exact bug class that kicked off this work: **in here mode the movement row must be the user's own GPS speed/altitude, never departures/arrivals** (which are always 0/0 off-airport). It also covers FlightAware gating, ATC-only-with-frequencies, the km/h⇄mph default, and no-GPS-fix em dashes.

## Validation
Display-neutral — the rendered `StatTile` props are identical to before (verified prop-by-prop). `pnpm test` (123 files) passes incl. the new `sidebarStatsModel` cases; `tsc --noEmit` no new errors. No version bump (refactor, no product-visible change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)