### PR TITLE
feat(map): time-of-day colour temperature + fix ambient tint visibility (v3.2.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -264,15 +264,16 @@ function AirportExplorerContent({
     aircraft: traffic.aircraft,
     radiusNm: notificationPreferences.nearbyAircraftRadiusNm,
   });
-  // Ambient map ombiance: aircraft glyphs pick up a weather-driven "mood"
+  // Ambient map ambiance: aircraft glyphs combine a weather-driven "mood"
   // (clear/overcast/severe, from the flight-rules category already fetched
-  // above) and a simplified light-direction shading (see
-  // aircraftAmbientModel.ts — not a real day/night terminator).
+  // above; sets chroma/lightness) with a time-of-day colour temperature
+  // (dawn/day/dusk/night; sets hue) plus a simplified light-direction shading
+  // (see aircraftAmbientModel.ts — none of this is a real day/night terminator).
   const weatherMood = useMemo(
     () => resolveWeatherMood(weather.metar?.flightCategory),
     [weather.metar],
   );
-  const lightBearingDeg = useSimplifiedLightBearing();
+  const { lightBearingDeg, timeOfDay } = useSimplifiedLightBearing();
   const effectiveUserLocation =
     (nearMe ? null : userLocationLayer.userLocation) || nearMeMapUserLocation;
   const userLocationActive = Boolean(effectiveUserLocation);
@@ -692,6 +693,7 @@ function AirportExplorerContent({
               loadingOverlaySources={loadingOverlaySources}
               userLocation={effectiveUserLocation}
               weatherMood={weatherMood}
+              timeOfDay={timeOfDay}
               lightBearingDeg={lightBearingDeg}
             />
           </Suspense>

--- a/src/components/map/AircraftCanvasLayer.tsx
+++ b/src/components/map/AircraftCanvasLayer.tsx
@@ -39,6 +39,7 @@ import {
 import { recordAircraftCanvasFrame } from "../../features/aircraft/canvas/aircraftCanvasPerfMonitor";
 import {
   resolveAircraftLightBucket,
+  type TimeOfDay,
   type WeatherMood,
 } from "../../features/aircraft/canvas/aircraftAmbientModel";
 
@@ -339,32 +340,63 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
   },
 });
 
-// Weather-mood tints for the "at rest" glyph colours (departure/arrival/
-// unknown/ground) only — deliberately hand-picked hex, not a runtime colour
-// blend (canvas has no CSS `color-mix()`, and these change rarely enough that
-// a small lookup table is simpler and cheaper than any blending math). Kept
-// muted/desaturated on purpose: this is ambient atmosphere, not a status
-// alert, and must never compete with the single orange (focal) / blue
-// (selected) accent colours below, which mood never touches.
-const MOOD_REST_COLOR: Record<
-  Exclude<WeatherMood, "clear">,
-  { dark: string; light: string }
-> = {
-  overcast: { dark: "#33383c", light: "#c9cdd2" },
-  severe: { dark: "#403f45", light: "#b8b4bd" },
+// Ambient tint for the "at rest" glyph colours (departure/arrival/unknown/
+// ground) — weather mood sets chroma + lightness (how vivid / how dim),
+// time-of-day sets hue (colour temperature), and the two combine into one
+// oklch() string per aircraft. Composed at mood/time-of-day CHANGE time
+// (a handful of times an hour), never per-frame or per-aircraft, so this
+// stays a cheap lookup-and-format, not runtime colour blending. Kept away
+// from the single orange (focal) / blue (selected) accent colours below,
+// which neither dimension ever touches.
+//
+// Tuned deliberately more saturated than a first pass that turned out
+// imperceptible at 20px glyph size — small colour chips need MORE chroma to
+// read at a glance, not less.
+const TIME_OF_DAY_HUE: Record<TimeOfDay, number> = {
+  dawn: 55, // warm amber sunrise
+  day: 95, // neutral, closest to the old flat aircraft grey
+  dusk: 35, // warm orange-red sunset
+  night: 250, // cool blue
 };
-const MOOD_GROUND_COLOR: Record<
-  Exclude<WeatherMood, "clear">,
-  { dark: string; light: string }
-> = {
-  overcast: { dark: "#4a4e52", light: "#a9adb2" },
-  severe: { dark: "#524f57", light: "#9d99a3" },
+const MOOD_CHROMA: Record<WeatherMood, number> = {
+  clear: 0.13,
+  overcast: 0.07,
+  severe: 0.035,
 };
+const MOOD_LIGHTNESS_DARK: Record<WeatherMood, number> = {
+  clear: 0.4,
+  overcast: 0.34,
+  severe: 0.28,
+};
+const MOOD_LIGHTNESS_LIGHT: Record<WeatherMood, number> = {
+  clear: 0.78,
+  overcast: 0.72,
+  severe: 0.66,
+};
+// Ground traffic sits at one fixed mid lightness regardless of theme (it
+// always read as "duller than airborne" in both themes before this — this
+// keeps that cue while still carrying the mood/time-of-day hue+chroma).
+const GROUND_LIGHTNESS = 0.5;
+const GROUND_CHROMA_SCALE = 0.6;
+
+function resolveAmbientRestColor(mood: WeatherMood, timeOfDay: TimeOfDay, dark: boolean) {
+  const hue = TIME_OF_DAY_HUE[timeOfDay];
+  const chroma = MOOD_CHROMA[mood];
+  const lightness = dark ? MOOD_LIGHTNESS_DARK[mood] : MOOD_LIGHTNESS_LIGHT[mood];
+  return `oklch(${lightness} ${chroma} ${hue})`;
+}
+
+function resolveAmbientGroundColor(mood: WeatherMood, timeOfDay: TimeOfDay) {
+  const hue = TIME_OF_DAY_HUE[timeOfDay];
+  const chroma = MOOD_CHROMA[mood] * GROUND_CHROMA_SCALE;
+  return `oklch(${GROUND_LIGHTNESS} ${chroma} ${hue})`;
+}
 
 function resolveAircraftCanvasPalette(
   map: any,
   theme: string,
   mood: WeatherMood = "clear",
+  timeOfDay: TimeOfDay = "day",
 ): AircraftCanvasPalette {
   const dark = theme !== "light";
   let read = (_name: string, fallback: string) => fallback;
@@ -375,22 +407,13 @@ function resolveAircraftCanvasPalette(
   } catch {
     /* keep fallbacks */
   }
-  // "clear" keeps reading the theme's CSS variables unchanged (today's exact
-  // behaviour); overcast/severe swap in the mood lookup instead of trying to
-  // blend the CSS-variable value at runtime.
-  const restColor =
-    mood === "clear"
-      ? null
-      : (MOOD_REST_COLOR[mood][dark ? "dark" : "light"] as string);
-  const groundColor =
-    mood === "clear"
-      ? null
-      : (MOOD_GROUND_COLOR[mood][dark ? "dark" : "light"] as string);
+  const restColor = resolveAmbientRestColor(mood, timeOfDay, dark);
+  const groundColor = resolveAmbientGroundColor(mood, timeOfDay);
   return {
-    departure: restColor ?? read("--aircraft-departure", dark ? "#2a2a26" : "#dcd9d0"),
-    arrival: restColor ?? read("--aircraft-arrival", dark ? "#2a2a26" : "#dcd9d0"),
-    unknown: restColor ?? read("--aircraft-unknown", dark ? "#2a2a26" : "#dcd9d0"),
-    ground: groundColor ?? read("--aircraft-ground", dark ? "#46463f" : "#b7b4ab"),
+    departure: restColor,
+    arrival: restColor,
+    unknown: restColor,
+    ground: groundColor,
     // PRIMARY (focal/tracked) target = orange signal accent; SECONDARY
     // (clicked) target = a high-contrast NEUTRAL (near-white grey on the dark
     // canvas, near-black grey on the light canvas) — distinguished by luminance
@@ -424,6 +447,8 @@ export interface AircraftCanvasLayerProps {
   hitTestRef?: { current: ((containerPoint: any) => string | null) | null };
   /** Ambient weather mood for the "at rest" glyph colours; defaults to "clear". */
   weatherMood?: WeatherMood;
+  /** Ambient time-of-day colour temperature; defaults to "day". */
+  timeOfDay?: TimeOfDay;
   /** Simplified light-source bearing (deg); null disables the light-mask overlay entirely. */
   lightBearingDeg?: number | null;
 }
@@ -440,6 +465,7 @@ export default function AircraftCanvasLayer({
   onSelectAircraft,
   hitTestRef,
   weatherMood = "clear",
+  timeOfDay = "day",
   lightBearingDeg = null,
 }: AircraftCanvasLayerProps) {
   const map = useMapInstance();
@@ -501,7 +527,7 @@ export default function AircraftCanvasLayer({
       traceActive,
       showCallsigns,
       matchesFilters,
-      palette: resolveAircraftCanvasPalette(map, theme, weatherMood),
+      palette: resolveAircraftCanvasPalette(map, theme, weatherMood, timeOfDay),
       reducedMotion,
       lightBearingDeg,
     });
@@ -516,6 +542,7 @@ export default function AircraftCanvasLayer({
     showCallsigns,
     matchesFilters,
     weatherMood,
+    timeOfDay,
     lightBearingDeg,
   ]);
 

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -127,6 +127,7 @@ export default function AirportMap({
   flightTerminalReason = "",
   userLocation = null,
   weatherMood = "clear",
+  timeOfDay = "day",
   lightBearingDeg = null,
   children = null,
 }: Record<string, any>) {
@@ -752,6 +753,7 @@ export default function AirportMap({
             onSelectAircraft={onSelectAircraft}
             hitTestRef={aircraftHitTestRef}
             weatherMood={weatherMood}
+            timeOfDay={timeOfDay}
             lightBearingDeg={lightBearingDeg}
           />
         </MapContext.Provider>

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 67;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v3.2.2",
+    version: "v3.2.3",
     kind: "feat",
     title: {
       en: "Aircraft blend into the weather and light",
@@ -81,6 +81,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Fixed: the weather mood always read as \"clear\" regardless of the real METAR — a wrong property path silently swallowed the flight-rules category. Confirmed live: aircraft now correctly shift tone as conditions change.",
         zh: "修复:天气氛围色调之前恒为「clear」,与真实 METAR 无关——一处属性路径写错,悄悄吞掉了飞行规则类别。已用真实天气变化现场验证修复生效。",
+      },
+      {
+        en: "The ambient tint got a lot more visible, and gained a time-of-day dimension: hue now shifts through the day — warm amber at dawn, neutral at midday, warm amber-red at dusk, cool blue at night — layered with the weather mood (which now sets vividness/dimness instead of hue alone). The first pass was too subtle to read at 20px; this one is a clear, deliberate colour, confirmed visible at real map scale.",
+        zh: "氛围色调的辨识度大幅提升,并新增了时间维度:色相随一天时间变化——黎明暖橙、正午中性、黄昏暖橙红、夜晚冷蓝——与天气 mood(现在决定鲜艳度/暗淡度,而不再单独决定色相)有机叠加。第一版在 20px 图标上太细微看不出来;这一版是明确、刻意的颜色,已在真实地图比例下确认可见。",
       },
     ],
   },

--- a/src/features/aircraft/canvas/aircraftAmbientModel.test.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.test.ts
@@ -4,9 +4,13 @@ import {
   relativeLightAngleDeg,
   resolveAircraftLightBucket,
   resolveLightBucketWithHysteresis,
+  resolveTimeOfDayBucket,
   resolveWeatherMood,
   simplifiedLightBearingDeg,
 } from "./aircraftAmbientModel";
+
+const dateMs = (hour: number, minute = 0) =>
+  new Date(2026, 0, 15, hour, minute, 0, 0).getTime();
 
 // --- resolveWeatherMood ----------------------------------------------------
 
@@ -33,15 +37,27 @@ import {
 // --- simplifiedLightBearingDeg ---------------------------------------------
 
 {
-  const dateMs = (hour: number, minute = 0) => {
-    const d = new Date(2026, 0, 15, hour, minute, 0, 0);
-    return d.getTime();
-  };
   assert.equal(simplifiedLightBearingDeg(dateMs(3)), 90); // before dawn, clamped
   assert.equal(simplifiedLightBearingDeg(dateMs(6)), 90); // dawn
   assert.equal(simplifiedLightBearingDeg(dateMs(12)), 180); // solar noon-ish, midway
   assert.equal(simplifiedLightBearingDeg(dateMs(18)), 270); // dusk
   assert.equal(simplifiedLightBearingDeg(dateMs(22)), 270); // after dusk, clamped
+}
+
+// --- resolveTimeOfDayBucket -------------------------------------------------
+
+{
+  assert.equal(resolveTimeOfDayBucket(dateMs(2)), "night");
+  assert.equal(resolveTimeOfDayBucket(dateMs(4, 59)), "night");
+  assert.equal(resolveTimeOfDayBucket(dateMs(5)), "dawn");
+  assert.equal(resolveTimeOfDayBucket(dateMs(7, 30)), "dawn");
+  assert.equal(resolveTimeOfDayBucket(dateMs(8)), "day");
+  assert.equal(resolveTimeOfDayBucket(dateMs(12)), "day");
+  assert.equal(resolveTimeOfDayBucket(dateMs(16, 59)), "day");
+  assert.equal(resolveTimeOfDayBucket(dateMs(17)), "dusk");
+  assert.equal(resolveTimeOfDayBucket(dateMs(19, 59)), "dusk");
+  assert.equal(resolveTimeOfDayBucket(dateMs(20)), "night");
+  assert.equal(resolveTimeOfDayBucket(dateMs(23, 59)), "night");
 }
 
 // --- relativeLightAngleDeg + lightBucketForRelativeAngle -------------------

--- a/src/features/aircraft/canvas/aircraftAmbientModel.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.ts
@@ -53,6 +53,32 @@ export function simplifiedLightBearingDeg(nowMs: number): number {
   return DAWN_BEARING_DEG + t * (DUSK_BEARING_DEG - DAWN_BEARING_DEG);
 }
 
+export type TimeOfDay = "dawn" | "day" | "dusk" | "night";
+
+// Time-of-day colour-temperature bucket — a SEPARATE ambient dimension from
+// the light-direction bearing above (that one drives the highlight/shadow
+// mask; this one drives hue, so aircraft actually read as "morning gold" /
+// "midday neutral" / "sunset amber" / "night blue" at a glance, layered with
+// the weather mood in AircraftCanvasLayer's colour table). Local clock hours,
+// same simplification stance as simplifiedLightBearingDeg — not tied to
+// actual sunrise/sunset for the map's location.
+const TIME_OF_DAY_BOUNDARIES: Array<[number, TimeOfDay]> = [
+  [5, "night"],
+  [8, "dawn"],
+  [17, "day"],
+  [20, "dusk"],
+  [24, "night"],
+];
+
+export function resolveTimeOfDayBucket(nowMs: number): TimeOfDay {
+  const date = new Date(nowMs);
+  const hour = date.getHours() + date.getMinutes() / 60;
+  for (const [beforeHour, bucket] of TIME_OF_DAY_BOUNDARIES) {
+    if (hour < beforeHour) return bucket;
+  }
+  return "night";
+}
+
 function normalizeDeg(deg: number): number {
   return ((deg % 360) + 360) % 360;
 }

--- a/src/hooks/useSimplifiedLightBearing.ts
+++ b/src/hooks/useSimplifiedLightBearing.ts
@@ -1,26 +1,40 @@
 import { useEffect, useState } from "react";
-import { simplifiedLightBearingDeg } from "@/features/aircraft/canvas/aircraftAmbientModel";
+import {
+  resolveTimeOfDayBucket,
+  simplifiedLightBearingDeg,
+  type TimeOfDay,
+} from "@/features/aircraft/canvas/aircraftAmbientModel";
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
+function resolveAmbientTimeSignal(nowMs: number) {
+  return {
+    lightBearingDeg: simplifiedLightBearingDeg(nowMs),
+    timeOfDay: resolveTimeOfDayBucket(nowMs),
+  };
+}
+
 /**
- * Tracks the simplified (non-astronomical) ambient light bearing used by the
- * aircraft canvas layer's light-direction shading. The underlying value only
- * drifts over hours, so a slow interval is enough — this deliberately does
- * NOT hook into the per-frame motion loop; a state update here just lets the
- * next natural redraw pick up the new bearing.
+ * Tracks the two time-derived ambient signals the aircraft canvas layer
+ * uses: the simplified (non-astronomical) light bearing for the highlight/
+ * shadow mask, and the time-of-day colour-temperature bucket for the
+ * weather-mood palette. Both only drift over hours, so one slow interval
+ * refreshes them together — this deliberately does NOT hook into the
+ * per-frame motion loop; a state update here just lets the next natural
+ * redraw pick up the new values.
  */
-export function useSimplifiedLightBearing(): number {
-  const [bearingDeg, setBearingDeg] = useState(() =>
-    simplifiedLightBearingDeg(Date.now()),
-  );
+export function useSimplifiedLightBearing(): {
+  lightBearingDeg: number;
+  timeOfDay: TimeOfDay;
+} {
+  const [signal, setSignal] = useState(() => resolveAmbientTimeSignal(Date.now()));
 
   useEffect(() => {
     const timer = window.setInterval(() => {
-      setBearingDeg(simplifiedLightBearingDeg(Date.now()));
+      setSignal(resolveAmbientTimeSignal(Date.now()));
     }, REFRESH_INTERVAL_MS);
     return () => window.clearInterval(timer);
   }, []);
 
-  return bearingDeg;
+  return signal;
 }


### PR DESCRIPTION
## 做了什么

v3.2.0 的天气氛围色调改动上线后,你反馈"看不出来"。核实后确认:颜色确实在正确变化(像素采样能验证),但在 20px 的飞机图标尺寸下,原来那套"细微深浅差异的灰"根本不够醒目,肉眼分辨不出来。

这次重新设计配色系统:
- **天气 mood** 现在决定鲜艳度和明暗(clear 最鲜艳、overcast 更暗淡、severe 最洗白/低对比)
- **新增时间维度**:黎明暖橙、正午中性、黄昏暖橙红、夜晚冷蓝(复用已有的"简化本地时钟"思路,和光照方向是同一个简化立场)
- 二者组合成一个 `oklch()` 字符串,只在时段/天气切换时(一小时几次)才重新计算,不是每帧/每架飞机,性能特性不变——只是从一维查表变成二维,而且饱和度调高了不少,让它真的能一眼看出来

## 关键改动

- `aircraftAmbientModel.ts` 新增 `resolveTimeOfDayBucket()`(纯函数,已测试)
- `useSimplifiedLightBearing` 现在从同一个慢定时器同时返回 `lightBearingDeg` 和 `timeOfDay`(原来只有前者,现在共用一个定时器而不是两个)
- `AircraftCanvasLayer.tsx` 的配色生成逻辑重写:mood 决定 chroma/lightness,time-of-day 决定 hue

## Validation

- local test — `pnpm test` 130 文件全过(新增 `resolveTimeOfDayBucket` 的时段边界测试);`changelog.test.ts` 版本同步 ✅;typecheck 无新增错误
- local browser —**这次做了真正的肉眼可辨验证**,不只是像素采样:
  1. 用真实渲染函数画了一张 170px 大尺寸的 3(mood)×4(time-of-day)=12 格色卡网格,肉眼确认全部 12 种组合两两可辨(dawn=暖橙棕、day=橄榄黄绿、dusk=珊瑚橙红、night=蓝;severe 行明显更暗更灰,clear 行最鲜艳)
  2. 在真实 KJFK 地图上(真实数据,IFR + 本地时间 16:43 = severe/day 组合)确认实际渲染出的橄榄棕色调,和色卡网格的预测完全吻合

Release: v3.2.3(patch,修正+扩展刚上线不久的氛围色调功能)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)