### PR TITLE
v2.32.10: Rate-limit aircraft marker motion (zoom/focal-adaptive, ≤30fps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.9",
+  "version": "2.32.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -93,6 +93,26 @@ const getAircraftColor = (ac, showArrow) => {
   return AIRCRAFT_COLORS.unknown;
 };
 
+// Per-marker animation cadence. Moving every marker at the full 60fps keeps the
+// GPU compositor near saturation on a busy map (each marker is its own layer,
+// and at high DPR there's a lot to recomposite), so a sidebar scroll — which
+// also needs the compositor — tips it into dropped frames. Cap marker motion at
+// MAP_MOTION_MAX_FPS and coarsen it as you zoom out (markers barely move
+// on-screen when far), while the focal / selected "main target" keeps the full
+// 30fps so the one plane you're watching stays smooth.
+const MAP_MOTION_MAX_FPS = 30;
+const MAP_MOTION_MIN_INTERVAL_MS = 1000 / MAP_MOTION_MAX_FPS;
+
+function resolveMotionIntervalMs(map, isFocal) {
+  if (isFocal) return MAP_MOTION_MIN_INTERVAL_MS;
+  const zoom = typeof map?.getZoom === "function" ? map.getZoom() : 12;
+  let interval;
+  if (zoom >= 13) interval = 100; // near → ~10fps
+  else if (zoom >= 9) interval = 500; // mid → ~2fps
+  else interval = 1000; // far → ~1fps
+  return Math.max(MAP_MOTION_MIN_INTERVAL_MS, interval);
+}
+
 function AircraftPosition({
   aircraft,
   theme = "dark",
@@ -111,6 +131,12 @@ function AircraftPosition({
   const lastVisualPositionRef = useRef<{ lat: number; lon: number } | null>(
     null,
   );
+  const lastAppliedAtRef = useRef(0);
+  // Focal state read through a ref so applyMarkerPosition stays referentially
+  // stable — selecting an aircraft must not recreate the callback (and with it
+  // the Leaflet marker). The focal/selected plane animates at the full cap.
+  const focalRef = useRef(false);
+  focalRef.current = forceSilhouette || selected;
   const aircraftLat = aircraft?.lat;
   const aircraftLon = aircraft?.lon;
   const attitudeTrackerRef = useRef(null);
@@ -143,18 +169,30 @@ function AircraftPosition({
     if (!marker || !motion) return false;
 
     const shouldContinue = shouldAnimateInCurrentViewport(motion, now);
+    // Animated markers move at most at the zoom/focal-derived cadence (see
+    // resolveMotionIntervalMs) — the loop still wakes every frame, but the
+    // GPU-visible setLatLng is rate-limited. Settled / off-viewport markers
+    // (shouldContinue=false) skip the gate and just place once.
+    if (
+      shouldContinue &&
+      now - lastAppliedAtRef.current <
+        resolveMotionIntervalMs(map, focalRef.current)
+    ) {
+      return true;
+    }
     const pos = shouldContinue
       ? calculateAircraftVisualPosition(motion, now)
       : resolveAircraftLatLng(motion.lat, motion.lon);
     if (!pos) return false;
 
+    lastAppliedAtRef.current = now;
     const last = lastVisualPositionRef.current;
     if (!last || pos.lat !== last.lat || pos.lon !== last.lon) {
       marker.setLatLng([pos.lat, pos.lon]);
       lastVisualPositionRef.current = pos;
     }
     return shouldContinue;
-  }, [shouldAnimateInCurrentViewport]);
+  }, [shouldAnimateInCurrentViewport, map]);
   const stopMotionLoop = useCallback(() => {
     unsubscribeMotionFrameRef.current?.();
     unsubscribeMotionFrameRef.current = null;

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.9",
+    version: "v2.32.10",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -93,6 +93,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Sidebar scroll performance: the desktop airport/flight sidebar dropped its live backdrop-filter blur for an opaque frosted tint. The sidebar IS the scroll container, so scrolling a long aircraft list under a live blur forced the GPU compositor to re-rasterize the whole panel every frame — a production trace showed ~86% of frames dropped while the main thread sat ~87% idle (the cost was entirely GPU compositing, not JS or React). The opaque tint keeps the frosted material read at zero per-frame GPU cost, so a busy airport's list scrolls smoothly again.",
         zh: "侧栏滚动性能:桌面机场/航班侧栏去掉了实时 backdrop-filter 毛玻璃,改用不透明磨砂底色。侧栏本身就是滚动容器,长长的飞机列表在实时模糊下滚动会迫使 GPU 合成器每帧重新光栅整块面板——一段生产 trace 显示约 86% 的帧被丢弃,而主线程约 87% 时间是空闲的(成本全在 GPU 合成,不是 JS/React)。不透明磨砂保留了磨砂质感、每帧零 GPU 成本,繁忙机场的列表重新顺滑滚动。",
+      },
+      {
+        en: "Aircraft marker motion is now rate-limited instead of moving every animation frame. Each marker is its own composited layer, so animating a busy map at 60fps kept the GPU compositor near saturation — leaving no headroom when the sidebar also needed to composite a scroll. Markers now move at most 30fps, and slower as you zoom out (markers barely move on-screen when far: ~10fps near, ~2fps mid, ~1fps far), while the focal / selected aircraft you're tracking keeps the full 30fps. The inferred/extrapolated positions are unchanged — only how often the marker is repainted.",
+        zh: "飞机 marker 的运动现在限频,不再每个动画帧都移动。每个 marker 都是独立的合成层,满载地图 60fps 动画会把 GPU 合成器压到接近满载——侧栏要合成滚动时就没有余量了。marker 现在最高 30fps 移动,且越缩小越慢(缩到最远时几乎不动:近 ~10fps、中 ~2fps、远 ~1fps),而你正在追踪的焦点/选中飞机仍保持满 30fps。推算/外推位置本身不变——只是 marker 重绘的频率降了。",
       },
     ],
   },


### PR DESCRIPTION
## Why
A **v2.32.9 production trace** (after the backdrop-blur fix #570) showed the GPU was *still* the bottleneck: `GPU Process / CrGpuMain` was by far the busiest thread while the renderer main thread + JS stayed idle. Each aircraft marker is its own composited layer; animating ~80 of them at 60fps (display DPR ~1.8 → ~3.2× pixels) kept the compositor near saturation, so a sidebar scroll — which also needs the compositor — tipped it into dropped frames.

## Fix (per the user's spec)
Rate-limit each marker's animated move. The motion loop still wakes every frame, but the GPU-visible `setLatLng` is throttled:
- **focal / selected** aircraft (the "main target"): **30fps**
- **otherwise by zoom** — near (≥13) ~10fps, mid (≥9) ~2fps, far ~1fps (markers barely move on-screen when zoomed out)
- **never above 30fps**

Focal state is read through a ref so  stays referentially stable (selecting an aircraft must not recreate its Leaflet marker). The inferred/extrapolated-position path is unchanged — only how often the marker repaints (guardrail-safe).

Validation: local preview confirmed markers still render (59) and still animate, no errors. The GPU/fps win is compositing and can't be measured in the throttled headless preview — **please verify on the Railway deploy**: scroll the JFK list, it should hold framerate now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)