### PR TITLE
fix(data-service): run-local.sh cd's into its own dir before go run

### DIFF
--- a/services/data-service/run-local.sh
+++ b/services/data-service/run-local.sh
@@ -45,6 +45,7 @@ done
 
 echo "starting adsbao-data-service on :$PORT (OPENAIP=$([ -n "${OPENAIP_API_KEY:-}" ] && echo set || echo MISSING), DB=$([ -n "${DATABASE_URL:-}" ] && echo set || echo MISSING))"
 
+cd "$SCRIPT_DIR"
 PORT="$PORT" \
 INTERNAL_ACCESS_ENABLED="${INTERNAL_ACCESS_ENABLED:-${FLIGHTAWARE_ACCESS_ENABLED:-true}}" \
 ADSBAO_REALTIME_AUTH_SECRET="${ADSBAO_REALTIME_AUTH_SECRET:-local-dev-secret}" \


### PR DESCRIPTION
## 做了什么

`run-local.sh` 里 `exec go run ./cmd/adsbao-data-service` 是相对于 Go module 根目录(`services/data-service/`)的路径,但脚本只用 `SCRIPT_DIR` 去定位 `.env.local`,从没真正 `cd` 进那个目录。只要不是先手动 `cd services/data-service` 再跑脚本,就会报 "cannot find main module"。

修复:在 `go run` 之前加一行 `cd "$SCRIPT_DIR"`,让脚本无论从哪里调用都能正确工作。

## Validation

Validation: local test — 实际用这个修复过的脚本起了本地 data-service(`OPENAIP=set, DB=set`),`curl /health` 返回 `ok:true`,并用真实数据(KJFK,130 架真实飞机、真实 METAR IFR 天气)跑通了整个前后端链路。

无产品影响,纯本地开发工具修复,不涉及版本号。

🤖 Generated with [Claude Code](https://claude.com/claude-code)