### PR TITLE
fix(flightaware): bound concurrent route lookups so busy airports stay fast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.39.1",
+  "version": "2.39.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/data-service/internal/providers/route/client.go
+++ b/services/data-service/internal/providers/route/client.go
@@ -22,7 +22,14 @@ const (
 	defaultTimeout       = 9 * time.Second
 	defaultMaxBytes      = 2 * 1024 * 1024
 	defaultQueueInterval = 500 * time.Millisecond
-	userAgent            = "ADSBao data-service/1.0 (+https://adsbao.dev)"
+	// FlightAware route scrapes are fast in isolation (~0.6s) but degrade sharply
+	// under concurrency (≈2s at 10-way, 5–10s at 40-way), which is how busy
+	// airports used to blow past the timeout. Cap how many run at once so each
+	// stays fast and we don't hammer the scraper into rate-limiting. adsbdb keeps
+	// its own serial interval queue instead — a strict serial queue would be far
+	// too slow for the dozens of FlightAware lookups a busy airport fires.
+	defaultFlightAwareConcurrency = 8
+	userAgent                     = "ADSBao data-service/1.0 (+https://adsbao.dev)"
 )
 
 // Cache is a best-effort persistent route cache keyed by callsign+provider.
@@ -34,14 +41,15 @@ type Cache interface {
 }
 
 type Options struct {
-	HTTPClient              *http.Client
-	ADSBDBBaseURL           string
-	FlightAwareRouteFetcher func(context.Context, string, realtime.MetricsSink) (map[string]any, error)
-	Timeout                 time.Duration
-	MaxBytes                int64
-	QueueInterval           time.Duration
-	DisableQueue            bool
-	Cache                   Cache
+	HTTPClient                *http.Client
+	ADSBDBBaseURL             string
+	FlightAwareRouteFetcher   func(context.Context, string, realtime.MetricsSink) (map[string]any, error)
+	Timeout                   time.Duration
+	MaxBytes                  int64
+	QueueInterval             time.Duration
+	DisableQueue              bool
+	Cache                     Cache
+	MaxFlightAwareConcurrency int
 }
 
 type Client struct {
@@ -52,6 +60,7 @@ type Client struct {
 	maxBytes                int64
 	queueInterval           time.Duration
 	cache                   Cache
+	faSem                   chan struct{}
 	mu                      sync.Mutex
 	lastStarted             time.Time
 }
@@ -77,6 +86,10 @@ func NewClient(options Options) *Client {
 	if queueInterval == 0 && !options.DisableQueue {
 		queueInterval = defaultQueueInterval
 	}
+	faConcurrency := options.MaxFlightAwareConcurrency
+	if faConcurrency <= 0 {
+		faConcurrency = defaultFlightAwareConcurrency
+	}
 	return &Client{
 		httpClient:              httpClient,
 		adsbdbBaseURL:           adsbdbBase,
@@ -85,6 +98,7 @@ func NewClient(options Options) *Client {
 		maxBytes:                maxBytes,
 		queueInterval:           queueInterval,
 		cache:                   options.Cache,
+		faSem:                   make(chan struct{}, faConcurrency),
 	}
 }
 
@@ -211,11 +225,36 @@ func (c *Client) fetchFlightAware(ctx context.Context, input realtime.FetchInput
 	if c.flightAwareRouteFetcher == nil {
 		return routeEvent(input.Channel, "flightaware", input.Target.Callsign, nil), nil
 	}
+	// Bound how many scrapes hit FlightAware at once so a busy airport's burst of
+	// lookups doesn't inflate each one into a multi-second, timeout-prone request.
+	if err := c.acquireFlightAware(ctx); err != nil {
+		return realtime.Event{}, err
+	}
+	defer c.releaseFlightAware()
 	route, err := c.flightAwareRouteFetcher(ctx, input.Target.Callsign, input.Metrics)
 	if err != nil {
 		return realtime.Event{}, err
 	}
 	return routeEvent(input.Channel, "flightaware", input.Target.Callsign, route), nil
+}
+
+func (c *Client) acquireFlightAware(ctx context.Context) error {
+	if c.faSem == nil {
+		return nil
+	}
+	select {
+	case c.faSem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Client) releaseFlightAware() {
+	if c.faSem == nil {
+		return
+	}
+	<-c.faSem
 }
 
 func (c *Client) do(ctx context.Context, requestURL, accept, ua string) (*http.Response, context.CancelFunc, error) {

--- a/services/data-service/internal/providers/route/client_cache_test.go
+++ b/services/data-service/internal/providers/route/client_cache_test.go
@@ -3,9 +3,11 @@ package route
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -115,6 +117,45 @@ func TestRouteCacheServesStaleOnUpstreamError(t *testing.T) {
 	}
 	if event.Data.(map[string]any)["route"] == nil {
 		t.Fatalf("expected last-known route on upstream failure")
+	}
+}
+
+func TestFlightAwareConcurrencyIsBounded(t *testing.T) {
+	const cap = 2
+	var cur, maxObserved int32
+	fetcher := func(ctx context.Context, callsign string, m realtime.MetricsSink) (map[string]any, error) {
+		n := atomic.AddInt32(&cur, 1)
+		for {
+			prev := atomic.LoadInt32(&maxObserved)
+			if n <= prev || atomic.CompareAndSwapInt32(&maxObserved, prev, n) {
+				break
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+		atomic.AddInt32(&cur, -1)
+		return map[string]any{
+			"origin":      map[string]any{"icao": "KBOS", "lat": 42.3, "lon": -71.0},
+			"destination": map[string]any{"icao": "KLAX", "lat": 33.9, "lon": -118.4},
+			"source":      "flightaware",
+		}, nil
+	}
+	client := NewClient(Options{FlightAwareRouteFetcher: fetcher, MaxFlightAwareConcurrency: cap, QueueInterval: 0})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 12; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = client.Fetch(context.Background(), routeInput(fmt.Sprintf("route:FA%d", i), fmt.Sprintf("FAT%d", i), "flightaware"))
+		}(i)
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxObserved); got > cap {
+		t.Fatalf("observed %d concurrent FlightAware scrapes, cap is %d", got, cap)
+	}
+	if atomic.LoadInt32(&maxObserved) == 0 {
+		t.Fatalf("fetcher was never invoked")
 	}
 }
 

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,15 +51,15 @@ export const CHANGELOG_TOTAL_COUNT = 63;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.39.1",
+    version: "v2.39.2",
     kind: "feat",
     title: {
       en: "Faster, more complete trace & route on busy airports",
       zh: "繁忙机场的航迹与航线更快、更全",
     },
     summary: {
-      en: "Returning to a flight you just left is quicker, and busy airports now show far more routes. The data-service keeps a short-lived (5-minute) shared cache of each flight's recent trace and route, so revisiting a flight (detail-page navigation fully reloads the page) serves them straight from the cache instead of re-fetching from the rate-limited upstreams (adsb.lol traces, adsbdb / FlightAware routes); a just-expired entry is shown instantly and refreshed in the background. We also fixed a cause of missing routes on busy airports: a FlightAware route scrape can take 5–10s under a burst of many simultaneous lookups, and the data-service was cutting them off at 7s — dropping a large share of valid commercial routes. Route lookups now get a longer timeout, so they complete instead of being killed. Live aircraft position is unaffected and stays real-time.",
-      zh: "刚离开又点回来的航班加载更快了,繁忙机场也能显示出多得多的航线。数据服务为每个航班的最近航迹和航线保留一份短时(5 分钟)共享缓存,重访航班(详情页跳转是整页重载)时直接从缓存返回,而不再向限流上游(adsb.lol 航迹、adsbdb / FlightAware 航线)重拉;刚过期的条目会立即返回并在后台刷新。同时修了繁忙机场漏航线的一个成因:一次性大量并发查询时,单次 FlightAware 航线抓取要 5–10 秒,而数据服务在 7 秒处就把它掐断,丢掉了一大批有效的商业航线。现在航线查询有了更长的超时,能跑完而不被提前掐断。飞机实时位置不受影响,仍保持实时。",
+      en: "Returning to a flight you just left is quicker, and busy airports now show far more routes. The data-service keeps a short-lived (5-minute) shared cache of each flight's recent trace and route, so revisiting a flight (detail-page navigation fully reloads the page) serves them straight from the cache instead of re-fetching from the rate-limited upstreams (adsb.lol traces, adsbdb / FlightAware routes); a just-expired entry is shown instantly and refreshed in the background. We also fixed a cause of missing routes on busy airports: a FlightAware route scrape is fast on its own (~0.6s) but balloons to 5–10s when dozens fire at once, and those were being cut off at 7s — dropping a large share of valid commercial routes. We now cap how many FlightAware lookups run at once (so each stays fast) and give the rest a longer timeout, so valid routes complete instead of being dropped. Live aircraft position is unaffected and stays real-time.",
+      zh: "刚离开又点回来的航班加载更快了,繁忙机场也能显示出多得多的航线。数据服务为每个航班的最近航迹和航线保留一份短时(5 分钟)共享缓存,重访航班(详情页跳转是整页重载)时直接从缓存返回,而不再向限流上游(adsb.lol 航迹、adsbdb / FlightAware 航线)重拉;刚过期的条目会立即返回并在后台刷新。同时修了繁忙机场漏航线的一个成因:单次 FlightAware 航线抓取本身很快(~0.6 秒),但几十个一起打就会膨胀到 5–10 秒,这些会在 7 秒处被掐断,丢掉一大批有效的商业航线。现在我们给 FlightAware 查询限制了并发(让每次都保持快),其余的也给了更长的超时,有效航线能跑完而不被丢弃。飞机实时位置不受影响,仍保持实时。",
     },
     highlights: [
       {
@@ -75,8 +75,8 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         zh: "FlightAware 与 adsbdb 航线分开缓存、绝不混用;数据库不可用时自动回退为直连上游。",
       },
       {
-        en: "Busy airports show more routes: slow FlightAware route scrapes (5–10s under load) are no longer cut off at 7s, so valid commercial routes that used to silently drop now resolve.",
-        zh: "繁忙机场显示更多航线:慢的 FlightAware 航线抓取(高并发下 5–10 秒)不再被 7 秒掐断,以前会悄悄丢掉的商业航线现在能解析出来。",
+        en: "Busy airports show more routes: FlightAware lookups are now concurrency-bounded so each stays ~fast instead of ballooning to 5–10s under a burst, with a longer timeout as a backstop — valid commercial routes that used to silently drop now resolve.",
+        zh: "繁忙机场显示更多航线:FlightAware 查询现在限制了并发,每次都保持较快,不再在突发下膨胀到 5–10 秒,并以更长超时兜底——以前会悄悄丢掉的商业航线现在能解析出来。",
       },
     ],
   },


### PR DESCRIPTION
## Why

Follow-up to #587. The timeout raise there was a backstop; this addresses the **root cause** that @ruyyi0323 flagged: FlightAware route lookups had no concurrency limit (adsbdb has a serial interval queue, FA had nothing).

## Measurement (against the private FlightAware service, no caching in between)

| concurrency | per-request latency |
|---|---|
| 1 (serial) | p50 **0.62s**, max 0.88s |
| 10 | p50 1.3s, p90 **2.2s** |
| 39 (busy-airport burst) | p50 5.4s, p90 **9.3s** |

The slowness is **concurrency-induced** — one scrape is ~0.6s; dozens at once degrade to 5–10s, which is what pushed them past the timeout and dropped routes.

## Fix

Add a **bounded-concurrency semaphore** (default **8** in-flight) around `fetchFlightAware`, so a burst of lookups can't inflate each other into multi-second, timeout-prone requests — and so we don't hammer the scraper into rate-limiting.

Why a semaphore and not adsbdb's serial interval queue: a strict serial queue (≥500ms/lookup) would take ~40s to drain the dozens of lookups a busy airport fires. A semaphore keeps each request fast (~2s at the cap) while draining the set in ~12s. The longer route timeout from #587 stays as a backstop.

## Validation

- `go build ./...` + `go test -race ./...` pass, incl. `TestFlightAwareConcurrencyIsBounded` (12 concurrent Fetches never exceed the cap).
- `pnpm test` — 122 files pass.
- Rolling changelog → **v2.39.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)