### PR TITLE
fix(toolbar): keep a single divider per toolbar layout (v2.42.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "2.42.3",
+  "version": "2.42.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/map/controls/MapControlRail.tsx
+++ b/src/components/map/controls/MapControlRail.tsx
@@ -54,50 +54,40 @@ export default function MapControlRail({
   return (
     <Toolbar className="isolate">
       {showSidebarToggle ? (
-        <>
-          <ToolbarButton
-            tone="rail"
-            title={t("map.openDetails")}
-            aria-label={t("map.openDetails")}
-            onClick={onToggleSidebar}
-          >
-            <MapControlIcon iconKey="panelsTopLeft" />
-          </ToolbarButton>
-          <ToolbarSeparator />
-        </>
+        <ToolbarButton
+          tone="rail"
+          title={t("map.openDetails")}
+          aria-label={t("map.openDetails")}
+          onClick={onToggleSidebar}
+        >
+          <MapControlIcon iconKey="panelsTopLeft" />
+        </ToolbarButton>
       ) : null}
 
       {showMapButton ? (
-        <>
-          <ToolbarButton
-            tone="rail"
-            title={t("nav.map")}
-            aria-label={t("nav.map")}
-            onClick={onMap}
-          >
-            <MapControlIcon iconKey="map" />
-          </ToolbarButton>
-          <ToolbarSeparator />
-        </>
+        <ToolbarButton
+          tone="rail"
+          title={t("nav.map")}
+          aria-label={t("nav.map")}
+          onClick={onMap}
+        >
+          <MapControlIcon iconKey="map" />
+        </ToolbarButton>
       ) : null}
 
       {/* 缩放滑条 + 航迹视图(完整航迹/所有记录点)全部收进这一个按钮的子菜单,
           避免工具栏过长。航迹两项只在飞机追踪页有。缩放与设置只在能看到地图时才有
-          意义,所以移动端 sidebar(surface="sidebar")里隐藏它们(连同其后的分隔符)。 */}
+          意义,所以移动端 sidebar(surface="sidebar")里隐藏它们。 */}
       {showZoom ? (
-        <>
-          <ZoomSliderButton
-            activeZoom={activeZoom}
-            min={zoomMin}
-            max={zoomMax}
-            disabled={zoomDisabled}
-            onZoom={onZoom}
-            traceItems={traceItems}
-            menuPlacement={menuPlacement}
-          />
-
-          <ToolbarSeparator />
-        </>
+        <ZoomSliderButton
+          activeZoom={activeZoom}
+          min={zoomMin}
+          max={zoomMax}
+          disabled={zoomDisabled}
+          onZoom={onZoom}
+          traceItems={traceItems}
+          menuPlacement={menuPlacement}
+        />
       ) : null}
 
       {showSettings ? (
@@ -144,8 +134,6 @@ export default function MapControlRail({
         menuPlacement={menuPlacement}
         menuAlign="center"
       />
-
-      <ToolbarSeparator />
 
       {/* Clerk auth — signed-in users get the UserButton avatar /
           dropdown, signed-out users get a Sign-in CTA styled like the

--- a/src/components/navigation/PageNavigationDock.tsx
+++ b/src/components/navigation/PageNavigationDock.tsx
@@ -116,8 +116,6 @@ export default function PageNavigationDock() {
           menuAlign="right"
         />
 
-        <ToolbarSeparator />
-
         {!isLoaded ? (
           <ToolbarAccountSlot aria-hidden="true" />
         ) : showSignedIn ? (

--- a/src/components/sidebar/SidebarShell.tsx
+++ b/src/components/sidebar/SidebarShell.tsx
@@ -152,7 +152,6 @@ export default function SidebarShell({
                     menuPlacement="bottom"
                     menuAlign="center"
                   />
-                  <ToolbarSeparator />
                   {!isLoaded ? (
                     <ToolbarAccountSlot aria-hidden="true" />
                   ) : showSignedIn ? (

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 66;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v2.42.3",
+    version: "v2.42.4",
     kind: "feat",
     title: {
       en: "A zoom slider for the map, and clearer building footprints",
@@ -85,6 +85,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "On mobile, opening the detail sidebar now hides the zoom and map-settings buttons from its toolbar — they only apply to the map, which isn't visible there.",
         zh: "移动端打开详情侧栏时,工具栏不再显示缩放和地图设置按钮——它们只对地图生效,而此时看不到地图。",
+      },
+      {
+        en: "Toolbars are less busy: every toolbar (map controls, page nav, sidebar) now keeps a single divider before the language/theme/account cluster instead of one between every group.",
+        zh: "工具栏更清爽:各处工具栏(地图控制、页面导航、侧栏)只在语言/主题/账号这一组前保留一条分隔符,不再每组之间都放一条。",
       },
     ],
   },


### PR DESCRIPTION
## What

Toolbars had too many dividers. The map control rail stacked **up to five** `ToolbarSeparator`s (one between every group); the page-nav dock and the sidebar fallback toolbar carried **two** each. All three now keep a **single** divider — before the language / theme / account cluster — so every layout shows **0–2** separators.

| Layout | Before | After |
|---|---|---|
| Map rail (map surface) | `nav │ zoom │ settings·wakelock │ lang·theme │ auth` (4) | `nav zoom settings wakelock │ lang theme auth` (1) |
| Map rail (mobile sidebar) | `map │ wakelock │ lang·theme │ auth` (3) | `map wakelock │ lang theme auth` (1) |
| Page nav dock | `items │ lang·theme │ auth` (2) | `items │ lang theme auth` (1) |
| Sidebar fallback | `home·map │ lang·theme │ auth` (2) | `home map │ lang theme auth` (1) |

Also dropped the now-redundant single-child `<>…</>` fragments in the rail's conditional blocks.

## Version

Patch **v2.42.4** (visual declutter), folded into the rolling v2.42 changelog entry. `package.json` + `changelog.ts` in sync.

## Validation

Mode 2 (local browser) — verified on `/airport/KLAX` at mobile and native widths: the map-surface rail and (after opening the detail sidebar) the sidebar-surface rail each render a single divider before the language/theme/account group. `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)