### PR TITLE
fix(sidebar): Here-mode Nearby/Speed equal-weight primary tiles (v3.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/SidebarViewSwitch.tsx
+++ b/src/components/sidebar/SidebarViewSwitch.tsx
@@ -82,7 +82,7 @@ export default function SidebarViewSwitch({
     ],
   );
 
-  const renderStat = (stat: SidebarStat) => {
+  const renderStat = (stat: SidebarStat, size: "md" | "lg" = "md") => {
     const { id, labelKey, value, display, unit, prefix, interaction } = stat;
     let active: boolean | undefined;
     let onClick: (() => void) | undefined;
@@ -110,6 +110,7 @@ export default function SidebarViewSwitch({
     return (
       <StatTile
         key={id}
+        size={size}
         label={t(labelKey)}
         value={rendered}
         unit={unit || undefined}
@@ -121,60 +122,81 @@ export default function SidebarViewSwitch({
     );
   };
 
-  const headlineLabel = nearMe ? t("sidebar.nearby") : t("sidebar.flights");
   // The flight-count is the hero only on the traffic view. On the other
   // sub-views it demotes to a compact summary row so it does not stack a
   // second hero above that view's own hero (e.g. the weather flight-rules
   // block). The headline stays a tab back to traffic; structure is unchanged.
   const isTraffic = activeView === "traffic";
+  const selfSpeedStat = stats.movementRow.find((stat) => stat.id === "selfSpeed");
+  const selfAltitudeStat = stats.movementRow.find(
+    (stat) => stat.id === "selfAltitude",
+  );
 
   return (
     <div className="px-[var(--airport-sidebar-inset)] pt-3.5">
       <div className="overflow-hidden rounded-[var(--atc-radius-panel)] border border-[color-mix(in_oklab,var(--atc-text)_8%,transparent)] bg-[color-mix(in_oklab,var(--atc-text)_3.5%,transparent)]">
-        {/* One morphing layout (not two swapped branches) so switching to/from
-            the traffic view animates: the hero block expands via a max-height
-            transition, the count cross-fades between its compact (inline, right)
-            and hero (large, below) positions, and the padding eases. The
-            isTraffic-driven class swaps (not group-data variants) are what the
-            CSS transitions interpolate. */}
-        <button
-          type="button"
-          data-active={isTraffic ? "true" : undefined}
-          onClick={() => onViewChange?.("traffic")}
-          aria-pressed={isTraffic}
-          className={`relative block w-full px-[11px] text-left transition-[background-color,padding] duration-300 ease-[cubic-bezier(0.34,1.2,0.64,1)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-[2px] before:origin-center before:scale-x-0 before:bg-[var(--atc-signal-accent)] before:transition-transform before:duration-300 before:ease-[cubic-bezier(0.34,1.3,0.64,1)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:before:scale-x-100 ${
-            isTraffic ? "pb-3 pt-[15px]" : "py-[14px]"
-          }`}
-        >
-          <div className="flex items-baseline justify-between gap-2">
-            <span className="text-[calc(10px*var(--sb-body-scale))] font-semibold uppercase tracking-[0.14em] text-atc-faint">
-              {headlineLabel}
-            </span>
-            <span
-              className={`tabular-nums text-[calc(16px*var(--sb-body-scale))] font-normal text-atc-text transition-opacity duration-200 ease-out ${
-                isTraffic ? "opacity-0" : "opacity-100"
-              }`}
-            >
-              <NumberFlow value={aircraft.length} />
-            </span>
+        {nearMe ? (
+          // Here mode: nearby-count and speed are both a primary read (same
+          // lg StatTile treatment as the tracked-flight sidebar's speed/
+          // altitude pair) — two equally-weighted tiles, not one hero over a
+          // demoted footer metric.
+          <div className="grid grid-cols-2">
+            <StatTile
+              size="lg"
+              label={t("sidebar.nearby")}
+              active={isTraffic}
+              onClick={() => onViewChange?.("traffic")}
+              value={<NumberFlow value={aircraft.length} />}
+            />
+            {selfSpeedStat ? renderStat(selfSpeedStat, "lg") : null}
           </div>
-          <div
-            className={`overflow-hidden transition-[max-height,opacity] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] ${
-              isTraffic ? "max-h-[80px] opacity-100" : "max-h-0 opacity-0"
+        ) : (
+          // One morphing layout (not two swapped branches) so switching to/from
+          // the traffic view animates: the hero block expands via a max-height
+          // transition, the count cross-fades between its compact (inline, right)
+          // and hero (large, below) positions, and the padding eases. The
+          // isTraffic-driven class swaps (not group-data variants) are what the
+          // CSS transitions interpolate.
+          <button
+            type="button"
+            data-active={isTraffic ? "true" : undefined}
+            onClick={() => onViewChange?.("traffic")}
+            aria-pressed={isTraffic}
+            className={`relative block w-full px-[11px] text-left transition-[background-color,padding] duration-300 ease-[cubic-bezier(0.34,1.2,0.64,1)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-[2px] before:origin-center before:scale-x-0 before:bg-[var(--atc-signal-accent)] before:transition-transform before:duration-300 before:ease-[cubic-bezier(0.34,1.3,0.64,1)] hover:bg-[var(--atc-control-hover-bg)] data-[active=true]:bg-[color-mix(in_oklab,var(--atc-signal-accent)_11%,transparent)] data-[active=true]:before:scale-x-100 ${
+              isTraffic ? "pb-3 pt-[15px]" : "py-[14px]"
             }`}
           >
-            <span className="block pt-1.5 text-[calc(44px*var(--sb-body-scale))] font-normal leading-[0.9] tracking-[-0.02em] tabular-nums text-atc-text">
-              <NumberFlow value={aircraft.length} />
-            </span>
-          </div>
-        </button>
-        {stats.movementRow.length > 0 ? (
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="text-[calc(10px*var(--sb-body-scale))] font-semibold uppercase tracking-[0.14em] text-atc-faint">
+                {t("sidebar.flights")}
+              </span>
+              <span
+                className={`tabular-nums text-[calc(16px*var(--sb-body-scale))] font-normal text-atc-text transition-opacity duration-200 ease-out ${
+                  isTraffic ? "opacity-0" : "opacity-100"
+                }`}
+              >
+                <NumberFlow value={aircraft.length} />
+              </span>
+            </div>
+            <div
+              className={`overflow-hidden transition-[max-height,opacity] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] ${
+                isTraffic ? "max-h-[80px] opacity-100" : "max-h-0 opacity-0"
+              }`}
+            >
+              <span className="block pt-1.5 text-[calc(44px*var(--sb-body-scale))] font-normal leading-[0.9] tracking-[-0.02em] tabular-nums text-atc-text">
+                <NumberFlow value={aircraft.length} />
+              </span>
+            </div>
+          </button>
+        )}
+        {!nearMe && stats.movementRow.length > 0 ? (
           <div className="flex border-t border-[var(--app-frost-border)]">
-            {stats.movementRow.map(renderStat)}
+            {stats.movementRow.map((stat) => renderStat(stat))}
           </div>
         ) : null}
         <div className="flex border-t border-[var(--app-frost-border)]">
-          {stats.contextRow.map(renderStat)}
+          {nearMe && selfAltitudeStat ? renderStat(selfAltitudeStat) : null}
+          {stats.contextRow.map((stat) => renderStat(stat))}
         </div>
       </div>
     </div>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 67;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v3.2.0",
+    version: "v3.2.1",
     kind: "feat",
     title: {
       en: "Aircraft blend into the weather and light",
@@ -73,6 +73,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Both effects are cache-friendly by design — mood tints reuse the existing sprite cache, and the light gradient is a handful of pre-baked masks composited on draw, not a new per-aircraft cache dimension.",
         zh: "两个效果都对缓存友好——天气色调复用现有的 sprite 缓存,光照渐变则是几张预先烘焙好的蒙版在绘制时合成,不会给每架飞机新增缓存维度。",
+      },
+      {
+        en: "Here mode's stat row: Nearby and Speed are now equally-weighted primary tiles (matching the tracked-flight sidebar's speed/altitude pair), instead of one large hero over a demoted speed cell.",
+        zh: "「我的位置」的指标行:附近和速度现在是同权重的主要 tile(和飞行追踪侧栏的速度/高度那对一致),不再是一个大 hero 压着一个被降级的速度格。",
       },
     ],
   },


### PR DESCRIPTION
## 做了什么

「我的位置」模式的指标行原来是一个不对称的"变形 hero"(飞机数量,只有 traffic 视图下才变大)压在一个和高度共享一行的、被降级的小 Speed 格上。现在(仅 nearMe 模式)改成 2 列等宽的 `lg` StatTile 网格——附近 + 速度——和飞行追踪侧栏"两个大指标在上、小 footer 在下"的既有模式一致。机场详情页的 hero(起飞/到达 view-switch)完全不变。

## Validation

- local test — `pnpm test` 130 文件全过;`changelog.test.ts` 版本同步 ✅
- local browser — mock geolocation 后在 `/here` 验证:Nearby / Speed 两个 tile 等大、view-switch 与速度单位切换(km/h⇄mph)交互都正常;切到 Wx/Atc 视图时激活态横条正确移动;`/airport/KBOS` 确认机场详情模式的原 hero 未受影响

Release: v3.2.1(patch,UX 修正)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)