### PR TITLE
fix(here): refresh local weather only when the place name changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.39.3",
+  "version": "2.39.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/WeatherBriefingStack.tsx
+++ b/src/components/sidebar/WeatherBriefingStack.tsx
@@ -13,6 +13,7 @@ import {
   Sun,
 } from "lucide-react";
 import { useLocalWeather } from "@/hooks/useLocalWeather";
+import { useStablePlaceWeatherCoords } from "@/hooks/useStablePlaceWeatherCoords";
 import FlightRuleGlyph, { type FlightRule } from "@/components/weather/FlightRuleGlyph";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
@@ -68,12 +69,19 @@ export default function WeatherBriefingStack({
   airportLon = 0,
   nearMe = false,
 }) {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const { preferences: units } = useUnitPreferences();
   const [view, setView] = useState("metar");
+  // In here-mode the device position streams in continuously; gate the weather
+  // fetch on the reverse-geocoded place name so it only refreshes when we cross
+  // into a new place, not on every GPS micro-update. Fixed airports pass through.
+  const weatherCoords = useStablePlaceWeatherCoords(airportLat, airportLon, {
+    enabled: nearMe,
+    language: locale,
+  });
   const { weather: local, loading: localLoading } = useLocalWeather(
-    airportLat,
-    airportLon,
+    weatherCoords.lat,
+    weatherCoords.lon,
   );
   const effectiveView = nearMe ? "local" : view;
 

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 63;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.39.3",
+    version: "v2.39.4",
     kind: "feat",
     title: {
       en: "Faster, more complete trace & route on busy airports",
@@ -77,6 +77,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Busy airports show more routes: FlightAware lookups are now concurrency-bounded so each stays ~fast instead of ballooning to 5–10s under a burst, with a longer timeout and a few quick retries as backstops — valid commercial routes that used to silently drop now resolve.",
         zh: "繁忙机场显示更多航线:FlightAware 查询现在限制了并发,每次都保持较快,不再在突发下膨胀到 5–10 秒,并以更长超时和几次快速重试兜底——以前会悄悄丢掉的商业航线现在能解析出来。",
+      },
+      {
+        en: "Here-mode weather no longer flickers: the local-weather card now refreshes only when you move into a new place (city/area) instead of on every GPS micro-update.",
+        zh: "Here 模式天气不再频繁闪烁:本地天气卡现在只在你移动到新的地点(城市/地区)时才刷新,而不是每次 GPS 微小抖动都重新请求。",
       },
     ],
   },

