### PR TITLE
feat(here): decode-text transition on the place name when you change place

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.39.4",
+  "version": "2.39.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/AirportIdentity.tsx
+++ b/src/components/sidebar/AirportIdentity.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../utils/airport";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useReverseGeocode } from "@/hooks/useReverseGeocode";
+import DecodeText from "@/components/ui/DecodeText";
 
 export default function AirportIdentity({
   icao = "",
@@ -89,12 +90,16 @@ export default function AirportIdentity({
       </span>
       <h1 className="mt-3 text-[calc(22px*var(--sb-title-scale))] font-normal leading-[1.08] text-atc-text">
         <span className="airport-sidebar-display-mono notranslate" translate="no">
-          {codeLine || t("sidebar.unknownAirport")}
+          {nearMe ? (
+            <DecodeText text={codeLine || t("sidebar.unknownAirport")} />
+          ) : (
+            codeLine || t("sidebar.unknownAirport")
+          )}
         </span>
       </h1>
       {nameLine ? (
         <div className="mt-2 text-[calc(13px*var(--sb-title-scale))] leading-snug text-atc-dim">
-          {nameLine}
+          {nearMe ? <DecodeText text={nameLine} /> : nameLine}
         </div>
       ) : null}
       {metaLine ? (

--- a/src/components/ui/DecodeText.tsx
+++ b/src/components/ui/DecodeText.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+
+// A "decode" text transition: when `text` changes, the new value resolves
+// left-to-right out of a stream of random scramble characters. Used for the
+// here-mode place name so crossing into a new city/area reads as the label
+// being decoded rather than hard-cutting.
+//
+// Conventions match the rest of the app's motion (see FlightRuleGlyph): the
+// effect plays only on a real value change, and `prefers-reduced-motion`
+// jumps straight to the final text. Scramble characters are drawn from a pool
+// that matches the target's script (CJK target → CJK scramble) so glyph width
+// stays stable and the line doesn't jitter mid-animation.
+
+const LATIN_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#%&@$*<>/";
+
+function prefersReducedMotion() {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+function isCjk(ch: string) {
+  const code = ch.codePointAt(0) ?? 0;
+  return code >= 0x2e80 && code <= 0x9fff;
+}
+
+function scrambleChar(target: string) {
+  if (isCjk(target)) {
+    // Random common-CJK code point keeps the (double-width) glyph stable.
+    return String.fromCodePoint(0x4e00 + Math.floor(Math.random() * 0x5176));
+  }
+  return LATIN_POOL[Math.floor(Math.random() * LATIN_POOL.length)] ?? "";
+}
+
+export default function DecodeText({
+  text,
+  className,
+  intervalMs = 45,
+  minTicks = 8,
+  maxTicks = 22,
+}: {
+  text: string;
+  className?: string;
+  intervalMs?: number;
+  minTicks?: number;
+  maxTicks?: number;
+}) {
+  const [display, setDisplay] = useState(text);
+  const prevTextRef = useRef(text);
+
+  useEffect(() => {
+    const target = text ?? "";
+    const prev = prevTextRef.current;
+    prevTextRef.current = target;
+
+    // No animation on first mount, an unchanged value, an empty target, or
+    // when the user prefers reduced motion — show the final text immediately.
+    if (prev === target || !target || prefersReducedMotion()) {
+      setDisplay(target);
+      return undefined;
+    }
+
+    const chars = Array.from(target);
+    const totalTicks = Math.min(
+      maxTicks,
+      Math.max(minTicks, chars.length + 4),
+    );
+    let tick = 0;
+    const id = setInterval(() => {
+      tick += 1;
+      if (tick >= totalTicks) {
+        setDisplay(target);
+        clearInterval(id);
+        return;
+      }
+      const revealed = Math.floor((tick / totalTicks) * chars.length);
+      setDisplay(
+        chars
+          .map((ch, i) =>
+            i < revealed || /\s/.test(ch) ? ch : scrambleChar(ch),
+          )
+          .join(""),
+      );
+    }, intervalMs);
+
+    return () => clearInterval(id);
+  }, [text, intervalMs, minTicks, maxTicks]);
+
+  // aria-label carries the resolved text so assistive tech never reads the
+  // transient scramble.
+  return (
+    <span className={className} aria-label={text}>
+      {display}
+    </span>
+  );
+}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 63;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.39.4",
+    version: "v2.39.5",
     kind: "feat",
     title: {
       en: "Faster, more complete trace & route on busy airports",
@@ -81,6 +81,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Here-mode weather no longer flickers: the local-weather card now refreshes only when you move into a new place (city/area) instead of on every GPS micro-update.",
         zh: "Here 模式天气不再频繁闪烁:本地天气卡现在只在你移动到新的地点(城市/地区)时才刷新,而不是每次 GPS 微小抖动都重新请求。",
+      },
+      {
+        en: "Crossing into a new place in here-mode now plays a decode-text transition on the place name (city/state) instead of a hard cut; respects reduced-motion.",
+        zh: "Here 模式下走进新地点时,地点名(城市/州省)会以解码文字的动效过渡,而不是硬切换;尊重系统的减少动态设置。",
       },
     ],
   },


### PR DESCRIPTION
## 背景

接 #591 的地点门控:here 模式下走进新城市/地区时,侧栏的地点名(城市行 + 州/省行)原本是硬切换。加一个轻量"解码文字"过渡动效。

## 改动

- `src/components/ui/DecodeText.tsx`(新增)— `text` 变化时,新值从随机乱码里逐字(左→右)解码还原。
  - 仅在真正换值时播放(首次挂载/未变/空值不播)。
  - `prefers-reduced-motion` 直接跳终态。
  - 乱码字符按目标脚本取池(CJK 目标→CJK 乱码),保证等宽不抖动。
  - `aria-label` 始终携带最终文字,辅助技术不会念到乱码。
- `AirportIdentity.tsx` — 仅 `nearMe` 时,大标题(城市)与副标题(州/省)包进 `DecodeText`;机场模式不变。

与 #591 的地点门控配套:同城走动地点名不变→不触发动画;真正换地点才播放。首次定位从占位文案解码成真实地点也会播一次。坐标行不做动画。

## 版本

Patch:v2.39.4 → v2.39.5(折叠进当前 minor 滚动条目,`package.json` + `changelog.ts` 已同步)。

## Validation

Validation: local browser — 改动通过 dev server HMR 在 \`/here\` 上即时可见(首次定位解码一次)。纯前端动画 polish,无逻辑分支需要单测。完整的"跨城再触发"需真机 GPS 移动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)