### PR TITLE
feat: 拆分 Explorer god-context + memo 化航班列表 — v2.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.36.0",
+  "version": "2.37.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -45,6 +45,13 @@ import {
   writeStoredMapSettings,
 } from "@/features/airport/map-settings/mapSettingsStorage";
 const ExplorerUiContext = createContext(null);
+// 按变更频率/关注点拆出的聚焦切片 context。只读某一组状态的消费者(如 AircraftTable
+// 只读 filters、MapFitToTraceController 只读 selection)订阅对应切片,即可在无关字段
+// (selection / mapZoom / 图层开关 等)变化时跳过重渲染——前提是该消费者本身被 memo
+// 化,从而不被父组件级联重渲染。useExplorerUi() 仍提供完整聚合(facade),读取面广的
+// 消费者(AirportExplorer / ExplorerMapMenu / FlightExplorer)无需改动。
+const ExplorerFilterContext = createContext(null);
+const ExplorerSelectionContext = createContext(null);
 const DEFAULT_USER_LOCATION_PREFERENCES =
   mapSettingsToUserLocationPreferences(DEFAULT_MAP_SETTINGS);
 
@@ -1077,9 +1084,92 @@ export function ExplorerUiProvider({ children }) {
     ],
   );
 
+  // 切片:filters。回调都是 useCallback 稳定引用,因此本 memo 实际只在筛选状态变化时
+  // 产生新对象 → 订阅它的 AircraftTable 不再因 selection/zoom/图层变化而重渲染。
+  const filterValue = useMemo(
+    () => ({
+      trafficFilter,
+      typeFilter,
+      altitudeLevel,
+      entityFilter,
+      setTrafficFilter,
+      setTypeFilter,
+      setAltitudeLevel,
+      setEntityFilter,
+    }),
+    [
+      trafficFilter,
+      typeFilter,
+      altitudeLevel,
+      entityFilter,
+      setTrafficFilter,
+      setTypeFilter,
+      setAltitudeLevel,
+      setEntityFilter,
+    ],
+  );
+
+  // 切片:selection(选中实体 + 选择/fit/follow 回调)。只在选中相关状态变化时更新。
+  const selectionValue = useMemo(
+    () => ({
+      selectedAircraftId,
+      selectedAirportIcao,
+      selectedNavaidKey,
+      selectedReportingPointKey,
+      selectedAirspaceId,
+      selectedAirspaceIds,
+      selectedCandidateWatchingSpotId,
+      fitToTraceSignal,
+      mapFollowsAircraft,
+      selectAircraft,
+      setSelectedAircraftId,
+      selectAirport,
+      selectNavaid,
+      setSelectedNavaidKey,
+      selectReportingPoint,
+      setSelectedReportingPointKey,
+      selectAirspace,
+      setSelectedAirspaceId,
+      selectCandidateWatchingSpot,
+      setSelectedCandidateWatchingSpotId,
+      clearAllPreviewSelections,
+      fitToTrace,
+      suspendMapFollow,
+    }),
+    [
+      selectedAircraftId,
+      selectedAirportIcao,
+      selectedNavaidKey,
+      selectedReportingPointKey,
+      selectedAirspaceId,
+      selectedAirspaceIds,
+      selectedCandidateWatchingSpotId,
+      fitToTraceSignal,
+      mapFollowsAircraft,
+      selectAircraft,
+      setSelectedAircraftId,
+      selectAirport,
+      selectNavaid,
+      setSelectedNavaidKey,
+      selectReportingPoint,
+      setSelectedReportingPointKey,
+      selectAirspace,
+      setSelectedAirspaceId,
+      selectCandidateWatchingSpot,
+      setSelectedCandidateWatchingSpotId,
+      clearAllPreviewSelections,
+      fitToTrace,
+      suspendMapFollow,
+    ],
+  );
+
   return (
     <ExplorerUiContext.Provider value={value}>
-      {children}
+      <ExplorerFilterContext.Provider value={filterValue}>
+        <ExplorerSelectionContext.Provider value={selectionValue}>
+          {children}
+        </ExplorerSelectionContext.Provider>
+      </ExplorerFilterContext.Provider>
     </ExplorerUiContext.Provider>
   );
 }
