### PR TITLE
feat(data-service): cache recent trace + route in Postgres (SWR, 5min)

### DIFF
--- a/database/migrations/007_proxy_response_cache.sql
+++ b/database/migrations/007_proxy_response_cache.sql
@@ -1,0 +1,38 @@
+-- Short-lived server-side cache for upstream aircraft trace + flight route
+-- lookups. Both upstreams (adsb.lol traces, adsbdb/FlightAware routes) are
+-- rate-limited or quota'd, and the tracked-flight page re-fetches them every
+-- time the user navigates away and back (detail-page navigation is a hard
+-- reload, so in-process caches die). These tables let the data-service serve a
+-- recently-fetched result without hitting the upstream, shared across users.
+--
+-- The data-service treats both tables as best-effort: missing rows, missing
+-- tables, or query errors all fall back to a direct upstream fetch, so the app
+-- keeps working even before this migration is applied.
+
+create schema if not exists runtime;
+
+-- Rolling "recent" aircraft trace, keyed by ICAO hex (the trace endpoint only
+-- ever sees the hex, never the callsign). Full traces are multi-MB and are
+-- intentionally NOT cached here — they stay client-side (localStorage seed).
+create table if not exists runtime.aircraft_trace_cache (
+  hex        text primary key,
+  response   jsonb not null,
+  fetched_at timestamptz not null default now()
+);
+
+create index if not exists aircraft_trace_cache_fetched_at_idx
+  on runtime.aircraft_trace_cache (fetched_at);
+
+-- Resolved flight route, keyed by callsign AND provider. FlightAware and adsbdb
+-- are mutually exclusive providers (product guardrail): a row written by one
+-- provider must never be served to the other, so provider is part of the key.
+create table if not exists runtime.flight_route_cache (
+  callsign   text not null,
+  provider   text not null,
+  route      jsonb not null,
+  fetched_at timestamptz not null default now(),
+  primary key (callsign, provider)
+);
+
+create index if not exists flight_route_cache_fetched_at_idx
+  on runtime.flight_route_cache (fetched_at);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.38.1",
+  "version": "2.39.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/cmd/adsbao-data-service/main.go
+++ b/services/data-service/cmd/adsbao-data-service/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/adsbao/adsbao/services/data-service/internal/providers/adsb"
 	"github.com/adsbao/adsbao/services/data-service/internal/providers/flightaware"
 	"github.com/adsbao/adsbao/services/data-service/internal/providers/route"
+	"github.com/adsbao/adsbao/services/data-service/internal/proxycache"
 	"github.com/adsbao/adsbao/services/data-service/internal/realtime"
 	"github.com/adsbao/adsbao/services/data-service/internal/scheduler"
 	"github.com/adsbao/adsbao/services/data-service/internal/ws"
