### PR TITLE
fix(preview): match Plane Hunter camera button to Track's size (v3.1.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/aircraft/preview/AircraftPreviewCard.tsx
+++ b/src/components/aircraft/preview/AircraftPreviewCard.tsx
@@ -368,13 +368,14 @@ export default function AircraftPreviewCard({
                     </MobilePreviewTrackButton>
                   )}
                   {showMobilePlaneHunterTrigger && (
-                    <MobilePreviewIconButton
+                    <MobilePreviewTrackButton
+                      className="flex flex-1 items-center justify-center border-[color-mix(in_oklab,var(--atc-signal-accent)_88%,black_8%)] bg-[var(--atc-signal-accent)] text-white"
                       onClick={() => setPlaneHunterOpen(true)}
                       aria-label={t("preview.planeHunter")}
                       title={t("preview.planeHunter")}
                     >
                       <Camera aria-hidden="true" className="size-[16px]" strokeWidth={1.8} />
-                    </MobilePreviewIconButton>
+                    </MobilePreviewTrackButton>
                   )}
                   {showMobileFeedbackTrigger && (
                     <MobilePreviewIconButton

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 66;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v3.1.1",
+    version: "v3.1.2",
     kind: "feat",
     title: {
       en: "Proximity alerts: airport nearby (Here mode) and aircraft closing in",
@@ -73,6 +73,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Both alerts default OFF and each has its own adjustable range preset; a clear note appears if the browser's notification permission is blocked or unsupported.",
         zh: "两个提醒默认关闭,各自有独立可调的范围预设;浏览器通知权限被拒绝或不支持时,会显示明确提示。",
+      },
+      {
+        en: "Aircraft preview card: the Plane Hunter camera button is now the same size as Track (both primary), leaving only the suggest-correction button as a small icon button.",
+        zh: "飞机预览卡片:拍机相机按钮现在和追踪按钮同大小(都是 primary 样式),只有反馈建议按钮保留为小图标按钮。",
       },
     ],
   },


### PR DESCRIPTION
## 做了什么

移动端 preview card 操作行:拍机相机(Plane Hunter)按钮从小号中性图标按钮改成和 Track 按钮同尺寸的 primary 橙色按钮(`MobilePreviewTrackButton` + `flex-1`),两者在 flex 行里平分宽度。举手(反馈建议)按钮不变,仍是小图标按钮。

## Validation

Validation: local test — 运行 `pnpm test`(129 文件全过)和 `changelog.test.ts`(版本同步)。

⚠️ 未做浏览器视觉验证:本地缺 `services/data-service/.env.local`(`OPENAIP_API_KEY`/`DATABASE_URL`),起不来完整后端,预览环境选不中真实飞机来触发这张 preview card。改动是纯组件替换 + flex-1 布局,宽度相等由 flexbox 保证,但建议在有完整本地栈/真机上过一眼实际效果。

Release: v3.1.2(patch,小的 UX 修正)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)