### PR TITLE
fix(map): zoom button as compact viewfinder frame (v2.42.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.42.0",
+  "version": "2.42.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/map/controls/MapControlRail.tsx
+++ b/src/components/map/controls/MapControlRail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { SignInButton, UserButton, useUser } from "@/platform/auth/clerkClient";
-import { Check, LogIn, Search } from "lucide-react";
+import { Check, LogIn, Scan } from "lucide-react";
 import { getThemeIconKey } from "@/features/app-shell/themePreference";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import LanguageSwitch from "@/components/app-shell/LanguageSwitch";
@@ -275,12 +275,18 @@ function ZoomSliderButton({
         aria-label={title}
         aria-expanded={open}
         aria-haspopup="dialog"
-        className="w-auto gap-1 px-2"
         onClick={() => setOpen((value) => !value)}
       >
-        <Search aria-hidden="true" />
-        <span className="text-[11px] font-semibold leading-none tabular-nums">
-          {current}x
+        {/* Viewfinder frame as anchor; current zoom is a decorative read-out
+            centered in the open frame (the real value is read by opening the
+            menu). The frame's hollow center clears the corner brackets, so the
+            glyph has room and never crowds the strokes — semantically still a
+            "map range / framing" control. */}
+        <span className="relative inline-flex items-center justify-center">
+          <Scan aria-hidden="true" />
+          <span className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-[8px] font-semibold leading-none tracking-[-0.03em] tabular-nums">
+            {current}
+          </span>
         </span>
       </ToolbarButton>
     </div>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,20 +51,20 @@ export const CHANGELOG_TOTAL_COUNT = 65;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.42.0",
+    version: "v2.42.1",
     kind: "feat",
     title: {
       en: "A zoom slider for the map, and clearer building footprints",
       zh: "地图缩放滑条 + 更清晰的建筑轮廓",
     },
     summary: {
-      en: "The map's Far / Medium / Near zoom menu became a single magnifier button that shows the current level (e.g. 13x) and opens a slider — drag from 10x to 15x, snapping at each whole step, while the map stays centred on the airport instead of jumping between three fixed levels. On the flight-tracking page the full-trace and all-points view toggles fold into that same submenu so the toolbar stays short. Separately, building footprints on the standard map now read with more contrast, so the surrounding city stays legible at neighbourhood zoom.",
-      zh: "地图的 远 / 中 / 近 三档缩放菜单,变成一个显示当前倍数(如 13x)的放大镜按钮,点开是一根滑条——从 10x 拖到 15x、每一级吸附,缩放时地图始终以机场为中心,不再在三个固定档位间跳。飞机追踪页的「完整航迹 / 所有记录点」也收进同一个子菜单,工具栏更短。另外,标准地图的建筑轮廓提高了对比度,放大到街区级时周边城市更清晰。",
+      en: "The map's Far / Medium / Near zoom menu became a single compact viewfinder button that frames the current level (e.g. 13) and opens a slider — drag from 10x to 15x, snapping at each whole step, while the map stays centred on the airport instead of jumping between three fixed levels. The button stays the same compact size as the rest of the toolbar. On the flight-tracking page the full-trace and all-points view toggles fold into that same submenu so the toolbar stays short. Separately, building footprints on the standard map now read with more contrast, so the surrounding city stays legible at neighbourhood zoom.",
+      zh: "地图的 远 / 中 / 近 三档缩放菜单,变成一个把当前倍数(如 13)框在取景框里的紧凑按钮,点开是一根滑条——从 10x 拖到 15x、每一级吸附,缩放时地图始终以机场为中心,不再在三个固定档位间跳。按钮与工具栏其他按钮一样紧凑等宽。飞机追踪页的「完整航迹 / 所有记录点」也收进同一个子菜单,工具栏更短。另外,标准地图的建筑轮廓提高了对比度,放大到街区级时周边城市更清晰。",
     },
     highlights: [
       {
-        en: "Zoom is a slider now (10x–15x, snaps each step) on a magnifier button that shows the current level — replacing the three fixed Far / Medium / Near presets.",
-        zh: "缩放改成滑条(10x–15x、逐级吸附),放大镜按钮上显示当前倍数——取代原来的 远 / 中 / 近 三档。",
+        en: "Zoom is a slider now (10x–15x, snaps each step) on a compact viewfinder button that frames the current level — replacing the three fixed Far / Medium / Near presets.",
+        zh: "缩放改成滑条(10x–15x、逐级吸附),紧凑的取景框按钮里显示当前倍数——取代原来的 远 / 中 / 近 三档。",
       },
       {
         en: "Zooming keeps the airport centred; the map no longer jumps between fixed levels.",


### PR DESCRIPTION
## What

The map toolbar's zoom control was a `w-auto` pill (magnifier icon + `13x` text) that stretched the toolbar noticeably longer than every other (square) button. This swaps it for a standard square toolbar cell using a **viewfinder frame** (`Scan`) whose hollow centre holds the current zoom level as a small decorative read-out.

- Toolbar is uniform-width again — no more over-long capsule.
- The viewfinder's open centre clears the corner brackets, so 1- or 2-digit values never crowd the strokes (the prior magnifier-lens approach risked the ring crowding the digits).
- Semantically still a *map range / framing* control; the precise value is read by opening the slider menu. `title`/`aria-label` keep the full `Map range: NNx`.

## Why viewfinder over magnifier

Per discussion: the inline number is decorative (users open the menu for the real value), and a hollow framing glyph guarantees space for the digits without crowding any stroke — unlike the closed magnifier lens.

## Version

Patch **v2.42.1**, folded into the existing v2.42.0 zoom-slider changelog entry (same minor); `package.json` + `changelog.ts` kept in sync for the update toast.

## Validation

Mode 2 (local browser) — verified on `/airport/KLAX` at desktop width; confirmed the button renders the `Scan` frame with the centred level, stays the same square footprint as sibling toolbar buttons, and (zoomed inspection) the 2-digit level sits clear of the frame strokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)