### PR TITLE
feat(map): weather ambient tint + simplified light shading for aircraft (v3.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "3.1.2",
+  "version": "3.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -46,6 +46,8 @@ import { useNotificationPreferences } from "@/features/notifications/Notificatio
 import { useNotificationPermission } from "@/features/notifications/useNotificationPermission";
 import { useAirportProximityNotifier } from "@/features/notifications/useAirportProximityNotifier";
 import { useAircraftProximityNotifier } from "@/features/notifications/useAircraftProximityNotifier";
+import { resolveWeatherMood } from "@/features/aircraft/canvas/aircraftAmbientModel";
+import { useSimplifiedLightBearing } from "@/hooks/useSimplifiedLightBearing";
 
 const AirportMap = lazy(() => import("@/components/map/AirportMap"));
 const AircraftPreviewCard = lazy(() => import("../../aircraft/preview/AircraftPreviewCard"));
@@ -262,6 +264,15 @@ function AirportExplorerContent({
     aircraft: traffic.aircraft,
     radiusNm: notificationPreferences.nearbyAircraftRadiusNm,
   });
+  // Ambient map ombiance: aircraft glyphs pick up a weather-driven "mood"
+  // (clear/overcast/severe, from the flight-rules category already fetched
+  // above) and a simplified light-direction shading (see
+  // aircraftAmbientModel.ts — not a real day/night terminator).
+  const weatherMood = useMemo(
+    () => resolveWeatherMood(weather.metar?.parsed?.flightCategory),
+    [weather.metar],
+  );
+  const lightBearingDeg = useSimplifiedLightBearing();
   const effectiveUserLocation =
     (nearMe ? null : userLocationLayer.userLocation) || nearMeMapUserLocation;
   const userLocationActive = Boolean(effectiveUserLocation);
@@ -680,6 +691,8 @@ function AirportExplorerContent({
               loadingOverlayActive={loadingOverlayActive}
               loadingOverlaySources={loadingOverlaySources}
               userLocation={effectiveUserLocation}
+              weatherMood={weatherMood}
+              lightBearingDeg={lightBearingDeg}
             />
           </Suspense>
 

--- a/src/components/map/AircraftCanvasLayer.tsx
+++ b/src/components/map/AircraftCanvasLayer.tsx
@@ -37,6 +37,10 @@ import {
   aircraftSpriteCacheSize,
 } from "../../features/aircraft/canvas/aircraftSpriteCache";
 import { recordAircraftCanvasFrame } from "../../features/aircraft/canvas/aircraftCanvasPerfMonitor";
+import {
+  resolveAircraftLightBucket,
+  type WeatherMood,
+} from "../../features/aircraft/canvas/aircraftAmbientModel";
 
 const HIT_RADIUS_PX = 17; // matches the old 34px invisible hit target
 const HEADING_EASE = 0.25; // per-draw catch-up toward target heading
@@ -72,6 +76,7 @@ interface AircraftCanvasSetData {
   matchesFilters: (aircraft: any) => boolean;
   palette: AircraftCanvasPalette;
   reducedMotion: boolean;
+  lightBearingDeg?: number | null;
 }
 
 const AircraftCanvasRenderer = (L as any).Renderer.extend({
@@ -87,6 +92,8 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
     this._drawList = [] as AircraftDrawDescriptor[];
     this._motion = new Map();
     this._heading = new Map();
+    this._lightBucket = new Map();
+    this._lightBearingDeg = null;
     this._hitPoints = [];
     this._lastDraw = 0;
     this._anyAnimating = false;
@@ -238,7 +245,16 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
         continue;
       }
       const heading = this._ease(d.id, d.headingDeg, reducedMotion);
-      drawAircraftGlyph(ctx, d, lp.x, lp.y, heading, palette, dpr);
+      const lightBucket =
+        this._lightBearingDeg == null
+          ? null
+          : resolveAircraftLightBucket(
+              this._lightBearingDeg,
+              heading,
+              this._lightBucket.get(d.id) ?? null,
+            );
+      if (lightBucket != null) this._lightBucket.set(d.id, lightBucket);
+      drawAircraftGlyph(ctx, d, lp.x, lp.y, heading, palette, dpr, lightBucket);
       if (d.showLabel) drawAircraftLabel(ctx, d, lp.x, lp.y, palette);
       drawn += 1;
       if (animating) anyAnimating = true;
@@ -264,6 +280,7 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
     this._focalId = data.focalId;
     this._palette = data.palette;
     this._reducedMotion = data.reducedMotion;
+    this._lightBearingDeg = data.lightBearingDeg ?? null;
     this._drawList = buildDrawList(data.aircraft, {
       selectedId: data.selectedId,
       focalId: data.focalId,
@@ -289,6 +306,9 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
     this._motion = nextMotion;
     for (const id of Array.from(this._heading.keys()) as string[]) {
       if (!liveIds.has(id)) this._heading.delete(id);
+    }
+    for (const id of Array.from(this._lightBucket.keys()) as string[]) {
+      if (!liveIds.has(id)) this._lightBucket.delete(id);
     }
 
     this._startLoop();
@@ -319,9 +339,32 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
   },
 });
 
+// Weather-mood tints for the "at rest" glyph colours (departure/arrival/
+// unknown/ground) only — deliberately hand-picked hex, not a runtime colour
+// blend (canvas has no CSS `color-mix()`, and these change rarely enough that
+// a small lookup table is simpler and cheaper than any blending math). Kept
+// muted/desaturated on purpose: this is ambient atmosphere, not a status
+// alert, and must never compete with the single orange (focal) / blue
+// (selected) accent colours below, which mood never touches.
+const MOOD_REST_COLOR: Record<
+  Exclude<WeatherMood, "clear">,
+  { dark: string; light: string }
+> = {
+  overcast: { dark: "#33383c", light: "#c9cdd2" },
+  severe: { dark: "#403f45", light: "#b8b4bd" },
+};
+const MOOD_GROUND_COLOR: Record<
+  Exclude<WeatherMood, "clear">,
+  { dark: string; light: string }
+> = {
+  overcast: { dark: "#4a4e52", light: "#a9adb2" },
+  severe: { dark: "#524f57", light: "#9d99a3" },
+};
+
 function resolveAircraftCanvasPalette(
   map: any,
   theme: string,
+  mood: WeatherMood = "clear",
 ): AircraftCanvasPalette {
   const dark = theme !== "light";
   let read = (_name: string, fallback: string) => fallback;
@@ -332,11 +375,22 @@ function resolveAircraftCanvasPalette(
   } catch {
     /* keep fallbacks */
   }
+  // "clear" keeps reading the theme's CSS variables unchanged (today's exact
+  // behaviour); overcast/severe swap in the mood lookup instead of trying to
+  // blend the CSS-variable value at runtime.
+  const restColor =
+    mood === "clear"
+      ? null
+      : (MOOD_REST_COLOR[mood][dark ? "dark" : "light"] as string);
+  const groundColor =
+    mood === "clear"
+      ? null
+      : (MOOD_GROUND_COLOR[mood][dark ? "dark" : "light"] as string);
   return {
-    departure: read("--aircraft-departure", dark ? "#2a2a26" : "#dcd9d0"),
-    arrival: read("--aircraft-arrival", dark ? "#2a2a26" : "#dcd9d0"),
-    unknown: read("--aircraft-unknown", dark ? "#2a2a26" : "#dcd9d0"),
-    ground: read("--aircraft-ground", dark ? "#46463f" : "#b7b4ab"),
+    departure: restColor ?? read("--aircraft-departure", dark ? "#2a2a26" : "#dcd9d0"),
+    arrival: restColor ?? read("--aircraft-arrival", dark ? "#2a2a26" : "#dcd9d0"),
+    unknown: restColor ?? read("--aircraft-unknown", dark ? "#2a2a26" : "#dcd9d0"),
+    ground: groundColor ?? read("--aircraft-ground", dark ? "#46463f" : "#b7b4ab"),
     // PRIMARY (focal/tracked) target = orange signal accent; SECONDARY
     // (clicked) target = a high-contrast NEUTRAL (near-white grey on the dark
     // canvas, near-black grey on the light canvas) — distinguished by luminance
@@ -368,6 +422,10 @@ export interface AircraftCanvasLayerProps {
   matchesFilters: (aircraft: any) => boolean;
   onSelectAircraft?: (id: string) => void;
   hitTestRef?: { current: ((containerPoint: any) => string | null) | null };
+  /** Ambient weather mood for the "at rest" glyph colours; defaults to "clear". */
+  weatherMood?: WeatherMood;
+  /** Simplified light-source bearing (deg); null disables the light-mask overlay entirely. */
+  lightBearingDeg?: number | null;
 }
 
 export default function AircraftCanvasLayer({
@@ -381,6 +439,8 @@ export default function AircraftCanvasLayer({
   matchesFilters,
   onSelectAircraft,
   hitTestRef,
+  weatherMood = "clear",
+  lightBearingDeg = null,
 }: AircraftCanvasLayerProps) {
   const map = useMapInstance();
   const rendererRef = useRef<any>(null);
@@ -441,8 +501,9 @@ export default function AircraftCanvasLayer({
       traceActive,
       showCallsigns,
       matchesFilters,
-      palette: resolveAircraftCanvasPalette(map, theme),
+      palette: resolveAircraftCanvasPalette(map, theme, weatherMood),
       reducedMotion,
+      lightBearingDeg,
     });
   }, [
     map,
@@ -454,6 +515,8 @@ export default function AircraftCanvasLayer({
     traceActive,
     showCallsigns,
     matchesFilters,
+    weatherMood,
+    lightBearingDeg,
   ]);
 
   return null;

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -126,6 +126,8 @@ export default function AirportMap({
   loadingOverlaySources = {},
   flightTerminalReason = "",
   userLocation = null,
+  weatherMood = "clear",
+  lightBearingDeg = null,
   children = null,
 }: Record<string, any>) {
   const { locale } = useI18n();
@@ -749,6 +751,8 @@ export default function AirportMap({
             matchesFilters={aircraftCanvasMatchesFilters}
             onSelectAircraft={onSelectAircraft}
             hitTestRef={aircraftHitTestRef}
+            weatherMood={weatherMood}
+            lightBearingDeg={lightBearingDeg}
           />
         </MapContext.Provider>
       )}

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -47,36 +47,32 @@ export function resolveChangelogText(
 
 export const CHANGELOG_INITIAL_LIMIT = 1;
 export const CHANGELOG_PAGE_SIZE = 20;
-export const CHANGELOG_TOTAL_COUNT = 66;
+export const CHANGELOG_TOTAL_COUNT = 67;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v3.1.2",
+    version: "v3.2.0",
     kind: "feat",
     title: {
-      en: "Proximity alerts: airport nearby (Here mode) and aircraft closing in",
-      zh: "接近提醒:附近机场(我的位置模式)与飞机接近",
+      en: "Aircraft blend into the weather and light",
+      zh: "飞机融入天气与光照氛围",
     },
     summary: {
-      en: "A new Notifications section in map settings adds two opt-in system-notification alerts, both off by default. In Here mode, turning on the airport alert pings you once — with the airport's name and distance — the first time you wander within your chosen range (3/5/10/20 NM); it goes quiet after that until you toggle it off and back on. The aircraft alert works everywhere (Here mode and airport pages) and fires per plane, with its callsign and aircraft type, each time one crosses into your chosen range (2/5/10/20 NM) — not on every refresh while it lingers, and it fires again if it leaves and comes back. Both need the browser's notification permission; the settings sheet shows a clear note if that's blocked or unsupported.",
-      zh: "地图设置新增「通知」分区,两个默认关闭的可选系统通知。在「我的位置」模式下打开机场提醒后,第一次进入你设定的范围(3/5/10/20 海里)会弹出一条提醒(机场名称 + 距离),之后保持安静,直到你关闭再重新打开。飞机提醒在任何模式下都生效(我的位置和机场详情页),每架飞机每次进入你设定的范围(2/5/10/20 海里)都会带着呼号和机型提醒一次——停留期间不会反复提醒,离开后再次接近会重新提醒。两者都需要浏览器的系统通知权限;权限被拒绝或浏览器不支持时,设置面板会给出明确提示。",
+      en: "The aircraft on the map now carry a bit of ambient atmosphere. Their at-rest colour shifts with the current flight-rules weather at that airport — clear, overcast, or low-visibility each read as a subtly different, muted tone (the orange tracked-target and blue clicked-target colours never change, so the one-accent rule holds). Each aircraft also gets a soft highlight/shadow gradient from a simplified light direction that sweeps east to west over the day (not real solar position — a deliberate simplification, not a claim of astronomical accuracy). Both effects are pure lookups and a handful of cached gradient overlays, so drawing hundreds of aircraft at once costs the same as before.",
+      zh: "地图上的飞机现在带上了一点环境氛围。它们的静息态颜色会随当前机场的飞行规则天气变化——晴朗、多云或低能见度各自呈现一个略有差异的低饱和度色调(追踪目标的橙色和点选目标的蓝色不受影响,全局单一强调色的规则不变)。每架飞机还会有一层柔和的高光/阴影渐变,来自一个简化的光源方向——沿东西轴随一天时间摆动(不是真实太阳位置计算,是刻意的简化,不追求天文精度)。两个效果都只是查表加几张缓存好的渐变蒙版,同屏渲染几百架飞机的开销和之前完全一样。",
     },
     highlights: [
       {
-        en: "Here-mode airport alert: one system notification with the airport's name and distance the first time you're within range; quiet after that until re-enabled.",
-        zh: "「我的位置」机场提醒:进入范围后弹出一次机场名称 + 距离的系统通知,之后保持安静,直到重新开启。",
+        en: "Aircraft colour shifts with the airport's current flight-rules category (clear / overcast / low-visibility) — muted, ambient tones that never touch the orange (tracked) or blue (clicked) accent colours.",
+        zh: "飞机颜色随机场当前飞行规则(晴朗/多云/低能见度)变化——低饱和度的氛围色调,不影响橙色(追踪目标)与蓝色(点选目标)强调色。",
       },
       {
-        en: "Aircraft alert (all modes): a system notification per aircraft — callsign and type — on each new approach into range, never repeating while it just lingers nearby.",
-        zh: "飞机提醒(全部模式):每架飞机每次新进入范围都弹一次呼号 + 机型的系统通知,停留附近期间不会重复。",
+        en: "A subtle highlight/shadow gradient follows a simplified light direction that sweeps east to west over the day; the highlight side holds steady (with hysteresis) instead of flickering as a plane's heading wobbles near a boundary.",
+        zh: "柔和的高光/阴影渐变跟随一个沿东西轴随时间摆动的简化光源方向;高光朝向带滞后判定,不会因航向在边界附近轻微抖动而闪烁。",
       },
       {
-        en: "Both alerts default OFF and each has its own adjustable range preset; a clear note appears if the browser's notification permission is blocked or unsupported.",
-        zh: "两个提醒默认关闭,各自有独立可调的范围预设;浏览器通知权限被拒绝或不支持时,会显示明确提示。",
-      },
-      {
-        en: "Aircraft preview card: the Plane Hunter camera button is now the same size as Track (both primary), leaving only the suggest-correction button as a small icon button.",
-        zh: "飞机预览卡片:拍机相机按钮现在和追踪按钮同大小(都是 primary 样式),只有反馈建议按钮保留为小图标按钮。",
+        en: "Both effects are cache-friendly by design — mood tints reuse the existing sprite cache, and the light gradient is a handful of pre-baked masks composited on draw, not a new per-aircraft cache dimension.",
+        zh: "两个效果都对缓存友好——天气色调复用现有的 sprite 缓存,光照渐变则是几张预先烘焙好的蒙版在绘制时合成,不会给每架飞机新增缓存维度。",
       },
     ],
   },

--- a/src/config/changelogHistory.ts
+++ b/src/config/changelogHistory.ts
@@ -170,6 +170,36 @@ export const CHANGELOG_HISTORY_ZH_COPY: Record<string, ChangelogLocalizedRelease
 
 export const CHANGELOG_HISTORY: ChangelogEntry[] = [
   {
+    version: "v3.1.2",
+    kind: "feat",
+    title: {
+      en: "Proximity alerts: airport nearby (Here mode) and aircraft closing in",
+      zh: "接近提醒:附近机场(我的位置模式)与飞机接近",
+    },
+    summary: {
+      en: "A new Notifications section in map settings adds two opt-in system-notification alerts, both off by default. In Here mode, turning on the airport alert pings you once — with the airport's name and distance — the first time you wander within your chosen range (3/5/10/20 NM); it goes quiet after that until you toggle it off and back on. The aircraft alert works everywhere (Here mode and airport pages) and fires per plane, with its callsign and aircraft type, each time one crosses into your chosen range (2/5/10/20 NM) — not on every refresh while it lingers, and it fires again if it leaves and comes back. Both need the browser's notification permission; the settings sheet shows a clear note if that's blocked or unsupported.",
+      zh: "地图设置新增「通知」分区,两个默认关闭的可选系统通知。在「我的位置」模式下打开机场提醒后,第一次进入你设定的范围(3/5/10/20 海里)会弹出一条提醒(机场名称 + 距离),之后保持安静,直到你关闭再重新打开。飞机提醒在任何模式下都生效(我的位置和机场详情页),每架飞机每次进入你设定的范围(2/5/10/20 海里)都会带着呼号和机型提醒一次——停留期间不会反复提醒,离开后再次接近会重新提醒。两者都需要浏览器的系统通知权限;权限被拒绝或浏览器不支持时,设置面板会给出明确提示。",
+    },
+    highlights: [
+      {
+        en: "Here-mode airport alert: one system notification with the airport's name and distance the first time you're within range; quiet after that until re-enabled.",
+        zh: "「我的位置」机场提醒:进入范围后弹出一次机场名称 + 距离的系统通知,之后保持安静,直到重新开启。",
+      },
+      {
+        en: "Aircraft alert (all modes): a system notification per aircraft — callsign and type — on each new approach into range, never repeating while it just lingers nearby.",
+        zh: "飞机提醒(全部模式):每架飞机每次新进入范围都弹一次呼号 + 机型的系统通知,停留附近期间不会重复。",
+      },
+      {
+        en: "Both alerts default OFF and each has its own adjustable range preset; a clear note appears if the browser's notification permission is blocked or unsupported.",
+        zh: "两个提醒默认关闭,各自有独立可调的范围预设;浏览器通知权限被拒绝或不支持时,会显示明确提示。",
+      },
+      {
+        en: "Aircraft preview card: the Plane Hunter camera button is now the same size as Track (both primary), leaving only the suggest-correction button as a small icon button.",
+        zh: "飞机预览卡片:拍机相机按钮现在和追踪按钮同大小(都是 primary 样式),只有反馈建议按钮保留为小图标按钮。",
+      },
+    ],
+  },
+  {
     version: "v3.0.1",
     kind: "feat",
     title: {

--- a/src/features/aircraft/canvas/aircraftAmbientModel.test.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import {
+  lightBucketForRelativeAngle,
+  relativeLightAngleDeg,
+  resolveAircraftLightBucket,
+  resolveLightBucketWithHysteresis,
+  resolveWeatherMood,
+  simplifiedLightBearingDeg,
+} from "./aircraftAmbientModel";
+
+// --- resolveWeatherMood ----------------------------------------------------
+
+{
+  assert.equal(resolveWeatherMood("IFR"), "severe");
+  assert.equal(resolveWeatherMood("LIFR"), "severe");
+  assert.equal(resolveWeatherMood("lifr"), "severe"); // case-insensitive
+  assert.equal(resolveWeatherMood("MVFR"), "overcast");
+  assert.equal(resolveWeatherMood("VFR"), "clear");
+  assert.equal(resolveWeatherMood(null), "clear");
+  assert.equal(resolveWeatherMood(""), "clear");
+}
+
+// Cloud cover is only consulted when there's no decisive flight category —
+// heavy cover bumps a "clear"/unset category to overcast, light cover doesn't.
+{
+  assert.equal(resolveWeatherMood(null, 85), "overcast");
+  assert.equal(resolveWeatherMood(null, 40), "clear");
+  assert.equal(resolveWeatherMood("VFR", 90), "overcast");
+  // A decisive severe category is never downgraded by cloud cover.
+  assert.equal(resolveWeatherMood("IFR", 0), "severe");
+}
+
+// --- simplifiedLightBearingDeg ---------------------------------------------
+
+{
+  const dateMs = (hour: number, minute = 0) => {
+    const d = new Date(2026, 0, 15, hour, minute, 0, 0);
+    return d.getTime();
+  };
+  assert.equal(simplifiedLightBearingDeg(dateMs(3)), 90); // before dawn, clamped
+  assert.equal(simplifiedLightBearingDeg(dateMs(6)), 90); // dawn
+  assert.equal(simplifiedLightBearingDeg(dateMs(12)), 180); // solar noon-ish, midway
+  assert.equal(simplifiedLightBearingDeg(dateMs(18)), 270); // dusk
+  assert.equal(simplifiedLightBearingDeg(dateMs(22)), 270); // after dusk, clamped
+}
+
+// --- relativeLightAngleDeg + lightBucketForRelativeAngle -------------------
+
+{
+  // Light dead ahead of the nose -> 0deg -> bucket 0 (front).
+  assert.equal(relativeLightAngleDeg(90, 90), 0);
+  assert.equal(lightBucketForRelativeAngle(0), 0);
+  // Light off the right wing.
+  assert.equal(relativeLightAngleDeg(180, 90), 90);
+  assert.equal(lightBucketForRelativeAngle(90), 1);
+  // Light behind.
+  assert.equal(lightBucketForRelativeAngle(180), 2);
+  // Light off the left wing.
+  assert.equal(lightBucketForRelativeAngle(270), 3);
+  // Wraps correctly at the boundary.
+  assert.equal(lightBucketForRelativeAngle(359), 0);
+  assert.equal(lightBucketForRelativeAngle(-10), 0);
+}
+
+// --- resolveLightBucketWithHysteresis --------------------------------------
+
+// First observation (no previous bucket) always takes the raw quantized value.
+{
+  assert.equal(resolveLightBucketWithHysteresis(10, null), 0);
+  assert.equal(resolveLightBucketWithHysteresis(100, null), 1);
+}
+
+// Small drift near a boundary does NOT flip the bucket — this is the core
+// guard against every-few-seconds flicker from normal ADS-B track noise.
+{
+  // Currently bucket 0 (front, centre 0deg). The nominal boundary to bucket 1
+  // is at 45deg; with hysteresis the angle must pass ~58deg before switching.
+  assert.equal(resolveLightBucketWithHysteresis(46, 0), 0, "stays put just past the naive boundary");
+  assert.equal(resolveLightBucketWithHysteresis(50, 0), 0, "still within the hysteresis margin");
+  assert.equal(resolveLightBucketWithHysteresis(60, 0), 1, "switches once clearly past the margin");
+}
+
+// Once switched, hysteresis re-centres on the NEW bucket (doesn't snap back
+// just because the angle dips slightly below the old switch threshold).
+{
+  const afterSwitch = resolveLightBucketWithHysteresis(60, 0);
+  assert.equal(afterSwitch, 1);
+  assert.equal(
+    resolveLightBucketWithHysteresis(50, afterSwitch),
+    1,
+    "holds the new bucket even though 50deg is closer to the old centre than the switch threshold would allow from bucket 0",
+  );
+}
+
+// A large jump (well beyond any single-bucket hop) still resolves to the
+// nearest bucket rather than getting stuck.
+{
+  assert.equal(resolveLightBucketWithHysteresis(181, 0), 2);
+}
+
+// --- resolveAircraftLightBucket (end-to-end convenience wrapper) -----------
+
+{
+  // Light bearing due east (90), aircraft heading due east (90) -> light dead
+  // ahead -> bucket 0, regardless of prior state.
+  assert.equal(resolveAircraftLightBucket(90, 90, null), 0);
+  // Aircraft turns to heading 0 (due north): light is now off its right side.
+  assert.equal(resolveAircraftLightBucket(90, 0, null), 1);
+  // A tiny heading wobble around a boundary does not flip the held bucket.
+  const held = resolveAircraftLightBucket(90, 0, null);
+  assert.equal(resolveAircraftLightBucket(90, 4, held), held);
+}
+
+console.log("aircraftAmbientModel.test.ts ok");

--- a/src/features/aircraft/canvas/aircraftAmbientModel.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.ts
@@ -1,0 +1,133 @@
+// Pure environmental-shading model for the aircraft canvas renderer: a
+// weather-driven ambient "mood" (feeds palette lookup) and a simplified,
+// deliberately-not-astronomical light bearing (feeds the 4-direction gradient
+// mask picked in aircraftLightMask.ts). Kept framework/canvas-free so the
+// mapping and hysteresis math are unit-testable without a browser.
+//
+// This is a distinct, narrower thing than a real day/night terminator: the
+// light bearing here is a linear East->West sweep over the browser's local
+// clock, not a solar-position calculation. That's an explicit, user-approved
+// simplification for this ambient glyph-shading effect only.
+
+export type WeatherMood = "clear" | "overcast" | "severe";
+
+const OVERCAST_CLOUD_COVER_PCT = 70;
+
+// Weather -> ambient mood. Flight-rules category takes priority (it already
+// captures the "how bad is it" signal pilots use); cloud cover is a fallback
+// for callers that only have Open-Meteo data (e.g. here-mode with no nearby
+// METAR station yet). VFR/MVFR are visually merged into "overcast" only when
+// cloud cover is heavy — otherwise both read as "clear" ambience, since the
+// mood is meant to convey a coarse atmosphere, not the four-way FAA category.
+export function resolveWeatherMood(
+  flightCategory: unknown,
+  cloudCoverPct: unknown = null,
+): WeatherMood {
+  const category = String(flightCategory || "").trim().toUpperCase();
+  if (category === "IFR" || category === "LIFR") return "severe";
+  if (category === "MVFR") return "overcast";
+  const cloudCover = Number(cloudCoverPct);
+  if (Number.isFinite(cloudCover) && cloudCover >= OVERCAST_CLOUD_COVER_PCT) {
+    return "overcast";
+  }
+  return "clear";
+}
+
+const DAWN_HOUR = 6;
+const DUSK_HOUR = 18;
+const DAWN_BEARING_DEG = 90;
+const DUSK_BEARING_DEG = 270;
+
+// Simplified light source bearing: sweeps linearly from due-east at dawn to
+// due-west at dusk using the browser's local clock, clamping outside that
+// window. Not solar-accurate (no latitude/season/declination) — that
+// precision belongs to a real day/night terminator overlay, a separate,
+// deferred feature. This is intentionally just "does the sun feel like it's
+// behind me or ahead of me right now".
+export function simplifiedLightBearingDeg(nowMs: number): number {
+  const date = new Date(nowMs);
+  const hour = date.getHours() + date.getMinutes() / 60;
+  if (hour <= DAWN_HOUR) return DAWN_BEARING_DEG;
+  if (hour >= DUSK_HOUR) return DUSK_BEARING_DEG;
+  const t = (hour - DAWN_HOUR) / (DUSK_HOUR - DAWN_HOUR);
+  return DAWN_BEARING_DEG + t * (DUSK_BEARING_DEG - DAWN_BEARING_DEG);
+}
+
+function normalizeDeg(deg: number): number {
+  return ((deg % 360) + 360) % 360;
+}
+
+// Angle of the light source relative to the aircraft's own nose (0deg = light
+// dead ahead, 90deg = light off the right side, ...). This is the frame the
+// gradient mask must be picked in, since the mask composites AFTER the
+// canvas has already been rotated by heading.
+export function relativeLightAngleDeg(
+  lightBearingDeg: number,
+  headingDeg: number,
+): number {
+  return normalizeDeg(lightBearingDeg - headingDeg);
+}
+
+// Quantizes a relative angle into `bucketCount` equal-width buckets centred
+// on 0/90/180/270 (for the default 4) — front/right/back/left.
+export function lightBucketForRelativeAngle(
+  relativeAngleDeg: number,
+  bucketCount = 4,
+): number {
+  const bucketWidthDeg = 360 / bucketCount;
+  const normalized = normalizeDeg(relativeAngleDeg);
+  return Math.floor((normalized + bucketWidthDeg / 2) / bucketWidthDeg) % bucketCount;
+}
+
+function bucketCenterDeg(bucket: number, bucketCount: number): number {
+  return (bucket * (360 / bucketCount)) % 360;
+}
+
+// Signed-shortest angular distance between two compass angles, in [0, 180].
+function angularDistanceDeg(a: number, b: number): number {
+  return Math.abs(((a - b + 540) % 360) - 180);
+}
+
+export interface LightBucketHysteresisOptions {
+  bucketCount?: number;
+  /**
+   * How far the relative angle must drift from the CURRENT bucket's centre
+   * (in degrees) before switching buckets. Deliberately larger than half the
+   * bucket width (45deg for 4 buckets) so a heading that hovers near a
+   * bucket boundary — normal ADS-B track noise — doesn't flip the highlight
+   * side every time new data arrives (schmitt-trigger style hysteresis).
+   */
+  switchThresholdDeg?: number;
+}
+
+// Given the raw relative angle and the bucket currently held for this
+// aircraft, decide whether to keep it or switch. `previousBucket` is null
+// the first time an aircraft is seen (no hysteresis to apply yet).
+export function resolveLightBucketWithHysteresis(
+  relativeAngleDeg: number,
+  previousBucket: number | null,
+  { bucketCount = 4, switchThresholdDeg = 58 }: LightBucketHysteresisOptions = {},
+): number {
+  const normalized = normalizeDeg(relativeAngleDeg);
+  if (previousBucket == null) {
+    return lightBucketForRelativeAngle(normalized, bucketCount);
+  }
+  const distanceFromCurrentCenter = angularDistanceDeg(
+    normalized,
+    bucketCenterDeg(previousBucket, bucketCount),
+  );
+  if (distanceFromCurrentCenter <= switchThresholdDeg) return previousBucket;
+  return lightBucketForRelativeAngle(normalized, bucketCount);
+}
+
+// Convenience wrapper for the call site (per-aircraft, per render): combines
+// the light-bearing/heading angle with the hysteresis decision in one call.
+export function resolveAircraftLightBucket(
+  lightBearingDeg: number,
+  headingDeg: number,
+  previousBucket: number | null,
+  options?: LightBucketHysteresisOptions,
+): number {
+  const relativeAngleDeg = relativeLightAngleDeg(lightBearingDeg, headingDeg);
+  return resolveLightBucketWithHysteresis(relativeAngleDeg, previousBucket, options);
+}

--- a/src/features/aircraft/canvas/aircraftCanvasDraw.ts
+++ b/src/features/aircraft/canvas/aircraftCanvasDraw.ts
@@ -3,9 +3,17 @@
 // space, so these draw in CSS pixels. Visual spec (user-approved): silhouette /
 // arrow / dot + heading + colour + a single static drop-shadow + label; a
 // minimal selected ring. NO 3D tilt, plate disc, nose beam, or nav lights.
+//
+// One authorized exception: a subtle ambient-light highlight/shadow gradient
+// (see aircraftLightMask.ts), composited on top of the already-drawn
+// silhouette/arrow with `source-atop` so it never needs its own cache
+// dimension. This is environmental shading tied to a simplified sun bearing,
+// not a reintroduction of the rejected nose-beam / nav-light / 3D-tilt ideas
+// above — it doesn't change the glyph's shape, rotation, or the "flat" spec.
 
 import type { AircraftDrawDescriptor } from "./aircraftCanvasModel";
 import { getAircraftSprite } from "./aircraftSpriteCache";
+import { getLightMask } from "./aircraftLightMask";
 
 const AIRCRAFT_GLYPH_BASE_PX = 20;
 const DOT_RADIUS_PX = 3.5;
@@ -56,6 +64,24 @@ function drawArrowPath(ctx: CanvasRenderingContext2D, scale: number) {
   ctx.closePath();
 }
 
+// Composites the ambient-light mask for `lightBucket` over whatever was just
+// drawn into the given (already translated + rotated) square region, clipped
+// to it via `source-atop`. No-op if the mask hasn't loaded (SSR / no DOM) or
+// `lightBucket` is null (ambient lighting disabled/not yet resolved).
+function applyLightMask(
+  ctx: CanvasRenderingContext2D,
+  lightBucket: number | null | undefined,
+  sizePx: number,
+) {
+  if (lightBucket == null) return;
+  const mask = getLightMask(lightBucket);
+  if (!mask) return;
+  ctx.save();
+  ctx.globalCompositeOperation = "source-atop";
+  ctx.drawImage(mask, -sizePx / 2, -sizePx / 2, sizePx, sizePx);
+  ctx.restore();
+}
+
 /** Draw the rotated glyph (silhouette sprite, or arrow / dot fallback). */
 export function drawAircraftGlyph(
   ctx: CanvasRenderingContext2D,
@@ -65,6 +91,7 @@ export function drawAircraftGlyph(
   displayedHeadingDeg: number,
   palette: AircraftCanvasPalette,
   dpr: number,
+  lightBucket: number | null = null,
 ) {
   const color = colorFor(d, palette);
   ctx.save();
@@ -100,13 +127,21 @@ export function drawAircraftGlyph(
     // Sprite already carries the baked drop-shadow — plain drawImage, no shadow.
     const s = sprite.sizeCss * scale;
     ctx.drawImage(sprite.canvas, -s / 2, -s / 2, s, s);
+    applyLightMask(ctx, lightBucket, s);
   } else {
-    // Arrow fallback (no silhouette, or sprite still loading).
+    // Arrow fallback (no silhouette, or sprite still loading). Gets the same
+    // ambient mask so there's no flat-colour -> gradient pop the moment the
+    // silhouette sprite finishes loading in.
     ctx.shadowColor = palette.halo;
     ctx.shadowBlur = FALLBACK_SHADOW_BLUR_PX;
     ctx.fillStyle = color;
     drawArrowPath(ctx, scale);
     ctx.fill();
+    // Shadow must not carry into the mask composite below (canvas shadow
+    // state applies to any subsequent draw, and would otherwise blur-shadow
+    // the mask rectangle itself).
+    ctx.shadowBlur = 0;
+    applyLightMask(ctx, lightBucket, AIRCRAFT_GLYPH_BASE_PX * scale);
   }
   ctx.restore();
 }

--- a/src/features/aircraft/canvas/aircraftLightMask.ts
+++ b/src/features/aircraft/canvas/aircraftLightMask.ts
@@ -1,0 +1,59 @@
+// Static ambient-light gradient masks for the aircraft canvas renderer.
+//
+// Unlike aircraftSpriteCache.ts (keyed by icon/colour/size/dpr, one bake per
+// visually-distinct aircraft), these masks depend on NOTHING but the light
+// bucket (0-3: front/right/back/left) — there are only ever 4 of them, baked
+// once on first use and kept forever. They are composited on top of an
+// already-drawn glyph with `source-atop`, so the gradient is clipped to
+// whatever was just drawn without needing to know the aircraft's silhouette
+// shape at all.
+//
+// Direction convention: the mask is drawn AFTER the canvas has already been
+// translated to the aircraft's centre and rotated by its heading, so "up"
+// (-Y) is the nose. Bucket angle 0 = light from the nose, 90 = from the
+// right, 180 = from the tail, 270 = from the left.
+
+const MASK_SIZE_PX = 48;
+const HIGHLIGHT_COLOR = "rgba(255,255,255,0.26)";
+const SHADOW_COLOR = "rgba(0,0,0,0.20)";
+
+const masks = new Map<number, HTMLCanvasElement>();
+
+function buildLightMask(bucketAngleDeg: number): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = MASK_SIZE_PX;
+  canvas.height = MASK_SIZE_PX;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return canvas;
+
+  const center = MASK_SIZE_PX / 2;
+  const radius = MASK_SIZE_PX / 2;
+  const rad = (bucketAngleDeg * Math.PI) / 180;
+  const dx = Math.sin(rad);
+  const dy = -Math.cos(rad);
+
+  const gradient = ctx.createLinearGradient(
+    center + dx * radius,
+    center + dy * radius,
+    center - dx * radius,
+    center - dy * radius,
+  );
+  gradient.addColorStop(0, HIGHLIGHT_COLOR);
+  gradient.addColorStop(0.5, "rgba(255,255,255,0)");
+  gradient.addColorStop(1, SHADOW_COLOR);
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, MASK_SIZE_PX, MASK_SIZE_PX);
+  return canvas;
+}
+
+/** Lazily bakes and caches the gradient mask for a light bucket (0-3). */
+export function getLightMask(bucket: number, bucketCount = 4): HTMLCanvasElement | null {
+  if (typeof document === "undefined") return null;
+  const cached = masks.get(bucket);
+  if (cached) return cached;
+  const bucketAngleDeg = bucket * (360 / bucketCount);
+  const mask = buildLightMask(bucketAngleDeg);
+  masks.set(bucket, mask);
+  return mask;
+}

--- a/src/features/aircraft/canvas/aircraftSpriteCache.ts
+++ b/src/features/aircraft/canvas/aircraftSpriteCache.ts
@@ -12,7 +12,13 @@
 
 const SHADOW_BLUR_PX = 2.2;
 const SHADOW_OFFSET_Y_PX = 0.5;
-const MAX_SPRITES = 280;
+// Bumped from 280: the weather-mood palette (AircraftCanvasLayer.tsx) triples
+// the distinct "at rest" colour strings that can feed this cache (clear /
+// overcast / severe), so the realistic (icon x colour) key space grew
+// proportionally. The light-direction gradient deliberately does NOT touch
+// this cache (see aircraftLightMask.ts) — it composites a bucket-independent
+// mask at draw time instead, so it doesn't multiply this number further.
+const MAX_SPRITES = 500;
 
 export interface AircraftSprite {
   canvas: HTMLCanvasElement;

--- a/src/hooks/useSimplifiedLightBearing.ts
+++ b/src/hooks/useSimplifiedLightBearing.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { simplifiedLightBearingDeg } from "@/features/aircraft/canvas/aircraftAmbientModel";
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Tracks the simplified (non-astronomical) ambient light bearing used by the
+ * aircraft canvas layer's light-direction shading. The underlying value only
+ * drifts over hours, so a slow interval is enough — this deliberately does
+ * NOT hook into the per-frame motion loop; a state update here just lets the
+ * next natural redraw pick up the new bearing.
+ */
+export function useSimplifiedLightBearing(): number {
+  const [bearingDeg, setBearingDeg] = useState(() =>
+    simplifiedLightBearingDeg(Date.now()),
+  );
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setBearingDeg(simplifiedLightBearingDeg(Date.now()));
+    }, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  return bearingDeg;
+}


### PR DESCRIPTION
## 做了什么

从一次"地图/飞机沉浸感"brainstorm 里挑出的两个方向,经过两轮调研 + 一次方案压力测试后落地:

1. **天气氛围色调** — 飞机的"静息态"颜色(departure/arrival/ground/unknown)随机场当前飞行规则(VFR/MVFR/IFR/LIFR,复用已在 fetch 的 METAR)在 clear/overcast/severe 三档之间变化。纯查表,不做运行时颜色数学;`focal`(追踪目标,橙色)/`selected`(点选目标,蓝色)强调色完全不受影响,不违反"全局单一橙色强调色"规则。
2. **简化光照渐变** — 每架飞机叠加一层柔和的高光/阴影渐变,光源方向是一个"假想太阳沿东西轴摆动"的简化模型(不是真实天文计算,这是用户明确认可的简化;真实的地图级昼夜分界线是另一个已保留、暂缓的独立想法)。

## 关键工程决策(经过压力测试确认)

- **光照渐变没有进 sprite cache**:最初设想把光照桶烘焙进现有的飞机 sprite 缓存,压力测试算出这会把 cache key 空间推到几千量级,远超现有 `MAX_SPRITES` 的设计前提,稳态下会持续触发重新烘焙。改为"4 张预烘焙的通用渐变蒙版 + `source-atop` 合成",完全不碰 sprite cache,每帧只多一次固定成本的 `drawImage`。
- **桶切换带滞后(hysteresis)**:飞机航向数据(ADS-B)秒级推送,如果直接按精确角度量化,航向卡在桶边界附近会导致高光每隔几秒"跳"一下——这是压力测试确认过的真实缺陷,不是低概率场景。用类似现有 heading easing 的 schmitt-trigger 滞后带解决。
- **代码红线更新**:`aircraftCanvasDraw.ts` 顶部有一条"NO 3D tilt, plate disc, nose beam, or nav lights"的产品红线注释,这次明确记录了"环境光渐变"是一个经过授权的新例外,不是重新加回被拒绝的效果。

## Validation

- local test — `pnpm test` 130 个文件全过(新增 `aircraftAmbientModel.test.ts`,覆盖 mood 映射、简化光源角度插值、桶量化、滞后判断的边界用例);`changelog.test.ts` 版本同步 ✅
- `pnpm typecheck` 未引入新的类型错误(对比 main 基线,错误列表完全一致)
- local browser — 通过动态 import 直接调用实际的 `aircraftLightMask.ts`/`aircraftCanvasDraw.ts` 模块渲染测试网格,像素级验证了 3 档天气色调 × 4 个光照桶(前/右/后/左)全部方向正确;确认页面在无真实飞机/天气数据(本地无完整后端)时无异常,渲染与改动前一致

⚠️ 无法在本地做真实天气数据的端到端可视化验证(缺 `services/data-service/.env.local` 起不来完整后端),建议合并后用真实机场天气数据看一眼实际效果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)