### PR TITLE
feat(routes): prioritize the focused/selected flight's route (v2.42.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.42.1",
+  "version": "2.42.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -235,6 +235,7 @@ function AirportExplorerContent({
     : airportProfile.icao;
   const { weather, traffic } = useAirportExplorerData(airportProfile, {
     metarIcao,
+    selectedAircraftId,
   });
   const effectiveUserLocation =
     (nearMe ? null : userLocationLayer.userLocation) || nearMeMapUserLocation;

--- a/src/components/flight/explorer/FlightExplorer.tsx
+++ b/src/components/flight/explorer/FlightExplorer.tsx
@@ -519,12 +519,24 @@ function FlightExplorerContent({ callsign, icaoHint = "" }) {
       nearbyAircraft,
     });
   }, [showNearbyTrafficContext, trackedAircraftForDisplay, nearbyAircraft]);
+  // Whatever the user has focused/selected gets its route fetched first, then
+  // the tracked aircraft, then the URL callsign. selectedAircraftId is an
+  // identity (hex, or callsign fallback), so resolve it to a callsign against
+  // the raw list before it reaches the priority queue.
+  const selectedPriorityCallsign = useMemo(() => {
+    if (!selectedAircraftId) return "";
+    const selected = rawAircraft.find(
+      (item) => getAircraftIdentity(item) === selectedAircraftId,
+    );
+    return selected ? normalizeCallsign(selected.callsign) : "";
+  }, [rawAircraft, selectedAircraftId]);
   const routePriorityCallsigns = useMemo(
     () => [
+      selectedPriorityCallsign,
       trackedAircraftForDisplay?.callsign,
       callsign,
     ],
-    [callsign, trackedAircraftForDisplay?.callsign],
+    [callsign, selectedPriorityCallsign, trackedAircraftForDisplay?.callsign],
   );
 
   // Look up routes for the tracked aircraft and any nearby traffic the user

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -47,11 +47,11 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 65;
+export const CHANGELOG_TOTAL_COUNT = 66;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.42.1",
+    version: "v2.42.2",
     kind: "feat",
     title: {
       en: "A zoom slider for the map, and clearer building footprints",
@@ -78,35 +78,9 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "Standard-map building footprints get more contrast for legibility at neighbourhood zoom.",
         zh: "标准地图建筑轮廓提高对比度,街区级缩放更清晰。",
       },
