### PR TITLE
feat: 降低实时航空器订阅抖动(前端 + Go 后端)— v2.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.35.0",
+  "version": "2.36.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/cmd/adsbao-data-service/main.go
+++ b/services/data-service/cmd/adsbao-data-service/main.go
@@ -96,6 +96,7 @@ func main() {
 		},
 		MinInterval:       cfg.MinPollInterval,
 		MaxInterval:       cfg.MaxPollInterval,
+		IdleGracePeriod:   cfg.ChannelIdleGracePeriod,
 		MaxActiveChannels: cfg.MaxActiveChannels,
 		JitterRatio:       cfg.PollJitterRatio,
 		Metrics:           registry,

--- a/services/data-service/internal/config/config.go
+++ b/services/data-service/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Port                          int
 	MinPollInterval               time.Duration
 	MaxPollInterval               time.Duration
+	ChannelIdleGracePeriod        time.Duration
 	MaxActiveChannels             int
 	PollJitterRatio               float64
 	MaxSocketSubscriptions        int
@@ -44,6 +45,9 @@ func FromEnv(lookup LookupFunc) Config {
 		Port:                          intValue(lookup("PORT"), 8080),
 		MinPollInterval:               durationMS(lookup("MIN_POLL_INTERVAL_MS"), time.Second),
 		MaxPollInterval:               durationMS(lookup("MAX_POLL_INTERVAL_MS"), 30*time.Minute),
+		// 频道最后一个订阅者离开后,轮询循环再保留多久才停止(订阅抖动的后端兜底:
+		// 窗口内若有新订阅者到达,循环不中断、无重建/重取)。
+		ChannelIdleGracePeriod:        durationMS(lookup("CHANNEL_IDLE_GRACE_PERIOD_MS"), 5*time.Second),
 		MaxActiveChannels:             intValue(lookup("MAX_ACTIVE_CHANNELS"), 250),
 		PollJitterRatio:               floatValue(lookup("POLL_JITTER_RATIO"), 0.1),
 		MaxSocketSubscriptions:        intValue(lookup("MAX_SOCKET_SUBSCRIPTIONS"), 96),

--- a/services/data-service/internal/config/config_test.go
+++ b/services/data-service/internal/config/config_test.go
@@ -10,6 +10,7 @@ func TestFromEnvParsesCompatibleDataServiceVariables(t *testing.T) {
 		"PORT":                             "9090",
 		"MIN_POLL_INTERVAL_MS":             "1500",
 		"MAX_POLL_INTERVAL_MS":             "120000",
+		"CHANNEL_IDLE_GRACE_PERIOD_MS":     "7000",
 		"MAX_ACTIVE_CHANNELS":              "12",
 		"POLL_JITTER_RATIO":                "0.25",
 		"MAX_SOCKET_SUBSCRIPTIONS":         "7",
@@ -37,6 +38,9 @@ func TestFromEnvParsesCompatibleDataServiceVariables(t *testing.T) {
 	}
 	if cfg.MinPollInterval != 1500*time.Millisecond || cfg.MaxPollInterval != 120*time.Second {
 		t.Fatalf("poll intervals = %s/%s", cfg.MinPollInterval, cfg.MaxPollInterval)
+	}
+	if cfg.ChannelIdleGracePeriod != 7*time.Second {
+		t.Fatalf("channel idle grace = %s", cfg.ChannelIdleGracePeriod)
 	}
 	if cfg.MaxActiveChannels != 12 || cfg.MaxSocketSubscriptions != 7 {
 		t.Fatalf("limits = %d/%d", cfg.MaxActiveChannels, cfg.MaxSocketSubscriptions)
@@ -75,6 +79,7 @@ func TestFromEnvDefaultsMatchProductionService(t *testing.T) {
 	if cfg.Port != 8080 ||
 		cfg.MinPollInterval != time.Second ||
 		cfg.MaxPollInterval != 30*time.Minute ||
+		cfg.ChannelIdleGracePeriod != 5*time.Second ||
 		cfg.MaxActiveChannels != 250 ||
 		cfg.MaxSocketSubscriptions != 96 ||
 		cfg.PollJitterRatio != 0.1 ||

--- a/services/data-service/internal/scheduler/scheduler.go
+++ b/services/data-service/internal/scheduler/scheduler.go
@@ -18,6 +18,7 @@ type Options struct {
 	Fetch             realtime.FetchFunc
 	MinInterval       time.Duration
 	MaxInterval       time.Duration
+	IdleGracePeriod   time.Duration
 	MaxActiveChannels int
 	JitterRatio       float64
 	CacheTTL          time.Duration
@@ -28,6 +29,7 @@ type Scheduler struct {
 	fetch             realtime.FetchFunc
 	minInterval       time.Duration
 	maxInterval       time.Duration
+	idleGracePeriod   time.Duration
 	maxActiveChannels int
 	jitterRatio       float64
 	cacheTTL          time.Duration
@@ -56,6 +58,9 @@ type channelState struct {
 	subscribers         map[int64]func(realtime.Event)
 	ctx                 context.Context
 	cancel              context.CancelFunc
+	// idle grace 待停定时器:最后一个订阅者离开后启动,到期才真正停轮询;
+	// 窗口内有新订阅者命中本 state 时会被 Stop。
+	graceTimer *time.Timer
 }
 
 type cacheEntry struct {
@@ -84,6 +89,8 @@ func New(options Options) *Scheduler {
 		fetch:             options.Fetch,
 		minInterval:       minInterval,
 		maxInterval:       maxInterval,
+		// 默认 0 = 保持「最后退订即停」的既有语义;>0 才启用 idle grace。
+		idleGracePeriod:   options.IdleGracePeriod,
 		maxActiveChannels: maxActive,
 		jitterRatio:       options.JitterRatio,
 		cacheTTL:          cacheTTL,
@@ -133,6 +140,11 @@ func (s *Scheduler) Subscribe(channel string, params realtime.SubscribeParams, s
 		}
 		s.channels[key] = state
 		go s.run(state)
+	} else if state.graceTimer != nil {
+		// 命中处于 idle grace 窗口的频道:取消待停定时器,轮询循环原地续用,
+		// 不重建 goroutine、不触发重取(消除订阅抖动的后端兜底)。
+		state.graceTimer.Stop()
+		state.graceTimer = nil
 	}
 	s.subscriberID++
 	id := s.subscriberID
@@ -179,6 +191,9 @@ func (s *Scheduler) Dispose() {
 	s.cache = map[string]cacheEntry{}
 	s.mu.Unlock()
 	for _, state := range states {
+		if state.graceTimer != nil {
+			state.graceTimer.Stop()
+		}
 		state.cancel()
 	}
 }
@@ -192,10 +207,45 @@ func (s *Scheduler) unsubscribe(key string, id int64) {
 	}
 	delete(state.subscribers, id)
 	if len(state.subscribers) == 0 {
-		delete(s.channels, key)
-		state.cancel()
+		if s.idleGracePeriod <= 0 {
+			s.stopChannelLocked(state)
+		} else {
+			s.scheduleGraceStopLocked(state)
+		}
 	}
 	s.mu.Unlock()
+}
+
+// 立即停止频道:从活动表移除并取消轮询 goroutine。须在持有 s.mu 时调用。
+func (s *Scheduler) stopChannelLocked(state *channelState) {
+	if state.graceTimer != nil {
+		state.graceTimer.Stop()
+		state.graceTimer = nil
+	}
+	delete(s.channels, state.key)
+	state.cancel()
+}
+
+// idle grace:最后一个订阅者离开后,等 idleGracePeriod 再停。窗口内若有新订阅者
+// 到达(Subscribe 命中同一 state 并 Stop 本定时器),轮询循环全程不中断。
+// 到期回调里复检:仍是同一 state 且确无订阅者,才真正停止——从而保证 grace 过后
+// 「最后退订即停」的既有保证依然成立。
+func (s *Scheduler) scheduleGraceStopLocked(state *channelState) {
+	if state.graceTimer != nil {
+		state.graceTimer.Stop()
+	}
+	state.graceTimer = time.AfterFunc(s.idleGracePeriod, func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.channels[state.key] != state {
+			return
+		}
+		state.graceTimer = nil
+		if len(state.subscribers) == 0 {
+			delete(s.channels, state.key)
+			state.cancel()
+		}
+	})
 }
 
 func (s *Scheduler) run(state *channelState) {
@@ -212,8 +262,11 @@ func (s *Scheduler) run(state *channelState) {
 		}
 		s.poll(state)
 		s.mu.Lock()
+		// 只看频道是否还在活动表里:idle grace 期间订阅者已归零但 state 仍在表中,
+		// 循环继续轮询以便窗口内的新订阅者能立刻拿到新鲜数据;grace 到期会把 state
+		// 从表中删除并 cancel,届时这里 active=false 退出(或 delay 等待时被 ctx 唤醒)。
 		_, active := s.channels[state.key]
-		if !active || len(state.subscribers) == 0 {
+		if !active {
 			s.mu.Unlock()
 			return
 		}

--- a/services/data-service/internal/scheduler/scheduler_test.go
+++ b/services/data-service/internal/scheduler/scheduler_test.go
@@ -60,6 +60,89 @@ func TestSchedulerSharesLoopAndStopsAfterLastUnsubscribe(t *testing.T) {
 	}
 }
 
+func newGraceScheduler(grace time.Duration, calls *atomic.Int64) *Scheduler {
+	return New(Options{
+		MinInterval:       25 * time.Millisecond,
+		MaxActiveChannels: 10,
+		JitterRatio:       0,
+		IdleGracePeriod:   grace,
+		Fetch: func(input realtime.FetchInput) (realtime.Event, error) {
+			calls.Add(1)
+			return realtime.Event{
+				Type:      "aircraft:update",
+				Channel:   input.Channel,
+				Source:    "test-provider",
+				FetchedAt: time.Unix(0, 0).UTC().Format(time.RFC3339),
+				Data:      map[string]any{"ac": []any{}},
+			}, nil
+		},
+	})
+}
+
+// idle grace 期间:最后一个订阅者离开后,轮询循环不立即拆除(频道仍在活动表中),
+// 直到 grace 到期才真正停止。轮询节拍由 BaseInterval(秒级)决定,因此这里用
+// DebugChannels 的存在与否来判定循环是否被拆除——正是验收关注的语义。
+func TestSchedulerKeepsLoopDuringGrace(t *testing.T) {
+	var calls atomic.Int64
+	s := newGraceScheduler(200*time.Millisecond, &calls)
+	defer s.Dispose()
+
+	events := make(chan realtime.Event, 4)
+	unsub, err := s.Subscribe("traffic:center:42.3656:-71.0096:40", nil, func(event realtime.Event) {
+		events <- event
+	})
+	if err != nil {
+		t.Fatalf("subscribe returned error: %v", err)
+	}
+	waitEvent(t, events)
+
+	unsub()
+	// grace 窗口内:频道仍在活动表中(轮询 goroutine 未被 cancel)。
+	time.Sleep(80 * time.Millisecond)
+	if len(s.DebugChannels()) != 1 {
+		t.Fatalf("channel torn down within grace: %#v", s.DebugChannels())
+	}
+
+	// grace 到期后:频道被移除,既有「最后退订即停」保证依然成立。
+	time.Sleep(250 * time.Millisecond)
+	if len(s.DebugChannels()) != 0 {
+		t.Fatalf("channel still active after grace expired: %#v", s.DebugChannels())
+	}
+}
+
+// grace 窗口内重新订阅:取消待停定时器,频道存活,即使越过原 grace 截止点。
+func TestSchedulerCancelsGraceOnResubscribe(t *testing.T) {
+	var calls atomic.Int64
+	s := newGraceScheduler(150*time.Millisecond, &calls)
+	defer s.Dispose()
+
+	events := make(chan realtime.Event, 4)
+	unsubFirst, err := s.Subscribe("traffic:center:42.3656:-71.0096:40", nil, func(event realtime.Event) {
+		events <- event
+	})
+	if err != nil {
+		t.Fatalf("first subscribe returned error: %v", err)
+	}
+	waitEvent(t, events)
+
+	unsubFirst()
+	// 在 grace 窗口内(<150ms)重新订阅同一频道。
+	time.Sleep(50 * time.Millisecond)
+	unsubSecond, err := s.Subscribe("traffic:center:42.3656:-71.0096:40", nil, func(event realtime.Event) {
+		events <- event
+	})
+	if err != nil {
+		t.Fatalf("resubscribe returned error: %v", err)
+	}
+
+	// 越过原 grace 截止点后,频道仍应存活(grace 已被取消,循环从未中断)。
+	time.Sleep(200 * time.Millisecond)
+	if len(s.DebugChannels()) != 1 {
+		t.Fatalf("channel stopped despite resubscribe within grace: %#v", s.DebugChannels())
+	}
+	unsubSecond()
+}
+
 func waitEvent(t *testing.T, ch <-chan realtime.Event) realtime.Event {
 	t.Helper()
 	select {

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -47,32 +47,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 59;
+export const CHANGELOG_TOTAL_COUNT = 60;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.35.0",
+    version: "v2.36.0",
     kind: "feat",
     title: {
-      en: "Adaptive aircraft position smoothing",
-      zh: "自适应飞机位置平滑",
+      en: "Steadier realtime aircraft subscriptions",
+      zh: "更稳的实时航空器订阅",
     },
     summary: {
-      en: "Aircraft marker movement between ADS-B fixes is rebuilt as an adaptive dead-reckoning + critically-damped easing system. Each fix becomes an anchor positioned by its own source timestamp (position age), so multi-source updates align on one timeline. Targets are extrapolated forward only above a speed threshold (off for slow/taxiing aircraft, where the per-update displacement is the same size as ADS-B noise — the old cause of high-zoom \"drift\"), and the displayed marker eases toward the target with a frame-rate-independent low-pass filter whose time constant adapts to zoom (smoother when zoomed in, tighter when zoomed out). A new fix only moves the anchor, so the marker never teleports, and source switches are absorbed by the easing instead of jumping.",
-      zh: "飞机标记在两次 ADS-B 定位之间的运动重做成一套自适应航位推算 + 临界阻尼缓动系统。每次定位成为一个 anchor,按其数据源自身的时间戳(位置年龄)定位,因此多源更新对齐在同一条时间线上。只有速度超过阈值才向前外推(慢速/滑行飞机关闭——这时每次更新的位移和 ADS-B 噪声同量级,正是旧版高 zoom “漂移”的根因);显示标记以与帧率无关的低通滤波缓动逼近目标,其时间常数随 zoom 自适应(放大更顺、缩小更跟手)。新定位只移动 anchor,标记永不瞬移,数据源切换被缓动吸收而非跳变。",
+      en: "The realtime aircraft pipeline now resists subscription churn end-to-end. Rapidly opening and closing an aircraft detail no longer tears down and rebuilds its WebSocket subscription (and, for FlightAware, re-authenticates) on every toggle: the client holds callsign/aircraft subscriptions for a short grace window and reuses them if you come back, and the Go data-service mirrors that with a configurable idle grace before it stops a channel's polling loop — so a returning subscriber keeps the same warm loop with no rebuild or re-fetch spike. Switching between aircraft also stops flickering: the previous aircraft's data stays on screen until the new channel delivers instead of blanking instantly.",
+      zh: "实时航空器数据管线现在端到端地抵抗订阅抖动。快速开关某架飞机详情,不再每次都拆掉并重建它的 WebSocket 订阅(FlightAware 还要重新鉴权):客户端会把 callsign/aircraft 订阅保留一个短的 grace 窗口,期间再次进入则原地复用;Go 数据服务以一个可配置的 idle grace 镜像同样行为——最后一个订阅者离开后延迟停止该频道的轮询循环,于是 grace 窗口内返回的订阅者续用同一个热循环,无重建、无重取尖峰。切换不同飞机也不再闪烁:上一架的数据会保留到新频道送来数据,而不是瞬间清空。",
     },
     highlights: [
       {
-        en: "Slow/taxiing aircraft no longer drift the wrong way then snap back at high zoom (extrapolation gates off below ~8–25kt and on the ground); steady targets sit visually still at far/mid zoom (per-frame jitter ~0).",
-        zh: "慢速/滑行飞机在高 zoom 下不再先朝错误方向漂移再回弹(约 8–25kt 以下及地面时关闭外推);稳定目标在远/中 zoom 下视觉上保持静止(逐帧抖动 ~0)。",
+        en: "Opening/closing the same aircraft repeatedly now sends at most one subscribe and one unsubscribe (after the grace), instead of a churn of teardown/rebuild messages.",
+        zh: "反复开关同一架飞机,现在最多发出一次 subscribe、一次 unsubscribe(grace 之后),而不再是一连串拆除/重建消息。",
       },
       {
-        en: "Runs inside the existing single-canvas render loop — a few float ops per aircraft per frame (~0.16µs/plane), no new map layers or repaints. Tuning constants live in one POSITION_SMOOTHING config block.",
-        zh: "运行在现有单 canvas 渲染循环内——每架飞机每帧几次浮点运算(约 0.16µs/架),不新增地图图层或重绘。调参常量集中在一个 POSITION_SMOOTHING 配置块。",
+        en: "Switching between aircraft details no longer blanks the view — the previous aircraft stays until the new channel delivers, killing the detail-switch flicker.",
+        zh: "在不同飞机详情间切换不再清空视图——上一架会保留到新频道送达,消除了切换闪烁。",
       },
       {
-        en: "Proven before wiring to the display: real KLAX fix sequences (slow, fast-cruise, and source-switching targets) were recorded and replayed through an offline harness that asserts jitter, lag, drift, and source-switch thresholds across far/mid/high zoom. Fixtures and harness are committed for repeatability.",
-        zh: "接入显示前先证明:录制真实 KLAX 定位序列(慢速、巡航、跨源切换目标)并通过离线 harness 重放,在远/中/高 zoom 下对抖动、滞后、漂移、源切换阈值逐一断言。fixtures 与 harness 已入库可复跑。",
+        en: "Backend symmetry: the data-service keeps a channel's polling loop alive for a configurable idle grace (CHANNEL_IDLE_GRACE_PERIOD_MS) after the last unsubscribe, while still guaranteeing the loop stops once the grace expires.",
+        zh: "前后端对称:数据服务在最后退订后,会按可配置的 idle grace(CHANNEL_IDLE_GRACE_PERIOD_MS)保留频道的轮询循环;grace 到期后仍保证循环停止。",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -170,6 +170,32 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.35.0",
+    kind: "feat",
+    title: {
+      en: "Adaptive aircraft position smoothing",
+      zh: "自适应飞机位置平滑",
+    },
+    summary: {
+      en: "Aircraft marker movement between ADS-B fixes is rebuilt as an adaptive dead-reckoning + critically-damped easing system. Each fix becomes an anchor positioned by its own source timestamp (position age), so multi-source updates align on one timeline. Targets are extrapolated forward only above a speed threshold (off for slow/taxiing aircraft, where the per-update displacement is the same size as ADS-B noise — the old cause of high-zoom \"drift\"), and the displayed marker eases toward the target with a frame-rate-independent low-pass filter whose time constant adapts to zoom (smoother when zoomed in, tighter when zoomed out). A new fix only moves the anchor, so the marker never teleports, and source switches are absorbed by the easing instead of jumping.",
+      zh: "飞机标记在两次 ADS-B 定位之间的运动重做成一套自适应航位推算 + 临界阻尼缓动系统。每次定位成为一个 anchor,按其数据源自身的时间戳(位置年龄)定位,因此多源更新对齐在同一条时间线上。只有速度超过阈值才向前外推(慢速/滑行飞机关闭——这时每次更新的位移和 ADS-B 噪声同量级,正是旧版高 zoom “漂移”的根因);显示标记以与帧率无关的低通滤波缓动逼近目标,其时间常数随 zoom 自适应(放大更顺、缩小更跟手)。新定位只移动 anchor,标记永不瞬移,数据源切换被缓动吸收而非跳变。",
+    },
+    highlights: [
+      {
+        en: "Slow/taxiing aircraft no longer drift the wrong way then snap back at high zoom (extrapolation gates off below ~8–25kt and on the ground); steady targets sit visually still at far/mid zoom (per-frame jitter ~0).",
+        zh: "慢速/滑行飞机在高 zoom 下不再先朝错误方向漂移再回弹(约 8–25kt 以下及地面时关闭外推);稳定目标在远/中 zoom 下视觉上保持静止(逐帧抖动 ~0)。",
+      },
+      {
+        en: "Runs inside the existing single-canvas render loop — a few float ops per aircraft per frame (~0.16µs/plane), no new map layers or repaints. Tuning constants live in one POSITION_SMOOTHING config block.",
+        zh: "运行在现有单 canvas 渲染循环内——每架飞机每帧几次浮点运算(约 0.16µs/架),不新增地图图层或重绘。调参常量集中在一个 POSITION_SMOOTHING 配置块。",
+      },
+      {
+        en: "Proven before wiring to the display: real KLAX fix sequences (slow, fast-cruise, and source-switching targets) were recorded and replayed through an offline harness that asserts jitter, lag, drift, and source-switch thresholds across far/mid/high zoom. Fixtures and harness are committed for repeatability.",
+        zh: "接入显示前先证明:录制真实 KLAX 定位序列(慢速、巡航、跨源切换目标)并通过离线 harness 重放,在远/中/高 zoom 下对抖动、滞后、漂移、源切换阈值逐一断言。fixtures 与 harness 已入库可复跑。",
+      },
+    ],
+  },
+  {
     version: "v2.34.1",
     kind: "feat",
     title: {

--- a/src/features/aircraft/positions/normalizeRealtimePayload.ts
+++ b/src/features/aircraft/positions/normalizeRealtimePayload.ts
@@ -1,0 +1,11 @@
+// 把实时频道(traffic / callsign / aircraft)推送的 payload 统一规整成
+// `{ ac: [...] }` 结构。上游可能直接发数组,也可能发带 `ac` 字段的对象;
+// 两种都接受,其余一律退化为空数组。useAircraftPositions 与 useTrackedAircraft
+// 之前各自维护了一份等价实现,这里抽成唯一来源(Part D 去重)。
+export function normalizeRealtimeAircraftPayload(data: unknown): Record<string, any> {
+  if (Array.isArray(data)) return { ac: data };
+  if (data && typeof data === "object" && Array.isArray((data as any).ac)) {
+    return data as Record<string, any>;
+  }
+  return { ac: [] };
+}

--- a/src/hooks/useAircraftPositions.ts
+++ b/src/hooks/useAircraftPositions.ts
@@ -12,7 +12,11 @@ import {
   normalizeLongitude,
 } from "../features/aircraft/tracking/flightTrackingContextModel";
 import { createAircraftPositionClient } from "../features/aircraft/positions/aircraftPositionClient";
-import { useRealtimeAircraftChannel } from "./useRealtimeAircraftChannel";
+import { normalizeRealtimeAircraftPayload } from "../features/aircraft/positions/normalizeRealtimePayload";
+import {
+  EMPTY_REALTIME_PARAMS,
+  useRealtimeAircraftChannel,
+} from "./useRealtimeAircraftChannel";
 import { buildAircraftTrafficChannel } from "../lib/realtime/realtimeChannels";
 import { resolveRealtimeStatusLabel } from "../lib/realtime/realtimeStatusModel";
 
@@ -23,14 +27,6 @@ const normalizeAircraftRangeNm = (value: unknown) => {
   if (!Number.isFinite(number)) return AIRCRAFT_TRAFFIC_CONFIG.rangeNm;
   return Math.max(1, Math.min(MAX_AIRCRAFT_RANGE_NM, number));
 };
-
-function normalizeRealtimeAircraftPayload(data: unknown) {
-  if (Array.isArray(data)) return { ac: data };
-  if (data && typeof data === "object" && Array.isArray((data as any).ac)) {
-    return data as Record<string, any>;
-  }
-  return { ac: [] };
-}
 
 function sourceFromAircraftPayload(payload: Record<string, any>) {
   if (typeof payload.source === "string" && payload.source.trim()) {
@@ -69,7 +65,11 @@ export function useAircraftPositions(
 
   const realtime = useRealtimeAircraftChannel({
     channel: realtimeRequest?.channel || "",
-    params: realtimeRequest?.params || {},
+    // 关键:用稳定的 frozen 常量兜底,避免 `|| {}` 每次 render 都 mint 新对象。
+    // params 是 useRealtimeAircraftChannel 里订阅 effect 的依赖,引用一变就会
+    // 触发 unsubscribe+resubscribe(订阅抖动)。realtimeRequest 非空时其 params
+    // 已在 useMemo 内稳定。
+    params: realtimeRequest?.params ?? EMPTY_REALTIME_PARAMS,
     enabled: hasActiveQuery && realtimeEnabled,
   });
   const channelKey = realtimeRequest?.channel || "";

--- a/src/hooks/useRealtimeAircraftChannel.ts
+++ b/src/hooks/useRealtimeAircraftChannel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   type AdsbaoRealtimeEvent,
   getAdsbaoRealtimeClient,
@@ -9,7 +9,14 @@ import {
 } from "@/lib/realtime/realtimeChannels";
 
 const INITIAL_REALTIME_GRACE_MS = 8_000;
-const EMPTY_REALTIME_PARAMS: Record<string, unknown> = Object.freeze({});
+// 频道切换后,最多保留上一架的数据多久(无新数据则清空)。切换实时航空器详情时
+// 不立即 setEvent(null),先沿用上一架直到新频道送来首个事件,消除切换闪烁;
+// 若新频道在该窗口内始终无数据,再清掉残留的旧机。WS warm socket + 后端 idle
+// grace 让重订阅几乎立刻拿到缓存快照,所以正常切换根本到不了这个兜底。
+const CHANNEL_SWITCH_STALE_MS = 2_500;
+// 共享的稳定空 params 引用。任何不带参数的频道都应复用它,而不是写内联 `{}`,
+// 否则订阅 effect 的 params 依赖每次 render 都变 → 订阅抖动。
+export const EMPTY_REALTIME_PARAMS: Record<string, unknown> = Object.freeze({});
 
 type RealtimeHookOptions = {
   channel?: string;
@@ -33,6 +40,7 @@ export function useRealtimeAircraftChannel({
   const [event, setEvent] = useState<AdsbaoRealtimeEvent | null>(null);
   const [graceExpired, setGraceExpired] = useState(false);
   const available = enabled && client.enabled && Boolean(channel);
+  const prevChannelRef = useRef("");
 
   useEffect(() => {
     const unsubscribe = client.onConnectionState(setConnectionState);
@@ -42,11 +50,29 @@ export function useRealtimeAircraftChannel({
   }, [client]);
 
   useEffect(() => {
-    setEvent(null);
     setGraceExpired(false);
-    if (!available) return undefined;
+    const switchedChannel = prevChannelRef.current !== channel;
+    prevChannelRef.current = channel;
 
-    const timer = window.setTimeout(
+    // 频道关闭/不可用时才真正清空——此时没有可继续显示的有效频道。
+    if (!available) {
+      setEvent(null);
+      return undefined;
+    }
+
+    let receivedForThisChannel = false;
+
+    // 切换频道时不立即清空上一架 event(消除详情切换闪烁);仅当本频道在
+    // CHANNEL_SWITCH_STALE_MS 内仍无数据,再清掉残留的旧机。首次挂载(无上一个
+    // 频道)不需要这个兜底——本来就没有可显示的数据。
+    const staleTimer =
+      switchedChannel
+        ? window.setTimeout(() => {
+            if (!receivedForThisChannel) setEvent(null);
+          }, CHANNEL_SWITCH_STALE_MS)
+        : null;
+
+    const graceTimer = window.setTimeout(
       () => setGraceExpired(true),
       INITIAL_REALTIME_GRACE_MS,
     );
@@ -55,6 +81,7 @@ export function useRealtimeAircraftChannel({
       params,
       listener: (nextEvent) => {
         if (nextEvent.type === "aircraft:update" || nextEvent.type === "channel:error") {
+          receivedForThisChannel = true;
           setEvent(nextEvent);
           setGraceExpired(false);
         }
@@ -62,7 +89,8 @@ export function useRealtimeAircraftChannel({
     });
 
     return () => {
-      window.clearTimeout(timer);
+      if (staleTimer != null) window.clearTimeout(staleTimer);
+      window.clearTimeout(graceTimer);
       unsubscribe();
     };
   }, [available, channel, client, params]);

--- a/src/hooks/useTrackedAircraft.ts
+++ b/src/hooks/useTrackedAircraft.ts
@@ -12,20 +12,12 @@ import {
 import {
   getAdsbaoRealtimeClient,
 } from "../lib/realtime/adsbaoRealtimeClient";
+import { normalizeRealtimeAircraftPayload } from "../features/aircraft/positions/normalizeRealtimePayload";
 import { resolveRealtimeStatusLabel } from "../lib/realtime/realtimeStatusModel";
 import { useAircraftTrackingRealtime } from "./useRealtimeAircraftChannel";
 
-function normalizeRealtimeTrackedPayload(data: unknown) {
-  if (data && typeof data === "object" && Array.isArray((data as any).ac)) {
-    return data as Record<string, any>;
-  }
-  if (Array.isArray(data)) return { ac: data };
-  return { ac: [] };
-}
-
-function normalizeTrackedPayload(data: unknown) {
-  return normalizeRealtimeTrackedPayload(data);
-}
+// 与 useAircraftPositions 共用同一份规整逻辑(Part D 去重)。
+const normalizeTrackedPayload = normalizeRealtimeAircraftPayload;
 
 export function useTrackedAircraft(
   callsign: unknown,

--- a/src/lib/realtime/adsbaoRealtimeClient.test.ts
+++ b/src/lib/realtime/adsbaoRealtimeClient.test.ts
@@ -420,4 +420,57 @@ assert.equal(
   assert.equal(socket.readyState, FakeSocket.CLOSED);
 }
 
+// 订阅级 idle grace:反复开关同一 callsign 详情,只应发出一次 subscribe、
+// (grace 到期后)一次 unsubscribe。窗口内的再订阅原地复用,不发任何消息。
+{
+  FakeSocket.instances = [];
+  const timers = createTimerHost();
+  const client = new AdsbaoRealtimeClient("ws://example.test/ws", {
+    WebSocketCtor: FakeSocket as any,
+    timerHost: timers.host as any,
+    heartbeatIntervalMs: 0,
+    idleDisconnectMs: 10_000,
+    subscriptionIdleGraceMs: 3_000,
+  });
+
+  const unsubFirst = client.subscribe({
+    channel: "callsign:UAL123",
+    listener: () => {},
+  });
+  const socket = FakeSocket.instances[0];
+  socket.open();
+  const messageTypes = () => socket.sent.map((p) => JSON.parse(p).type);
+  assert.deepEqual(messageTypes(), ["subscribe"]);
+
+  // 关闭详情:退订被推迟,不立即发 unsubscribe;订阅仍在,socket 保持。
+  unsubFirst();
+  assert.deepEqual(messageTypes(), ["subscribe"]);
+  assert.equal(socket.readyState, FakeSocket.OPEN);
+  assert.equal(timers.timeoutCount, 1, "exactly one pending teardown timer");
+
+  // 窗口内重新打开同一架:取消待退订、原地复用,不发新的 subscribe。
+  const unsubSecond = client.subscribe({
+    channel: "callsign:UAL123",
+    listener: () => {},
+  });
+  assert.deepEqual(messageTypes(), ["subscribe"], "no resubscribe within grace");
+  assert.equal(timers.timeoutCount, 0, "pending teardown cancelled on reuse");
+
+  // 再次关闭并让 grace 到期:此时才真正发出唯一一次 unsubscribe。
+  unsubSecond();
+  assert.equal(timers.timeoutCount, 1);
+  timers.runNextTimeout();
+  assert.deepEqual(messageTypes(), ["subscribe", "unsubscribe"]);
+  assert.equal(
+    messageTypes().filter((t) => t === "subscribe").length,
+    1,
+    "at most one subscribe across open/close churn",
+  );
+  assert.equal(
+    messageTypes().filter((t) => t === "unsubscribe").length,
+    1,
+    "at most one unsubscribe after grace",
+  );
+}
+
 console.log("adsbaoRealtimeClient.test.ts ok");

--- a/src/lib/realtime/adsbaoRealtimeClient.ts
+++ b/src/lib/realtime/adsbaoRealtimeClient.ts
@@ -59,6 +59,7 @@ type AdsbaoRealtimeClientOptions = {
   heartbeatTimeoutMs?: number;
   authTokenFetcher?: RealtimeAuthTokenFetcher | null;
   idleDisconnectMs?: number;
+  subscriptionIdleGraceMs?: number;
 };
 
 type RealtimeLocationLike = {
@@ -171,6 +172,7 @@ export class AdsbaoRealtimeClient {
   private readonly heartbeatTimeoutMs: number;
   private readonly authTokenFetcher: RealtimeAuthTokenFetcher | null;
   private readonly idleDisconnectMs: number;
+  private readonly subscriptionIdleGraceMs: number;
   private socket: RealtimeSocket | null = null;
   private connectionState: ConnectionState;
   private reconnectTimer: number | null = null;
@@ -182,6 +184,13 @@ export class AdsbaoRealtimeClient {
   private intentionalClose = false;
   private reconnectAttempt = 0;
   private readonly subscriptions = new Map<string, StoredRealtimeSubscription>();
+  // 订阅级 idle grace 的待退订定时器(key → timer id)。callsign:/aircraft: 频道
+  // 最后一个 listener 离开后,退订被推迟到这里;窗口内同 key 再订阅会取消它。
+  private readonly pendingTeardownTimers = new Map<string, number>();
+  // churn 计数器(仅 dev 经 syncDebug 暴露到 window.__adsbaoRealtimeDebug,供验收)。
+  private subscribeMessages = 0;
+  private unsubscribeMessages = 0;
+  private gracefulReuses = 0;
   private readonly listeners = new Set<(event: AdsbaoRealtimeEvent) => void>();
   private readonly stateListeners = new Set<(state: ConnectionState) => void>();
   private readonly handleWindowReconnect = () => this.reconnectIfNeeded("window");
@@ -209,6 +218,7 @@ export class AdsbaoRealtimeClient {
         ? fetchRealtimeAuthToken
         : options.authTokenFetcher;
     this.idleDisconnectMs = options.idleDisconnectMs ?? 0;
+    this.subscriptionIdleGraceMs = options.subscriptionIdleGraceMs ?? 0;
     this.connectionState = url ? "closed" : "disabled";
     this.installLifecycleReconnectHandlers();
     this.syncDebug({
@@ -338,6 +348,10 @@ export class AdsbaoRealtimeClient {
   }: RealtimeSubscription): () => void {
     if (!channel) return () => {};
     const key = realtimeSubscriptionKey(channel, params);
+    // 若该 key 正处于退订 grace 窗口(订阅仍在表中、只是等待延迟退订),
+    // 取消待退订定时器并复用现有订阅:不发任何 subscribe/unsubscribe 消息。
+    // 这正是「反复开关同一架飞机详情」时消除订阅抖动的关键。
+    this.cancelPendingTeardown(key);
     const existing = this.subscriptions.get(key);
     if (existing) {
       existing.listeners.add(listener);
@@ -359,25 +373,80 @@ export class AdsbaoRealtimeClient {
     this.cancelIdleDisconnect();
     this.connect();
     if (!existing) {
+      this.subscribeMessages += 1;
+      this.syncDebug({ subscribeMessages: this.subscribeMessages });
       this.sendSubscribe({ channel, params });
     }
     return () => {
       const current = this.subscriptions.get(key);
       if (!current) return;
       current.listeners.delete(listener);
-      if (current.listeners.size === 0) {
-        this.subscriptions.delete(key);
-        this.syncDebug({
-          lastUnsubscribeAt: new Date().toISOString(),
-          lastUnsubscribeChannel: channel,
-          subscriptionCount: this.subscriptions.size,
-        });
-        this.send({ type: "unsubscribe", channel, params: current.params });
-        if (this.subscriptions.size === 0) {
-          this.scheduleIdleDisconnect();
-        }
+      if (current.listeners.size > 0) return;
+      // callsign:/aircraft: 这类单订阅频道:延迟退订(订阅级 idle grace);
+      // 其它频道(traffic: 已靠 grid 量化稳定)维持「最后退订即退」。
+      if (this.shouldDeferUnsubscribe(channel)) {
+        this.scheduleSubscriptionTeardown(key);
+      } else {
+        this.teardownSubscription(key);
       }
     };
+  }
+
+  // callsign:/aircraft: 频道通常只有一个订阅者,开关详情会立刻 unsubscribe 把后端
+  // 轮询循环拆掉、再订阅又重建+重取(+FlightAware re-auth)。延迟退订让窗口内的
+  // 再订阅原地复用,把这类抖动消除。traffic: 频道不走此路径。
+  private shouldDeferUnsubscribe(channel: string) {
+    return (
+      this.subscriptionIdleGraceMs > 0 &&
+      this.timerHost != null &&
+      (channel.startsWith("callsign:") || channel.startsWith("aircraft:"))
+    );
+  }
+
+  // 立即拆除订阅:从订阅表删除、发 unsubscribe、若无任何订阅再进入 socket 空闲断连。
+  private teardownSubscription(key: string) {
+    const current = this.subscriptions.get(key);
+    if (!current) return;
+    this.subscriptions.delete(key);
+    this.unsubscribeMessages += 1;
+    this.syncDebug({
+      lastUnsubscribeAt: new Date().toISOString(),
+      lastUnsubscribeChannel: current.channel,
+      subscriptionCount: this.subscriptions.size,
+      unsubscribeMessages: this.unsubscribeMessages,
+    });
+    this.send({ type: "unsubscribe", channel: current.channel, params: current.params });
+    if (this.subscriptions.size === 0) {
+      this.scheduleIdleDisconnect();
+    }
+  }
+
+  // 订阅级 idle grace:推迟退订 subscriptionIdleGraceMs;到期时若仍无 listener 才
+  // 真正退订(窗口内若有新订阅,cancelPendingTeardown 会取消本定时器)。
+  private scheduleSubscriptionTeardown(key: string) {
+    if (!this.timerHost || this.subscriptionIdleGraceMs <= 0) {
+      this.teardownSubscription(key);
+      return;
+    }
+    const existingTimer = this.pendingTeardownTimers.get(key);
+    if (existingTimer != null) this.timerHost.clearTimeout(existingTimer);
+    const timer = this.timerHost.setTimeout(() => {
+      this.pendingTeardownTimers.delete(key);
+      const current = this.subscriptions.get(key);
+      if (current && current.listeners.size === 0) {
+        this.teardownSubscription(key);
+      }
+    }, this.subscriptionIdleGraceMs);
+    this.pendingTeardownTimers.set(key, timer);
+  }
+
+  private cancelPendingTeardown(key: string) {
+    const timer = this.pendingTeardownTimers.get(key);
+    if (timer == null) return;
+    if (this.timerHost) this.timerHost.clearTimeout(timer);
+    this.pendingTeardownTimers.delete(key);
+    this.gracefulReuses += 1;
+    this.syncDebug({ gracefulReuses: this.gracefulReuses });
   }
 
   onMessage(listener: (event: AdsbaoRealtimeEvent) => void) {
@@ -407,6 +476,8 @@ export class AdsbaoRealtimeClient {
 
   private resubscribeAll() {
     for (const subscription of this.subscriptions.values()) {
+      // 处于退订 grace 窗口的订阅(已无 listener)不在重连时复活。
+      if (subscription.listeners.size === 0) continue;
       this.sendSubscribe(subscription);
     }
   }
@@ -682,6 +753,10 @@ let singleton: AdsbaoRealtimeClient | null = null;
 
 export function getAdsbaoRealtimeClient() {
   if (!singleton)
-    singleton = new AdsbaoRealtimeClient(undefined, { idleDisconnectMs: 10_000 });
+    singleton = new AdsbaoRealtimeClient(undefined, {
+      idleDisconnectMs: 10_000,
+      // callsign:/aircraft: 频道退订前的 grace,镜像 socket 级 idleDisconnectMs。
+      subscriptionIdleGraceMs: 3_000,
+    });
   return singleton;
 }


### PR DESCRIPTION
实时航空器管线效率改造的 **PR1 / 3**(Part A 订阅抖动 + Part D normalize 去重)。
架构不重写,只扩展 WS client 与 Go scheduler。计划见会话内 plan 文件。

## 背景
WS 单例的 warm socket 阻止了**连接**抖动,但挡不住**订阅**抖动:`callsign:`/`aircraft:`
频道通常只有单个订阅者,每次开关详情都会 unsubscribe 把后端轮询循环拆掉,再订阅时
重建 + 重取(FlightAware 还要 re-auth)。本 PR 前后端对称地消除这类抖动,并顺手去除
两份重复的 normalize helper(Part D)。

## 改动
**前端**
- `useAircraftPositions`:`params: realtimeRequest?.params ?? EMPTY_REALTIME_PARAMS`
  替代内联 `|| {}`,避免订阅 effect 的 `params` 依赖每次 render mint 新对象。
- `useRealtimeAircraftChannel`:频道切换不再立即 `setEvent(null)`——保留上一架数据
  直到新频道送达或 `CHANNEL_SWITCH_STALE_MS` 到期,消除详情切换闪烁。
- `adsbaoRealtimeClient`:对 `callsign:`/`aircraft:` 频道加**订阅级 idle grace**
  (`subscriptionIdleGraceMs`,singleton = 3s)。最后一个 listener 离开后延迟退订;
  窗口内同 key 再订阅则取消定时器、原地复用,不发任何消息。新增 churn 计数器
  (`gracefulReuses` / `subscribeMessages` / `unsubscribeMessages`)。默认 grace=0,
  既有行为与测试不变。
- **Part D**:抽共享 `normalizeRealtimeAircraftPayload`,`useAircraftPositions` 与
  `useTrackedAircraft` 复用。

**后端(Go data-service)**
- `scheduler` 加可配置 idle grace(`CHANNEL_IDLE_GRACE_PERIOD_MS`,默认 5s):最后一个
  订阅者离开后用 `time.AfterFunc` 延迟停轮询;窗口内有新订阅者命中同一 state 则
  `Stop` 定时器、循环不中断、无重建/重取。`run` 循环改为只看频道是否仍在活动表。
  grace 到期后仍保证「最后退订即停」。`config` 按现有 `durationMS` 惯例新增该项。

不触碰任何渲染/canvas 代码 → 帧率不受影响(有意义的 pan FPS 对比留给会改动 React
渲染的 PR2)。

## 验收(带证据)
- **前端 churn 单测**(`adsbaoRealtimeClient.test.ts`):反复开关同一 `callsign:UAL123`
  → 恰好一次 subscribe、(grace 后)一次 unsubscribe,窗口内复用不发消息。✅
- **Go 测试**:`TestSchedulerKeepsLoopDuringGrace`(grace 内频道不拆)、
  `TestSchedulerCancelsGraceOnResubscribe`(窗口内重订取消 grace)、既有
  `TestSchedulerSharesLoopAndStopsAfterLastUnsubscribe`(默认 grace=0 仍通过)。✅
- **浏览器实测**:KLAX 详情订阅 `callsign:SWA2383`,`window.__adsbaoRealtimeDebug`
  的 `gracefulReuses` 计数随 grace 复用增长(StrictMode 双挂载从「真实退订+重订」
  变为 0-churn 复用);无 PR 相关控制台错误。
- `pnpm test` 122 文件全过;`go test ./...` 全过;`pnpm knip` 干净。

## 版本
v2.36.0(minor:production 行为改善)。changelog 双语条目已加,`package.json` 同步。

Validation: local test + local browser — 见上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)