--- a/src/features/weather/placeWeatherGate.test.ts
+++ b/src/features/weather/placeWeatherGate.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import {
+  buildPlaceKey,
+  nextPlaceCoordState,
+  type PlaceCoordGateState,
+} from "./placeWeatherGate";
+
+// buildPlaceKey: stable identity, coarser than coordinates.
+assert.equal(buildPlaceKey(null), "");
+assert.equal(
+  buildPlaceKey({ countryCode: "US", state: "Massachusetts", city: "Boston" }),
+  "US|Massachusetts|Boston",
+);
+// Whitespace-only / missing fields are dropped, not rendered as empty segments.
+assert.equal(
+  buildPlaceKey({ countryCode: "US", state: "  ", county: "Suffolk", city: "" }),
+  "US|Suffolk",
+);
+
+const boston = { lat: 42.3601, lon: -71.0589 };
+const cambridge = { lat: 42.3736, lon: -71.1097 };
+const bostonKey = "US|Massachusetts|Boston";
+const cambridgeKey = "US|Massachusetts|Cambridge";
+
+// First fix seeds at the live position even before the place name resolves.
+{
+  const seeded = nextPlaceCoordState(null, boston, "");
+  assert.deepEqual(seeded, { placeKey: "", lat: boston.lat, lon: boston.lon });
+}
+
+// Seeded-before-resolve: micro-updates with no place yet never move the snapshot.
+{
+  const seeded: PlaceCoordGateState = { placeKey: "", ...boston };
+  const after = nextPlaceCoordState(seeded, { lat: 42.3605, lon: -71.0591 }, "");
+  assert.equal(after, seeded);
+}
+
+// The first resolved name adopts the key but keeps the original snapshot coords.
+{
+  const seeded: PlaceCoordGateState = { placeKey: "", ...boston };
+  const after = nextPlaceCoordState(seeded, cambridge, bostonKey);
+  assert.deepEqual(after, { placeKey: bostonKey, lat: boston.lat, lon: boston.lon });
+}
+
+// Same place, new live coords → snapshot stays frozen (no weather refetch).
+{
+  const settled: PlaceCoordGateState = { placeKey: bostonKey, ...boston };
+  const after = nextPlaceCoordState(settled, { lat: 42.362, lon: -71.06 }, bostonKey);
+  assert.equal(after, settled);
+}
+
+// Crossing into a new place advances the snapshot to the current position.
+{
+  const settled: PlaceCoordGateState = { placeKey: bostonKey, ...boston };
+  const after = nextPlaceCoordState(settled, cambridge, cambridgeKey);
+  assert.deepEqual(after, {
+    placeKey: cambridgeKey,
+    lat: cambridge.lat,
+    lon: cambridge.lon,
+  });
+}
+
+// A transient empty key (geocode hiccup) does not move a settled snapshot.
+{
+  const settled: PlaceCoordGateState = { placeKey: bostonKey, ...boston };
+  const after = nextPlaceCoordState(settled, cambridge, "");
+  assert.equal(after, settled);
+}
+
+console.log("placeWeatherGate.test.ts passed");

--- a/src/features/weather/placeWeatherGate.ts
+++ b/src/features/weather/placeWeatherGate.ts
@@ -1,0 +1,59 @@
+// In here-mode the device position streams in continuously (GPS jitter plus
+// `watchPosition`). Feeding every micro-update straight into the local-weather
+// fetch makes the briefing card reload constantly. Local weather only changes
+// at a place granularity, so we keep a snapshot of the coordinates the weather
+// was last fetched for and only advance it when the reverse-geocoded place
+// identity changes.
+
+export type PlaceCoords = { lat: number; lon: number };
+
+export type PlaceCoordGateState = {
+  // The place identity the snapshot was taken for. `null` means "not seeded
+  // yet"; `""` means "seeded before the geocode resolved a name".
+  placeKey: string | null;
+  lat: number;
+  lon: number;
+};
+
+// Build a stable identity string from a reverse-geocode result. Coarser than
+// the raw coordinates on purpose: only a real change of city / county / state /
+// country should advance the weather fetch. Returns "" while no place is known.
+export function buildPlaceKey(
+  place: {
+    countryCode?: string;
+    state?: string;
+    county?: string;
+    city?: string;
+  } | null,
+): string {
+  if (!place) return "";
+  const parts = [place.countryCode, place.state, place.county, place.city]
+    .map((part) => String(part || "").trim())
+    .filter(Boolean);
+  return parts.join("|");
+}
+
+// Decide the next gate state given the latest live position and resolved place
+// key. The very first fix seeds the snapshot so weather can load immediately;
+// after that only a genuine place change moves it.
+export function nextPlaceCoordState(
+  state: PlaceCoordGateState | null,
+  live: PlaceCoords,
+  placeKey: string,
+): PlaceCoordGateState {
+  // First fix — seed the snapshot at the current position regardless of
+  // whether the place name has resolved yet.
+  if (!state || state.placeKey === null) {
+    return { placeKey, lat: live.lat, lon: live.lon };
+  }
+  // Seeded before the geocode resolved: adopt the first real place name
+  // without moving the snapshot — it already describes this location.
+  if (state.placeKey === "") {
+    return placeKey ? { placeKey, lat: state.lat, lon: state.lon } : state;
+  }
+  // A real change of place advances the snapshot to the current position.
+  if (placeKey && placeKey !== state.placeKey) {
+    return { placeKey, lat: live.lat, lon: live.lon };
+  }
+  return state;
+}

