### PR TITLE
v2.32.9: Drop the sidebar's live backdrop-blur (GPU-compositor scroll jank)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.8",
+  "version": "2.32.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.8",
+    version: "v2.32.9",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -89,6 +89,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "The tracked-flight telemetry grid (speed / altitude / vertical speed / track / phase) now shares one stat-tile primitive with the airport and here-mode hero stats. Its numbers drop to regular weight like everywhere else in the frosted UI — hierarchy comes from size and luminance, not bold — and the selected metric now shows the same orange top-rail used across the app instead of a one-off inset bar.",
         zh: "被追踪航班的遥测面板(速度 / 高度 / 升降率 / 航向 / 阶段)现在与机场、here 模式的 hero 统计共用同一个 stat-tile 原语。数字改为与 frosted 界面其余部分一致的常规字重——层级靠字号与明度,而非加粗——选中的指标也改用全 app 统一的橙色顶条,取代原先一次性的 inset 边条。",
+      },
+      {
+        en: "Sidebar scroll performance: the desktop airport/flight sidebar dropped its live backdrop-filter blur for an opaque frosted tint. The sidebar IS the scroll container, so scrolling a long aircraft list under a live blur forced the GPU compositor to re-rasterize the whole panel every frame — a production trace showed ~86% of frames dropped while the main thread sat ~87% idle (the cost was entirely GPU compositing, not JS or React). The opaque tint keeps the frosted material read at zero per-frame GPU cost, so a busy airport's list scrolls smoothly again.",
+        zh: "侧栏滚动性能:桌面机场/航班侧栏去掉了实时 backdrop-filter 毛玻璃,改用不透明磨砂底色。侧栏本身就是滚动容器,长长的飞机列表在实时模糊下滚动会迫使 GPU 合成器每帧重新光栅整块面板——一段生产 trace 显示约 86% 的帧被丢弃,而主线程约 87% 时间是空闲的(成本全在 GPU 合成,不是 JS/React)。不透明磨砂保留了磨砂质感、每帧零 GPU 成本,繁忙机场的列表重新顺滑滚动。",
       },
     ],
   },

--- a/src/style.css
+++ b/src/style.css
@@ -3804,22 +3804,19 @@ body {
 .airport-map-kit .airport-desktop-sidebar .flight-sidebar-panel,
 .airport-map-kit .airport-sidebar-panel--mobile,
 .airport-map-kit .flight-sidebar-panel--mobile {
-    /* Translucent frosted glass over the now full-bleed map. A SMALL blur(8px)
-       (was 26px) keeps the live-map diffusion the user asked to see through the
-       panel, at roughly a third of the per-frame GPU cost of the old radius. */
+    /* OPAQUE frosted tint — NO backdrop-filter. This element is the sidebar
+       SCROLL container; scrolling its content under a live blur forced a full
+       re-raster + recomposite of the panel every frame. A production trace
+       pinned exactly this as the scroll jank: GPU VizCompositorThread saturated
+       + ~86% of frames dropped while the main thread sat ~87% idle. An opaque
+       tint keeps the frosted material read with zero per-frame GPU cost. */
     background:
         radial-gradient(
             120% 70% at 18% 0%,
             color-mix(in oklab, white 32%, transparent),
             transparent 46%
         ),
-        linear-gradient(
-            180deg,
-            color-mix(in oklab, var(--app-frost-tint) 94%, transparent),
-            color-mix(in oklab, var(--app-frost-tint) 98%, transparent)
-        );
-    -webkit-backdrop-filter: saturate(1.4) blur(8px);
-    backdrop-filter: saturate(1.4) blur(8px);
+        var(--app-frost-tint);
     border-right: 1px solid var(--app-frost-border);
     box-shadow:
         inset -1px 0 0 color-mix(in oklab, white 40%, transparent),
@@ -3874,15 +3871,13 @@ body {
     --atc-control-inset-shadow:
         inset 0 1px 0 color-mix(in oklab, var(--atc-text) 12%, transparent),
         inset 0 0 0 1px color-mix(in oklab, var(--atc-text) 7%, transparent);
-    /* Translucent frosted glass (dark) over the full-bleed map — small blur(8px)
-       shows the live map diffused through the deep-gray panel. */
+    /* Opaque dark frosted tint — NO backdrop-filter (see the light rule above:
+       a scrolling sidebar can't carry a live blur without GPU-compositor jank). */
     background: linear-gradient(
         180deg,
-        color-mix(in oklab, oklch(0.215 0.003 100) 92%, transparent),
-        color-mix(in oklab, oklch(0.135 0.003 100) 96%, transparent)
+        oklch(0.215 0.003 100),
+        oklch(0.135 0.003 100)
     );
-    -webkit-backdrop-filter: saturate(1.5) blur(8px);
-    backdrop-filter: saturate(1.5) blur(8px);
     border-right: 1px solid color-mix(in oklab, var(--atc-text) 9%, transparent);
     box-shadow:
         inset -1px 0 0 color-mix(in oklab, var(--atc-text) 6%, transparent),


### PR DESCRIPTION
## Root cause (from a PRODUCTION Performance trace)
Scrolling a busy airport's aircraft list dropped to ~15-20fps. A production trace pinned it to the **GPU compositor**, not JS/React:
- busiest thread = `GPU Process / VizCompositorThread`
- **~86% of frames dropped** (`DroppedFrame` 2141 / `BeginFrame` 2486)
- renderer **main thread ~87% idle** — so the bottleneck is entirely off the main thread

`.sidebar-shell` (the desktop sidebar) **is the scroll container** and carried `backdrop-filter: saturate(1.4) blur(8px)`. Scrolling its content forces the compositor to re-rasterize + recomposite the whole blurred panel every frame.

## Fix
Drop the live `backdrop-filter` on the desktop airport/flight sidebar (light + dark) and make the background an **opaque** frosted tint. It was already 94–98% `--app-frost-tint`; now 100% (no transparency). Same frosted material read, **zero per-frame GPU cost**.

Tradeoff (user-approved): the sidebar no longer shows the map blurred through it — it's an opaque frosted panel.

## Why earlier diagnoses were wrong
Dev-mode traces were dominated by React 19's per-render `console.createTask` (owner stacks) + the React DevTools profiling build (`logComponentRender`) — `createTask` alone was 25% of a dev trace. That noise made it look React-bound. LoAF's "paint" stat also only covers main-thread paint, not GPU raster/composite, so it read low. The production trace (no dev instrumentation) made the real GPU-compositing cost obvious.

Validation: local preview confirmed the sidebar renders correctly as an opaque frosted panel (light theme), layout intact. The fps win is GPU-compositing and can't be measured in the throttled headless preview — **please verify on the Railway deploy / production**: scroll the JFK list, it should be smooth now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)