@@ -1089,6 +1179,26 @@ export function useExplorerUi() {
   if (!context) {
     throw new Error(
       "useExplorerUi must be used within ExplorerUiProvider",
+    );
+  }
+  return context;
+}
+
+// 聚焦切片 hook:只订阅 filters,避免无关字段变化造成的重渲染(配合 memo 化的消费者)。
+export function useExplorerFilters() {
+  const context = useContext(ExplorerFilterContext);
+  if (!context) {
+    throw new Error("useExplorerFilters must be used within ExplorerUiProvider");
+  }
+  return context;
+}
+
+// 聚焦切片 hook:只订阅 selection。
+export function useExplorerSelection() {
+  const context = useContext(ExplorerSelectionContext);
+  if (!context) {
+    throw new Error(
+      "useExplorerSelection must be used within ExplorerUiProvider",
     );
   }
   return context;

--- a/src/components/map/MapFitToTraceController.tsx
+++ b/src/components/map/MapFitToTraceController.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import L from "leaflet";
 import { useMapInstance } from "./MapContext";
-import { useExplorerUi } from "@/components/explorer/ExplorerUiContext";
+import { useExplorerSelection } from "@/components/explorer/ExplorerUiContext";
 import { useSelectedAircraftTrace } from "@/components/aircraft/trace/SelectedAircraftTraceContext";
 import {
   buildTraceFitPoints,
@@ -40,7 +40,7 @@ export default function MapFitToTraceController({
   onAutoFit,
 }: Record<string, any>) {
   const map = useMapInstance();
-  const { fitToTraceSignal } = useExplorerUi();
+  const { fitToTraceSignal } = useExplorerSelection();
   const { traces } = useSelectedAircraftTrace();
   const lastSignalRef = useRef(0);
   const lastAutoFitKeyRef = useRef("");

--- a/src/components/sidebar/AircraftTable.tsx
+++ b/src/components/sidebar/AircraftTable.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from "react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Check, ChevronDown, Minus, Search } from "lucide-react";
 import {
@@ -21,7 +21,7 @@ import {
   MenuItemLabel,
   MenuItemCount,
 } from "@/components/ui/MenuPanel";
-import { useExplorerUi } from "@/components/explorer/ExplorerUiContext";
+import { useExplorerFilters } from "@/components/explorer/ExplorerUiContext";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useListReorderMotion } from "@/animations/useListReorderMotion";
 import {
@@ -52,7 +52,7 @@ import VirtualNearbyList from "./VirtualNearbyList";
 type AircraftLike = Record<string, any>;
 type AirportLike = Record<string, any>;
 
-export default function AircraftTable({
+function AircraftTable({
   aircraft = [],
   airports = [],
   focusLat = null,
@@ -76,7 +76,7 @@ export default function AircraftTable({
     setTypeFilter,
     setAltitudeLevel,
     setEntityFilter,
-  } = useExplorerUi();
+  } = useExplorerFilters();
   const [query, setQuery] = useState("");
   const selectedTypes = useMemo(
     () => (Array.isArray(typeFilter) ? typeFilter : []),
@@ -853,3 +853,8 @@ function altitudeSortValue(aircraft: AircraftLike = {}) {
   if (aircraft.onGround) return -1;
   return toNumber(aircraft.altitude) ?? -2;
 }
+
+// memo 化容器:配合 useExplorerFilters() 切片订阅,使无关的高频更新(mapZoom、图层
+// 开关、sidebar、mapSettings)在父组件级联重渲染时被浅比较拦下——AircraftTable 只在
+// 自身 props(aircraft / 选中 / focus)或筛选状态变化时才重新渲染这条最热的列表。
+export default memo(AircraftTable);

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -47,32 +47,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 60;
+export const CHANGELOG_TOTAL_COUNT = 61;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.36.0",
+    version: "v2.37.0",
     kind: "feat",
     title: {
-      en: "Steadier realtime aircraft subscriptions",
-      zh: "更稳的实时航空器订阅",
+      en: "Lighter Explorer re-renders",
+      zh: "更轻的 Explorer 重渲染",
     },
     summary: {
-      en: "The realtime aircraft pipeline now resists subscription churn end-to-end. Rapidly opening and closing an aircraft detail no longer tears down and rebuilds its WebSocket subscription (and, for FlightAware, re-authenticates) on every toggle: the client holds callsign/aircraft subscriptions for a short grace window and reuses them if you come back, and the Go data-service mirrors that with a configurable idle grace before it stops a channel's polling loop — so a returning subscriber keeps the same warm loop with no rebuild or re-fetch spike. Switching between aircraft also stops flickering: the previous aircraft's data stays on screen until the new channel delivers instead of blanking instantly.",
-      zh: "实时航空器数据管线现在端到端地抵抗订阅抖动。快速开关某架飞机详情,不再每次都拆掉并重建它的 WebSocket 订阅(FlightAware 还要重新鉴权):客户端会把 callsign/aircraft 订阅保留一个短的 grace 窗口,期间再次进入则原地复用;Go 数据服务以一个可配置的 idle grace 镜像同样行为——最后一个订阅者离开后延迟停止该频道的轮询循环,于是 grace 窗口内返回的订阅者续用同一个热循环,无重建、无重取尖峰。切换不同飞机也不再闪烁:上一架的数据会保留到新频道送来数据,而不是瞬间清空。",
+      en: "The airport Explorer's UI state used to live in one large context object: any change — selecting an aircraft, panning, zooming, toggling a map layer — produced a new object and re-rendered every consumer, including the busy aircraft list. The context is now split into focused slices so a component can subscribe to just what it reads (the aircraft list subscribes only to the list filters), and the list itself is memoized. High-frequency updates that the list doesn't care about — zooming and map-layer toggles — no longer re-run the list's rendering work, while genuine changes (new traffic data, selecting a row) still update only what changed.",
+      zh: "机场 Explorer 的 UI 状态过去集中在一个大 context 对象里:任何变化——选中飞机、平移、缩放、切换地图图层——都会生成新对象并重渲染所有消费者,包括繁忙的航班列表。现在 context 拆成聚焦切片,组件只订阅自己读取的部分(航班列表只订阅列表筛选项),列表本身也做了 memo 化。列表不关心的高频更新——缩放、图层开关——不再触发列表的渲染工作;而真正的变化(新流量数据、选中某行)仍只更新发生变化的部分。",
     },
     highlights: [
       {
-        en: "Opening/closing the same aircraft repeatedly now sends at most one subscribe and one unsubscribe (after the grace), instead of a churn of teardown/rebuild messages.",
-        zh: "反复开关同一架飞机,现在最多发出一次 subscribe、一次 unsubscribe(grace 之后),而不再是一连串拆除/重建消息。",
+        en: "ExplorerUiContext is split into focused slices (filters, selection) alongside the full aggregate, so consumers re-render on their slice rather than on every unrelated field.",
+        zh: "ExplorerUiContext 在保留完整聚合的同时拆出聚焦切片(filters、selection),消费者只在自己的切片变化时重渲染,而非任何无关字段。",
       },
       {
-        en: "Switching between aircraft details no longer blanks the view — the previous aircraft stays until the new channel delivers, killing the detail-switch flicker.",
-        zh: "在不同飞机详情间切换不再清空视图——上一架会保留到新频道送达,消除了切换闪烁。",
+        en: "The aircraft list is memoized and subscribes only to the list filters: zooming and map-layer toggles no longer re-render it (≈3× fewer list re-renders during a zoom versus a full-context consumer).",
+        zh: "航班列表 memo 化并只订阅列表筛选项:缩放和图层开关不再触发它重渲染(缩放期间列表重渲染约为全量 context 消费者的 1/3)。",
       },
       {
-        en: "Backend symmetry: the data-service keeps a channel's polling loop alive for a configurable idle grace (CHANNEL_IDLE_GRACE_PERIOD_MS) after the last unsubscribe, while still guaranteeing the loop stops once the grace expires.",
-        zh: "前后端对称:数据服务在最后退订后,会按可配置的 idle grace(CHANNEL_IDLE_GRACE_PERIOD_MS)保留频道的轮询循环;grace 到期后仍保证循环停止。",
+        en: "Selecting an aircraft still updates only the changed rows, not the whole list (existing per-row memoization), and the map canvas continues to own per-frame aircraft motion — no per-frame React work was added.",
+        zh: "选中飞机仍只更新变化的行、而非整列表(沿用既有逐行 memo);逐帧的飞机运动依旧由地图 canvas 负责——没有新增任何逐帧 React 工作。",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -170,6 +170,32 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.36.0",
+    kind: "feat",
+    title: {
+      en: "Steadier realtime aircraft subscriptions",
+      zh: "更稳的实时航空器订阅",
+    },
+    summary: {
+      en: "The realtime aircraft pipeline now resists subscription churn end-to-end. Rapidly opening and closing an aircraft detail no longer tears down and rebuilds its WebSocket subscription (and, for FlightAware, re-authenticates) on every toggle: the client holds callsign/aircraft subscriptions for a short grace window and reuses them if you come back, and the Go data-service mirrors that with a configurable idle grace before it stops a channel's polling loop — so a returning subscriber keeps the same warm loop with no rebuild or re-fetch spike. Switching between aircraft also stops flickering: the previous aircraft's data stays on screen until the new channel delivers instead of blanking instantly.",
+      zh: "实时航空器数据管线现在端到端地抵抗订阅抖动。快速开关某架飞机详情,不再每次都拆掉并重建它的 WebSocket 订阅(FlightAware 还要重新鉴权):客户端会把 callsign/aircraft 订阅保留一个短的 grace 窗口,期间再次进入则原地复用;Go 数据服务以一个可配置的 idle grace 镜像同样行为——最后一个订阅者离开后延迟停止该频道的轮询循环,于是 grace 窗口内返回的订阅者续用同一个热循环,无重建、无重取尖峰。切换不同飞机也不再闪烁:上一架的数据会保留到新频道送来数据,而不是瞬间清空。",
+    },
+    highlights: [
+      {
+        en: "Opening/closing the same aircraft repeatedly now sends at most one subscribe and one unsubscribe (after the grace), instead of a churn of teardown/rebuild messages.",
+        zh: "反复开关同一架飞机,现在最多发出一次 subscribe、一次 unsubscribe(grace 之后),而不再是一连串拆除/重建消息。",
+      },
+      {
+        en: "Switching between aircraft details no longer blanks the view — the previous aircraft stays until the new channel delivers, killing the detail-switch flicker.",
+        zh: "在不同飞机详情间切换不再清空视图——上一架会保留到新频道送达,消除了切换闪烁。",
+      },
+      {
+        en: "Backend symmetry: the data-service keeps a channel's polling loop alive for a configurable idle grace (CHANNEL_IDLE_GRACE_PERIOD_MS) after the last unsubscribe, while still guaranteeing the loop stops once the grace expires.",
+        zh: "前后端对称:数据服务在最后退订后,会按可配置的 idle grace(CHANNEL_IDLE_GRACE_PERIOD_MS)保留频道的轮询循环;grace 到期后仍保证循环停止。",
+      },
+    ],
+  },
+  {
     version: "v2.35.0",
     kind: "feat",
     title: {


### PR DESCRIPTION
实时航空器管线效率改造的 **PR2 / 3**(Part C 重渲染效率)。承接 PR1(#584)。

## 背景
机场 Explorer 的 UI 状态过去集中在一个 ~1095 行的 `ExplorerUiContext` 单一 value 对象里:
任一字段变化(选中、平移、缩放、切换图层)都会生成新对象并重渲染**所有**消费者,包括最热
的航班列表。本 PR 按变更频率/关注点拆出聚焦切片,并 memo 化航班列表,使无关高频更新不再
触发它的渲染工作。

## 改动
**C1 — 拆 ExplorerUiContext(低风险:facade 保留)**
- 保留完整聚合 `useExplorerUi()`(读取面广的 `AirportExplorer`/`ExplorerMapMenu`/
  `FlightExplorer` 零改动),新增聚焦切片 context:`ExplorerFilterContext`、
  `ExplorerSelectionContext`,各自独立 `useMemo`。回调本就 `useCallback` 稳定,故切片对象
  只在自身状态变化时更新。
- `AircraftTable` 改订阅 `useExplorerFilters()`;`MapFitToTraceController` 改订阅
  `useExplorerSelection()`。

**C2 — memo 化最热列表**
- `AircraftTable` 容器用 `React.memo` 包裹。父组件因 zoom/图层/sidebar 等无关变化级联
  重渲染时,其 props(aircraft / airports / focus / 选中 / onSelect* 回调)引用稳定,
  memo 浅比较将其拦下。逐行 memo(既有)继续保证选中只更新变化的行。

不触碰 canvas 每帧运动循环,未新增任何逐帧 React 工作。

## 验收(带证据)
- **本地 render 计数(KLAX,临时插桩后已还原)**:单次缩放紧窗口内(<3s,无 traffic),
  facade 消费者 `ExplorerMapMenu` 渲染 3 次(逻辑,已扣除 dev StrictMode 双调用),
  `AircraftTable` 仅 1 次——这条最热列表在 zoom 期间的重渲染降到约 **1/3**。改造前
  `AircraftTable` 用全量 context 且未 memo,会与 facade 同频重渲染。
- 选中飞机仍只更新变化的行、而非整列表(沿用既有逐行 memo)。
- `pnpm test` 122 文件全过;`pnpm knip` 干净;`typecheck` 无新增错误。
- **帧率**:headless preview 下 rAF 被节流,formal pan FPS 不可测;本 PR 仅减少重渲染、
  不增加每帧工作,帧率不会回退。

## 版本
v2.37.0(minor:重渲染架构改善)。changelog 双语条目已加,`package.json` 同步。

Validation: local test + local browser(render 计数)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)