### PR TITLE
v2.34.1: Airport buildings filtered to the aerodrome polygon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.34.0",
+  "version": "2.34.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/api/webapi/airport_surface.go
+++ b/services/data-service/internal/api/webapi/airport_surface.go
@@ -22,7 +22,10 @@ const (
 	defaultAirportSurfaceOSMMapBaseURL = "https://api.openstreetmap.org/api/0.6/map"
 	defaultAirportSurfaceCacheTTL      = 6 * time.Hour
 	airportSurfaceRequestTimeout       = 3 * time.Second
-	airportSurfaceOSMMapRequestTimeout = 12 * time.Second
+	// Structures use an aerodrome-area Overpass filter, which is heavier than
+	// the flat-bbox pavement query, so they get more headroom.
+	airportSurfaceStructuresRequestTimeout = 12 * time.Second
+	airportSurfaceOSMMapRequestTimeout     = 12 * time.Second
 	airportSurfaceBBoxPaddingMeters    = 400
 	airportSurfaceCenterRadiusMeters   = 1200
 	airportSurfaceFallbackRadiusMeters = 4500
@@ -190,8 +193,12 @@ func (h *Handler) fetchAirportSurfacePayload(
 		return nil, false
 	}
 
+	timeout := airportSurfaceRequestTimeout
+	if normalizeAirportSurfaceScope(mode) == airportSurfaceScopeStructures {
+		timeout = airportSurfaceStructuresRequestTimeout
+	}
 	var payload map[string]any
-	status, err := h.fetchAirportSurfaceJSON(ctx, requestURL.String(), query, &payload)
+	status, err := h.fetchAirportSurfaceJSON(ctx, requestURL.String(), query, timeout, &payload)
 	if err != nil || status < 200 || status >= 300 {
 		log.Printf("airport surface fetch failed airport=%s mode=%s status=%d error=%v", airport, mode, status, err)
 		return nil, false
@@ -199,8 +206,8 @@ func (h *Handler) fetchAirportSurfacePayload(
 	return payload, true
 }
 
-func (h *Handler) fetchAirportSurfaceJSON(ctx context.Context, upstream string, query string, out any) (int, error) {
-	ctx, cancel := context.WithTimeout(ctx, airportSurfaceRequestTimeout)
+func (h *Handler) fetchAirportSurfaceJSON(ctx context.Context, upstream string, query string, timeout time.Duration, out any) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	body := strings.NewReader(url.Values{"data": {query}}.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstream, body)
@@ -357,12 +364,23 @@ func buildAirportSurfaceStructuresOverpassQuery(bbox airportSurfaceBBox) string 
 		formatBBoxCoordinate(bbox.east),
 	}, ",")
 
-	return fmt.Sprintf(`[out:json][timeout:3];
+	// Buildings are filtered to inside the aerodrome polygon (aeroway=aerodrome,
+	// mapped to an area) so surrounding city buildings are excluded. Terminals
+	// and hangars are also matched directly in the bbox as a safety net for
+	// airports whose aerodrome polygon is missing (the area set is then empty
+	// and the area-filtered building selector simply yields nothing).
+	return fmt.Sprintf(`[out:json][timeout:25];
+(
+  way["aeroway"="aerodrome"](%s);
+  rel["aeroway"="aerodrome"](%s);
+)->.ad;
+.ad map_to_area->.adarea;
 (
   way["aeroway"="terminal"](%s);
   way["building"="hangar"](%s);
+  way["building"](area.adarea);
 );
-out tags geom;`, formatted, formatted)
+out tags geom;`, formatted, formatted, formatted, formatted)
 }
 
 func buildAirportSurfaceOverpassQuery(bbox airportSurfaceBBox, scope string) string {

--- a/services/data-service/internal/api/webapi/airport_surface_test.go
+++ b/services/data-service/internal/api/webapi/airport_surface_test.go
@@ -58,13 +58,13 @@ func TestBuildAirportSurfaceStructuresOverpassQuery(t *testing.T) {
 		east:  -70.986,
 	})
 
-	if !strings.Contains(query, `way["aeroway"="terminal"](42.344000,-71.031000,42.385000,-70.986000);`) ||
+	if !strings.Contains(query, `way["aeroway"="aerodrome"](42.344000,-71.031000,42.385000,-70.986000);`) ||
+		!strings.Contains(query, `rel["aeroway"="aerodrome"](42.344000,-71.031000,42.385000,-70.986000);`) ||
+		!strings.Contains(query, `.ad map_to_area->.adarea;`) ||
+		!strings.Contains(query, `way["building"](area.adarea);`) ||
+		!strings.Contains(query, `way["aeroway"="terminal"](42.344000,-71.031000,42.385000,-70.986000);`) ||
 		!strings.Contains(query, `way["building"="hangar"](42.344000,-71.031000,42.385000,-70.986000);`) ||
-		strings.Contains(query, `way["building"](42.344000,-71.031000,42.385000,-70.986000);`) ||
 		strings.Contains(query, `transportation`) ||
-		strings.Contains(query, `relation`) ||
-		strings.Contains(query, `map_to_area`) ||
-		strings.Contains(query, `aerodrome`) ||
 		strings.Contains(query, `taxiway`) {
 		t.Fatalf("unexpected structures query:\n%s", query)
 	}