@@ -60,6 +61,15 @@ func main() {
 	if db != nil {
 		defer db.Close()
 	}
+	// Short-lived shared cache for upstream trace + route lookups. Nil when
+	// there is no database — every call site then falls back to direct fetches.
+	proxyCache := proxycache.New(db, 5*time.Minute, registry)
+	var routeCache route.Cache
+	var traceCache webapi.TraceCache
+	if proxyCache != nil {
+		routeCache = proxyCache
+		traceCache = proxyCache
+	}
 
 	remoteFlightAware := flightaware.NewRemoteClient(flightaware.RemoteOptions{
 		BaseURL:    cfg.FlightAwareServiceBaseURL,
@@ -81,6 +91,7 @@ func main() {
 	routeClient := route.NewClient(route.Options{
 		HTTPClient:              providerHTTPClient,
 		FlightAwareRouteFetcher: flightAwareRouteFetcher,
+		Cache:                   routeCache,
 	})
 	polling := scheduler.New(scheduler.Options{
 		Fetch: func(input realtime.FetchInput) (realtime.Event, error) {
@@ -133,6 +144,7 @@ func main() {
 			cfg.ClerkAPIBaseURL,
 		),
 		UserDataStore: webapi.NewUserDataStore(db, cfg.FeatureFlagsEnvironment, registry),
+		TraceCache:    traceCache,
 		FeatureFlags:  defaultFeatureFlags,
 	})
 	handler := instrumentHTTPHandler(registry, httpapi.New(httpapi.ServerOptions{
@@ -153,6 +165,9 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	if proxyCache != nil {
+		go proxyCache.RunJanitor(ctx, 15*time.Minute, time.Hour)
+	}
 	go reportMetrics(ctx, registry, started, cfg.MetricsReportInterval, polling.DebugChannels)
 	go logForwarder.Run(ctx, cfg.LogsReportInterval)
 	serverErr := make(chan error, 1)

--- a/services/data-service/internal/api/webapi/handler.go
+++ b/services/data-service/internal/api/webapi/handler.go
@@ -38,9 +38,18 @@ type Options struct {
 	Metrics                   realtime.MetricsSink
 	Authenticator             *ClerkAuthenticator
 	UserDataStore             *UserDataStore
+	TraceCache                TraceCache
 	FlightAwareServiceBaseURL string
 	FlightAwareServiceToken   string
 	FeatureFlags              map[string]bool
+}
+
+// TraceCache is a best-effort persistent cache for the rolling recent aircraft
+// trace, keyed by hex. A nil TraceCache disables caching.
+type TraceCache interface {
+	GetTrace(ctx context.Context, hex string) (json.RawMessage, time.Duration, bool)
+	PutTrace(ctx context.Context, hex string, response json.RawMessage)
+	TTL() time.Duration
 }
 
 type Handler struct {
@@ -54,6 +63,9 @@ type Handler struct {
 	metrics                   realtime.MetricsSink
 	authenticator             *ClerkAuthenticator
 	userDataStore             *UserDataStore
+	traceCache                TraceCache
+	traceRefreshMu            sync.Mutex
+	traceRefreshing           map[string]bool
 	flightAwareServiceBaseURL string
 	flightAwareServiceToken   string
 	featureFlags              map[string]bool
@@ -94,6 +106,8 @@ func New(options Options) *Handler {
 		metrics:                   options.Metrics,
 		authenticator:             options.Authenticator,
 		userDataStore:             options.UserDataStore,
+		traceCache:                options.TraceCache,
+		traceRefreshing:           map[string]bool{},
 		flightAwareServiceBaseURL: strings.TrimRight(strings.TrimSpace(options.FlightAwareServiceBaseURL), "/"),
 		flightAwareServiceToken:   strings.TrimSpace(options.FlightAwareServiceToken),
 		featureFlags:              cloneFeatureFlags(options.FeatureFlags),

--- a/services/data-service/internal/api/webapi/proxy.go
+++ b/services/data-service/internal/api/webapi/proxy.go
@@ -213,18 +213,30 @@ func (h *Handler) handleAircraftTrace(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "Invalid aircraft trace query"})
 		return
 	}
-	lower := strings.ToLower(strings.TrimPrefix(hex, "~"))
-	suffix := lower
-	if len(suffix) > 2 {
-		suffix = suffix[len(suffix)-2:]
+	full := r.URL.Query().Get("full") == "1"
+
+	// Only the rolling recent trace is cached. Full traces run multi-MB and are
+	// seeded client-side, so they always go straight to the upstream.
+	if !full && h.traceCache != nil {
+		if raw, age, ok := h.traceCache.GetTrace(r.Context(), hex); ok {
+			cacheState := "fresh"
+			if age >= h.traceCache.TTL() {
+				// Stale-while-revalidate: serve the cached copy now, refresh in
+				// the background so the next reader gets fresh data.
+				cacheState = "stale"
+				h.refreshTraceAsync(hex)
+			}
+			writeRawJSONWithHeaders(w, http.StatusOK, raw, map[string]string{
+				"Cache-Control": "no-store",
+				"X-Data-Source": "adsb.lol",
+				"X-Cache":       cacheState,
+			})
+			return
+		}
 	}
-	name := "trace_recent_" + lower + ".json"
-	if r.URL.Query().Get("full") == "1" {
-		name = "trace_full_" + lower + ".json"
-	}
-	upstream := fmt.Sprintf("https://adsb.lol/data/traces/%s/%s?_=%d", url.PathEscape(suffix), url.PathEscape(name), time.Now().UnixMilli())
-	payload, status, err := h.fetchJSONAnyWithTimeout(r.Context(), upstream, adsbHeaders(), aircraftTraceTimeout)
-	if err != nil || status < 200 || status >= 300 {
+
+	payload, status, err, ok := h.fetchAircraftTrace(r.Context(), hex, full)
+	if !ok {
 		writeJSONWithHeaders(w, http.StatusOK, emptyAircraftTracePayload(hex, status, err), map[string]string{
 			"Cache-Control":       "no-store",
 			"X-Data-Source":       "adsb.lol",
@@ -233,15 +245,100 @@ func (h *Handler) handleAircraftTrace(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	writeJSONWithHeaders(w, http.StatusOK, map[string]any{
+	response := map[string]any{
 		"hex":    hex,
 		"recent": payload,
 		"source": "adsb.lol",
-	}, map[string]string{
+	}
+	headers := map[string]string{
 		"Cache-Control":       "no-store",
 		"X-Data-Source":       "adsb.lol",
 		"X-Provider-Attempts": "adsb.lol:200",
-	})
+	}
+	if !full && h.traceCache != nil && traceHasPoints(payload) {
+		headers["X-Cache"] = "miss"
+		if raw, marshalErr := json.Marshal(response); marshalErr == nil {
+			h.traceCache.PutTrace(r.Context(), hex, raw)
+		}
+	}
+	writeJSONWithHeaders(w, http.StatusOK, response, headers)
+}
+
+// fetchAircraftTrace pulls a recent or full trace from adsb.lol. ok is false on
+// any transport error or non-2xx upstream status.
+func (h *Handler) fetchAircraftTrace(ctx context.Context, hex string, full bool) (any, int, error, bool) {
+	lower := strings.ToLower(strings.TrimPrefix(hex, "~"))
+	suffix := lower
+	if len(suffix) > 2 {
+		suffix = suffix[len(suffix)-2:]
+	}
+	name := "trace_recent_" + lower + ".json"
+	if full {
+		name = "trace_full_" + lower + ".json"
+	}
+	upstream := fmt.Sprintf("https://adsb.lol/data/traces/%s/%s?_=%d", url.PathEscape(suffix), url.PathEscape(name), time.Now().UnixMilli())
+	payload, status, err := h.fetchJSONAnyWithTimeout(ctx, upstream, adsbHeaders(), aircraftTraceTimeout)
+	if err != nil || status < 200 || status >= 300 {
+		return nil, status, err, false
+	}
+	return payload, status, nil, true
+}
+
+// refreshTraceAsync revalidates a stale recent-trace entry in the background.
+// At most one refresh per hex runs at a time so concurrent readers don't
+// stampede the upstream.
+func (h *Handler) refreshTraceAsync(hex string) {
+	if h.traceCache == nil {
+		return
+	}
+	h.traceRefreshMu.Lock()
+	if h.traceRefreshing == nil {
+		h.traceRefreshing = map[string]bool{}
+	}
+	if h.traceRefreshing[hex] {
+		h.traceRefreshMu.Unlock()
+		return
+	}
+	h.traceRefreshing[hex] = true
+	h.traceRefreshMu.Unlock()
+
+	go func() {
+		defer func() {
+			h.traceRefreshMu.Lock()
+			delete(h.traceRefreshing, hex)
+			h.traceRefreshMu.Unlock()
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), aircraftTraceTimeout)
+		defer cancel()
+		payload, _, _, ok := h.fetchAircraftTrace(ctx, hex, false)
+		if !ok || !traceHasPoints(payload) {
+			return
+		}
+		response := map[string]any{"hex": hex, "recent": payload, "source": "adsb.lol"}
+		if raw, err := json.Marshal(response); err == nil {
+			h.traceCache.PutTrace(ctx, hex, raw)
+		}
+	}()
+}
+
+// traceHasPoints reports whether an adsb.lol recent payload carries at least
+// one trace sample. Empty payloads are not worth caching.
+func traceHasPoints(payload any) bool {
+	record, ok := payload.(map[string]any)
+	if !ok {
+		return false
+	}
+	trace, ok := record["trace"].([]any)
+	return ok && len(trace) > 0
+}
+
+func writeRawJSONWithHeaders(w http.ResponseWriter, status int, raw json.RawMessage, headers map[string]string) {
+	for key, value := range headers {
+		w.Header().Set(key, value)
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = w.Write(raw)
 }
 
 func (h *Handler) handleAircraftPhoto(w http.ResponseWriter, r *http.Request) {

--- a/services/data-service/internal/api/webapi/trace_cache_test.go
+++ b/services/data-service/internal/api/webapi/trace_cache_test.go
@@ -1,0 +1,164 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeTraceCache struct {
+	mu       sync.Mutex
+	raw      json.RawMessage
+	age      time.Duration
+	ok       bool
+	ttl      time.Duration
+	getCalls int
+	failGet  bool
+	t        *testing.T
+	putCh    chan json.RawMessage
+}
+
+func (c *fakeTraceCache) GetTrace(ctx context.Context, hex string) (json.RawMessage, time.Duration, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.getCalls++
+	if c.failGet {
+		c.t.Fatalf("GetTrace must not be called")
+	}
+	return c.raw, c.age, c.ok
+}
+
+func (c *fakeTraceCache) PutTrace(ctx context.Context, hex string, response json.RawMessage) {
+	if c.putCh != nil {
+		c.putCh <- response
+	}
+}
+
+func (c *fakeTraceCache) TTL() time.Duration { return c.ttl }
+
+func TestAircraftTraceServesFreshCache(t *testing.T) {
+	cache := &fakeTraceCache{
+		raw: json.RawMessage(`{"hex":"C00DEA","recent":{"trace":[1]},"source":"adsb.lol","cached":true}`),
+		age: time.Minute,
+		ok:  true,
+		ttl: 5 * time.Minute,
+	}
+	handler := New(Options{
+		TraceCache: cache,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("upstream must not be called on a fresh cache hit")
+			return nil, nil
+		})},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/aircraft/trace/C00DEA", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("X-Cache") != "fresh" {
+		t.Fatalf("X-Cache = %q", rr.Header().Get("X-Cache"))
+	}
+	if rr.Body.String() != string(cache.raw) {
+		t.Fatalf("body = %s", rr.Body.String())
+	}
+}
+
+func TestAircraftTraceCachesRecentMiss(t *testing.T) {
+	putCh := make(chan json.RawMessage, 1)
+	cache := &fakeTraceCache{ok: false, ttl: 5 * time.Minute, putCh: putCh}
+	handler := New(Options{
+		TraceCache: cache,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{"trace":[[0,42.3,-71.0]]}`), nil
+		})},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/aircraft/trace/C00DEA", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("X-Cache") != "miss" {
+		t.Fatalf("X-Cache = %q", rr.Header().Get("X-Cache"))
+	}
+	select {
+	case raw := <-putCh:
+		var stored map[string]any
+		if err := json.Unmarshal(raw, &stored); err != nil {
+			t.Fatalf("stored json: %v", err)
+		}
+		if stored["source"] != "adsb.lol" || stored["hex"] != "C00DEA" {
+			t.Fatalf("stored = %#v", stored)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected PutTrace on a successful recent fetch")
+	}
+}
+
+func TestAircraftTraceFullBypassesCache(t *testing.T) {
+	cache := &fakeTraceCache{ttl: 5 * time.Minute, failGet: true, t: t, putCh: make(chan json.RawMessage, 1)}
+	handler := New(Options{
+		TraceCache: cache,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{"trace":[[0,42.3,-71.0]]}`), nil
+		})},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/aircraft/trace/C00DEA?full=1", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if cache.getCalls != 0 {
+		t.Fatalf("full trace must not read the cache (getCalls=%d)", cache.getCalls)
+	}
+	select {
+	case <-cache.putCh:
+		t.Fatalf("full trace must not be cached")
+	default:
+	}
+}
+
+func TestAircraftTraceStaleServesAndRevalidates(t *testing.T) {
+	putCh := make(chan json.RawMessage, 1)
+	cache := &fakeTraceCache{
+		raw:   json.RawMessage(`{"hex":"C00DEA","recent":{"trace":[1]},"source":"adsb.lol","stale":true}`),
+		age:   10 * time.Minute,
+		ok:    true,
+		ttl:   5 * time.Minute,
+		putCh: putCh,
+	}
+	handler := New(Options{
+		TraceCache: cache,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{"trace":[[0,42.3,-71.0]]}`), nil
+		})},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/aircraft/trace/C00DEA", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Header().Get("X-Cache") != "stale" {
+		t.Fatalf("X-Cache = %q", rr.Header().Get("X-Cache"))
+	}
+	if rr.Body.String() != string(cache.raw) {
+		t.Fatalf("stale body = %s", rr.Body.String())
+	}
+	select {
+	case <-putCh: // background revalidation refreshed the cache
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected background revalidation to refresh the cache")
+	}
+}

--- a/services/data-service/internal/providers/route/client.go
+++ b/services/data-service/internal/providers/route/client.go
@@ -25,6 +25,14 @@ const (
 	userAgent            = "ADSBao data-service/1.0 (+https://adsbao.dev)"
 )
 
+// Cache is a best-effort persistent route cache keyed by callsign+provider.
+// A nil Cache disables caching entirely.
+type Cache interface {
+	GetRoute(ctx context.Context, callsign, provider string) (json.RawMessage, time.Duration, bool)
+	PutRoute(ctx context.Context, callsign, provider string, route json.RawMessage)
+	TTL() time.Duration
+}
+
 type Options struct {
 	HTTPClient              *http.Client
 	ADSBDBBaseURL           string
@@ -33,6 +41,7 @@ type Options struct {
 	MaxBytes                int64
 	QueueInterval           time.Duration
 	DisableQueue            bool
+	Cache                   Cache
 }
 
 type Client struct {
@@ -42,6 +51,7 @@ type Client struct {
 	timeout                 time.Duration
 	maxBytes                int64
 	queueInterval           time.Duration
+	cache                   Cache
 	mu                      sync.Mutex
 	lastStarted             time.Time
 }
@@ -74,6 +84,7 @@ func NewClient(options Options) *Client {
 		timeout:                 timeout,
 		maxBytes:                maxBytes,
 		queueInterval:           queueInterval,
+		cache:                   options.Cache,
 	}
 }
 
@@ -81,10 +92,81 @@ func (c *Client) Fetch(ctx context.Context, input realtime.FetchInput) (realtime
 	if input.Target.Kind != "route" {
 		return realtime.Event{}, errors.New("Expected route polling target")
 	}
+	provider := "adsbdb"
 	if input.Target.RouteProvider == "flightaware" {
+		provider = "flightaware"
+	}
+	callsign := input.Target.Callsign
+
+	// Serve a fresh cached route without touching the upstream (also skips the
+	// adsbdb rate-limit queue). Provider is part of the key, so a FlightAware
+	// lookup never reads an adsbdb row and vice versa.
+	if c.cache != nil && callsign != "" {
+		if raw, age, ok := c.cache.GetRoute(ctx, callsign, provider); ok && age < c.cache.TTL() {
+			return cachedRouteEvent(input.Channel, provider, callsign, raw), nil
+		}
+	}
+
+	event, err := c.fetchUpstream(ctx, input, provider)
+	if err != nil {
+		// Upstream failed — fall back to the last-known route if we have one
+		// (stale-while-revalidate), rather than surfacing an empty/error route.
+		if c.cache != nil && callsign != "" {
+			if raw, _, ok := c.cache.GetRoute(ctx, callsign, provider); ok {
+				return cachedRouteEvent(input.Channel, provider, callsign, raw), nil
+			}
+		}
+		return event, err
+	}
+
+	// Cache only successful lookups that actually resolved a route.
+	if c.cache != nil && callsign != "" {
+		if raw := routeJSONFromEvent(event); raw != nil {
+			c.cache.PutRoute(ctx, callsign, provider, raw)
+		}
+	}
+	return event, nil
+}
+
+func (c *Client) fetchUpstream(ctx context.Context, input realtime.FetchInput, provider string) (realtime.Event, error) {
+	if provider == "flightaware" {
 		return c.fetchFlightAware(ctx, input)
 	}
 	return c.fetchADSBDB(ctx, input)
+}
+
+func cachedRouteEvent(channel, source, callsign string, raw json.RawMessage) realtime.Event {
+	var route map[string]any
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &route)
+	}
+	return realtime.Event{
+		Type:      "route:update",
+		Channel:   channel,
+		Source:    source,
+		FetchedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Stale:     false,
+		Data: map[string]any{
+			"callsign": callsign,
+			"route":    route,
+		},
+	}
+}
+
+func routeJSONFromEvent(event realtime.Event) json.RawMessage {
+	data, ok := event.Data.(map[string]any)
+	if !ok {
+		return nil
+	}
+	route, ok := data["route"].(map[string]any)
+	if !ok || route == nil {
+		return nil
+	}
+	raw, err := json.Marshal(route)
+	if err != nil {
+		return nil
+	}
+	return raw
 }
 
 func (c *Client) fetchADSBDB(ctx context.Context, input realtime.FetchInput) (realtime.Event, error) {

--- a/services/data-service/internal/providers/route/client_cache_test.go
+++ b/services/data-service/internal/providers/route/client_cache_test.go
@@ -1,0 +1,156 @@
+package route
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/adsbao/adsbao/services/data-service/internal/realtime"
+)
+
+type fakeRouteCache struct {
+	mu      sync.Mutex
+	entries map[string]json.RawMessage
+	age     time.Duration
+	ttl     time.Duration
+	puts    int
+}
+
+func newFakeRouteCache(ttl time.Duration) *fakeRouteCache {
+	return &fakeRouteCache{entries: map[string]json.RawMessage{}, ttl: ttl}
+}
+
+func (c *fakeRouteCache) key(callsign, provider string) string { return provider + "|" + callsign }
+
+func (c *fakeRouteCache) GetRoute(ctx context.Context, callsign, provider string) (json.RawMessage, time.Duration, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	raw, ok := c.entries[c.key(callsign, provider)]
+	if !ok {
+		return nil, 0, false
+	}
+	return raw, c.age, true
+}
+
+func (c *fakeRouteCache) PutRoute(ctx context.Context, callsign, provider string, route json.RawMessage) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[c.key(callsign, provider)] = route
+	c.puts++
+}
+
+func (c *fakeRouteCache) TTL() time.Duration { return c.ttl }
+
+func routeInput(channel, callsign, provider string) realtime.FetchInput {
+	return realtime.FetchInput{
+		Channel:     channel,
+		ChannelType: realtime.ChannelRoute,
+		Target:      realtime.PollingTarget{Kind: "route", Callsign: callsign, RouteProvider: provider},
+	}
+}
+
+func TestRouteCacheFreshHitSkipsUpstream(t *testing.T) {
+	cache := newFakeRouteCache(5 * time.Minute)
+	cache.age = time.Minute
+	cache.entries[cache.key("DAL123", "adsbdb")] =
+		json.RawMessage(`{"origin":{"icao":"KATL"},"destination":{"icao":"KBOS"},"source":"adsbdb"}`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("upstream must not be called on a fresh cache hit")
+	}))
+	defer server.Close()
+
+	client := NewClient(Options{ADSBDBBaseURL: server.URL + "/v0", QueueInterval: 0, Cache: cache})
+	event, err := client.Fetch(context.Background(), routeInput("route:DAL123", "DAL123", ""))
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	route := event.Data.(map[string]any)["route"].(map[string]any)
+	if route["source"] != "adsbdb" {
+		t.Fatalf("route = %#v", route)
+	}
+	if cache.puts != 0 {
+		t.Fatalf("a fresh hit should not rewrite the cache")
+	}
+}
+
+func TestRouteCacheStoresSuccessfulLookup(t *testing.T) {
+	cache := newFakeRouteCache(5 * time.Minute)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"response":{"flightroute":{"callsign":"DAL123","airline":{"icao":"DAL"},"origin":{"icao_code":"KATL","latitude":33.6,"longitude":-84.4},"destination":{"icao_code":"KBOS","latitude":42.3,"longitude":-71.0}}}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Options{ADSBDBBaseURL: server.URL + "/v0", QueueInterval: 0, Cache: cache})
+	if _, err := client.Fetch(context.Background(), routeInput("route:DAL123", "DAL123", "")); err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if cache.puts != 1 {
+		t.Fatalf("expected one cache write, got %d", cache.puts)
+	}
+	if _, _, ok := cache.GetRoute(context.Background(), "DAL123", "adsbdb"); !ok {
+		t.Fatalf("expected an adsbdb-keyed cache entry")
+	}
+}
+
+func TestRouteCacheServesStaleOnUpstreamError(t *testing.T) {
+	cache := newFakeRouteCache(5 * time.Minute)
+	cache.age = 10 * time.Minute // stale
+	cache.entries[cache.key("DAL123", "adsbdb")] =
+		json.RawMessage(`{"origin":{"icao":"KATL"},"destination":{"icao":"KBOS"},"source":"adsbdb"}`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewClient(Options{ADSBDBBaseURL: server.URL + "/v0", QueueInterval: 0, Cache: cache})
+	event, err := client.Fetch(context.Background(), routeInput("route:DAL123", "DAL123", ""))
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	if event.Data.(map[string]any)["route"] == nil {
+		t.Fatalf("expected last-known route on upstream failure")
+	}
+}
+
+func TestRouteCacheKeyedByProvider(t *testing.T) {
+	cache := newFakeRouteCache(5 * time.Minute)
+	cache.age = time.Minute
+	// Only an adsbdb entry exists; a FlightAware lookup must not read it.
+	cache.entries[cache.key("AAL1234", "adsbdb")] =
+		json.RawMessage(`{"origin":{"icao":"KATL"},"destination":{"icao":"KBOS"},"source":"adsbdb"}`)
+
+	var flightAwareCalled bool
+	client := NewClient(Options{
+		QueueInterval: 0,
+		Cache:         cache,
+		FlightAwareRouteFetcher: func(ctx context.Context, callsign string, m realtime.MetricsSink) (map[string]any, error) {
+			flightAwareCalled = true
+			return map[string]any{
+				"origin":      map[string]any{"icao": "KBOS", "lat": 42.3, "lon": -71.0},
+				"destination": map[string]any{"icao": "KLAX", "lat": 33.9, "lon": -118.4},
+				"source":      "flightaware",
+			}, nil
+		},
+	})
+
+	event, err := client.Fetch(context.Background(), routeInput("route:AAL1234", "AAL1234", "flightaware"))
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if !flightAwareCalled {
+		t.Fatalf("a FlightAware lookup must not be served from an adsbdb cache entry")
+	}
+	route := event.Data.(map[string]any)["route"].(map[string]any)
+	if route["source"] != "flightaware" {
+		t.Fatalf("route = %#v", route)
+	}
+	if _, _, ok := cache.GetRoute(context.Background(), "AAL1234", "flightaware"); !ok {
+		t.Fatalf("expected a flightaware-keyed cache entry")
+	}
+}

--- a/services/data-service/internal/proxycache/store.go
+++ b/services/data-service/internal/proxycache/store.go
@@ -1,0 +1,164 @@
+// Package proxycache is a best-effort, short-lived Postgres cache for upstream
+// aircraft-trace and flight-route lookups. It is deliberately forgiving: a nil
+// store (no DATABASE_URL), a missing table, or any query error simply behaves
+// as a cache miss so callers fall back to a direct upstream fetch.
+//
+// Freshness is owned here via a single TTL so the trace handler and the route
+// client agree on what "fresh" means. Reads return the row's age (computed by
+// Postgres to avoid app/db clock skew); the caller compares it against TTL().
+package proxycache
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"time"
+)
+
+const defaultTTL = 5 * time.Minute
+
+type metricsSink interface {
+	RecordDBTransaction(operation, result string, durationMS int64)
+}
+
+// Store wraps the shared *sql.DB. All methods are nil-receiver safe.
+type Store struct {
+	db      *sql.DB
+	ttl     time.Duration
+	metrics metricsSink
+}
+
+// New returns nil when db is nil so callers can treat "no database" as "no
+// cache" without special-casing every call site.
+func New(db *sql.DB, ttl time.Duration, metrics metricsSink) *Store {
+	if db == nil {
+		return nil
+	}
+	if ttl <= 0 {
+		ttl = defaultTTL
+	}
+	return &Store{db: db, ttl: ttl, metrics: metrics}
+}
+
+// TTL is the freshness window. Rows older than this are stale (still returned,
+// but the caller is expected to revalidate).
+func (s *Store) TTL() time.Duration {
+	if s == nil {
+		return defaultTTL
+	}
+	return s.ttl
+}
+
+// GetTrace returns the cached recent-trace response for a hex, its age, and
+// whether a row was found.
+func (s *Store) GetTrace(ctx context.Context, hex string) (json.RawMessage, time.Duration, bool) {
+	return s.get(ctx, "trace_cache_get",
+		`select response, extract(epoch from (now() - fetched_at))::float8
+		 from runtime.aircraft_trace_cache
+		 where hex = $1`,
+		hex,
+	)
+}
+
+// PutTrace upserts the recent-trace response for a hex.
+func (s *Store) PutTrace(ctx context.Context, hex string, response json.RawMessage) {
+	s.exec(ctx, "trace_cache_put",
+		`insert into runtime.aircraft_trace_cache (hex, response, fetched_at)
+		 values ($1, $2::jsonb, now())
+		 on conflict (hex) do update
+		   set response = excluded.response, fetched_at = excluded.fetched_at`,
+		hex, string(response),
+	)
+}
+
+// GetRoute returns the cached route for a callsign+provider, its age, and
+// whether a row was found. Provider is part of the key: FlightAware and adsbdb
+// routes never cross over.
+func (s *Store) GetRoute(ctx context.Context, callsign, provider string) (json.RawMessage, time.Duration, bool) {
+	return s.get(ctx, "route_cache_get",
+		`select route, extract(epoch from (now() - fetched_at))::float8
+		 from runtime.flight_route_cache
+		 where callsign = $1 and provider = $2`,
+		callsign, provider,
+	)
+}
+
+// PutRoute upserts a resolved route for a callsign+provider.
+func (s *Store) PutRoute(ctx context.Context, callsign, provider string, route json.RawMessage) {
+	s.exec(ctx, "route_cache_put",
+		`insert into runtime.flight_route_cache (callsign, provider, route, fetched_at)
+		 values ($1, $2, $3::jsonb, now())
+		 on conflict (callsign, provider) do update
+		   set route = excluded.route, fetched_at = excluded.fetched_at`,
+		callsign, provider, string(route),
+	)
+}
+
+// Cleanup deletes rows older than the retention window from both tables. Run
+// periodically so the tables don't accumulate one row per aircraft ever viewed.
+func (s *Store) Cleanup(ctx context.Context, retention time.Duration) {
+	if s == nil || s.db == nil || retention <= 0 {
+		return
+	}
+	cutoff := time.Now().Add(-retention)
+	s.exec(ctx, "trace_cache_cleanup",
+		`delete from runtime.aircraft_trace_cache where fetched_at < $1`, cutoff)
+	s.exec(ctx, "route_cache_cleanup",
+		`delete from runtime.flight_route_cache where fetched_at < $1`, cutoff)
+}
+
+// RunJanitor blocks running Cleanup on an interval until ctx is cancelled.
+func (s *Store) RunJanitor(ctx context.Context, interval, retention time.Duration) {
+	if s == nil || s.db == nil || interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.Cleanup(ctx, retention)
+		}
+	}
+}
+
+func (s *Store) get(ctx context.Context, operation, query string, args ...any) (json.RawMessage, time.Duration, bool) {
+	if s == nil || s.db == nil {
+		return nil, 0, false
+	}
+	started := time.Now()
+	var raw []byte
+	var ageSeconds float64
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(&raw, &ageSeconds)
+	s.record(operation, err, started)
+	if err != nil || len(raw) == 0 {
+		return nil, 0, false
+	}
+	age := time.Duration(ageSeconds * float64(time.Second))
+	if age < 0 {
+		age = 0
+	}
+	return json.RawMessage(raw), age, true
+}
+
+func (s *Store) exec(ctx context.Context, operation, query string, args ...any) {
+	if s == nil || s.db == nil {
+		return
+	}
+	started := time.Now()
+	_, err := s.db.ExecContext(ctx, query, args...)
+	s.record(operation, err, started)
+}
+
+func (s *Store) record(operation string, err error, started time.Time) {
+	if s == nil || s.metrics == nil {
+		return
+	}
+	result := "success"
+	if err != nil && err != sql.ErrNoRows {
+		result = "error"
+	}
+	s.metrics.RecordDBTransaction(operation, result, time.Since(started).Milliseconds())
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -47,36 +47,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 62;
+export const CHANGELOG_TOTAL_COUNT = 63;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.38.1",
+    version: "v2.39.0",
     kind: "feat",
     title: {
-      en: "Frosted map labels, colour-coded targets, steadier flight pages",
-      zh: "磨砂地图标签、目标配色与更稳的飞行页",
+      en: "Faster trace & route when you revisit a flight",
+      zh: "重访航班时航迹与航线加载更快",
     },
     summary: {
-      en: "The map's labels for airports, navaids and reporting points are now the same frosted-glass pill as the toolbar, so the whole map reads as one material. Targets gain a clear colour hierarchy: the page's primary target — the focal airport, or the tracked aircraft — is the orange signal accent, while an aircraft you click is a high-contrast neutral, so the two are distinct at a glance. Flight tracking pages are also far more stable: navigating between detail pages now loads each page fresh (no stale map, no leftover connections), the map shows a clear loading animation while acquiring a signal, and a flight with no live position — including a trans-oceanic leg with no coverage — shows an explicit card (\"no live position\" / \"signal lost\" / \"flight ended\") instead of an endless spinner or an unrelated fallback map.",
-      zh: "地图上机场、导航台、报告点的标签现在统一为和工具栏一致的磨砂玻璃胶囊,整张地图读起来是同一种材质。目标有了清晰的颜色层级:页面的首要目标——所在机场,或被追踪的飞机——用橙色信号强调色,而你点选的飞机是高对比中性色,一眼就能区分。飞行追踪页也更稳定:在详情页之间跳转现在会整页全新加载(没有残留地图、没有残留连接),获取信号时地图显示清晰的加载动画,而没有实时位置的航班——包括无覆盖的跨洋航段——会显示明确的卡片(\"暂无实时位置\"/\"信号丢失\"/\"航班已结束\"),而不是无尽转圈或一张不相干的兜底地图。",
+      en: "Returning to a flight you just left is quicker. The data-service now keeps a short-lived (5-minute) shared cache of each flight's recent trace and route. Because navigating between detail pages fully reloads the page, the trace and route used to be re-fetched from the upstream providers every single time you came back; now they're served straight from the cache, so they appear faster and the rate-limited upstreams (adsb.lol traces, adsbdb / FlightAware routes) are hit far less. The cache is stale-while-revalidate: a just-expired entry is shown instantly and refreshed in the background, and if an upstream is briefly down the last known route is still shown. Live aircraft position is unaffected and stays real-time.",
+      zh: "刚离开又点回来的航班加载更快了。数据服务现在为每个航班的最近航迹和航线保留一份短时(5 分钟)共享缓存。由于详情页之间跳转是整页重载,以前每次回来都要重新向上游重拉航迹和航线;现在直接从缓存返回,显示更快,也大幅减少对限流上游(adsb.lol 航迹、adsbdb / FlightAware 航线)的请求。缓存采用 stale-while-revalidate:刚过期的条目会立即返回并在后台刷新;上游短暂不可用时仍会显示最后一次已知的航线。飞机实时位置不受影响,仍保持实时。",
     },
     highlights: [
       {
-        en: "Airport / navaid / reporting-point map labels and the navaid count marker are now the toolbar's frosted-glass pill — one consistent material across the map.",
-        zh: "机场 / 导航台 / 报告点的地图标签以及导航台计数标记,现在都是工具栏那种磨砂玻璃胶囊——全图统一材质。",
+        en: "Recent trace and route are cached server-side for 5 minutes and shared across users, so returning to a flight within that window doesn't re-hit the upstream.",
+        zh: "最近航迹与航线在服务端缓存 5 分钟且跨用户共享,在此窗口内重访航班不再重打上游。",
       },
       {
-        en: "Map target colours: the primary target (focal airport or tracked aircraft) uses the orange accent; a clicked aircraft uses a high-contrast neutral — distinct at a glance, theme-aware in light and dark.",
-        zh: "地图目标配色:首要目标(所在机场或被追踪飞机)用橙色强调色;点选的飞机用高对比中性色——一眼可分,明暗主题各自适配。",
+        en: "Stale-while-revalidate: a just-expired entry is served instantly and refreshed in the background; multi-MB full traces are never cached (they stay client-side).",
+        zh: "Stale-while-revalidate:刚过期的条目即时返回并在后台刷新;多兆字节的完整航迹不进缓存(仍留在客户端)。",
       },
       {
-        en: "Stable detail-page navigation: each flight/airport page loads fresh on navigation (the old realtime connection is torn down), with a clear loading animation and an explicit no-live-position / signal-lost / flight-ended state instead of a stuck spinner or fallback map.",
-        zh: "更稳的详情页跳转:跳转时每个飞机/机场页都全新加载(旧实时连接被切断),配清晰的加载动画,以及明确的「暂无实时位置 / 信号丢失 / 航班已结束」状态,而非卡住的转圈或兜底地图。",
-      },
-      {
-        en: "The tracked flight now defaults to its full recorded trace (all available history), not just the trail since you opened the page; clicked aircraft still show their recent trail.",
-        zh: "被追踪航班现在默认显示完整记录航迹(全部可用历史),而不只是你打开页面之后的那一段;点选的飞机仍显示最近航迹。",
+        en: "FlightAware and adsbdb routes are cached separately and never mixed, and the cache falls back to direct fetches when the database is unavailable.",
+        zh: "FlightAware 与 adsbdb 航线分开缓存、绝不混用;数据库不可用时自动回退为直连上游。",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -170,6 +170,36 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.38.1",
+    kind: "feat",
+    title: {
+      en: "Frosted map labels, colour-coded targets, steadier flight pages",
+      zh: "磨砂地图标签、目标配色与更稳的飞行页",
+    },
+    summary: {
+      en: "The map's labels for airports, navaids and reporting points are now the same frosted-glass pill as the toolbar, so the whole map reads as one material. Targets gain a clear colour hierarchy: the page's primary target — the focal airport, or the tracked aircraft — is the orange signal accent, while an aircraft you click is a high-contrast neutral, so the two are distinct at a glance. Flight tracking pages are also far more stable: navigating between detail pages now loads each page fresh (no stale map, no leftover connections), the map shows a clear loading animation while acquiring a signal, and a flight with no live position — including a trans-oceanic leg with no coverage — shows an explicit card (\"no live position\" / \"signal lost\" / \"flight ended\") instead of an endless spinner or an unrelated fallback map.",
+      zh: "地图上机场、导航台、报告点的标签现在统一为和工具栏一致的磨砂玻璃胶囊,整张地图读起来是同一种材质。目标有了清晰的颜色层级:页面的首要目标——所在机场,或被追踪的飞机——用橙色信号强调色,而你点选的飞机是高对比中性色,一眼就能区分。飞行追踪页也更稳定:在详情页之间跳转现在会整页全新加载(没有残留地图、没有残留连接),获取信号时地图显示清晰的加载动画,而没有实时位置的航班——包括无覆盖的跨洋航段——会显示明确的卡片(\"暂无实时位置\"/\"信号丢失\"/\"航班已结束\"),而不是无尽转圈或一张不相干的兜底地图。",
+    },
+    highlights: [
+      {
+        en: "Airport / navaid / reporting-point map labels and the navaid count marker are now the toolbar's frosted-glass pill — one consistent material across the map.",
+        zh: "机场 / 导航台 / 报告点的地图标签以及导航台计数标记,现在都是工具栏那种磨砂玻璃胶囊——全图统一材质。",
+      },
+      {
+        en: "Map target colours: the primary target (focal airport or tracked aircraft) uses the orange accent; a clicked aircraft uses a high-contrast neutral — distinct at a glance, theme-aware in light and dark.",
+        zh: "地图目标配色:首要目标(所在机场或被追踪飞机)用橙色强调色;点选的飞机用高对比中性色——一眼可分,明暗主题各自适配。",
+      },
+      {
+        en: "Stable detail-page navigation: each flight/airport page loads fresh on navigation (the old realtime connection is torn down), with a clear loading animation and an explicit no-live-position / signal-lost / flight-ended state instead of a stuck spinner or fallback map.",
+        zh: "更稳的详情页跳转:跳转时每个飞机/机场页都全新加载(旧实时连接被切断),配清晰的加载动画,以及明确的「暂无实时位置 / 信号丢失 / 航班已结束」状态,而非卡住的转圈或兜底地图。",
+      },
+      {
+        en: "The tracked flight now defaults to its full recorded trace (all available history), not just the trail since you opened the page; clicked aircraft still show their recent trail.",
+        zh: "被追踪航班现在默认显示完整记录航迹(全部可用历史),而不只是你打开页面之后的那一段;点选的飞机仍显示最近航迹。",
+      },
+    ],
+  },
+  {
     version: "v2.37.0",
     kind: "feat",
     title: {


### PR DESCRIPTION
## What

Returning to a flight you just left used to re-fetch its recent **trace** (adsb.lol) and **route** (adsbdb/FlightAware) from the upstream every time — detail-page navigation is a hard reload, so in-process caches die. Both upstreams are rate-limited/quota'd.

This adds a short-lived, **cross-user Postgres cache** so the data-service serves a recently-fetched result without hitting the upstream.

## How

- **Migration 007** — two tables in `runtime`:
  - `aircraft_trace_cache` keyed by **hex** (the trace endpoint only ever sees the hex, never the callsign).
  - `flight_route_cache` keyed by **(callsign, provider)** — FlightAware and adsbdb are mutually exclusive, so provider is part of the key and rows never cross over.
- **`internal/proxycache.Store`** — best-effort, nil-safe; one TTL (**5 min**), row age computed in Postgres (no app/db clock skew); periodic janitor deletes rows older than 1h.
- **Trace handler (`recent` only)** — full **stale-while-revalidate**: fresh → serve from cache; stale → serve immediately + background revalidate (per-hex in-flight de-dupe); miss → fetch upstream. Multi-MB `full` traces are **never** cached (kept client-side).
- **Route client** — read-through keyed by callsign+provider, with **stale fallback** when the upstream is briefly down. The scheduler's continuous polling acts as the revalidation loop.
- **Only successful results cached** (route actually resolved / trace has ≥1 point). adsbdb 404s and empty traces are not cached.
- **Graceful degradation** — no `DATABASE_URL` → nil cache → direct upstream fetches (unchanged behavior). The app works **before** the migration is applied; the cache simply activates once it is.

Live aircraft position is unaffected — it stays real-time on its own channel.

## Validation

- `go build ./...` + `go test ./...` (data-service) pass, including new `-race` tests:
  - route: fresh-hit skips upstream, success is cached, stale-on-error fallback, **provider keying** (FlightAware lookup never reads an adsbdb row).
  - trace: fresh serves cache, miss caches, `full=1` bypasses cache, stale serves + background revalidate.
- `pnpm test` — 122 files pass (changelog/version sync).

## Follow-up (not in this PR)

The new tables need `pnpm migrate:database` against the target Postgres to activate the cache. Until then the service runs unchanged (graceful no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)