### PR TITLE
fix(map): hide zoom + settings in the mobile sidebar toolbar (v2.42.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.42.2",
+  "version": "2.42.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/map/controls/MapControlRail.tsx
+++ b/src/components/map/controls/MapControlRail.tsx
@@ -38,6 +38,8 @@ export default function MapControlRail({
   settingsSheetId,
   showSidebarToggle = true,
   showMapButton = false,
+  showZoom = true,
+  showSettings = true,
   wakeLockActive = false,
   wakeLockSupported = false,
   onToggleSidebar,
@@ -80,30 +82,37 @@ export default function MapControlRail({
       ) : null}
 
       {/* 缩放滑条 + 航迹视图(完整航迹/所有记录点)全部收进这一个按钮的子菜单,
-          避免工具栏过长。航迹两项只在飞机追踪页有。 */}
-      <ZoomSliderButton
-        activeZoom={activeZoom}
-        min={zoomMin}
-        max={zoomMax}
-        disabled={zoomDisabled}
-        onZoom={onZoom}
-        traceItems={traceItems}
-        menuPlacement={menuPlacement}
-      />
+          避免工具栏过长。航迹两项只在飞机追踪页有。缩放与设置只在能看到地图时才有
+          意义,所以移动端 sidebar(surface="sidebar")里隐藏它们(连同其后的分隔符)。 */}
+      {showZoom ? (
+        <>
+          <ZoomSliderButton
+            activeZoom={activeZoom}
+            min={zoomMin}
+            max={zoomMax}
+            disabled={zoomDisabled}
+            onZoom={onZoom}
+            traceItems={traceItems}
+            menuPlacement={menuPlacement}
+          />
 
-      <ToolbarSeparator />
+          <ToolbarSeparator />
+        </>
+      ) : null}
 
-      <ToolbarButton
-        tone="rail"
-        active={settingsOpen}
-        aria-expanded={settingsOpen}
-        aria-controls={settingsSheetId}
-        title={t("map.settings")}
-        aria-label={t("map.settings")}
-        onClick={onToggleSettings}
-      >
-        <MapControlIcon iconKey={SETTINGS_ICON_KEY} />
-      </ToolbarButton>
+      {showSettings ? (
+        <ToolbarButton
+          tone="rail"
+          active={settingsOpen}
+          aria-expanded={settingsOpen}
+          aria-controls={settingsSheetId}
+          title={t("map.settings")}
+          aria-label={t("map.settings")}
+          onClick={onToggleSettings}
+        >
+          <MapControlIcon iconKey={SETTINGS_ICON_KEY} />
+        </ToolbarButton>
+      ) : null}
 
       <ToolbarButton
         tone="rail"

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -79,6 +79,11 @@ export default function MapControlBar({
     setSettingsOpen((value) => !value);
   };
 
+  // Zoom + settings only make sense while the map is visible. In the mobile
+  // sidebar surface the map isn't shown, so hide both controls (and the now
+  // unreachable settings sheet).
+  const showMapViewControls = surface !== "sidebar";
+
   return (
     <div
       ref={controlZone}
@@ -87,7 +92,8 @@ export default function MapControlBar({
         surface === "sidebar" && "map-ctrl-zone--sidebar",
       )}
     >
-      <MapSettingsSheet
+      {showMapViewControls && (
+        <MapSettingsSheet
         id={MAP_SETTINGS_SHEET_ID}
         open={settingsOpen}
         onOpenChange={setSettingsOpen}
@@ -119,7 +125,8 @@ export default function MapControlBar({
         onToggleCandidateWatchingSpots={onToggleCandidateWatchingSpots}
         onToggleShowCallsigns={onToggleShowCallsigns}
         onToggleUserLocation={onToggleUserLocation}
-      />
+        />
+      )}
 
       <MapControlRail
         menuPlacement={menuPlacement}
@@ -136,6 +143,8 @@ export default function MapControlBar({
         settingsSheetId={MAP_SETTINGS_SHEET_ID}
         showSidebarToggle={showSidebarToggle}
         showMapButton={showMapButton}
+        showZoom={showMapViewControls}
+        showSettings={showMapViewControls}
         wakeLockActive={wakeLockActive}
         wakeLockSupported={wakeLockSupported}
         onToggleSidebar={onToggleSidebar}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 66;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.42.2",
+    version: "v2.42.3",
     kind: "feat",
     title: {
       en: "A zoom slider for the map, and clearer building footprints",
@@ -81,6 +81,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Selecting an aircraft on any tracking page now fetches its route first, so the focused flight's origin/destination fills in ahead of the surrounding traffic.",
         zh: "在任意追踪页选中一架飞机,现在会优先拉取它的航线,聚焦航班的出发/到达会先于周边交通显示出来。",
+      },
+      {
+        en: "On mobile, opening the detail sidebar now hides the zoom and map-settings buttons from its toolbar — they only apply to the map, which isn't visible there.",
+        zh: "移动端打开详情侧栏时,工具栏不再显示缩放和地图设置按钮——它们只对地图生效,而此时看不到地图。",
       },
     ],
   },


### PR DESCRIPTION
## What

On mobile, opening the detail **sidebar** showed a toolbar that still carried the **zoom** (viewfinder) and **map-settings** buttons. Those only act on the map, which isn't visible in the sidebar surface — so they're now hidden there.

| Surface | Toolbar |
|---|---|
| `map` (map visible) | sidebar-toggle · **zoom** · **settings** · wake-lock · lang · theme · auth (unchanged) |
| `sidebar` (mobile details open) | map-button · ~~zoom~~ · ~~settings~~ · wake-lock · lang · theme · auth |

## How

`MapControlBar` derives `showMapViewControls = surface !== "sidebar"`, gates the (now unreachable) `MapSettingsSheet`, and passes `showZoom` / `showSettings` to `MapControlRail`, which conditionally renders the `ZoomSliderButton` (with its trailing separator, so no dangling divider) and the settings button. Both props default to `true`, so the map surface and every other caller are unchanged.

## Version

Patch **v2.42.3** (user-visible UX correction), folded into the rolling v2.42 changelog entry. `package.json` + `changelog.ts` in sync.

## Validation

Mode 2 (local browser) — mobile (375px): on the map surface the toolbar still shows zoom + settings; after opening the detail sidebar, the toolbar shows only map-button · wake-lock · lang · theme · auth (no zoom, no settings). `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)