@@ -364,10 +364,10 @@ func TestAirportSurfaceScopesKeepPavementSeparateFromStructures(t *testing.T) {
 				strings.Contains(data, `taxiway`) {
 				t.Fatalf("second query should be structures-only: %s", data)
 			}
-			if strings.Contains(data, `transportation`) ||
-				strings.Contains(data, `relation`) ||
-				strings.Contains(data, `map_to_area`) {
-				t.Fatalf("second query should be narrow bbox structures: %s", data)
+			if !strings.Contains(data, `aeroway"="aerodrome"`) ||
+				!strings.Contains(data, `map_to_area`) ||
+				!strings.Contains(data, `building"](area.adarea)`) {
+				t.Fatalf("structures query should filter buildings to the aerodrome area: %s", data)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"elements":[{

--- a/src/components/map/AirportSurfaceLayer.tsx
+++ b/src/components/map/AirportSurfaceLayer.tsx
@@ -22,11 +22,15 @@ const shouldShowAirportSurfaceForZoom = (zoom: unknown) => {
 const shouldRenderAirportSurfaceFeature = (
   feature: Record<string, any>,
   nightLighting: boolean,
+  detailZoom: boolean,
 ) => {
   const kind = String(feature?.properties?.kind || "");
   // At night, taxiways are drawn as lit green/blue lines by
   // AirportGroundLightingLayer — suppress the generic pavement line here.
   if (nightLighting && (kind === "taxiway" || kind === "taxilane")) return false;
+  // Buildings/terminals are detail-zoom only — at wider zoom they're clutter,
+  // and the aerodrome-filtered set can be large.
+  if ((kind === "building" || kind === "terminal") && !detailZoom) return false;
   return (
     kind === "runway" ||
     kind === "taxiway" ||
@@ -135,7 +139,8 @@ export default function AirportSurfaceLayer({
   // Night lighting is on in the dark theme at airport-detail zoom and closer;
   // taxiway pavement lines are then suppressed (the lighting layer draws lit
   // green/blue taxiways) and the runway pavement dims under the bright edges.
-  const nightLighting = theme === "dark" && Number(zoom) >= ZOOM_DETAIL;
+  const detailZoom = Number(zoom) >= ZOOM_DETAIL;
+  const nightLighting = theme === "dark" && detailZoom;
   // Second-level ("airport") zoom band, between the wide approach view and the
   // detail view — the runway is drawn as a thin clean bar here.
   const midZoom =
@@ -161,6 +166,7 @@ export default function AirportSurfaceLayer({
         return shouldRenderAirportSurfaceFeature(
           feature as Record<string, any>,
           nightLighting,
+          detailZoom,
         );
       },
       style(feature) {
@@ -185,7 +191,7 @@ export default function AirportSurfaceLayer({
       renderer.remove();
       layerRef.current = null;
     };
-  }, [map, surfaceFeatures, theme, surfaceVisible, nightLighting, midZoom]);
+  }, [map, surfaceFeatures, theme, surfaceVisible, nightLighting, midZoom, detailZoom]);
 
   return null;
 }

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 58;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.34.0",
+    version: "v2.34.1",
     kind: "feat",
     title: {
       en: "Crisp-line airport night lighting",
@@ -69,6 +69,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Zoom-gated to the detail view (nothing built or drawn below it) and dark-theme only; daytime keeps the tan runway/taxiway surfaces. The old per-point FAA model, its canvas renderer, the LOD-band system and ~790 net lines of code are removed.",
         zh: "灯光门控在详情 zoom(以下不构建不绘制)且仅暗色主题;白天保留 tan 色跑道/滑行道铺面。旧的逐点 FAA 模型、其 canvas 渲染器、LOD 分级系统及净约 790 行代码已移除。",
+      },
+      {
+        en: "v2.34.1: airport buildings now show at the detail zoom. The OSM lookup widened from terminals + hangars to all buildings, filtered to inside the aerodrome polygon (aeroway=aerodrome) so surrounding city blocks are excluded, and the runway is drawn as a thin clean bar at the medium zoom.",
+        zh: "v2.34.1:机场建筑现在在详情 zoom 显示。OSM 取数从航站楼+机库扩到全部建筑,并过滤到机场边界多边形(aeroway=aerodrome)以内,排除周边城市街区;中间 zoom 档跑道改为细线。",
       },
     ],
   },


### PR DESCRIPTION
## What

PR2 of the airport-ground-rendering work (after v2.34.0 night lighting). Makes airport **buildings** appear at the detail zoom.

### Backend
The Overpass `structures` query widened from `aeroway=terminal` + `building=hangar` to **all `building=*`**, filtered to **inside the `aeroway=aerodrome` polygon** (`map_to_area`) so surrounding city blocks are excluded. Terminal + hangar are still matched directly in the bbox as a safety net for airports whose aerodrome polygon is missing (the area set is then empty and the area-filtered building selector simply yields nothing). The structures scope also gets a longer fetch timeout, since the area query is heavier than the flat-bbox pavement query.

### Frontend
Buildings/terminals are **gated to the detail zoom** — at wider zoom they're clutter, and the aerodrome-filtered set can be large (KBOS ≈ 180 structures). The frontend already fetched + rendered the structures scope, so this is just the zoom gate. Also folds in the medium-zoom runway thinning.

## Validation

- **Live Overpass check** (KBOS): the aerodrome-area query returns **184 structures** (5 terminals, hangars, jet-bridges, `building=yes`…), all inside the airport — city buildings excluded.
- Go — `go vet` + `go test ./internal/api/webapi/` pass (the structures-query test updated for the new aerodrome-area form).
- Frontend — `pnpm test` (121 files pass); changelog/version sync test passes.

Buildings render once the rebuilt data-service deploys on Railway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)