### PR TITLE
feat(notifications): opt-in proximity alerts for airports and aircraft (v3.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -42,6 +42,10 @@ import { useUserLocationLayer } from "@/hooks/useUserLocationLayer";
 import { useCandidateWatchingSpots } from "@/features/airport/watcher/useCandidateWatchingSpots";
 import { useI18n } from "@/features/app-shell/i18n/useI18n";
 import { useWakeLock } from "@/hooks/useWakeLock";
+import { useNotificationPreferences } from "@/features/notifications/NotificationPreferencesProvider";
+import { useNotificationPermission } from "@/features/notifications/useNotificationPermission";
+import { useAirportProximityNotifier } from "@/features/notifications/useAirportProximityNotifier";
+import { useAircraftProximityNotifier } from "@/features/notifications/useAircraftProximityNotifier";
 
 const AirportMap = lazy(() => import("@/components/map/AirportMap"));
 const AircraftPreviewCard = lazy(() => import("../../aircraft/preview/AircraftPreviewCard"));
@@ -236,6 +240,27 @@ function AirportExplorerContent({
   const { weather, traffic } = useAirportExplorerData(airportProfile, {
     metarIcao,
     selectedAircraftId,
+  });
+  // Proximity alerts: airport alert is here-mode only and fires once per
+  // enabled session; aircraft alert runs in every mode (here + airport
+  // detail) and re-fires per aircraft on each new approach. Both stay fully
+  // inert unless the user both opted in AND already granted the browser
+  // Notification permission — no permission-request side effect lives here.
+  const { preferences: notificationPreferences } = useNotificationPreferences();
+  const { permission: notificationPermission } = useNotificationPermission();
+  const notificationsGranted = notificationPermission === "granted";
+  useAirportProximityNotifier({
+    enabled:
+      nearMe &&
+      notificationsGranted &&
+      notificationPreferences.nearbyAirportEnabled,
+    airports: nearbyAirports.airports,
+    radiusNm: notificationPreferences.nearbyAirportRadiusNm,
+  });
+  useAircraftProximityNotifier({
+    enabled: notificationsGranted && notificationPreferences.nearbyAircraftEnabled,
+    aircraft: traffic.aircraft,
+    radiusNm: notificationPreferences.nearbyAircraftRadiusNm,
   });
   const effectiveUserLocation =
     (nearMe ? null : userLocationLayer.userLocation) || nearMeMapUserLocation;

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -20,6 +20,12 @@ import {
   DISTANCE_UNITS,
   TEMPERATURE_UNITS,
 } from "@/features/app-shell/unitPreferences/unitPreferencesModel";
+import { useNotificationPreferences } from "@/features/notifications/NotificationPreferencesProvider";
+import { useNotificationPermission } from "@/features/notifications/useNotificationPermission";
+import {
+  NEARBY_AIRCRAFT_RADIUS_PRESETS_NM,
+  NEARBY_AIRPORT_RADIUS_PRESETS_NM,
+} from "@/features/notifications/notificationPreferencesModel";
 import AsyncStatusLine from "@/components/ui/AsyncStatusLine";
 import { MapControlIcon } from "./mapControlIcons";
 
@@ -241,6 +247,34 @@ function LayerToggleRow({
   );
 }
 
+// Distance-radius picker for a notification toggle — same segmented-button
+// visual language as the unit preferences below, just scoped to one row
+// instead of the whole units section.
+function RadiusPresetRow({ ariaLabel, options, unitLabel, value, onSelect }) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="map-settings-segmented-control mt-1 grid auto-cols-fr grid-flow-col gap-0.5 rounded-none border-0 bg-transparent p-0 shadow-none"
+    >
+      {options.map((option) => (
+        <button
+          key={option}
+          type="button"
+          role="radio"
+          aria-checked={value === option}
+          data-active={value === option ? "true" : "false"}
+          className={unitSegmentButtonClassName}
+          onClick={() => onSelect(option)}
+        >
+          {option}
+          {unitLabel}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export default function MapSettingsSheet({
   id,
   open,
@@ -277,6 +311,35 @@ export default function MapSettingsSheet({
   const { t } = useI18n();
   const { preferences: unitPreferences, setPreferences: setUnitPreferences } =
     useUnitPreferences();
+  const {
+    preferences: notificationPreferences,
+    setPreferences: setNotificationPreferences,
+  } = useNotificationPreferences();
+  const { permission: notificationPermission, request: requestNotificationPermission } =
+    useNotificationPermission();
+  const notificationsUnsupported = notificationPermission === "unsupported";
+  const notificationsDenied = notificationPermission === "denied";
+  const distanceUnitLabel = t(
+    `mapSettings.units.distance.options.${unitPreferences.distance}`,
+  );
+  // Flipping a toggle on always flips the stored preference — permission is a
+  // separate concern surfaced via the note below — but the FIRST time a user
+  // opts in with no permission decision yet, ask right away instead of making
+  // them dig for it.
+  const toggleAirportAlert = () => {
+    const next = !notificationPreferences.nearbyAirportEnabled;
+    setNotificationPreferences({ nearbyAirportEnabled: next });
+    if (next && notificationPermission === "default") {
+      requestNotificationPermission();
+    }
+  };
+  const toggleAircraftAlert = () => {
+    const next = !notificationPreferences.nearbyAircraftEnabled;
+    setNotificationPreferences({ nearbyAircraftEnabled: next });
+    if (next && notificationPermission === "default") {
+      requestNotificationPermission();
+    }
+  };
   const { isLoaded, isSignedIn } = useUser();
   const settings = normalizeMapSettings(mapSettings);
   const baseLayerOptions = getMapBaseLayerOptions();
@@ -536,6 +599,95 @@ export default function MapSettingsSheet({
                     </div>
                   );
                 })}
+              </div>
+            </section>
+
+            <section
+              className="map-settings-section"
+              aria-labelledby={`${id}-notifications`}
+            >
+              <h3
+                id={`${id}-notifications`}
+                className={sectionTitleClassName}
+              >
+                {t("mapSettings.notificationsSection")}
+              </h3>
+              <div className={settingsListGroupClassName}>
+                <LayerToggleRow
+                  active={notificationPreferences.nearbyAirportEnabled}
+                  ariaLabel={t("notifications.airport.label")}
+                  disabled={notificationsUnsupported}
+                  iconKey="towerControl"
+                  label={t("notifications.airport.label")}
+                  subtitle={
+                    notificationPreferences.nearbyAirportEnabled
+                      ? t("notifications.airport.subtitleOn")
+                      : t("notifications.airport.subtitleOff")
+                  }
+                  onClick={toggleAirportAlert}
+                />
+                {notificationPreferences.nearbyAirportEnabled ? (
+                  <RadiusPresetRow
+                    ariaLabel={t("notifications.radiusLabel")}
+                    options={NEARBY_AIRPORT_RADIUS_PRESETS_NM}
+                    unitLabel={distanceUnitLabel}
+                    value={notificationPreferences.nearbyAirportRadiusNm}
+                    onSelect={(radius) =>
+                      setNotificationPreferences({
+                        nearbyAirportRadiusNm: radius,
+                      })
+                    }
+                  />
+                ) : null}
+
+                <LayerToggleRow
+                  active={notificationPreferences.nearbyAircraftEnabled}
+                  ariaLabel={t("notifications.aircraft.label")}
+                  disabled={notificationsUnsupported}
+                  iconKey="radar"
+                  label={t("notifications.aircraft.label")}
+                  subtitle={
+                    notificationPreferences.nearbyAircraftEnabled
+                      ? t("notifications.aircraft.subtitleOn")
+                      : t("notifications.aircraft.subtitleOff")
+                  }
+                  onClick={toggleAircraftAlert}
+                />
+                {notificationPreferences.nearbyAircraftEnabled ? (
+                  <RadiusPresetRow
+                    ariaLabel={t("notifications.radiusLabel")}
+                    options={NEARBY_AIRCRAFT_RADIUS_PRESETS_NM}
+                    unitLabel={distanceUnitLabel}
+                    value={notificationPreferences.nearbyAircraftRadiusNm}
+                    onSelect={(radius) =>
+                      setNotificationPreferences({
+                        nearbyAircraftRadiusNm: radius,
+                      })
+                    }
+                  />
+                ) : null}
+              </div>
+              <div className="mt-1 space-y-1">
+                <div className="map-settings-note rounded-[calc(var(--atc-radius-card)-2px)] bg-transparent px-1 py-1 text-[10px] leading-snug text-atc-muted shadow-none">
+                  {t("notifications.airport.hint")}
+                </div>
+                {notificationsUnsupported ? (
+                  <div
+                    className="map-settings-note rounded-[calc(var(--atc-radius-card)-2px)] bg-transparent px-1 py-1 text-[10px] leading-snug text-[var(--atc-interaction-danger)] shadow-none"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {t("notifications.permissionUnsupported")}
+                  </div>
+                ) : notificationsDenied ? (
+                  <div
+                    className="map-settings-note rounded-[calc(var(--atc-radius-card)-2px)] bg-transparent px-1 py-1 text-[10px] leading-snug text-[var(--atc-interaction-danger)] shadow-none"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {t("notifications.permissionDenied")}
+                  </div>
+                ) : null}
               </div>
             </section>
           </div>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -47,40 +47,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 65;
+export const CHANGELOG_TOTAL_COUNT = 66;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v3.0.1",
+    version: "v3.1.1",
     kind: "feat",
     title: {
-      en: "Plane Hunter for everyone: one-screen capture studio, no flag",
-      zh: "拍机工作室面向所有人:一屏拍照,不再内测",
+      en: "Proximity alerts: airport nearby (Here mode) and aircraft closing in",
+      zh: "接近提醒:附近机场(我的位置模式)与飞机接近",
     },
     summary: {
-      en: "The Plane Hunter camera studio graduates from internal testing to everyone. It's a single screen: pick an aircraft, frame it in the live viewfinder with the overlay template rendering as you shoot, follow the compass ribbon up top to line the plane up (it turns green and snaps to centre when aligned), then one tap to capture and share. The two data-driven templates — a boarding-pass Card and a departure-board Brief — ship in Manrope with the design-system signal-orange accent. The old feature gate and the legacy two-step compose flow are both gone: there's now one modern studio for every user, on every supported device.",
-      zh: "拍机相机工作室从内测正式面向所有人。整个流程就在一屏:选一架飞机,在实时取景器里取景——模板边拍边实时渲染,跟着顶部的罗盘带把飞机对准(对齐时变绿并归中),一键拍照分享。两个数据驱动的模板——登机牌式 Card 和离港牌式 Brief——都用 Manrope 字体 + 设计系统的信号橙主色。旧的功能开关和旧版两步式编辑流程都已移除:现在所有用户、所有受支持设备上都是同一个 modern 工作室。",
+      en: "A new Notifications section in map settings adds two opt-in system-notification alerts, both off by default. In Here mode, turning on the airport alert pings you once — with the airport's name and distance — the first time you wander within your chosen range (3/5/10/20 NM); it goes quiet after that until you toggle it off and back on. The aircraft alert works everywhere (Here mode and airport pages) and fires per plane, with its callsign and aircraft type, each time one crosses into your chosen range (2/5/10/20 NM) — not on every refresh while it lingers, and it fires again if it leaves and comes back. Both need the browser's notification permission; the settings sheet shows a clear note if that's blocked or unsupported.",
+      zh: "地图设置新增「通知」分区,两个默认关闭的可选系统通知。在「我的位置」模式下打开机场提醒后,第一次进入你设定的范围(3/5/10/20 海里)会弹出一条提醒(机场名称 + 距离),之后保持安静,直到你关闭再重新打开。飞机提醒在任何模式下都生效(我的位置和机场详情页),每架飞机每次进入你设定的范围(2/5/10/20 海里)都会带着呼号和机型提醒一次——停留期间不会反复提醒,离开后再次接近会重新提醒。两者都需要浏览器的系统通知权限;权限被拒绝或浏览器不支持时,设置面板会给出明确提示。",
     },
     highlights: [
       {
-        en: "The internal feature flag that gated the studio is removed — every user gets the modern one-screen Plane Hunter, with no legacy fallback.",
-        zh: "门控工作室的内部 feature flag 已移除——所有用户都进 modern 一屏式拍机,没有旧版回落。",
+        en: "Here-mode airport alert: one system notification with the airport's name and distance the first time you're within range; quiet after that until re-enabled.",
+        zh: "「我的位置」机场提醒:进入范围后弹出一次机场名称 + 距离的系统通知,之后保持安静,直到重新开启。",
       },
       {
-        en: "Live template overlay on the viewfinder — what you frame is what you save; capture composites the exact capture area and shares it.",
-        zh: "取景器上实时套模板——所见即所存;拍照合成的正是取景区并直接分享。",
+        en: "Aircraft alert (all modes): a system notification per aircraft — callsign and type — on each new approach into range, never repeating while it just lingers nearby.",
+        zh: "飞机提醒(全部模式):每架飞机每次新进入范围都弹一次呼号 + 机型的系统通知,停留附近期间不会重复。",
       },
       {
-        en: "Compass ribbon up top: heading tape + degree readout + aircraft marker that points you left/right and turns green when the plane is centred.",
-        zh: "顶部罗盘带:航向尺 + 度数读数 + 飞机 marker,指引你左右,飞机居中时变绿。",
-      },
-      {
-        en: "Shutter → Retake / Share, a single tap-to-cycle template button, and full portrait + landscape support.",
-        zh: "快门 → 重拍/分享,单个点按循环的模板按钮,横竖屏完整支持。",
-      },
-      {
-        en: "Here mode's stat row now reads out your device-compass bearing instead of an always-empty spot count; compass and speed show an em dash (—) when the sensor has no signal, never a bogus 0.",
-        zh: "「我的位置」的指标行现在显示设备罗盘方位角,取代恒为空的拍机点计数;罗盘和速度在传感器无信号时显示 em dash(—),不再是误导性的 0。",
+        en: "Both alerts default OFF and each has its own adjustable range preset; a clear note appears if the browser's notification permission is blocked or unsupported.",
+        zh: "两个提醒默认关闭,各自有独立可调的范围预设;浏览器通知权限被拒绝或不支持时,会显示明确提示。",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -170,6 +170,40 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v3.0.1",
+    kind: "feat",
+    title: {
+      en: "Plane Hunter for everyone: one-screen capture studio, no flag",
+      zh: "拍机工作室面向所有人:一屏拍照,不再内测",
+    },
+    summary: {
+      en: "The Plane Hunter camera studio graduates from internal testing to everyone. It's a single screen: pick an aircraft, frame it in the live viewfinder with the overlay template rendering as you shoot, follow the compass ribbon up top to line the plane up (it turns green and snaps to centre when aligned), then one tap to capture and share. The two data-driven templates — a boarding-pass Card and a departure-board Brief — ship in Manrope with the design-system signal-orange accent. The old feature gate and the legacy two-step compose flow are both gone: there's now one modern studio for every user, on every supported device.",
+      zh: "拍机相机工作室从内测正式面向所有人。整个流程就在一屏:选一架飞机,在实时取景器里取景——模板边拍边实时渲染,跟着顶部的罗盘带把飞机对准(对齐时变绿并归中),一键拍照分享。两个数据驱动的模板——登机牌式 Card 和离港牌式 Brief——都用 Manrope 字体 + 设计系统的信号橙主色。旧的功能开关和旧版两步式编辑流程都已移除:现在所有用户、所有受支持设备上都是同一个 modern 工作室。",
+    },
+    highlights: [
+      {
+        en: "The internal feature flag that gated the studio is removed — every user gets the modern one-screen Plane Hunter, with no legacy fallback.",
+        zh: "门控工作室的内部 feature flag 已移除——所有用户都进 modern 一屏式拍机,没有旧版回落。",
+      },
+      {
+        en: "Live template overlay on the viewfinder — what you frame is what you save; capture composites the exact capture area and shares it.",
+        zh: "取景器上实时套模板——所见即所存;拍照合成的正是取景区并直接分享。",
+      },
+      {
+        en: "Compass ribbon up top: heading tape + degree readout + aircraft marker that points you left/right and turns green when the plane is centred.",
+        zh: "顶部罗盘带:航向尺 + 度数读数 + 飞机 marker,指引你左右,飞机居中时变绿。",
+      },
+      {
+        en: "Shutter → Retake / Share, a single tap-to-cycle template button, and full portrait + landscape support.",
+        zh: "快门 → 重拍/分享,单个点按循环的模板按钮,横竖屏完整支持。",
+      },
+      {
+        en: "Here mode's stat row now reads out your device-compass bearing instead of an always-empty spot count; compass and speed show an em dash (—) when the sensor has no signal, never a bogus 0.",
+        zh: "「我的位置」的指标行现在显示设备罗盘方位角,取代恒为空的拍机点计数;罗盘和速度在传感器无信号时显示 em dash(—),不再是误导性的 0。",
+      },
+    ],
+  },
+  {
     version: "v2.43.1",
     kind: "feat",
     title: {

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -691,6 +691,7 @@ const en = {
     baseMapSection: "Base map",
     layersSection: "Display",
     unitsSection: "Units",
+    notificationsSection: "Notifications",
     units: {
       distance: {
         title: "Distance",
@@ -722,6 +723,31 @@ const en = {
     baseLayerDescriptions: {
       standard: "Clean street map with no terrain shading.",
       terrain: "Hillshade and topographic relief under the base map.",
+    },
+  },
+  notifications: {
+    permissionUnsupported: "This browser doesn't support system notifications.",
+    permissionDenied:
+      "System notifications are blocked — enable them in your browser settings and try again.",
+    radiusLabel: "Alert range",
+    airport: {
+      label: "Nearby airport alert",
+      subtitleOn: "Notify once when an airport is in range",
+      subtitleOff: "No airport alerts",
+      hint: "Only active in Here mode, and only once per time it's turned on",
+    },
+    aircraft: {
+      label: "Nearby aircraft alert",
+      subtitleOn: "Notify with callsign and type when a plane is in range",
+      subtitleOff: "No aircraft alerts",
+    },
+    airportAlert: {
+      title: "Airport nearby: {name}",
+      body: "About {distance}{unit} away · {icao}",
+    },
+    aircraftAlert: {
+      title: "{callsign} is nearby",
+      body: "{type} · about {distance}{unit} away",
     },
   },
   watcherMode: {

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -681,6 +681,7 @@ const zhCN = {
     baseMapSection: "底图",
     layersSection: "显示",
     unitsSection: "单位",
+    notificationsSection: "通知",
     units: {
       distance: {
         title: "距离",
@@ -712,6 +713,30 @@ const zhCN = {
     baseLayerDescriptions: {
       standard: "干净的街道底图,无地形渲染。",
       terrain: "在底图下方叠加山体阴影和地势起伏。",
+    },
+  },
+  notifications: {
+    permissionUnsupported: "此浏览器不支持系统通知。",
+    permissionDenied: "系统通知权限已被拒绝,请在浏览器设置中开启后重试。",
+    radiusLabel: "提醒范围",
+    airport: {
+      label: "附近机场提醒",
+      subtitleOn: "进入范围内有机场时提醒一次",
+      subtitleOff: "不提醒附近机场",
+      hint: "仅在「我的位置」模式下生效,每次开启只提醒一次",
+    },
+    aircraft: {
+      label: "附近飞机提醒",
+      subtitleOn: "飞机进入范围时提醒呼号和机型",
+      subtitleOff: "不提醒附近飞机",
+    },
+    airportAlert: {
+      title: "附近有机场:{name}",
+      body: "距你约 {distance}{unit} · {icao}",
+    },
+    aircraftAlert: {
+      title: "{callsign} 正在接近",
+      body: "{type} · 距你约 {distance}{unit}",
     },
   },
   watcherMode: {

--- a/src/features/notifications/NotificationPreferencesProvider.tsx
+++ b/src/features/notifications/NotificationPreferencesProvider.tsx
@@ -1,0 +1,86 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  mergeNotificationPreferences,
+  normalizeNotificationPreferences,
+  type NotificationPreferences,
+} from "./notificationPreferencesModel";
+import {
+  readStoredNotificationPreferences,
+  writeStoredNotificationPreferences,
+} from "./notificationPreferencesStorage";
+
+interface NotificationPreferencesContextValue {
+  preferences: NotificationPreferences;
+  setPreferences: (patch: Partial<NotificationPreferences>) => void;
+  hydrated: boolean;
+}
+
+const DEFAULT_CONTEXT: NotificationPreferencesContextValue = {
+  preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+  setPreferences: () => {},
+  hydrated: false,
+};
+
+const NotificationPreferencesContext =
+  createContext<NotificationPreferencesContextValue>(DEFAULT_CONTEXT);
+
+export function NotificationPreferencesProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [preferences, setPreferencesState] = useState<NotificationPreferences>(
+    DEFAULT_NOTIFICATION_PREFERENCES,
+  );
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const stored = readStoredNotificationPreferences();
+    if (stored) setPreferencesState(stored);
+    setHydrated(true);
+  }, []);
+
+  const setPreferences = useCallback(
+    (patch: Partial<NotificationPreferences>) => {
+      setPreferencesState((current) => {
+        const next = mergeNotificationPreferences(current, patch);
+        writeStoredNotificationPreferences(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const normalized = useMemo(
+    () => normalizeNotificationPreferences(preferences),
+    [preferences],
+  );
+
+  const value = useMemo(
+    () => ({
+      preferences: normalized,
+      setPreferences,
+      hydrated,
+    }),
+    [normalized, setPreferences, hydrated],
+  );
+
+  return (
+    <NotificationPreferencesContext.Provider value={value}>
+      {children}
+    </NotificationPreferencesContext.Provider>
+  );
+}
+
+export function useNotificationPreferences() {
+  return useContext(NotificationPreferencesContext);
+}

--- a/src/features/notifications/browserNotificationModel.ts
+++ b/src/features/notifications/browserNotificationModel.ts
@@ -1,0 +1,56 @@
+// Thin wrapper over the browser Notification API. Kept separate from the
+// permission hook so the "is this even usable" checks are testable without
+// mocking React.
+
+export type NotificationPermissionState =
+  | "unsupported"
+  | "default"
+  | "granted"
+  | "denied";
+
+export function isNotificationSupported() {
+  return typeof window !== "undefined" && "Notification" in window;
+}
+
+export function getNotificationPermission(): NotificationPermissionState {
+  if (!isNotificationSupported()) return "unsupported";
+  return window.Notification.permission as NotificationPermissionState;
+}
+
+export async function requestNotificationPermission(): Promise<NotificationPermissionState> {
+  if (!isNotificationSupported()) return "unsupported";
+  try {
+    const result = await window.Notification.requestPermission();
+    return result as NotificationPermissionState;
+  } catch {
+    return getNotificationPermission();
+  }
+}
+
+export interface ShowNotificationOptions {
+  title: string;
+  body?: string;
+  tag?: string;
+  icon?: string;
+}
+
+// Fires a system notification when permission is already granted. Silently
+// no-ops otherwise — callers gate on permission state before wiring up the
+// proximity watchers, so this is a last-line defensive check, not the
+// primary gate.
+export function showBrowserNotification({
+  title,
+  body,
+  tag,
+  icon = "/icon.png",
+}: ShowNotificationOptions) {
+  if (getNotificationPermission() !== "granted") return null;
+  try {
+    return new window.Notification(title, { body, tag, icon });
+  } catch {
+    // Some browsers (notably mobile Chrome) reject direct construction in
+    // certain contexts even with permission granted — never let a
+    // notification failure break the surrounding proximity watcher.
+    return null;
+  }
+}

--- a/src/features/notifications/notificationPreferencesModel.test.ts
+++ b/src/features/notifications/notificationPreferencesModel.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  mergeNotificationPreferences,
+  normalizeNotificationPreferences,
+} from "./notificationPreferencesModel";
+
+// Both toggles default OFF — this is an opt-in feature, never a surprise
+// permission prompt or notification on first load.
+{
+  assert.equal(DEFAULT_NOTIFICATION_PREFERENCES.nearbyAirportEnabled, false);
+  assert.equal(DEFAULT_NOTIFICATION_PREFERENCES.nearbyAircraftEnabled, false);
+}
+
+// Garbage / missing input falls back to defaults entirely.
+{
+  assert.deepEqual(
+    normalizeNotificationPreferences(null),
+    DEFAULT_NOTIFICATION_PREFERENCES,
+  );
+  assert.deepEqual(
+    normalizeNotificationPreferences("nonsense"),
+    DEFAULT_NOTIFICATION_PREFERENCES,
+  );
+  assert.deepEqual(
+    normalizeNotificationPreferences({ nearbyAirportEnabled: "yes" }),
+    DEFAULT_NOTIFICATION_PREFERENCES,
+  );
+}
+
+// Radius values clamp to the preset bounds rather than being rejected.
+{
+  const tooLow = normalizeNotificationPreferences({
+    nearbyAirportRadiusNm: 0.1,
+  });
+  assert.equal(tooLow.nearbyAirportRadiusNm, 3);
+
+  const tooHigh = normalizeNotificationPreferences({
+    nearbyAircraftRadiusNm: 999,
+  });
+  assert.equal(tooHigh.nearbyAircraftRadiusNm, 20);
+
+  const withinRange = normalizeNotificationPreferences({
+    nearbyAirportRadiusNm: 10,
+  });
+  assert.equal(withinRange.nearbyAirportRadiusNm, 10);
+}
+
+// Merge only overwrites the patched fields.
+{
+  const merged = mergeNotificationPreferences(DEFAULT_NOTIFICATION_PREFERENCES, {
+    nearbyAircraftEnabled: true,
+  });
+  assert.equal(merged.nearbyAircraftEnabled, true);
+  assert.equal(merged.nearbyAirportEnabled, false);
+  assert.equal(merged.nearbyAircraftRadiusNm, 5);
+}
+
+console.log("notificationPreferencesModel.test.ts ok");

--- a/src/features/notifications/notificationPreferencesModel.ts
+++ b/src/features/notifications/notificationPreferencesModel.ts
@@ -1,0 +1,77 @@
+// User-pickable proximity-alert preferences. Stored client-side only (like
+// unitPreferences) — browser notification permission is inherently per-device,
+// so there is no server-side account sync to do here.
+
+export const NEARBY_AIRPORT_RADIUS_PRESETS_NM = [3, 5, 10, 20] as const;
+export const NEARBY_AIRCRAFT_RADIUS_PRESETS_NM = [2, 5, 10, 20] as const;
+
+export interface NotificationPreferences {
+  // Here-mode only: notify once when any airport comes within radius.
+  nearbyAirportEnabled: boolean;
+  nearbyAirportRadiusNm: number;
+  // All modes (here + airport detail): notify per aircraft that newly enters
+  // radius, with its callsign and aircraft type.
+  nearbyAircraftEnabled: boolean;
+  nearbyAircraftRadiusNm: number;
+}
+
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences =
+  Object.freeze({
+    nearbyAirportEnabled: false,
+    nearbyAirportRadiusNm: 5,
+    nearbyAircraftEnabled: false,
+    nearbyAircraftRadiusNm: 5,
+  });
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function normalizeRadiusNm(
+  value: unknown,
+  presets: readonly number[],
+  fallback: number,
+): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return fallback;
+  // Clamp to the nearest preset bound rather than rejecting an off-preset
+  // value outright — keeps a stored value usable even if the preset list
+  // changes between releases.
+  const min = presets[0];
+  const max = presets[presets.length - 1];
+  return Math.min(Math.max(numeric, min), max);
+}
+
+export function normalizeNotificationPreferences(
+  value: unknown = DEFAULT_NOTIFICATION_PREFERENCES,
+): NotificationPreferences {
+  const record =
+    value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  return {
+    nearbyAirportEnabled: normalizeBoolean(
+      record.nearbyAirportEnabled,
+      DEFAULT_NOTIFICATION_PREFERENCES.nearbyAirportEnabled,
+    ),
+    nearbyAirportRadiusNm: normalizeRadiusNm(
+      record.nearbyAirportRadiusNm,
+      NEARBY_AIRPORT_RADIUS_PRESETS_NM,
+      DEFAULT_NOTIFICATION_PREFERENCES.nearbyAirportRadiusNm,
+    ),
+    nearbyAircraftEnabled: normalizeBoolean(
+      record.nearbyAircraftEnabled,
+      DEFAULT_NOTIFICATION_PREFERENCES.nearbyAircraftEnabled,
+    ),
+    nearbyAircraftRadiusNm: normalizeRadiusNm(
+      record.nearbyAircraftRadiusNm,
+      NEARBY_AIRCRAFT_RADIUS_PRESETS_NM,
+      DEFAULT_NOTIFICATION_PREFERENCES.nearbyAircraftRadiusNm,
+    ),
+  };
+}
+
+export function mergeNotificationPreferences(
+  current: NotificationPreferences,
+  patch: Partial<NotificationPreferences>,
+): NotificationPreferences {
+  return normalizeNotificationPreferences({ ...current, ...patch });
+}

--- a/src/features/notifications/notificationPreferencesStorage.ts
+++ b/src/features/notifications/notificationPreferencesStorage.ts
@@ -1,0 +1,32 @@
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  normalizeNotificationPreferences,
+  type NotificationPreferences,
+} from "./notificationPreferencesModel";
+
+const STORAGE_KEY = "adsbao:notification-preferences:v1";
+
+export function readStoredNotificationPreferences(): NotificationPreferences | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return normalizeNotificationPreferences(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredNotificationPreferences(
+  preferences: NotificationPreferences = DEFAULT_NOTIFICATION_PREFERENCES,
+) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(normalizeNotificationPreferences(preferences)),
+    );
+  } catch {
+    // localStorage unavailable (private mode / quota) — in-memory still applies.
+  }
+}

--- a/src/features/notifications/proximityNotificationModel.test.ts
+++ b/src/features/notifications/proximityNotificationModel.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import {
+  aircraftProximityKey,
+  airportProximityKey,
+  selectAirportProximityHit,
+  selectNewlyEnteredAircraft,
+} from "./proximityNotificationModel";
+
+// --- selectAirportProximityHit -------------------------------------------
+
+// No airports, or nothing within radius, or a non-positive radius → no hit.
+{
+  assert.equal(selectAirportProximityHit([], 5), null);
+  assert.equal(selectAirportProximityHit(null, 5), null);
+  assert.equal(
+    selectAirportProximityHit([{ icao: "KPHL", distanceNm: 12 }], 5),
+    null,
+  );
+  assert.equal(
+    selectAirportProximityHit([{ icao: "KPHL", distanceNm: 1 }], 0),
+    null,
+  );
+}
+
+// Picks the CLOSEST qualifying airport when several are within radius.
+{
+  const hit = selectAirportProximityHit(
+    [
+      { icao: "KPHL", name: "Philadelphia Intl", distanceNm: 4.8 },
+      { icao: "KPNE", name: "Northeast Philadelphia", distanceNm: 2.1 },
+      { icao: "KTTN", name: "Trenton-Mercer", distanceNm: 40 },
+    ],
+    5,
+  );
+  assert.equal(hit?.icao, "KPNE");
+  assert.equal(hit?.distanceNm, 2.1);
+}
+
+// An airport with no usable identity key is skipped even if in range.
+{
+  const hit = selectAirportProximityHit(
+    [{ icao: "", ident: "", code: "", distanceNm: 1 }],
+    5,
+  );
+  assert.equal(hit, null);
+}
+
+// --- selectNewlyEnteredAircraft -------------------------------------------
+
+// First tick: every in-range aircraft is a fresh hit.
+{
+  const { hits, insideKeys } = selectNewlyEnteredAircraft(
+    [
+      { hex: "a1b2c3", callsign: "UAL123", distanceNm: 3 },
+      { hex: "d4e5f6", callsign: "DAL456", distanceNm: 20 },
+    ],
+    10,
+    new Set(),
+  );
+  assert.deepEqual(
+    hits.map((hit) => hit.callsign),
+    ["UAL123"],
+  );
+  assert.deepEqual([...insideKeys], ["a1b2c3"]);
+}
+
+// Second tick, same aircraft still inside → NOT re-notified (no repeat spam
+// while it lingers), but a newly-entered second aircraft IS notified.
+{
+  const previousInside = new Set(["a1b2c3"]);
+  const { hits, insideKeys } = selectNewlyEnteredAircraft(
+    [
+      { hex: "a1b2c3", callsign: "UAL123", distanceNm: 3.5 },
+      { hex: "d4e5f6", callsign: "DAL456", distanceNm: 8 },
+    ],
+    10,
+    previousInside,
+  );
+  assert.deepEqual(
+    hits.map((hit) => hit.callsign),
+    ["DAL456"],
+  );
+  assert.deepEqual([...insideKeys].sort(), ["a1b2c3", "d4e5f6"]);
+}
+
+// An aircraft that leaves and re-enters radius fires again — insideKeys no
+// longer contains it once it drops out, so the next inbound tick is fresh.
+{
+  const afterLeaving = selectNewlyEnteredAircraft(
+    [{ hex: "d4e5f6", callsign: "DAL456", distanceNm: 25 }],
+    10,
+    new Set(["a1b2c3", "d4e5f6"]),
+  );
+  assert.deepEqual(afterLeaving.hits, []);
+  assert.deepEqual([...afterLeaving.insideKeys], []);
+
+  const reentering = selectNewlyEnteredAircraft(
+    [{ hex: "d4e5f6", callsign: "DAL456", distanceNm: 4 }],
+    10,
+    afterLeaving.insideKeys,
+  );
+  assert.deepEqual(
+    reentering.hits.map((hit) => hit.callsign),
+    ["DAL456"],
+  );
+}
+
+// Falls back to icao24, then callsign, for the dedupe key when hex is absent;
+// an aircraft with no usable identity at all is skipped.
+{
+  assert.equal(aircraftProximityKey({ icao24: "abc123" }), "abc123");
+  assert.equal(aircraftProximityKey({ callsign: "N12345" }), "N12345");
+  assert.equal(airportProximityKey({ ident: "KPHL" }), "KPHL");
+
+  const { hits } = selectNewlyEnteredAircraft(
+    [{ callsign: "", hex: "", icao24: "", distanceNm: 1 }],
+    10,
+    new Set(),
+  );
+  assert.deepEqual(hits, []);
+}
+
+console.log("proximityNotificationModel.test.ts ok");

--- a/src/features/notifications/proximityNotificationModel.ts
+++ b/src/features/notifications/proximityNotificationModel.ts
@@ -1,0 +1,97 @@
+// Pure proximity-detection logic for the two notification watchers. Kept
+// framework-free (no Notification API, no React) so the "which airport/
+// aircraft just crossed into radius" decision is unit-testable without
+// mocking the browser.
+
+type AirportRecord = Record<string, unknown>;
+type AircraftRecord = Record<string, unknown>;
+
+export type AirportProximityHit = {
+  key: string;
+  icao: string;
+  name: string;
+  distanceNm: number;
+};
+
+export type AircraftProximityHit = {
+  key: string;
+  callsign: string;
+  distanceNm: number;
+  aircraft: AircraftRecord;
+};
+
+function toFiniteNumber(value: unknown): number | null {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+export function airportProximityKey(airport: AirportRecord): string {
+  return String(
+    airport?.icao || airport?.ident || airport?.code || "",
+  ).trim();
+}
+
+export function aircraftProximityKey(aircraft: AircraftRecord): string {
+  return String(
+    aircraft?.hex || aircraft?.icao24 || aircraft?.callsign || "",
+  ).trim();
+}
+
+// Here-mode airport-proximity alert fires ONCE per enabled session (never
+// per-airport) — the caller gates repeat calls with its own "already fired"
+// flag. This just answers "is anything within radius right now", picking
+// the closest if several airports qualify so the copy reads naturally.
+export function selectAirportProximityHit(
+  airports: AirportRecord[] | null | undefined,
+  radiusNm: number,
+): AirportProximityHit | null {
+  if (!Array.isArray(airports) || !(radiusNm > 0)) return null;
+  let closest: AirportProximityHit | null = null;
+  for (const airport of airports) {
+    const distanceNm = toFiniteNumber(airport?.distanceNm);
+    if (distanceNm == null || distanceNm > radiusNm) continue;
+    const key = airportProximityKey(airport);
+    if (!key) continue;
+    if (!closest || distanceNm < closest.distanceNm) {
+      closest = {
+        key,
+        icao: key,
+        name: String(airport?.name || "").trim(),
+        distanceNm,
+      };
+    }
+  }
+  return closest;
+}
+
+// Aircraft-proximity alert re-fires per aircraft on every new approach event
+// (crossing from outside radius to inside), never per-poll while it lingers
+// inside. Returns both the freshly-entered hits and the updated "currently
+// inside" key set the caller should keep for the next tick.
+export function selectNewlyEnteredAircraft(
+  aircraftList: AircraftRecord[] | null | undefined,
+  radiusNm: number,
+  previousInsideKeys: ReadonlySet<string>,
+): { hits: AircraftProximityHit[]; insideKeys: Set<string> } {
+  const insideKeys = new Set<string>();
+  const hits: AircraftProximityHit[] = [];
+  if (!Array.isArray(aircraftList) || !(radiusNm > 0)) {
+    return { hits, insideKeys };
+  }
+  for (const aircraft of aircraftList) {
+    const distanceNm = toFiniteNumber(aircraft?.distanceNm);
+    if (distanceNm == null || distanceNm > radiusNm) continue;
+    const key = aircraftProximityKey(aircraft);
+    if (!key) continue;
+    insideKeys.add(key);
+    if (!previousInsideKeys.has(key)) {
+      hits.push({
+        key,
+        callsign: String(aircraft?.callsign || "").trim() || key,
+        distanceNm,
+        aircraft,
+      });
+    }
+  }
+  return { hits, insideKeys };
+}

--- a/src/features/notifications/useAircraftProximityNotifier.ts
+++ b/src/features/notifications/useAircraftProximityNotifier.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from "react";
+import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplayModel";
+import { resolveAircraftDisplayModel } from "@/features/aircraft/aircraftTypeDisplayModel";
+import { showBrowserNotification } from "./browserNotificationModel";
+import { selectNewlyEnteredAircraft } from "./proximityNotificationModel";
+
+// All modes (here + airport detail): fires a system notification per
+// aircraft on each new approach — crossing from outside radius to inside —
+// never repeatedly while it lingers inside. Naming the callsign + aircraft
+// type distinguishes this from the here-mode airport ping, which never
+// repeats at all.
+export function useAircraftProximityNotifier({
+  enabled,
+  aircraft,
+  radiusNm,
+}: {
+  enabled: boolean;
+  aircraft: Record<string, unknown>[] | null | undefined;
+  radiusNm: number;
+}) {
+  const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
+  const insideKeysRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!enabled) insideKeysRef.current = new Set();
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const { hits, insideKeys } = selectNewlyEnteredAircraft(
+      aircraft,
+      radiusNm,
+      insideKeysRef.current,
+    );
+    insideKeysRef.current = insideKeys;
+    for (const hit of hits) {
+      const display = resolveAircraftDisplayModel(
+        hit.aircraft as Record<string, unknown>,
+      );
+      const distance = formatNearbyDistanceDisplay(
+        hit.distanceNm,
+        units.distance,
+      );
+      showBrowserNotification({
+        title: t("notifications.aircraftAlert.title", {
+          callsign: hit.callsign,
+        }),
+        body: t("notifications.aircraftAlert.body", {
+          type: display.shortName,
+          distance: distance?.text ?? distance?.value ?? "",
+          unit: distance?.unit ?? "",
+        }),
+        tag: `adsbao-aircraft-${hit.key}`,
+      });
+    }
+  }, [enabled, aircraft, radiusNm, t, units.distance]);
+}

--- a/src/features/notifications/useAirportProximityNotifier.ts
+++ b/src/features/notifications/useAirportProximityNotifier.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+import { useI18n } from "@/features/app-shell/i18n/useI18n";
+import { useUnitPreferences } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import { formatNearbyDistanceDisplay } from "@/features/aviation/distanceDisplayModel";
+import { showBrowserNotification } from "./browserNotificationModel";
+import { selectAirportProximityHit } from "./proximityNotificationModel";
+
+// Here-mode only: fires ONE system notification for the whole enabled
+// session as soon as any airport comes within radius, then goes quiet — this
+// is a "you've wandered near an airport" ping, not a running feed. Toggling
+// the setting off and back on re-arms it.
+export function useAirportProximityNotifier({
+  enabled,
+  airports,
+  radiusNm,
+}: {
+  enabled: boolean;
+  airports: Record<string, unknown>[] | null | undefined;
+  radiusNm: number;
+}) {
+  const { t } = useI18n();
+  const { preferences: units } = useUnitPreferences();
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (enabled) firedRef.current = false;
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || firedRef.current) return;
+    const hit = selectAirportProximityHit(airports, radiusNm);
+    if (!hit) return;
+    firedRef.current = true;
+    const distance = formatNearbyDistanceDisplay(hit.distanceNm, units.distance);
+    showBrowserNotification({
+      title: t("notifications.airportAlert.title", {
+        name: hit.name || hit.icao,
+      }),
+      body: t("notifications.airportAlert.body", {
+        icao: hit.icao,
+        distance: distance?.text ?? distance?.value ?? "",
+        unit: distance?.unit ?? "",
+      }),
+      tag: `adsbao-airport-${hit.key}`,
+    });
+  }, [enabled, airports, radiusNm, t, units.distance]);
+}

--- a/src/features/notifications/useNotificationPermission.ts
+++ b/src/features/notifications/useNotificationPermission.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  getNotificationPermission,
+  requestNotificationPermission,
+  type NotificationPermissionState,
+} from "./browserNotificationModel";
+
+// Tracks the live browser Notification permission and exposes a request
+// function. Re-reads on window focus so a permission grant/revoke made in
+// browser settings (in another tab, or via the site-info panel) while this
+// tab was backgrounded is picked up without a reload.
+export function useNotificationPermission() {
+  const [permission, setPermission] = useState<NotificationPermissionState>(
+    () => getNotificationPermission(),
+  );
+
+  useEffect(() => {
+    const refresh = () => setPermission(getNotificationPermission());
+    refresh();
+    window.addEventListener("focus", refresh);
+    return () => window.removeEventListener("focus", refresh);
+  }, []);
+
+  const request = useCallback(async () => {
+    const result = await requestNotificationPermission();
+    setPermission(result);
+    return result;
+  }, []);
+
+  return { permission, request };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import {
   resolveLocaleFromSearchParams,
 } from "@/features/app-shell/i18n/i18nModel";
 import { UnitPreferencesProvider } from "@/features/app-shell/unitPreferences/UnitPreferencesProvider";
+import { NotificationPreferencesProvider } from "@/features/notifications/NotificationPreferencesProvider";
 import WebMcpProvider from "@/features/webmcp/WebMcpProvider";
 import { runtimeEnvValue } from "@/platform/env/runtimeEnv";
 import { isConcreteTheme } from "@/utils/theme";
@@ -78,11 +79,13 @@ createRoot(root).render(
         <I18nProvider initialLocale={resolveInitialLocale()}>
           <QueryProvider>
             <UnitPreferencesProvider>
-              <WebMcpProvider />
-              <AppUpdateToast />
-              <div className="min-h-dvh bg-atc-bg text-atc-text">
-                <App />
-              </div>
+              <NotificationPreferencesProvider>
+                <WebMcpProvider />
+                <AppUpdateToast />
+                <div className="min-h-dvh bg-atc-bg text-atc-text">
+                  <App />
+                </div>
+              </NotificationPreferencesProvider>
             </UnitPreferencesProvider>
           </QueryProvider>
         </I18nProvider>


### PR DESCRIPTION
## 做了什么

设置里新增「通知」(Notifications) section,两个默认关闭的可选系统通知:

1. **附近机场提醒(仅 here 模式)** — 打开后,第一次进入你选定的范围(3/5/10/20 海里预设)会弹一条系统通知(机场名 + 距离),之后保持安静,直到关闭再重新打开才会再次武装。
2. **附近飞机提醒(全部模式:here + 机场详情页)** — 每架飞机每次新进入你选定的范围(2/5/10/20 海里预设)都通知一次呼号 + 机型;停留在范围内不会反复提醒,离开后再次接近会重新提醒。

两者都需要浏览器系统通知权限;权限被拒绝或浏览器不支持时,设置面板会显示明确提示而不是静默失效。

### 关于"使用已有设定"

调研确认代码里**没有**现成的"附近飞机距离"用户设置(只有写死的 `AIRCRAFT_TRAFFIC_CONFIG.rangeNm=40` 追踪半径常量,不是用户可调阈值,也不是提醒语义)。因此两个提醒各自内置了自己的可调范围预设(复用已有的分段按钮 UI 语言),而不是引用一个不存在的设置。

### 架构

- `src/features/notifications/proximityNotificationModel.ts` — 纯函数,判断"哪个机场/飞机刚进入范围",带完整单元测试
- `useAirportProximityNotifier` / `useAircraftProximityNotifier` — 两个小 hook,挂载在 `AirportExplorerContent`(唯一同时拿到 `nearMe`、附近机场列表、飞机列表的地方)
- 偏好只存 localStorage(仿 unitPreferences 模式)——通知权限本身就是设备级别的,不需要账号同步
- `browserNotificationModel.ts` / `useNotificationPermission.ts` — 浏览器 Notification API 的薄封装 + 权限状态 hook

## Validation

- local test — `pnpm test` 129 个文件全过;新增 `notificationPreferencesModel.test.ts` + `proximityNotificationModel.test.ts`(含"只进不出重复提醒""离开再进入重新提醒""无效 key 跳过"等边界);`changelog.test.ts` 版本同步 ✅
- `pnpm typecheck` 未引入新的类型错误(对比 main 基线,错误列表完全一致,均为改动前既存)
- local browser — 打开 Map Settings sheet,验证:两个 toggle 正确开关、范围预设正确显示/选中、状态写入 localStorage 并跨刷新持久化、中英文双语文案渲染正确、浏览器拒绝通知权限时正确显示红色提示文案
- 未做真实设备通知触发验证(需要真实 GPS + 真实附近机场/飞机数据,预览沙盒里 Notification 权限恒为 denied);建议合并后在真机上开启验证实际弹出的通知文案

## 版本

已 rebase 到 #603(v3.0.1,已合并)之后,版本设为 **v3.1.1**(minor,新的用户可见功能),changelog 与 package.json 同步;v3.0.1 的完整内容已折入 changelog history。

🤖 Generated with [Claude Code](https://claude.com/claude-code)