-    ],
-  },
-  {
-    version: "v2.41.3",
-    kind: "feat",
-    title: {
-      en: "Plane Hunter: live templates, a compass, and one-tap capture",
-      zh: "拍机工作室:实时套模板 + 罗盘指向 + 一键拍照分享",
-    },
-    summary: {
-      en: "Plane Hunter is now one screen. The overlay template renders live on the viewfinder as you frame — pick a preset and the shot updates instantly — so what you see is exactly what you save. The top of the frame became a compass ribbon: a heading tape with degree ticks, cardinals, and an aircraft marker driven by the device compass and the plane's bearing, so you can see whether to pan left or right; it reads out the offset (e.g. L 15°) and turns green and snaps to centre once you're aligned. The shutter freezes the shot straight to a Retake / Share pair (no settings step), the template presets collapse to a single tap-to-cycle button, and the whole flow works in portrait and landscape. The two templates were redesigned around our own data: a boarding-pass Card (callsign hero, flight data, an orange aircraft-type block bled into the corner) and a departure-board Brief (a single flush-bottom strip), both in Manrope with the design-system signal-orange accent.",
-      zh: "拍机工作室合并成一屏。取景时模板就实时渲染在画面上——切预设即时更新——所见即所得。顶部变成一条罗盘带:带刻度、东西南北和飞机 marker 的航向尺,由设备指南针 + 你到飞机的方位角驱动,告诉你该往左还是往右转;它读出偏移角(如 L 15°),对准时变绿并归中。快门把画面冻结后直接进重拍/分享(没有设置步骤),模板预设收成一个点按循环的按钮,整套流程横竖屏都支持。两个模板按我们自己的数据重做:登机牌式 Card(航班号主体 + 飞航数据 + 贴角的橙色机型块)和离港牌式 Brief(贴底单条),都用 Manrope 字体 + 设计系统的信号橙主色。",
-    },
-    highlights: [
       {
-        en: "Live template overlay on the viewfinder — the framing you see is the framing you save; capture composites the exact capture area and shares it.",
-        zh: "取景器上实时套模板——看到的就是保存的;拍照合成的正是取景区并直接分享。",
-      },
-      {
-        en: "Compass ribbon up top: heading tape + degree readout + aircraft marker that points you left/right and turns green when the plane is centred.",
-        zh: "顶部罗盘带:航向尺 + 度数读数 + 飞机 marker,指引你左右,飞机居中时变绿。",
-      },
-      {
-        en: "Shutter → Retake / Share, a single tap-to-cycle template button, and full portrait + landscape support.",
-        zh: "快门 → 重拍/分享,单个点按循环的模板按钮,横竖屏完整支持。",
-      },
-      {
-        en: "Redesigned Card (boarding-pass) and Brief (departure-board) templates in Manrope with the design-system orange accent; legacy settings/compose UI removed.",
-        zh: "重做的 Card(登机牌)与 Brief(离港牌)模板,Manrope 字体 + 设计系统橙色;移除了旧的设置/编辑界面。",
+        en: "Selecting an aircraft on any tracking page now fetches its route first, so the focused flight's origin/destination fills in ahead of the surrounding traffic.",
+        zh: "在任意追踪页选中一架飞机,现在会优先拉取它的航线,聚焦航班的出发/到达会先于周边交通显示出来。",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -170,6 +170,36 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v2.41.3",
+    kind: "feat",
+    title: {
+      en: "Plane Hunter: live templates, a compass, and one-tap capture",
+      zh: "拍机工作室:实时套模板 + 罗盘指向 + 一键拍照分享",
+    },
+    summary: {
+      en: "Plane Hunter is now one screen. The overlay template renders live on the viewfinder as you frame — pick a preset and the shot updates instantly — so what you see is exactly what you save. The top of the frame became a compass ribbon: a heading tape with degree ticks, cardinals, and an aircraft marker driven by the device compass and the plane's bearing, so you can see whether to pan left or right; it reads out the offset (e.g. L 15°) and turns green and snaps to centre once you're aligned. The shutter freezes the shot straight to a Retake / Share pair (no settings step), the template presets collapse to a single tap-to-cycle button, and the whole flow works in portrait and landscape. The two templates were redesigned around our own data: a boarding-pass Card (callsign hero, flight data, an orange aircraft-type block bled into the corner) and a departure-board Brief (a single flush-bottom strip), both in Manrope with the design-system signal-orange accent.",
+      zh: "拍机工作室合并成一屏。取景时模板就实时渲染在画面上——切预设即时更新——所见即所得。顶部变成一条罗盘带:带刻度、东西南北和飞机 marker 的航向尺,由设备指南针 + 你到飞机的方位角驱动,告诉你该往左还是往右转;它读出偏移角(如 L 15°),对准时变绿并归中。快门把画面冻结后直接进重拍/分享(没有设置步骤),模板预设收成一个点按循环的按钮,整套流程横竖屏都支持。两个模板按我们自己的数据重做:登机牌式 Card(航班号主体 + 飞航数据 + 贴角的橙色机型块)和离港牌式 Brief(贴底单条),都用 Manrope 字体 + 设计系统的信号橙主色。",
+    },
+    highlights: [
+      {
+        en: "Live template overlay on the viewfinder — the framing you see is the framing you save; capture composites the exact capture area and shares it.",
+        zh: "取景器上实时套模板——看到的就是保存的;拍照合成的正是取景区并直接分享。",
+      },
+      {
+        en: "Compass ribbon up top: heading tape + degree readout + aircraft marker that points you left/right and turns green when the plane is centred.",
+        zh: "顶部罗盘带:航向尺 + 度数读数 + 飞机 marker,指引你左右,飞机居中时变绿。",
+      },
+      {
+        en: "Shutter → Retake / Share, a single tap-to-cycle template button, and full portrait + landscape support.",
+        zh: "快门 → 重拍/分享,单个点按循环的模板按钮,横竖屏完整支持。",
+      },
+      {
+        en: "Redesigned Card (boarding-pass) and Brief (departure-board) templates in Manrope with the design-system orange accent; legacy settings/compose UI removed.",
+        zh: "重做的 Card(登机牌)与 Brief(离港牌)模板,Manrope 字体 + 设计系统橙色;移除了旧的设置/编辑界面。",
+      },
+    ],
+  },
+  {
     version: "v2.40.1",
     kind: "feat",
     title: {

--- a/src/features/airport/explorer/useAirportExplorerData.ts
+++ b/src/features/airport/explorer/useAirportExplorerData.ts
@@ -5,11 +5,13 @@ import { useMetar } from "@/hooks/useMetar";
 import { useFlightAwareEnabled } from "@/features/app-shell/auth/useFlightAwareEnabled";
 import { resolveRouteProvider } from "@/features/aviation/sourceDisplayModel";
 import { resolveRouteLookupEnabled } from "@/features/aviation/flight-routes/flightRouteLookupModel";
+import { getAircraftIdentity } from "@/features/airport/context/airportContextUiModel";
+import { normalizeCallsign } from "@/utils/callsign";
 import { enrichAircraftWithRoutes } from "./airportExplorerModel";
 
 export function useAirportExplorerData(
   airportProfile,
-  options: { metarIcao?: string } = {},
+  options: { metarIcao?: string; selectedAircraftId?: string } = {},
 ) {
   const { enabled: flightAwareEnabled, resolved: flightAwareResolved } = useFlightAwareEnabled();
   const routeProvider = resolveRouteProvider({ flightAwareEnabled });
@@ -45,6 +47,17 @@ export function useAirportExplorerData(
     airportProfile.lat,
     airportProfile.lon,
   );
+  // Fetch the focused/selected aircraft's route first. selectedAircraftId is
+  // an aircraft identity (hex, or callsign as fallback), so resolve it back to
+  // a callsign against the live list before handing it to the priority queue.
+  const priorityCallsigns = useMemo(() => {
+    if (!options.selectedAircraftId) return undefined;
+    const selected = aircraft.find(
+      (item) => getAircraftIdentity(item) === options.selectedAircraftId,
+    );
+    const callsign = selected ? normalizeCallsign(selected.callsign) : "";
+    return callsign ? [callsign] : undefined;
+  }, [aircraft, options.selectedAircraftId]);
   const {
     routesByCallsign,
     loadingCount: routeLoadingCount,
@@ -55,6 +68,7 @@ export function useAirportExplorerData(
       featureFlagsResolved: flightAwareResolved,
     }),
     routeProvider,
+    priorityCallsigns,
   });
 
   const aircraftWithRoutes = useMemo(

--- a/src/hooks/useFlightRoutes.ts
+++ b/src/hooks/useFlightRoutes.ts
@@ -54,6 +54,14 @@ export function useFlightRoutes(
     null,
   );
   const routeUnsubscribersRef = useRef(new Map<string, () => void>());
+  // Priority hints reorder the pending-lookup queue so a focused/selected
+  // aircraft is fetched ahead of the rest; they never feed cache keys or
+  // channel names (see buildRouteCacheKey / normalizeRouteContext), only the
+  // scheduler's queue ordering. Key the memo on the joined string so a fresh
+  // priority array each position poll doesn't churn routeContext.
+  const priorityCallsignsKey = Array.isArray(routeContextInput?.priorityCallsigns)
+    ? routeContextInput.priorityCallsigns.filter(Boolean).map(String).join("|")
+    : "";
   const routeContext = useMemo(
     () => ({
       icao: routeContextInput?.icao,
@@ -61,6 +69,9 @@ export function useFlightRoutes(
       lat: Number(routeContextInput?.lat),
       lon: Number(routeContextInput?.lon),
       routeProvider: routeContextInput?.routeProvider,
+      priorityCallsigns: priorityCallsignsKey
+        ? priorityCallsignsKey.split("|")
+        : undefined,
     }),
     [
       routeContextInput?.iata,
@@ -68,6 +79,7 @@ export function useFlightRoutes(
       routeContextInput?.lat,
       routeContextInput?.lon,
       routeContextInput?.routeProvider,
+      priorityCallsignsKey,
     ],
   );
   const routeTransport = useMemo(


### PR DESCRIPTION
## What

On any tracking page, selecting/focusing an aircraft now fetches **its** route first, ahead of the surrounding traffic — so the focused flight's origin/destination fills in immediately.

## Root cause it also fixes

The route scheduler already ranks a `priorityCallsigns` queue hint (`collectPendingRouteCandidates` in `flightRouteLookupModel.ts`, covered by tests). But `useFlightRoutes` rebuilt its internal `routeContext` **without** forwarding `priorityCallsigns`, so the hint was silently dropped — `FlightExplorer`'s existing priority list had **no effect**. This wires it through.

## Changes

- **`useFlightRoutes.ts`** — forward `priorityCallsigns` into `routeContext`. Keyed on the joined string so a fresh array each position poll doesn't churn `routeContext`. Verified it never enters cache keys (`buildRouteCacheKey`) or channel names (`normalizeRouteContext`), only the scheduler's queue ordering.
- **`useAirportExplorerData.ts` / `AirportExplorer.tsx`** — the airport map page passed **no** priority before. Resolve `selectedAircraftId` (an identity = hex, callsign fallback) back to a callsign against the live list and pass it as top priority.
- **`FlightExplorer.tsx`** — prepend the user-selected aircraft's callsign ahead of the tracked aircraft + URL callsign.

Re-selecting an already-fetched flight is a no-op (scheduler cache + dedup), matching the "repeats are served from cache" expectation.

## Changelog hygiene (pre-existing red test)

`changelog.test.ts` was already failing on `main`: [#594](https://github.com/orriduck/ADSBao/pull/594) (v2.42.0) added a recent entry without moving the prior one to history or bumping the count (`CHANGELOG_RECENT.length` 2 ≠ `CHANGELOG_INITIAL_LIMIT` 1; total versions 66 ≠ `CHANGELOG_TOTAL_COUNT` 65). Fixed as part of this release: fold this patch into the rolling **v2.42** entry, move **v2.41.3** to `CHANGELOG_HISTORY`, set `CHANGELOG_TOTAL_COUNT` 65 → 66.

## Version

Patch **v2.42.2** (behavior correction). `package.json` + `changelog.ts` kept in sync for the update toast.

## Validation

Mode 3 (local test) — `pnpm test` green (124 files, incl. the now-fixed `changelog.test.ts`; priority ordering covered by `flightRouteLookupModel.test.ts`). Local browser: `/airport/KLAX` renders and the traffic list/routes populate normally after the change.

> Note: while testing I found a **pre-existing** React "change in the order of Hooks" warning in `AirportExplorerContent` (reproduces on `main` with this branch's changes stashed — not introduced here). Flagged separately for its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)