### PR TITLE
fix(flightaware): longer route-lookup timeout so busy airports don't drop routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.39.0",
+  "version": "2.39.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/providers/flightaware/remote.go
+++ b/services/data-service/internal/providers/flightaware/remote.go
@@ -20,23 +20,31 @@ const remoteUserAgent = "ADSBao data-service/1.0 (+https://adsbao.dev; flightawa
 
 const (
 	defaultTimeout = 7 * time.Second
-	maxBodyBytes   = 2 * 1024 * 1024
+	// Route lookups scrape FlightAware and, on a busy airport, routinely run
+	// 5–10s under burst load (the callsign-fallback live-position path is more
+	// latency-sensitive and keeps the tighter default). 7s used to cut off the
+	// slow half, dropping otherwise-valid routes; the route cache makes a longer
+	// wait a one-time cost.
+	defaultRouteTimeout = 12 * time.Second
+	maxBodyBytes        = 2 * 1024 * 1024
 )
 
 var normalizedCallsignPattern = regexp.MustCompile(`^[A-Z][A-Z0-9]{2,7}$`)
 
 type RemoteOptions struct {
-	BaseURL    string
-	Token      string
-	HTTPClient *http.Client
-	Timeout    time.Duration
+	BaseURL      string
+	Token        string
+	HTTPClient   *http.Client
+	Timeout      time.Duration
+	RouteTimeout time.Duration
 }
 
 type RemoteClient struct {
-	baseURL    string
-	token      string
-	httpClient *http.Client
-	timeout    time.Duration
+	baseURL      string
+	token        string
+	httpClient   *http.Client
+	timeout      time.Duration
+	routeTimeout time.Duration
 }
 
 type remoteRequestError struct {
@@ -61,11 +69,16 @@ func NewRemoteClient(options RemoteOptions) *RemoteClient {
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
+	routeTimeout := options.RouteTimeout
+	if routeTimeout <= 0 {
+		routeTimeout = defaultRouteTimeout
+	}
 	return &RemoteClient{
-		baseURL:    strings.TrimRight(strings.TrimSpace(options.BaseURL), "/"),
-		token:      strings.TrimSpace(options.Token),
-		httpClient: httpClient,
-		timeout:    timeout,
+		baseURL:      strings.TrimRight(strings.TrimSpace(options.BaseURL), "/"),
+		token:        strings.TrimSpace(options.Token),
+		httpClient:   httpClient,
+		timeout:      timeout,
+		routeTimeout: routeTimeout,
 	}
 }
 
@@ -83,7 +96,7 @@ func (c *RemoteClient) ByCallsign(ctx context.Context, callsign string, metrics 
 		return errorResult("invalid_callsign", fetchedAt, "", nil), nil
 	}
 	var result adsb.FallbackResult
-	err := c.getJSON(ctx, "callsign", "/api/flightaware/callsign/"+url.PathEscape(normalized), &result, metrics)
+	err := c.getJSON(ctx, c.timeout, "callsign", "/api/flightaware/callsign/"+url.PathEscape(normalized), &result, metrics)
 	if err != nil {
 		var remoteErr remoteRequestError
 		if errors.As(err, &remoteErr) {
@@ -106,16 +119,16 @@ func (c *RemoteClient) Route(ctx context.Context, callsign string, metrics realt
 		return nil, errors.New("Invalid FlightAware route callsign")
 	}
 	var payload map[string]any
-	if err := c.getJSON(ctx, "route", "/api/flightaware/route/"+url.PathEscape(normalized), &payload, metrics); err != nil {
+	if err := c.getJSON(ctx, c.routeTimeout, "route", "/api/flightaware/route/"+url.PathEscape(normalized), &payload, metrics); err != nil {
 		return nil, err
 	}
 	return asMap(payload["route"]), nil
 }
 
-func (c *RemoteClient) getJSON(ctx context.Context, endpoint, path string, out any, metrics realtime.MetricsSink) error {
+func (c *RemoteClient) getJSON(ctx context.Context, timeout time.Duration, endpoint, path string, out any, metrics realtime.MetricsSink) error {
 	requestURL := c.baseURL + path
 	started := time.Now()
-	requestCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL, nil)
 	if err != nil {

--- a/services/data-service/internal/providers/flightaware/remote_test.go
+++ b/services/data-service/internal/providers/flightaware/remote_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestRemoteClientUsesPrivateService(t *testing.T) {
@@ -73,5 +74,45 @@ func TestRemoteClientFetchesPrivateRoute(t *testing.T) {
 	codes := route["route"].(map[string]any)
 	if route["source"] != "flightaware" || codes["iata"] != "BOS-LAX" {
 		t.Fatalf("route = %#v", route)
+	}
+}
+
+// Route lookups must use the longer routeTimeout, not the callsign-fallback
+// timeout — FlightAware route scrapes routinely run several seconds and were
+// being cut off, dropping valid routes on busy airports.
+func TestRemoteClientRouteUsesRouteTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"callsign":"AAL1234","route":{"origin":{"icao":"KBOS","lat":42.3,"lon":-71.0},"destination":{"icao":"KLAX","lat":33.9,"lon":-118.4},"source":"flightaware"}}`))
+	}))
+	defer server.Close()
+
+	// A tight callsign timeout would have killed this scrape; the generous
+	// route timeout lets it complete.
+	client := NewRemoteClient(RemoteOptions{
+		BaseURL:      server.URL,
+		Token:        "secret",
+		HTTPClient:   server.Client(),
+		Timeout:      20 * time.Millisecond,
+		RouteTimeout: 2 * time.Second,
+	})
+	route, err := client.Route(context.Background(), "AAL1234", nil)
+	if err != nil {
+		t.Fatalf("Route returned error despite generous route timeout: %v", err)
+	}
+	if route["source"] != "flightaware" {
+		t.Fatalf("route = %#v", route)
+	}
+
+	// And a too-tight route timeout still surfaces a timeout error.
+	tight := NewRemoteClient(RemoteOptions{
+		BaseURL:      server.URL,
+		Token:        "secret",
+		HTTPClient:   server.Client(),
+		RouteTimeout: 10 * time.Millisecond,
+	})
+	if _, err := tight.Route(context.Background(), "AAL1234", nil); err == nil {
+		t.Fatalf("expected a timeout error when routeTimeout is shorter than the scrape")
 	}
 }

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,15 +51,15 @@ export const CHANGELOG_TOTAL_COUNT = 63;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.39.0",
+    version: "v2.39.1",
     kind: "feat",
     title: {
-      en: "Faster trace & route when you revisit a flight",
-      zh: "重访航班时航迹与航线加载更快",
+      en: "Faster, more complete trace & route on busy airports",
+      zh: "繁忙机场的航迹与航线更快、更全",
     },
     summary: {
-      en: "Returning to a flight you just left is quicker. The data-service now keeps a short-lived (5-minute) shared cache of each flight's recent trace and route. Because navigating between detail pages fully reloads the page, the trace and route used to be re-fetched from the upstream providers every single time you came back; now they're served straight from the cache, so they appear faster and the rate-limited upstreams (adsb.lol traces, adsbdb / FlightAware routes) are hit far less. The cache is stale-while-revalidate: a just-expired entry is shown instantly and refreshed in the background, and if an upstream is briefly down the last known route is still shown. Live aircraft position is unaffected and stays real-time.",
-      zh: "刚离开又点回来的航班加载更快了。数据服务现在为每个航班的最近航迹和航线保留一份短时(5 分钟)共享缓存。由于详情页之间跳转是整页重载,以前每次回来都要重新向上游重拉航迹和航线;现在直接从缓存返回,显示更快,也大幅减少对限流上游(adsb.lol 航迹、adsbdb / FlightAware 航线)的请求。缓存采用 stale-while-revalidate:刚过期的条目会立即返回并在后台刷新;上游短暂不可用时仍会显示最后一次已知的航线。飞机实时位置不受影响,仍保持实时。",
+      en: "Returning to a flight you just left is quicker, and busy airports now show far more routes. The data-service keeps a short-lived (5-minute) shared cache of each flight's recent trace and route, so revisiting a flight (detail-page navigation fully reloads the page) serves them straight from the cache instead of re-fetching from the rate-limited upstreams (adsb.lol traces, adsbdb / FlightAware routes); a just-expired entry is shown instantly and refreshed in the background. We also fixed a cause of missing routes on busy airports: a FlightAware route scrape can take 5–10s under a burst of many simultaneous lookups, and the data-service was cutting them off at 7s — dropping a large share of valid commercial routes. Route lookups now get a longer timeout, so they complete instead of being killed. Live aircraft position is unaffected and stays real-time.",
+      zh: "刚离开又点回来的航班加载更快了,繁忙机场也能显示出多得多的航线。数据服务为每个航班的最近航迹和航线保留一份短时(5 分钟)共享缓存,重访航班(详情页跳转是整页重载)时直接从缓存返回,而不再向限流上游(adsb.lol 航迹、adsbdb / FlightAware 航线)重拉;刚过期的条目会立即返回并在后台刷新。同时修了繁忙机场漏航线的一个成因:一次性大量并发查询时,单次 FlightAware 航线抓取要 5–10 秒,而数据服务在 7 秒处就把它掐断,丢掉了一大批有效的商业航线。现在航线查询有了更长的超时,能跑完而不被提前掐断。飞机实时位置不受影响,仍保持实时。",
     },
     highlights: [
       {
@@ -73,6 +73,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "FlightAware and adsbdb routes are cached separately and never mixed, and the cache falls back to direct fetches when the database is unavailable.",
         zh: "FlightAware 与 adsbdb 航线分开缓存、绝不混用;数据库不可用时自动回退为直连上游。",
+      },
+      {
+        en: "Busy airports show more routes: slow FlightAware route scrapes (5–10s under load) are no longer cut off at 7s, so valid commercial routes that used to silently drop now resolve.",
+        zh: "繁忙机场显示更多航线:慢的 FlightAware 航线抓取(高并发下 5–10 秒)不再被 7 秒掐断,以前会悄悄丢掉的商业航线现在能解析出来。",
       },
     ],
   },


### PR DESCRIPTION
## Symptom

On a busy airport (e.g. KBOS, ~78 nearby aircraft) many commercial flights showed **no route** — JBU1354, DAL155, etc. — even though FlightAware has them.

## Diagnosis (evidence)

- **FA has the data.** Direct probe of the private FlightAware service: `JBU1354 → KDCA→KBOS`, `DAL155 → EIDW→KBOS`, with valid icao + lat/lon. So it's not FA dropping them, and not the data-service normalizer (`compactRoutePayload` accepts them).
- **It's latency, then a too-tight timeout.** A 39-way concurrent burst against the FA route endpoint measured **p50 5.4s, p90 9.3s, max 10.1s, 0 errors** — every route resolved, just slowly.
- **The data-service was cutting them off at 7s.** `flightaware.RemoteClient` used a single `defaultTimeout = 7s` for *both* the callsign-fallback and route lookups. Roughly the slow third-to-half of route scrapes exceed 7s → returned a `timeout` error → no route. That's the "drops so many commercial routes" symptom.

## Fix

Give route lookups their own **`RouteTimeout` (default 12s)**, threaded through `getJSON`, while keeping the **callsign-fallback live-position path at 7s** (it's latency-sensitive and ADS-B is primary). The new 5-minute Postgres route cache (v2.39.0) makes the occasional longer wait a one-time, cross-user cost.

## Validation

- `go build ./...` + `go test ./...` pass, incl. a new `TestRemoteClientRouteUsesRouteTimeout` (generous route timeout completes a slow scrape; a too-tight one still surfaces a timeout error).
- `pnpm test` — 122 files pass (changelog/version sync).
- Folded into the v2.39.x rolling changelog entry → **v2.39.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)