### PR TITLE
fix(proxycache): tighten cache janitor to ~2×TTL so stale rows don't pile up

### DIFF
--- a/services/data-service/cmd/adsbao-data-service/main.go
+++ b/services/data-service/cmd/adsbao-data-service/main.go
@@ -166,7 +166,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	if proxyCache != nil {
-		go proxyCache.RunJanitor(ctx, 15*time.Minute, time.Hour)
+		go proxyCache.RunJanitor(ctx)
 	}
 	go reportMetrics(ctx, registry, started, cfg.MetricsReportInterval, polling.DebugChannels)
 	go logForwarder.Run(ctx, cfg.LogsReportInterval)

--- a/services/data-service/internal/proxycache/store.go
+++ b/services/data-service/internal/proxycache/store.go
@@ -107,11 +107,22 @@ func (s *Store) Cleanup(ctx context.Context, retention time.Duration) {
 		`delete from runtime.flight_route_cache where fetched_at < $1`, cutoff)
 }
 
-// RunJanitor blocks running Cleanup on an interval until ctx is cancelled.
-func (s *Store) RunJanitor(ctx context.Context, interval, retention time.Duration) {
-	if s == nil || s.db == nil || interval <= 0 {
+// RunJanitor keeps the tables to roughly the live working set: it deletes rows
+// that have aged to 2×TTL — well past the freshness window, where they no longer
+// serve a fresh hit (a stale row would be re-fetched on access anyway, and the
+// browser keeps its own route cache). Retention tracks the TTL instead of being
+// an independent knob, so the two can't drift. Cleans immediately on start
+// (clears any backlog on deploy), then every TTL/2. Blocks until ctx is done.
+func (s *Store) RunJanitor(ctx context.Context) {
+	if s == nil || s.db == nil {
 		return
 	}
+	retention := 2 * s.ttl
+	interval := s.ttl / 2
+	if interval < 30*time.Second {
+		interval = 30 * time.Second
+	}
+	s.Cleanup(ctx, retention)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {


### PR DESCRIPTION
## Why

@ruyyi0323 noticed 20-minute-old route-cache rows sitting in Postgres. The janitor was working but far too lenient: **1h retention, 15m interval**. Measured prod state: **735 route rows, ~95% already past the 5m TTL, max age ~66m**.

Those stale rows have no value:
- A past-TTL row is re-fetched on access anyway (it's "stale").
- The browser keeps its own client-side route cache, so it still shows the route regardless of the server row.
- Route channels poll every **30m** (`channels.BaseInterval`), so an active flight's server row legitimately ages 0→30m between refreshes — but only the fresh `<TTL` window ever serves a hit; the 5–30m stale tail is pure dead weight.

## Fix

Couple retention to the TTL instead of an independent 1h knob:
- Delete rows older than **2×TTL** (10m), run every **TTL/2** (2.5m).
- **Clean once on startup** so a deploy clears the backlog immediately.

The table now holds roughly the live working set (~10–12m of data) with **no loss** of the navigate-back fast path (fresh `<TTL` rows) or the trace stale-while-revalidate window. `RunJanitor(ctx)` now derives its own cadence from the Store's TTL, so the two can't drift.

## Validation

`go build`, `go vet`, `go test ./...` pass. Internal cache hygiene only — no product-visible behavior change, so no version bump. I'll also run a one-off cleanup on prod so the existing backlog clears without waiting for the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)