### PR TITLE
fix(here): compass bearing in stat row, em dash on no signal (v3.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -511,6 +511,7 @@ function AirportExplorerContent({
     nearMeSelfAltitudeMeters: nearMe
       ? nearMeSelfLocation?.altitudeMeters ?? null
       : null,
+    nearMeSelfHeadingDeg: nearMe ? nearMeSelfLocation?.headingDeg ?? null : null,
     nearMeRefresh,
     onSelectAircraft: selectAircraft,
     onSelectAirport: selectAirport,

--- a/src/components/sidebar/AirportSidebar.tsx
+++ b/src/components/sidebar/AirportSidebar.tsx
@@ -45,6 +45,7 @@ export default function AirportSidebar({
   nearMe = false,
   nearMeSelfSpeedMps = null,
   nearMeSelfAltitudeMeters = null,
+  nearMeSelfHeadingDeg = null,
   nearMeRefresh,
   onSelectAircraft,
   onSelectAirport,
@@ -113,6 +114,7 @@ export default function AirportSidebar({
         nearMe={nearMe}
         nearMeSelfSpeedMps={nearMeSelfSpeedMps}
         nearMeSelfAltitudeMeters={nearMeSelfAltitudeMeters}
+        nearMeSelfHeadingDeg={nearMeSelfHeadingDeg}
         featureFlagsResolved={flightAwareResolved}
       />
     </>

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -30,6 +30,7 @@ export default function SidebarViewSwitch({
   nearMe = false,
   nearMeSelfSpeedMps = null,
   nearMeSelfAltitudeMeters = null,
+  nearMeSelfHeadingDeg = null,
   featureFlagsResolved = true,
 }) {
   const { t } = useI18n();
@@ -56,6 +57,7 @@ export default function SidebarViewSwitch({
         aircraft,
         selfSpeedMps: nearMeSelfSpeedMps,
         selfAltitudeMeters: nearMeSelfAltitudeMeters,
+        selfHeadingDeg: nearMeSelfHeadingDeg,
         groundSpeedUnit,
         metar,
         metarLoading,
@@ -70,6 +72,7 @@ export default function SidebarViewSwitch({
       aircraft,
       nearMeSelfSpeedMps,
       nearMeSelfAltitudeMeters,
+      nearMeSelfHeadingDeg,
       groundSpeedUnit,
       metar,
       metarLoading,

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 65;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v3.0.0",
+    version: "v3.0.1",
     kind: "feat",
     title: {
       en: "Plane Hunter for everyone: one-screen capture studio, no flag",
@@ -77,6 +77,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Shutter → Retake / Share, a single tap-to-cycle template button, and full portrait + landscape support.",
         zh: "快门 → 重拍/分享,单个点按循环的模板按钮,横竖屏完整支持。",
+      },
+      {
+        en: "Here mode's stat row now reads out your device-compass bearing instead of an always-empty spot count; compass and speed show an em dash (—) when the sensor has no signal, never a bogus 0.",
+        zh: "「我的位置」的指标行现在显示设备罗盘方位角,取代恒为空的拍机点计数;罗盘和速度在传感器无信号时显示 em dash(—),不再是误导性的 0。",
       },
     ],
   },

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -308,6 +308,7 @@ const en = {
     departures: "Dep",
     arrivals: "Arr",
     speed: "Speed",
+    heading: "Heading",
     atc: "ATC",
     spotting: "Spot",
     metricUnits: {

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -302,6 +302,7 @@ const zhCN = {
     departures: "起飞",
     arrivals: "到达",
     speed: "速度",
+    heading: "方位角",
     atc: "ATC",
     spotting: "拍机点",
     metricUnits: {

--- a/src/features/airport/explorer/sidebarStatsModel.test.ts
+++ b/src/features/airport/explorer/sidebarStatsModel.test.ts
@@ -17,6 +17,7 @@ function makeInput(
     aircraft: [],
     selfSpeedMps: null,
     selfAltitudeMeters: null,
+    selfHeadingDeg: null,
     groundSpeedUnit: "kmh",
     metar: null,
     metarLoading: false,
@@ -108,8 +109,8 @@ const ids = (row: { id: string }[]) => row.map((item) => item.id);
   assert.equal(noFix.movementRow[1].value, null);
 }
 
-// Context row: briefing always present; ATC only with frequencies; spotting
-// always present and routed to the dedicated open handler.
+// Context row (airport mode): briefing always present; ATC only with
+// frequencies; spotting always present and routed to the dedicated open handler.
 {
   const noAtc = buildSidebarStats(makeInput());
   assert.deepEqual(ids(noAtc.contextRow), ["briefing", "spotting"]);
@@ -118,6 +119,34 @@ const ids = (row: { id: string }[]) => row.map((item) => item.id);
   assert.deepEqual(ids(withAtc.contextRow), ["briefing", "atc", "spotting"]);
   const spotting = withAtc.contextRow.find((item) => item.id === "spotting");
   assert.equal(spotting?.interaction.kind, "spotting");
+}
+
+// Here mode replaces the (always-empty) spotting cell with the user's compass
+// bearing: padded to 3 digits with a degree unit, read-only, and an em dash
+// when the device compass has no signal.
+{
+  const withHeading = buildSidebarStats(
+    makeInput({ nearMe: true, selfHeadingDeg: 5 }),
+  );
+  assert.deepEqual(ids(withHeading.contextRow), ["briefing", "heading"]);
+  const heading = withHeading.contextRow.find((item) => item.id === "heading");
+  assert.equal(heading?.value, "005");
+  assert.equal(heading?.unit, "°");
+  assert.equal(heading?.interaction.kind, "readonly");
+
+  // Wraps past 360 and rounds.
+  assert.equal(
+    buildSidebarStats(makeInput({ nearMe: true, selfHeadingDeg: 359.6 }))
+      .contextRow.find((item) => item.id === "heading")?.value,
+    "000",
+  );
+
+  // No compass signal → em dash, no unit (never a bogus 0°).
+  const noCompass = buildSidebarStats(
+    makeInput({ nearMe: true, selfHeadingDeg: null }),
+  ).contextRow.find((item) => item.id === "heading");
+  assert.equal(noCompass?.value, null);
+  assert.equal(noCompass?.unit, undefined);
 }
 
 // Briefing temperature comes from the METAR raw temp; loading shows an em dash

--- a/src/features/airport/explorer/sidebarStatsModel.ts
+++ b/src/features/airport/explorer/sidebarStatsModel.ts
@@ -53,6 +53,8 @@ export type BuildSidebarStatsInput = {
   aircraft: Array<{ movement?: string }>;
   selfSpeedMps: number | null;
   selfAltitudeMeters: number | null;
+  // Device-compass heading in degrees, or null when the compass has no signal.
+  selfHeadingDeg: number | null;
   groundSpeedUnit: GroundSpeedUnit;
   metar: { rawTemp?: unknown } | null;
   metarLoading: boolean;
@@ -95,6 +97,7 @@ export function buildSidebarStats(input: BuildSidebarStatsInput): SidebarStats {
     aircraft,
     selfSpeedMps,
     selfAltitudeMeters,
+    selfHeadingDeg,
     groundSpeedUnit,
     metar,
     metarLoading,
@@ -175,13 +178,34 @@ export function buildSidebarStats(input: BuildSidebarStatsInput): SidebarStats {
       interaction: { kind: "view", view: "atc" },
     });
   }
-  contextRow.push({
-    id: "spotting",
-    labelKey: "sidebar.spotting",
-    value: spottingCount,
-    display: "numberFlow",
-    interaction: { kind: "spotting" },
-  });
+  if (nearMe) {
+    // Here mode has no airport, so there are never candidate spots to count —
+    // the cell becomes the user's own compass bearing instead. No signal → em
+    // dash (never a bogus 0°). Padded to the app's 3-digit bearing convention.
+    const bearing =
+      selfHeadingDeg == null || !Number.isFinite(selfHeadingDeg)
+        ? null
+        : String(((Math.round(selfHeadingDeg) % 360) + 360) % 360).padStart(
+            3,
+            "0",
+          );
+    contextRow.push({
+      id: "heading",
+      labelKey: "sidebar.heading",
+      value: bearing,
+      display: "text",
+      unit: bearing == null ? undefined : "°",
+      interaction: { kind: "readonly" },
+    });
+  } else {
+    contextRow.push({
+      id: "spotting",
+      labelKey: "sidebar.spotting",
+      value: spottingCount,
+      display: "numberFlow",
+      interaction: { kind: "spotting" },
+    });
+  }
 
   return { movementRow, contextRow };
 }


### PR DESCRIPTION
## 做了什么

/here「我的位置」的指标行里,原来的**拍机点 cell 永远显示 0**(here 模式没有机场 → 拍机点永不加载)。把它(仅 near-me)换成**设备罗盘方位角**:3 位补零的度数(如 `005`)、只读、单位 `°`;**罗盘无信号时显示 em dash `—` 而非误导性的 0°**。速度本来就在无 fix 时显示 `—`,现在两个传感器的"无信号"规则一致。

### 改动链路
- `sidebarStatsModel.ts` — nearMe 时用方位角 cell 取代 spotting cell(null → `—`);airport 模式保留 spotting
- `AirportExplorer` → `AirportSidebar` → `SidebarViewSwitch` — 串 `nearMeSelfHeadingDeg`(罗盘 heading,GPS 航向兜底)
- i18n:`方位角` / `Heading`

## Validation
- local test — `pnpm test` 全过(127 文件);新增 sidebarStatsModel 断言:方位角 cell、3 位补零、360 回绕(359.6→`000`)、无信号→`—` 无单位;`changelog.test.ts` 版本同步 ✅
- ⚠️ /here 依赖 GPS + 设备罗盘,桌面预览无罗盘信号(仅能验证 `方位角 —` 的无信号态);真机罗盘转动效果建议合入后手机确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)