--- a/src/hooks/useStablePlaceWeatherCoords.ts
+++ b/src/hooks/useStablePlaceWeatherCoords.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from "react";
+import { useReverseGeocode } from "./useReverseGeocode";
+import {
+  buildPlaceKey,
+  nextPlaceCoordState,
+  type PlaceCoordGateState,
+  type PlaceCoords,
+} from "@/features/weather/placeWeatherGate";
+
+// Returns coordinates that only advance when the reverse-geocoded place name
+// changes. In here-mode the device position updates continuously, but local
+// weather is the same across a city, so this freezes the coordinates fed into
+// the weather fetch until the user actually crosses into a new place.
+//
+// When `enabled` is false the input coordinates pass straight through (a fixed
+// airport doesn't move, so there's nothing to gate). The reverse-geocode call
+// shares the in-memory cache with the identity hero's lookup, so gating costs
+// no extra network request.
+export function useStablePlaceWeatherCoords(
+  lat: number,
+  lon: number,
+  { enabled = true, language = "en" }: { enabled?: boolean; language?: string } = {},
+): PlaceCoords {
+  const { data: place } = useReverseGeocode(
+    enabled ? lat : null,
+    enabled ? lon : null,
+    language,
+  );
+  const placeKey = buildPlaceKey(place);
+
+  const [coords, setCoords] = useState<PlaceCoords>({ lat, lon });
+  const stateRef = useRef<PlaceCoordGateState | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      stateRef.current = null;
+      setCoords((current) =>
+        current.lat === lat && current.lon === lon ? current : { lat, lon },
+      );
+      return;
+    }
+    const next = nextPlaceCoordState(stateRef.current, { lat, lon }, placeKey);
+    stateRef.current = next;
+    setCoords((current) =>
+      current.lat === next.lat && current.lon === next.lon
+        ? current
+        : { lat: next.lat, lon: next.lon },
+    );
+  }, [enabled, placeKey, lat, lon]);
+
+  return enabled ? coords : { lat, lon };
+}


### PR DESCRIPTION
## 问题

`/here` 模式下本地天气卡一直在刷新/闪烁。根因:`WeatherBriefingStack` 把 `useLocalWeather` 直接 key 在实时设备坐标上(手机 `watchPosition` + GPS 抖动持续更新),坐标每变一点就重新请求天气,而 `useLocalWeather` 每次请求前都会 `setWeather(null)`,于是表现为持续闪烁。

## 改动

在喂给天气请求的坐标与实时位置之间加一道"地点名门控":坐标只在反向地理编码出的地点标识(国家/州/县/市)变化时才推进——即用户真正走进新地点时才刷新。

- `src/features/weather/placeWeatherGate.ts`(新增)— 纯函数门控:`buildPlaceKey` + `nextPlaceCoordState`。首个定位先 seed 让天气立即加载,之后只有换地点才推进坐标。
- `src/hooks/useStablePlaceWeatherCoords.ts`(新增)— 封装为 hook,复用 `useReverseGeocode` 并与身份卡共享内存缓存,**零额外网络请求**;非 here 模式坐标原样透传(固定机场无需门控)。
- `WeatherBriefingStack.tsx` — here 模式用门控后的坐标驱动 `useLocalWeather`。
- `placeWeatherGate.test.ts`(新增)— 覆盖 seed、未解析期不漂移、首个名字仅采纳不移动、同地冻结、跨地推进、瞬时空值不误触发。

## 版本

Patch:v2.39.3 → v2.39.4(折叠进当前 minor 滚动条目,`package.json` + `changelog.ts` 已同步)。

## Validation

Validation: local test — ran `tsx src/features/weather/placeWeatherGate.test.ts`(通过)。可视化的"不再闪烁"需要真机 GPS 跨城移动才能完整验证,preview 无法模拟;核心门控逻辑已单测覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)