### PR TITLE
v2.32.11: Kill the per-scroll-frame forced layout (real scroll-jank cause)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.32.10",
+  "version": "2.32.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/map/AircraftPosition.tsx
+++ b/src/components/map/AircraftPosition.tsx
@@ -168,18 +168,20 @@ function AircraftPosition({
     const motion = motionRef.current;
     if (!marker || !motion) return false;
 
-    const shouldContinue = shouldAnimateInCurrentViewport(motion, now);
-    // Animated markers move at most at the zoom/focal-derived cadence (see
-    // resolveMotionIntervalMs) — the loop still wakes every frame, but the
-    // GPU-visible setLatLng is rate-limited. Settled / off-viewport markers
-    // (shouldContinue=false) skip the gate and just place once.
+    // Throttle BEFORE touching the map. shouldAnimateInCurrentViewport →
+    // resolveMotionBounds reads map.getBounds() + the container's clientWidth —
+    // a FORCED SYNCHRONOUS LAYOUT. Running that every frame interleaves with the
+    // sidebar scroll's own layout and thrashes the pipeline (low CPU/GPU yet low
+    // fps). During the zoom/focal throttle window we do ZERO per-frame layout —
+    // just keep the loop alive; viewport + position are re-evaluated only when
+    // the cadence interval elapses.
     if (
-      shouldContinue &&
       now - lastAppliedAtRef.current <
-        resolveMotionIntervalMs(map, focalRef.current)
+      resolveMotionIntervalMs(map, focalRef.current)
     ) {
       return true;
     }
+    const shouldContinue = shouldAnimateInCurrentViewport(motion, now);
     const pos = shouldContinue
       ? calculateAircraftVisualPosition(motion, now)
       : resolveAircraftLatLng(motion.lat, motion.lon);

--- a/src/components/sidebar/VirtualNearbyList.tsx
+++ b/src/components/sidebar/VirtualNearbyList.tsx
@@ -55,6 +55,14 @@ export default function VirtualNearbyList({
   const scrollRef = useSidebarScrollRef();
   const listRef = useRef<HTMLDivElement | null>(null);
   const [scrollMargin, setScrollMargin] = useState(0);
+  // Rows are a fixed height PER VIEWPORT (42px normally, ~51px where the
+  // .airport-map-kit override compresses them). Measure it ONCE (and on resize,
+  // in the same effect that tracks scrollMargin) and feed it as a fixed
+  // estimateSize — instead of attaching a per-row ResizeObserver via
+  // virtualizer.measureElement, whose getBoundingClientRect read on every
+  // scroll frame is a forced synchronous layout (a top contributor to the
+  // scroll-time pipeline stall).
+  const [rowHeight, setRowHeight] = useState(ROW_HEIGHT_ESTIMATE_PX);
 
   // How many rows of `items` are currently revealed. Reset to the first page
   // whenever the filter/selection context changes (resetSignal) so a fresh cut
@@ -82,6 +90,16 @@ export default function VirtualNearbyList({
         scrollEl.getBoundingClientRect().top +
         scrollEl.scrollTop;
       setScrollMargin((prev) => (Math.abs(prev - top) > 0.5 ? top : prev));
+      // Re-read the fixed row height from a rendered row. Rounded + compared
+      // exactly so sub-pixel noise never flips it — it only changes on a real
+      // viewport/context height change, replacing the per-row measurement.
+      const firstRow = listEl.querySelector("[data-index]");
+      const height = firstRow
+        ? Math.round(firstRow.getBoundingClientRect().height)
+        : 0;
+      if (height > 0) {
+        setRowHeight((prev) => (prev !== height ? height : prev));
+      }
     };
     measure();
     const schedule = () => {
@@ -120,7 +138,7 @@ export default function VirtualNearbyList({
   const virtualizer = useVirtualizer({
     count: visibleItems.length,
     getScrollElement: () => scrollRef?.current ?? null,
-    estimateSize: () => ROW_HEIGHT_ESTIMATE_PX,
+    estimateSize: () => rowHeight,
     overscan: OVERSCAN_ROWS,
     // Key by POSITION, not identity: a slot stays put at its index and its
     // occupant changes when the list re-sorts (see CardFlipSlot), so rows never
@@ -173,7 +191,7 @@ export default function VirtualNearbyList({
   // a full re-measure on every click was pure layout thrash.
   useEffect(() => {
     virtualizer.measure();
-  }, [visibleItems.length, resetSignal, virtualizer]);
+  }, [visibleItems.length, resetSignal, rowHeight, virtualizer]);
 
   const virtualRows = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
@@ -210,7 +228,6 @@ export default function VirtualNearbyList({
               : item.data?.icao === selectedAirportIcao;
           return (
             <NearbyVirtualRow
-              ref={virtualizer.measureElement}
               key={virtualRow.index}
               index={virtualRow.index}
               start={virtualRow.start - scrollMargin}
@@ -228,7 +245,6 @@ export default function VirtualNearbyList({
 }
 
 const NearbyVirtualRow = memo(function NearbyVirtualRow({
-  ref,
   index,
   start,
   shouldAnimateEnter,
@@ -264,7 +280,6 @@ const NearbyVirtualRow = memo(function NearbyVirtualRow({
   // card from 64px down to 51px.
   return (
     <div
-      ref={ref}
       data-index={index}
       className="absolute left-0 top-0 w-full"
       style={{

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 56;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.32.10",
+    version: "v2.32.11",
     kind: "feat",
     title: {
       en: "Animated flight-rule glyph in the weather briefing",
@@ -97,6 +97,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Aircraft marker motion is now rate-limited instead of moving every animation frame. Each marker is its own composited layer, so animating a busy map at 60fps kept the GPU compositor near saturation — leaving no headroom when the sidebar also needed to composite a scroll. Markers now move at most 30fps, and slower as you zoom out (markers barely move on-screen when far: ~10fps near, ~2fps mid, ~1fps far), while the focal / selected aircraft you're tracking keeps the full 30fps. The inferred/extrapolated positions are unchanged — only how often the marker is repainted.",
         zh: "飞机 marker 的运动现在限频,不再每个动画帧都移动。每个 marker 都是独立的合成层,满载地图 60fps 动画会把 GPU 合成器压到接近满载——侧栏要合成滚动时就没有余量了。marker 现在最高 30fps 移动,且越缩小越慢(缩到最远时几乎不动:近 ~10fps、中 ~2fps、远 ~1fps),而你正在追踪的焦点/选中飞机仍保持满 30fps。推算/外推位置本身不变——只是 marker 重绘的频率降了。",
+      },
+      {
+        en: "Sidebar scroll, take two: a production trace showed the real cost wasn't CPU or GPU (both mostly idle) but a stalled render pipeline — forced synchronous layout (reading clientWidth / getBoundingClientRect every scroll frame) thrashing against the scroll. Two sources were removed: the aircraft motion loop now rate-limits BEFORE reading the map bounds (so a throttled frame does zero layout), and the nearby list virtualizes at a measured fixed row height instead of attaching a per-row ResizeObserver that re-measured on every scroll frame.",
+        zh: "侧栏滚动第二弹:一段生产 trace 显示真正的成本既不在 CPU 也不在 GPU(两者大都空闲),而是渲染流水线被卡住——每个滚动帧都在读 clientWidth / getBoundingClientRect(强制同步布局),与滚动相互踩踏。移除了两个来源:飞机运动循环现在在读取地图 bounds **之前**就限频(被限的帧零布局开销),附近列表改用测得的定长行高做虚拟化,不再为每行挂一个会在每个滚动帧重新测量的 ResizeObserver。",
       },
     ],
   },


### PR DESCRIPTION
## The real cause (v2.32.10 production trace)
Neither CPU nor GPU was saturated — renderer main thread ~80% idle, the GPU's actual GPUTask only ~0.4s (my earlier "CrGpuMain ~18s busy" was a generic RunTask-container artifact) — yet only ~407 frames drawn (~10fps). Low-utilisation-but-low-fps = a stalled render pipeline, i.e. forced synchronous layout. The top non-idle renderer functions were exactly "get clientWidth" (327ms) + getBoundingClientRect (191ms), read every scroll frame and thrashing against the scroll.

## Fix — remove the two per-scroll-frame layout reads
1. AircraftPosition motion loop: throttle BEFORE shouldAnimateInCurrentViewport, so a rate-limited frame never calls resolveMotionBounds (which reads getBounds() + container clientWidth). v2.32.10 throttled AFTER that read — which is why it didn't move the needle.
2. VirtualNearbyList: virtualize at a measured fixed row height instead of a per-row measureElement ResizeObserver that did a getBoundingClientRect every scroll frame.

The blur (#570) and marker-fps (#572) changes stay (they cut real GPU compositing), but this targets the actual stall.

Validation: local preview — rows still tile exactly (42px, no gap) after scrolling, markers still render + animate, no errors. The fps win can't be measured in the throttled headless preview — please verify on the Railway deploy.

Honest note: this took several wrong turns (dev-trace createTask noise → "React"; a busy-time heuristic artifact → "GPU"). The v2.32.10 production trace with a proper GPU-process breakdown is what made the forced-layout stall clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
