### PR TITLE
fix(map): ambient hue collided with the reserved orange accent (v3.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -278,7 +278,9 @@ function AirportExplorerContent({
     () => resolveWeatherMood(weather.metar?.flightCategory),
     [weather.metar],
   );
-  const { lightBearingDeg, timeOfDay } = useSimplifiedLightBearing();
+  const { lightBearingDeg, timeOfDay } = useSimplifiedLightBearing(
+    airportProfile.lon,
+  );
   // Chrome edge glow: lets the floating toolbar's existing map-kit halo
   // (Toolbar.tsx) and the sidebar's map-facing border pick up a hint of the
   // same weather/time ambiance, without tinting either surface's own
@@ -299,24 +301,25 @@ function AirportExplorerContent({
     });
     return () => observer.disconnect();
   }, []);
-  // "Sidebar & toolbar colour" map setting: "theme" opts out of both the edge
-  // glow and the surface tint below, falling back to the plain pre-ambient
-  // look — the map wash and aircraft tint are a separate, always-on system
-  // this setting does not touch.
-  const chromeAmbientEnabled = mapSettings?.chromeAmbientMode !== "theme";
+  // "Ambient colour" map setting: "theme" opts the WHOLE ambient system out
+  // (map wash, aircraft weather/time tint + light-mask colour, sidebar edge
+  // glow + surface tint, floating toolbar edge glow + surface tint) back to
+  // the plain pre-ambient look, so the map is never left in an inconsistent
+  // half-tinted state.
+  const ambientEnabled = mapSettings?.ambientMode !== "theme";
   const ambientChromeEdgeColor = useMemo(
     () =>
-      chromeAmbientEnabled
+      ambientEnabled
         ? resolveAmbientChromeEdgeColor(weatherMood, timeOfDay, currentTheme !== "light")
         : null,
-    [chromeAmbientEnabled, weatherMood, timeOfDay, currentTheme],
+    [ambientEnabled, weatherMood, timeOfDay, currentTheme],
   );
   const ambientChromeSurfaceTint = useMemo(
     () =>
-      chromeAmbientEnabled
+      ambientEnabled
         ? resolveAmbientChromeSurfaceTint(weatherMood, timeOfDay, currentTheme !== "light")
         : null,
-    [chromeAmbientEnabled, weatherMood, timeOfDay, currentTheme],
+    [ambientEnabled, weatherMood, timeOfDay, currentTheme],
   );
   const effectiveUserLocation =
     (nearMe ? null : userLocationLayer.userLocation) || nearMeMapUserLocation;
@@ -751,7 +754,8 @@ function AirportExplorerContent({
               userLocation={effectiveUserLocation}
               weatherMood={weatherMood}
               timeOfDay={timeOfDay}
-              lightBearingDeg={lightBearingDeg}
+              lightBearingDeg={ambientEnabled ? lightBearingDeg : null}
+              ambientEnabled={ambientEnabled}
             />
           </Suspense>
 

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -48,6 +48,7 @@ import { useAirportProximityNotifier } from "@/features/notifications/useAirport
 import { useAircraftProximityNotifier } from "@/features/notifications/useAircraftProximityNotifier";
 import {
   resolveAmbientChromeEdgeColor,
+  resolveAmbientChromeSurfaceTint,
   resolveWeatherMood,
 } from "@/features/aircraft/canvas/aircraftAmbientModel";
 import { useSimplifiedLightBearing } from "@/hooks/useSimplifiedLightBearing";
@@ -298,10 +299,24 @@ function AirportExplorerContent({
     });
     return () => observer.disconnect();
   }, []);
+  // "Sidebar & toolbar colour" map setting: "theme" opts out of both the edge
+  // glow and the surface tint below, falling back to the plain pre-ambient
+  // look — the map wash and aircraft tint are a separate, always-on system
+  // this setting does not touch.
+  const chromeAmbientEnabled = mapSettings?.chromeAmbientMode !== "theme";
   const ambientChromeEdgeColor = useMemo(
     () =>
-      resolveAmbientChromeEdgeColor(weatherMood, timeOfDay, currentTheme !== "light"),
-    [weatherMood, timeOfDay, currentTheme],
+      chromeAmbientEnabled
+        ? resolveAmbientChromeEdgeColor(weatherMood, timeOfDay, currentTheme !== "light")
+        : null,
+    [chromeAmbientEnabled, weatherMood, timeOfDay, currentTheme],
+  );
+  const ambientChromeSurfaceTint = useMemo(
+    () =>
+      chromeAmbientEnabled
+        ? resolveAmbientChromeSurfaceTint(weatherMood, timeOfDay, currentTheme !== "light")
+        : null,
+    [chromeAmbientEnabled, weatherMood, timeOfDay, currentTheme],
   );
   const effectiveUserLocation =
     (nearMe ? null : userLocationLayer.userLocation) || nearMeMapUserLocation;
@@ -539,9 +554,17 @@ function AirportExplorerContent({
   const mapShellStyle = {
     ...(clientDeviceLayout.safeAreaCssVariables as CSSProperties | undefined),
     // Overrides Toolbar.tsx's map-kit halo token (and feeds the matching
-    // sidebar edge glow below) with the current weather/time ambiance —
-    // scoped selectors mean this is a no-op anywhere else in the app.
-    "--app-floating-edge-shadow": ambientChromeEdgeColor,
+    // sidebar edge glow) and blends a tint into the toolbar/sidebar surface
+    // itself (Toolbar.tsx / SidebarShell.tsx) with the current weather/time
+    // ambiance — scoped selectors mean this is a no-op anywhere else in the
+    // app. Left unset entirely when the "Sidebar & toolbar colour" setting
+    // is "theme", so both fall back to their plain pre-ambient CSS values.
+    ...(ambientChromeEdgeColor
+      ? { "--app-floating-edge-shadow": ambientChromeEdgeColor }
+      : {}),
+    ...(ambientChromeSurfaceTint
+      ? { "--app-ambient-chrome-tint": ambientChromeSurfaceTint }
+      : {}),
   } as CSSProperties;
   const sidebarProps = {
     icao: airportProfile.icao,

--- a/src/components/airport/explorer/AirportExplorer.tsx
+++ b/src/components/airport/explorer/AirportExplorer.tsx
@@ -46,8 +46,12 @@ import { useNotificationPreferences } from "@/features/notifications/Notificatio
 import { useNotificationPermission } from "@/features/notifications/useNotificationPermission";
 import { useAirportProximityNotifier } from "@/features/notifications/useAirportProximityNotifier";
 import { useAircraftProximityNotifier } from "@/features/notifications/useAircraftProximityNotifier";
-import { resolveWeatherMood } from "@/features/aircraft/canvas/aircraftAmbientModel";
+import {
+  resolveAmbientChromeEdgeColor,
+  resolveWeatherMood,
+} from "@/features/aircraft/canvas/aircraftAmbientModel";
 import { useSimplifiedLightBearing } from "@/hooks/useSimplifiedLightBearing";
+import { resolveDocumentTheme } from "@/features/airport/map/airportMapModel";
 
 const AirportMap = lazy(() => import("@/components/map/AirportMap"));
 const AircraftPreviewCard = lazy(() => import("../../aircraft/preview/AircraftPreviewCard"));
@@ -274,6 +278,31 @@ function AirportExplorerContent({
     [weather.metar],
   );
   const { lightBearingDeg, timeOfDay } = useSimplifiedLightBearing();
+  // Chrome edge glow: lets the floating toolbar's existing map-kit halo
+  // (Toolbar.tsx) and the sidebar's map-facing border pick up a hint of the
+  // same weather/time ambiance, without tinting either surface's own
+  // background or content — see resolveAmbientChromeEdgeColor's comment.
+  const [currentTheme, setCurrentTheme] = useState(() =>
+    typeof document !== "undefined"
+      ? resolveDocumentTheme(document.documentElement)
+      : "dark",
+  );
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const next = resolveDocumentTheme(document.documentElement);
+      setCurrentTheme((current) => (current === next ? current : next));
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
+  const ambientChromeEdgeColor = useMemo(
+    () =>
+      resolveAmbientChromeEdgeColor(weatherMood, timeOfDay, currentTheme !== "light"),
+    [weatherMood, timeOfDay, currentTheme],
+  );
   const effectiveUserLocation =
     (nearMe ? null : userLocationLayer.userLocation) || nearMeMapUserLocation;
   const userLocationActive = Boolean(effectiveUserLocation);
@@ -507,8 +536,13 @@ function AirportExplorerContent({
       {...toolbarContextProps}
     />
   );
-  const mapShellStyle =
-    clientDeviceLayout.safeAreaCssVariables as CSSProperties | undefined;
+  const mapShellStyle = {
+    ...(clientDeviceLayout.safeAreaCssVariables as CSSProperties | undefined),
+    // Overrides Toolbar.tsx's map-kit halo token (and feeds the matching
+    // sidebar edge glow below) with the current weather/time ambiance —
+    // scoped selectors mean this is a no-op anywhere else in the app.
+    "--app-floating-edge-shadow": ambientChromeEdgeColor,
+  } as CSSProperties;
   const sidebarProps = {
     icao: airportProfile.icao,
     iata: airportProfile.iata,

--- a/src/components/airport/explorer/AirportExplorerDesktopSidebar.tsx
+++ b/src/components/airport/explorer/AirportExplorerDesktopSidebar.tsx
@@ -1,4 +1,23 @@
 import AirportSidebar from "@/components/sidebar/AirportSidebar";
+import { cn } from "@/lib/utils";
+
+// Map-facing edge glow — same token + ~45% opacity multiplier as the
+// floating toolbar's halo (Toolbar.tsx's mapKitGlow), so the sidebar's
+// border picks up a hint of the current weather/time ambiance (via
+// AirportExplorer overriding --app-floating-edge-shadow) without ever
+// tinting the sidebar's own background or its text/icons. `isolate` +
+// a negative z-index keeps the glow painting behind the actual content.
+const mapKitEdgeGlow = cn(
+  "[.airport-map-kit_&]:after:content-['']",
+  "[.airport-map-kit_&]:after:absolute",
+  "[.airport-map-kit_&]:after:inset-y-0",
+  "[.airport-map-kit_&]:after:right-0",
+  "[.airport-map-kit_&]:after:w-12",
+  "[.airport-map-kit_&]:after:-z-10",
+  "[.airport-map-kit_&]:after:opacity-[0.45]",
+  "[.airport-map-kit_&]:after:pointer-events-none",
+  "[.airport-map-kit_&]:after:[background:linear-gradient(to_left,var(--app-floating-edge-shadow),transparent)]",
+);
 
 export default function AirportExplorerDesktopSidebar({
   open,
@@ -10,7 +29,10 @@ export default function AirportExplorerDesktopSidebar({
 
   return (
     <div
-      className="airport-desktop-sidebar shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+      className={cn(
+        "airport-desktop-sidebar relative isolate shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out",
+        mapKitEdgeGlow,
+      )}
       data-open={open ? "true" : "false"}
       data-collapsed={collapsed ? "true" : undefined}
       style={{ width: open ? visibleWidth : "0" }}

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -42,7 +42,7 @@ export default function ExplorerMapMenu({
     mapSettingsSaveCycle,
     setMapZoom,
     setMapBaseLayer,
-    setChromeAmbientMode,
+    setAmbientMode,
     toggleSidebar,
     toggleMapLabels,
     toggleRunwayBeams,
@@ -93,7 +93,7 @@ export default function ExplorerMapMenu({
       onToggleCandidateWatchingSpots={toggleCandidateWatchingSpots}
       onToggleShowCallsigns={toggleShowCallsigns}
       onSelectBaseLayer={setMapBaseLayer}
-      onSelectChromeAmbientMode={setChromeAmbientMode}
+      onSelectAmbientMode={setAmbientMode}
       onToggleUserLocation={onToggleUserLocation}
       onToggleSidebar={toggleSidebar}
       onMap={onMap}

--- a/src/components/explorer/ExplorerMapMenu.tsx
+++ b/src/components/explorer/ExplorerMapMenu.tsx
@@ -42,6 +42,7 @@ export default function ExplorerMapMenu({
     mapSettingsSaveCycle,
     setMapZoom,
     setMapBaseLayer,
+    setChromeAmbientMode,
     toggleSidebar,
     toggleMapLabels,
     toggleRunwayBeams,
@@ -92,6 +93,7 @@ export default function ExplorerMapMenu({
       onToggleCandidateWatchingSpots={toggleCandidateWatchingSpots}
       onToggleShowCallsigns={toggleShowCallsigns}
       onSelectBaseLayer={setMapBaseLayer}
+      onSelectChromeAmbientMode={setChromeAmbientMode}
       onToggleUserLocation={onToggleUserLocation}
       onToggleSidebar={toggleSidebar}
       onMap={onMap}

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -30,8 +30,8 @@ import {
   PRE_HYDRATION_VISUAL_LAYERS,
   buildCustomMapSettings,
   buildMapSettingsWithBaseLayer,
-  buildMapSettingsWithChromeAmbientMode,
-  isKnownChromeAmbientMode,
+  buildMapSettingsWithAmbientMode,
+  isKnownAmbientMode,
   isKnownMapBaseLayer,
   mapSettingsToExplorerLayers,
   mapSettingsToUserLocationPreferences,
@@ -235,16 +235,16 @@ function airportExplorerUiReducer(state, action) {
           baseLayer: action.baseLayer,
         }),
       );
-    case "setChromeAmbientMode":
-      if (!isKnownChromeAmbientMode(action.chromeAmbientMode)) return state;
-      if (state.mapSettings?.chromeAmbientMode === action.chromeAmbientMode) {
+    case "setAmbientMode":
+      if (!isKnownAmbientMode(action.ambientMode)) return state;
+      if (state.mapSettings?.ambientMode === action.ambientMode) {
         return state;
       }
       return applyMapSettingsToUiState(
         state,
-        buildMapSettingsWithChromeAmbientMode({
+        buildMapSettingsWithAmbientMode({
           settings: state.mapSettings,
-          chromeAmbientMode: action.chromeAmbientMode,
+          ambientMode: action.ambientMode,
         }),
       );
     case "hydrateMapSettings":
@@ -868,8 +868,8 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "setMapBaseLayer", baseLayer });
   }, []);
 
-  const setChromeAmbientMode = useCallback((chromeAmbientMode) => {
-    dispatch({ type: "setChromeAmbientMode", chromeAmbientMode });
+  const setAmbientMode = useCallback((ambientMode) => {
+    dispatch({ type: "setAmbientMode", ambientMode });
   }, []);
 
   const setUserLocationPreferences = useCallback(
@@ -1015,7 +1015,7 @@ export function ExplorerUiProvider({ children }) {
       toggleCandidateWatchingSpots,
       toggleShowCallsigns,
       setMapBaseLayer,
-      setChromeAmbientMode,
+      setAmbientMode,
       setUserLocationPreferences,
       selectAircraft,
       setSelectedAircraftId,
@@ -1085,7 +1085,7 @@ export function ExplorerUiProvider({ children }) {
       toggleCandidateWatchingSpots,
       toggleShowCallsigns,
       setMapBaseLayer,
-      setChromeAmbientMode,
+      setAmbientMode,
       setUserLocationPreferences,
       selectAircraft,
       setSelectedAircraftId,

--- a/src/components/explorer/ExplorerUiContext.tsx
+++ b/src/components/explorer/ExplorerUiContext.tsx
@@ -30,6 +30,8 @@ import {
   PRE_HYDRATION_VISUAL_LAYERS,
   buildCustomMapSettings,
   buildMapSettingsWithBaseLayer,
+  buildMapSettingsWithChromeAmbientMode,
+  isKnownChromeAmbientMode,
   isKnownMapBaseLayer,
   mapSettingsToExplorerLayers,
   mapSettingsToUserLocationPreferences,
@@ -231,6 +233,18 @@ function airportExplorerUiReducer(state, action) {
         buildMapSettingsWithBaseLayer({
           settings: state.mapSettings,
           baseLayer: action.baseLayer,
+        }),
+      );
+    case "setChromeAmbientMode":
+      if (!isKnownChromeAmbientMode(action.chromeAmbientMode)) return state;
+      if (state.mapSettings?.chromeAmbientMode === action.chromeAmbientMode) {
+        return state;
+      }
+      return applyMapSettingsToUiState(
+        state,
+        buildMapSettingsWithChromeAmbientMode({
+          settings: state.mapSettings,
+          chromeAmbientMode: action.chromeAmbientMode,
         }),
       );
     case "hydrateMapSettings":
@@ -854,6 +868,10 @@ export function ExplorerUiProvider({ children }) {
     dispatch({ type: "setMapBaseLayer", baseLayer });
   }, []);
 
+  const setChromeAmbientMode = useCallback((chromeAmbientMode) => {
+    dispatch({ type: "setChromeAmbientMode", chromeAmbientMode });
+  }, []);
+
   const setUserLocationPreferences = useCallback(
     ({ userLocationEnabled }) => {
       dispatch({
@@ -997,6 +1015,7 @@ export function ExplorerUiProvider({ children }) {
       toggleCandidateWatchingSpots,
       toggleShowCallsigns,
       setMapBaseLayer,
+      setChromeAmbientMode,
       setUserLocationPreferences,
       selectAircraft,
       setSelectedAircraftId,
@@ -1066,6 +1085,7 @@ export function ExplorerUiProvider({ children }) {
       toggleCandidateWatchingSpots,
       toggleShowCallsigns,
       setMapBaseLayer,
+      setChromeAmbientMode,
       setUserLocationPreferences,
       selectAircraft,
       setSelectedAircraftId,

--- a/src/components/map/AircraftCanvasLayer.tsx
+++ b/src/components/map/AircraftCanvasLayer.tsx
@@ -345,23 +345,27 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
 // time-of-day sets hue (colour temperature), and the two combine into one
 // oklch() string per aircraft. Composed at mood/time-of-day CHANGE time
 // (a handful of times an hour), never per-frame or per-aircraft, so this
-// stays a cheap lookup-and-format, not runtime colour blending. Kept away
-// from the single orange (focal) / blue (selected) accent colours below,
-// which neither dimension ever touches.
+// stays a cheap lookup-and-format, not runtime colour blending.
 //
-// Tuned deliberately more saturated than a first pass that turned out
-// imperceptible at 20px glyph size — small colour chips need MORE chroma to
-// read at a glance, not less.
+// Hue MUST stay clear of --atc-signal-accent (oklch(0.66 0.16 50), the
+// single reserved orange for focal/tracked targets) — an earlier pass used
+// warm hues near 35-55 for dawn/dusk and, in production, painted the ENTIRE
+// map (every aircraft + label) the same orange as the one thing that's
+// supposed to stand out, destroying the whole "one accent colour" hierarchy.
+// This palette is built around a >=60deg hue gap from 50 in every direction:
+// a sky-colour progression (dawn blush -> daytime cyan -> twilight violet ->
+// night blue) that reads as "time of day" without ever competing with orange.
+// Chroma is also dialed back from that pass — visible without being loud.
 const TIME_OF_DAY_HUE: Record<TimeOfDay, number> = {
-  dawn: 55, // warm amber sunrise
-  day: 95, // neutral, closest to the old flat aircraft grey
-  dusk: 35, // warm orange-red sunset
-  night: 250, // cool blue
+  dawn: 350, // soft rose/blush sunrise sky
+  day: 180, // cool daytime cyan-sky
+  dusk: 290, // twilight violet
+  night: 240, // night blue
 };
 const MOOD_CHROMA: Record<WeatherMood, number> = {
-  clear: 0.13,
-  overcast: 0.07,
-  severe: 0.035,
+  clear: 0.09,
+  overcast: 0.05,
+  severe: 0.025,
 };
 const MOOD_LIGHTNESS_DARK: Record<WeatherMood, number> = {
   clear: 0.4,

--- a/src/components/map/AircraftCanvasLayer.tsx
+++ b/src/components/map/AircraftCanvasLayer.tsx
@@ -39,6 +39,7 @@ import {
 import { recordAircraftCanvasFrame } from "../../features/aircraft/canvas/aircraftCanvasPerfMonitor";
 import {
   resolveAircraftLightBucket,
+  TIME_OF_DAY_HUE,
   type TimeOfDay,
   type WeatherMood,
 } from "../../features/aircraft/canvas/aircraftAmbientModel";
@@ -78,6 +79,7 @@ interface AircraftCanvasSetData {
   palette: AircraftCanvasPalette;
   reducedMotion: boolean;
   lightBearingDeg?: number | null;
+  timeOfDay?: TimeOfDay;
 }
 
 const AircraftCanvasRenderer = (L as any).Renderer.extend({
@@ -95,6 +97,7 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
     this._heading = new Map();
     this._lightBucket = new Map();
     this._lightBearingDeg = null;
+    this._timeOfDay = "day";
     this._hitPoints = [];
     this._lastDraw = 0;
     this._anyAnimating = false;
@@ -255,7 +258,17 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
               this._lightBucket.get(d.id) ?? null,
             );
       if (lightBucket != null) this._lightBucket.set(d.id, lightBucket);
-      drawAircraftGlyph(ctx, d, lp.x, lp.y, heading, palette, dpr, lightBucket);
+      drawAircraftGlyph(
+        ctx,
+        d,
+        lp.x,
+        lp.y,
+        heading,
+        palette,
+        dpr,
+        lightBucket,
+        this._timeOfDay,
+      );
       if (d.showLabel) drawAircraftLabel(ctx, d, lp.x, lp.y, palette);
       drawn += 1;
       if (animating) anyAnimating = true;
@@ -282,6 +295,7 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
     this._palette = data.palette;
     this._reducedMotion = data.reducedMotion;
     this._lightBearingDeg = data.lightBearingDeg ?? null;
+    this._timeOfDay = data.timeOfDay ?? "day";
     this._drawList = buildDrawList(data.aircraft, {
       selectedId: data.selectedId,
       focalId: data.focalId,
@@ -342,26 +356,11 @@ const AircraftCanvasRenderer = (L as any).Renderer.extend({
 
 // Ambient tint for the "at rest" glyph colours (departure/arrival/unknown/
 // ground) — weather mood sets chroma + lightness (how vivid / how dim),
-// time-of-day sets hue (colour temperature), and the two combine into one
-// oklch() string per aircraft. Composed at mood/time-of-day CHANGE time
-// (a handful of times an hour), never per-frame or per-aircraft, so this
-// stays a cheap lookup-and-format, not runtime colour blending.
-//
-// Hue MUST stay clear of --atc-signal-accent (oklch(0.66 0.16 50), the
-// single reserved orange for focal/tracked targets) — an earlier pass used
-// warm hues near 35-55 for dawn/dusk and, in production, painted the ENTIRE
-// map (every aircraft + label) the same orange as the one thing that's
-// supposed to stand out, destroying the whole "one accent colour" hierarchy.
-// This palette is built around a >=60deg hue gap from 50 in every direction:
-// a sky-colour progression (dawn blush -> daytime cyan -> twilight violet ->
-// night blue) that reads as "time of day" without ever competing with orange.
-// Chroma is also dialed back from that pass — visible without being loud.
-const TIME_OF_DAY_HUE: Record<TimeOfDay, number> = {
-  dawn: 350, // soft rose/blush sunrise sky
-  day: 180, // cool daytime cyan-sky
-  dusk: 290, // twilight violet
-  night: 240, // night blue
-};
+// time-of-day sets hue (colour temperature, shared with the map-level wash
+// via TIME_OF_DAY_HUE), and the two combine into one oklch() string per
+// aircraft. Composed at mood/time-of-day CHANGE time (a handful of times an
+// hour), never per-frame or per-aircraft, so this stays a cheap
+// lookup-and-format, not runtime colour blending.
 const MOOD_CHROMA: Record<WeatherMood, number> = {
   clear: 0.09,
   overcast: 0.05,
@@ -534,6 +533,7 @@ export default function AircraftCanvasLayer({
       palette: resolveAircraftCanvasPalette(map, theme, weatherMood, timeOfDay),
       reducedMotion,
       lightBearingDeg,
+      timeOfDay,
     });
   }, [
     map,

--- a/src/components/map/AircraftCanvasLayer.tsx
+++ b/src/components/map/AircraftCanvasLayer.tsx
@@ -400,6 +400,7 @@ function resolveAircraftCanvasPalette(
   theme: string,
   mood: WeatherMood = "clear",
   timeOfDay: TimeOfDay = "day",
+  ambientEnabled: boolean = true,
 ): AircraftCanvasPalette {
   const dark = theme !== "light";
   let read = (_name: string, fallback: string) => fallback;
@@ -410,13 +411,26 @@ function resolveAircraftCanvasPalette(
   } catch {
     /* keep fallbacks */
   }
-  const restColor = resolveAmbientRestColor(mood, timeOfDay, dark);
-  const groundColor = resolveAmbientGroundColor(mood, timeOfDay);
+  // "Theme colour" ambient-mode setting: revert to the original flat neutral
+  // palette that predates the weather/time tint (still theme-aware via these
+  // same CSS vars, just no mood/time hue) instead of the ambient resolvers.
+  const departure = ambientEnabled
+    ? resolveAmbientRestColor(mood, timeOfDay, dark)
+    : read("--aircraft-departure", dark ? "#2a2a26" : "#dcd9d0");
+  const arrival = ambientEnabled
+    ? departure
+    : read("--aircraft-arrival", dark ? "#2a2a26" : "#dcd9d0");
+  const unknown = ambientEnabled
+    ? departure
+    : read("--aircraft-unknown", dark ? "#2a2a26" : "#dcd9d0");
+  const ground = ambientEnabled
+    ? resolveAmbientGroundColor(mood, timeOfDay)
+    : read("--aircraft-ground", dark ? "#46463f" : "#b7b4ab");
   return {
-    departure: restColor,
-    arrival: restColor,
-    unknown: restColor,
-    ground: groundColor,
+    departure,
+    arrival,
+    unknown,
+    ground,
     // PRIMARY (focal/tracked) target = orange signal accent; SECONDARY
     // (clicked) target = a high-contrast NEUTRAL (near-white grey on the dark
     // canvas, near-black grey on the light canvas) — distinguished by luminance
@@ -454,6 +468,8 @@ export interface AircraftCanvasLayerProps {
   timeOfDay?: TimeOfDay;
   /** Simplified light-source bearing (deg); null disables the light-mask overlay entirely. */
   lightBearingDeg?: number | null;
+  /** "Ambient colour" map setting: false reverts to the original flat neutral palette. */
+  ambientEnabled?: boolean;
 }
 
 export default function AircraftCanvasLayer({
@@ -470,6 +486,7 @@ export default function AircraftCanvasLayer({
   weatherMood = "clear",
   timeOfDay = "day",
   lightBearingDeg = null,
+  ambientEnabled = true,
 }: AircraftCanvasLayerProps) {
   const map = useMapInstance();
   const rendererRef = useRef<any>(null);
@@ -530,7 +547,13 @@ export default function AircraftCanvasLayer({
       traceActive,
       showCallsigns,
       matchesFilters,
-      palette: resolveAircraftCanvasPalette(map, theme, weatherMood, timeOfDay),
+      palette: resolveAircraftCanvasPalette(
+        map,
+        theme,
+        weatherMood,
+        timeOfDay,
+        ambientEnabled,
+      ),
       reducedMotion,
       lightBearingDeg,
       timeOfDay,
@@ -548,6 +571,7 @@ export default function AircraftCanvasLayer({
     weatherMood,
     timeOfDay,
     lightBearingDeg,
+    ambientEnabled,
   ]);
 
   return null;

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -12,6 +12,7 @@ import ReportingPointLabelLayer from "./ReportingPointLabelLayer";
 import MapBadgeCollisionLayer from "./MapBadgeCollisionLayer";
 import CandidateWatchingSpotsLayer from "./CandidateWatchingSpotsLayer";
 import AircraftCanvasLayer from "./AircraftCanvasLayer";
+import AmbientWashLayer from "./AmbientWashLayer";
 import UserLocationMarker from "./UserLocationMarker";
 import SelectedAircraftTrace from "./SelectedAircraftTrace";
 import RunwayAnnotationLayer from "./RunwayAnnotationLayer";
@@ -636,6 +637,11 @@ export default function AirportMap({
             baseLayer={baseLayer}
             selectionActive={selectionActive}
             onReadinessChange={handleMapTileReadinessChange}
+          />
+          <AmbientWashLayer
+            theme={currentTheme}
+            weatherMood={weatherMood}
+            timeOfDay={timeOfDay}
           />
           <AirspaceLayer
             airspaces={renderedAirspaces}

--- a/src/components/map/AirportMap.tsx
+++ b/src/components/map/AirportMap.tsx
@@ -130,6 +130,7 @@ export default function AirportMap({
   weatherMood = "clear",
   timeOfDay = "day",
   lightBearingDeg = null,
+  ambientEnabled = true,
   children = null,
 }: Record<string, any>) {
   const { locale } = useI18n();
@@ -638,11 +639,13 @@ export default function AirportMap({
             selectionActive={selectionActive}
             onReadinessChange={handleMapTileReadinessChange}
           />
-          <AmbientWashLayer
-            theme={currentTheme}
-            weatherMood={weatherMood}
-            timeOfDay={timeOfDay}
-          />
+          {ambientEnabled && (
+            <AmbientWashLayer
+              theme={currentTheme}
+              weatherMood={weatherMood}
+              timeOfDay={timeOfDay}
+            />
+          )}
           <AirspaceLayer
             airspaces={renderedAirspaces}
             selectableAirspaceIds={selectableAirspaceIds}
@@ -761,6 +764,7 @@ export default function AirportMap({
             weatherMood={weatherMood}
             timeOfDay={timeOfDay}
             lightBearingDeg={lightBearingDeg}
+            ambientEnabled={ambientEnabled}
           />
         </MapContext.Provider>
       )}

--- a/src/components/map/AmbientWashLayer.tsx
+++ b/src/components/map/AmbientWashLayer.tsx
@@ -1,0 +1,78 @@
+// A single full-world rectangle, tinted by the current weather mood + time-
+// of-day, rendered into its own pane just above the raw tile imagery and
+// below every other annotation/aircraft pane (see AIRPORT_MAP_PANES.ambientWash
+// in config/airportMap.ts). This extends the ambient atmosphere effect from
+// the tiny aircraft glyphs (AircraftCanvasLayer) to the whole viewport, without
+// tinting runway surfaces, airspace fills, badges, trace, or aircraft — those
+// keep their own colours, and the orange/blue accent colours stay uncontaminated.
+//
+// Deliberately a plain Leaflet vector rectangle (not a custom canvas/DOM
+// overlay): Leaflet's own path renderer already keeps it correctly sized and
+// positioned across zoom changes for free, so there's no per-frame cost and
+// no custom pixel-math to get wrong.
+
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import { useMapInstance } from "./MapContext";
+import { ensureAirportMapPane } from "../../features/airport/map/mapPane";
+import { AIRPORT_MAP_PANES } from "../../config/airportMap";
+import {
+  safeAddToMap,
+  safeRemoveFromMap,
+} from "../../features/airport/map/leafletLayerSafety";
+import {
+  resolveAmbientOverlayColor,
+  type TimeOfDay,
+  type WeatherMood,
+} from "../../features/aircraft/canvas/aircraftAmbientModel";
+
+const WEB_MERCATOR_MAX_LAT = 85.05112878;
+const WORLD_BOUNDS = [
+  [-WEB_MERCATOR_MAX_LAT, -180],
+  [WEB_MERCATOR_MAX_LAT, 180],
+] as any;
+
+export interface AmbientWashLayerProps {
+  theme: string;
+  weatherMood: WeatherMood;
+  timeOfDay: TimeOfDay;
+}
+
+export default function AmbientWashLayer({
+  theme,
+  weatherMood,
+  timeOfDay,
+}: AmbientWashLayerProps) {
+  const map = useMapInstance();
+  const rectRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (!map) return undefined;
+    const paneName = ensureAirportMapPane(map, AIRPORT_MAP_PANES.ambientWash);
+    const rect = (L as any).rectangle(WORLD_BOUNDS, {
+      pane: paneName,
+      stroke: false,
+      interactive: false,
+      fillOpacity: 0,
+    });
+    safeAddToMap(rect, map, { label: "AmbientWashLayer" });
+    rectRef.current = rect;
+    return () => {
+      safeRemoveFromMap(rect, map);
+      rectRef.current = null;
+    };
+  }, [map]);
+
+  useEffect(() => {
+    const rect = rectRef.current;
+    if (!rect) return;
+    const { color, opacity } = resolveAmbientOverlayColor(
+      weatherMood,
+      timeOfDay,
+      theme !== "light",
+    );
+    rect.setStyle({ fillColor: color, fillOpacity: opacity });
+  }, [weatherMood, timeOfDay, theme]);
+
+  return null;
+}

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -1,7 +1,9 @@
 import { useUser } from "@/platform/auth/clerkClient";
 import {
+  DEFAULT_CHROME_AMBIENT_MODE,
   DEFAULT_MAP_BASE_LAYER,
   MAP_LAYER_KEYS,
+  getChromeAmbientModeOptions,
   getMapBaseLayerOptions,
   normalizeMapSettings,
 } from "@/features/airport/map-settings/mapSettingsModel";
@@ -296,6 +298,7 @@ export default function MapSettingsSheet({
   userLocationPositionReady = false,
   userLocationCompassHeadingDeg = null,
   onSelectBaseLayer,
+  onSelectChromeAmbientMode,
   onToggleMapLabels,
   onToggleBeams,
   onToggleNavaidMarkers,
@@ -344,6 +347,9 @@ export default function MapSettingsSheet({
   const settings = normalizeMapSettings(mapSettings);
   const baseLayerOptions = getMapBaseLayerOptions();
   const activeBaseLayerId = settings.baseLayer || DEFAULT_MAP_BASE_LAYER;
+  const chromeAmbientModeOptions = getChromeAmbientModeOptions();
+  const activeChromeAmbientModeId =
+    settings.chromeAmbientMode || DEFAULT_CHROME_AMBIENT_MODE;
   const state = {
     showMapLabels,
     showBeams,
@@ -434,6 +440,33 @@ export default function MapSettingsSheet({
                       title={t(option.labelKey)}
                       description={t(option.descriptionKey)}
                       onClick={() => onSelectBaseLayer?.(option.id)}
+                    />
+                  );
+                })}
+              </div>
+            </section>
+
+            <section
+              className="map-settings-section"
+              aria-labelledby={`${id}-chrome-ambient`}
+            >
+              <h3
+                id={`${id}-chrome-ambient`}
+                className={sectionTitleClassName}
+              >
+                {t("mapSettings.chromeAmbientSection")}
+              </h3>
+              <div className={settingsListGroupClassName}>
+                {chromeAmbientModeOptions.map((option) => {
+                  const active = activeChromeAmbientModeId === option.id;
+                  return (
+                    <SettingsOptionRow
+                      key={option.id}
+                      active={active}
+                      iconKey={option.iconKey}
+                      title={t(option.labelKey)}
+                      description={t(option.descriptionKey)}
+                      onClick={() => onSelectChromeAmbientMode?.(option.id)}
                     />
                   );
                 })}

--- a/src/components/map/controls/MapSettingsSheet.tsx
+++ b/src/components/map/controls/MapSettingsSheet.tsx
@@ -1,9 +1,9 @@
 import { useUser } from "@/platform/auth/clerkClient";
 import {
-  DEFAULT_CHROME_AMBIENT_MODE,
+  DEFAULT_AMBIENT_MODE,
   DEFAULT_MAP_BASE_LAYER,
   MAP_LAYER_KEYS,
-  getChromeAmbientModeOptions,
+  getAmbientModeOptions,
   getMapBaseLayerOptions,
   normalizeMapSettings,
 } from "@/features/airport/map-settings/mapSettingsModel";
@@ -298,7 +298,7 @@ export default function MapSettingsSheet({
   userLocationPositionReady = false,
   userLocationCompassHeadingDeg = null,
   onSelectBaseLayer,
-  onSelectChromeAmbientMode,
+  onSelectAmbientMode,
   onToggleMapLabels,
   onToggleBeams,
   onToggleNavaidMarkers,
@@ -347,9 +347,9 @@ export default function MapSettingsSheet({
   const settings = normalizeMapSettings(mapSettings);
   const baseLayerOptions = getMapBaseLayerOptions();
   const activeBaseLayerId = settings.baseLayer || DEFAULT_MAP_BASE_LAYER;
-  const chromeAmbientModeOptions = getChromeAmbientModeOptions();
-  const activeChromeAmbientModeId =
-    settings.chromeAmbientMode || DEFAULT_CHROME_AMBIENT_MODE;
+  const ambientModeOptions = getAmbientModeOptions();
+  const activeAmbientModeId =
+    settings.ambientMode || DEFAULT_AMBIENT_MODE;
   const state = {
     showMapLabels,
     showBeams,
@@ -454,11 +454,11 @@ export default function MapSettingsSheet({
                 id={`${id}-chrome-ambient`}
                 className={sectionTitleClassName}
               >
-                {t("mapSettings.chromeAmbientSection")}
+                {t("mapSettings.ambientSection")}
               </h3>
               <div className={settingsListGroupClassName}>
-                {chromeAmbientModeOptions.map((option) => {
-                  const active = activeChromeAmbientModeId === option.id;
+                {ambientModeOptions.map((option) => {
+                  const active = activeAmbientModeId === option.id;
                   return (
                     <SettingsOptionRow
                       key={option.id}
@@ -466,7 +466,7 @@ export default function MapSettingsSheet({
                       iconKey={option.iconKey}
                       title={t(option.labelKey)}
                       description={t(option.descriptionKey)}
-                      onClick={() => onSelectChromeAmbientMode?.(option.id)}
+                      onClick={() => onSelectAmbientMode?.(option.id)}
                     />
                   );
                 })}

--- a/src/components/map/controls/mapControlIcons.tsx
+++ b/src/components/map/controls/mapControlIcons.tsx
@@ -16,6 +16,7 @@ import {
   MonitorCheck,
   Moon,
   Mountain,
+  Palette,
   PanelsTopLeft,
   Plane,
   PlaneLanding,
@@ -27,6 +28,7 @@ import {
   SlidersHorizontal,
   Spotlight,
   Sun,
+  SunMoon,
   Telescope,
   Text,
   Type,
@@ -68,6 +70,8 @@ export function MapControlIcon({ iconKey }) {
       return <Moon />;
     case "mountain":
       return <Mountain />;
+    case "palette":
+      return <Palette />;
     case "panelsTopLeft":
       return <PanelsTopLeft />;
     case "plane":
@@ -88,6 +92,8 @@ export function MapControlIcon({ iconKey }) {
       return <Spotlight />;
     case "sun":
       return <Sun />;
+    case "sunMoon":
+      return <SunMoon />;
     case "telescope":
       return <Telescope />;
     case "text":

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -51,6 +51,7 @@ export default function MapControlBar({
   onToggleCandidateWatchingSpots,
   onToggleShowCallsigns,
   onSelectBaseLayer,
+  onSelectChromeAmbientMode,
   onMap = null,
   onToggleUserLocation = null,
   onToggleSidebar,
@@ -117,6 +118,7 @@ export default function MapControlBar({
         userLocationPositionReady={userLocationPositionReady}
         userLocationCompassHeadingDeg={userLocationCompassHeadingDeg}
         onSelectBaseLayer={onSelectBaseLayer}
+        onSelectChromeAmbientMode={onSelectChromeAmbientMode}
         onToggleMapLabels={onToggleMapLabels}
         onToggleBeams={onToggleRunwayBeams}
         onToggleNavaidMarkers={onToggleNavaidMarkers}

--- a/src/components/ui/MapControlBar.tsx
+++ b/src/components/ui/MapControlBar.tsx
@@ -51,7 +51,7 @@ export default function MapControlBar({
   onToggleCandidateWatchingSpots,
   onToggleShowCallsigns,
   onSelectBaseLayer,
-  onSelectChromeAmbientMode,
+  onSelectAmbientMode,
   onMap = null,
   onToggleUserLocation = null,
   onToggleSidebar,
@@ -118,7 +118,7 @@ export default function MapControlBar({
         userLocationPositionReady={userLocationPositionReady}
         userLocationCompassHeadingDeg={userLocationCompassHeadingDeg}
         onSelectBaseLayer={onSelectBaseLayer}
-        onSelectChromeAmbientMode={onSelectChromeAmbientMode}
+        onSelectAmbientMode={onSelectAmbientMode}
         onToggleMapLabels={onToggleMapLabels}
         onToggleBeams={onToggleRunwayBeams}
         onToggleNavaidMarkers={onToggleNavaidMarkers}

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -76,6 +76,17 @@ const mapKitGlow = cn(
   "[.airport-map-kit_&]:after:bg-[radial-gradient(ellipse_at_center,var(--app-floating-edge-shadow),transparent_72%)]",
 );
 
+// Ambient surface tint — blends a hint of the current weather/time colour
+// (--app-ambient-chrome-tint, set by AirportExplorer's "Sidebar & toolbar
+// colour" setting) into the toolbar's own surface, not just its edge halo
+// above. The self-referencing fallback (var(--app-ambient-chrome-tint,
+// var(--atc-toolbar-surface))) makes this a mathematical no-op — mixing a
+// colour with itself — whenever the tint variable isn't set (setting =
+// "theme", or any toolbar outside .airport-map-kit), so this never needs a
+// second "is ambient enabled" check here.
+const mapKitAmbientSurfaceTint =
+  "[.airport-map-kit_&]:[background:color-mix(in_oklab,var(--app-ambient-chrome-tint,var(--atc-toolbar-surface))_16%,var(--atc-toolbar-surface))]";
+
 const toolbarVariants = cva(
   cn(
     "relative items-center isolate",
@@ -96,6 +107,7 @@ const toolbarVariants = cva(
     // Tailwind spacing scale; only the fixed shell/cell dimensions are tokens.
     "min-h-[var(--atc-toolbar-shell-min-height)] gap-1 p-1",
     mapKitGlow,
+    mapKitAmbientSurfaceTint,
   ),
   {
     variants: {

--- a/src/config/airportMap.ts
+++ b/src/config/airportMap.ts
@@ -6,6 +6,15 @@ export const AIRPORT_MAP_FALLBACK_CENTER = {
 };
 
 export const AIRPORT_MAP_PANES = {
+  // Ambient time-of-day/weather colour wash over the raw tile imagery only —
+  // sits just above the (Leaflet default z=200) tile pane and below every
+  // other annotation pane here, so it never tints runway surfaces, airspace
+  // fills, badges, trace, or aircraft (whose orange/blue accent colours must
+  // stay uncontaminated).
+  ambientWash: {
+    name: "airport-map-ambient-wash",
+    zIndex: 250,
+  },
   surface: {
     name: "airport-map-surface-overlay",
     zIndex: 360,

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -90,6 +90,14 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "Fixed: dawn/dusk's warm amber hues sat right next to the single orange accent reserved for the tracked target — in production this painted every aircraft and label the same orange as the one thing meant to stand out. Replaced with a sky-colour palette (dawn blush, daytime cyan, twilight violet, night blue) that keeps a wide hue gap from the accent in every direction, and dialed back overall vividness to stay ambient rather than loud.",
         zh: "修复:黎明/黄昏的暖橙色调和唯一保留给追踪目标的橙色强调色挨得太近——生产环境里把所有飞机和标签都染成了本该用来突出重点的那个橙色。换成一套天空色调色板(黎明淡粉、白天青色、黄昏紫罗兰、夜晚蓝),在各个方向都和强调色保持足够色相距离,整体饱和度也调低,保持氛围感而不刺眼。",
       },
+      {
+        en: "The atmosphere now extends past the aircraft to the map itself: a soft colour wash over the base imagery (same sky-colour palette, well clear of the orange accent) so the whole view — not just the tiny glyphs — reads as dawn, day, dusk, or night. It sits below every label, badge, and aircraft, so nothing legible gets tinted.",
+        zh: "氛围感现在从飞机延伸到了地图本身:在底图之上叠加一层柔和色调遮罩(同一套天空色板,与橙色强调色保持距离),让整个视野——而不只是飞机小图标——读出黎明、白天、黄昏或夜晚的感觉。这层遮罩位于所有标签、徽标和飞机之下,不会染到任何需要看清的内容。",
+      },
+      {
+        en: "The aircraft's highlight/shadow gradient now also carries time-of-day colour instead of plain white/black — warm gold highlight with a cool violet shadow at dawn/dusk, cool blue-white at night, neutral at midday — so it reads more like real light (golden hour, moonlight) instead of a colourless sheen.",
+        zh: "飞机的高光/阴影渐变现在也带上了对应时间的色彩,不再是单纯的黑白——黎明/黄昏是暖金高光配冷紫阴影,夜晚是冷蓝白,正午则保持中性——让光影观感更接近真实光照(黄金时刻、月光),而不是一层无色的浮光。",
+      },
     ],
   },
 ];

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -98,6 +98,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "The aircraft's highlight/shadow gradient now also carries time-of-day colour instead of plain white/black — warm gold highlight with a cool violet shadow at dawn/dusk, cool blue-white at night, neutral at midday — so it reads more like real light (golden hour, moonlight) instead of a colourless sheen.",
         zh: "飞机的高光/阴影渐变现在也带上了对应时间的色彩,不再是单纯的黑白——黎明/黄昏是暖金高光配冷紫阴影,夜晚是冷蓝白,正午则保持中性——让光影观感更接近真实光照(黄金时刻、月光),而不是一层无色的浮光。",
       },
+      {
+        en: "The sidebar's map-facing border and the floating toolbar's existing glow now pick up a faint hint of the same ambiance too, so the effect doesn't stop dead at the map's edge — both stay a background-only accent well behind the text and icons, so nothing gets harder to read.",
+        zh: "侧栏朝向地图那一侧的边框、以及浮动工具栏本身的既有光晕,现在也会带上一点同样的氛围色调,让效果不会在地图边缘戛然而止——两处都只是文字和图标背后的一层背景点缀,不会影响任何内容的可读性。",
+      },
     ],
   },
 ];

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -103,8 +103,16 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         zh: "侧栏朝向地图那一侧的边框、以及浮动工具栏本身的既有光晕,现在也会带上一点同样的氛围色调,让效果不会在地图边缘戛然而止——两处都只是文字和图标背后的一层背景点缀,不会影响任何内容的可读性。",
       },
       {
-        en: "The sidebar and toolbar's own surface now blends in a stronger hint of the same weather/time colour too, not just their edge — and a new \"Sidebar & toolbar colour\" setting (Map settings) lets you pick Weather & time (default) or plain Theme colour if you'd rather the chrome stay static.",
-        zh: "侧栏和工具栏本身的底色现在也会融入更明显一点的同款天气/时间色调,不再只是边缘——地图设置里新增了「侧栏与工具栏配色」选项,可以选择「天气与时间」(默认)或「主题色」,想要界面保持纯色不变也可以。",
+        en: "The sidebar and toolbar's own surface now blends in a stronger hint of the same weather/time colour too, not just their edge.",
+        zh: "侧栏和工具栏本身的底色现在也会融入更明显一点的同款天气/时间色调,不再只是边缘。",
+      },
+      {
+        en: "Fixed: time of day was read from the viewer's own device clock, so an airport on the other side of the world could render \"night\" colours just because the viewer's own local clock said so. Now derived from the airport's longitude instead, independent of who's looking at it or from where.",
+        zh: "修复:时间氛围之前读取的是查看者自己设备的时钟,导致地球另一端的机场可能仅仅因为查看者本地是晚上,就被染成「夜间」色调。现在改为根据机场自身经度推算当地时间,不再受查看者所在地影响。",
+      },
+      {
+        en: "New \"Ambient colour\" setting (Map settings): Weather & time (default) ties the map wash, aircraft tint, sidebar, and toolbar together into one coordinated look; Theme colour turns all of it off at once, back to the plain pre-ambient appearance — no mixed half-tinted state either way.",
+        zh: "新增「氛围配色」设置(地图设置):「天气与时间」(默认)把地图遮罩、飞机色调、侧栏和工具栏统一成一套联动的观感;「主题色」则一次性全部关闭,回到氛围功能之前的朴素外观——不会出现两种状态混杂的中间态。",
       },
     ],
   },

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 67;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v3.2.3",
+    version: "v3.2.4",
     kind: "feat",
     title: {
       en: "Aircraft blend into the weather and light",
@@ -85,6 +85,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "The ambient tint got a lot more visible, and gained a time-of-day dimension: hue now shifts through the day — warm amber at dawn, neutral at midday, warm amber-red at dusk, cool blue at night — layered with the weather mood (which now sets vividness/dimness instead of hue alone). The first pass was too subtle to read at 20px; this one is a clear, deliberate colour, confirmed visible at real map scale.",
         zh: "氛围色调的辨识度大幅提升,并新增了时间维度:色相随一天时间变化——黎明暖橙、正午中性、黄昏暖橙红、夜晚冷蓝——与天气 mood(现在决定鲜艳度/暗淡度,而不再单独决定色相)有机叠加。第一版在 20px 图标上太细微看不出来;这一版是明确、刻意的颜色,已在真实地图比例下确认可见。",
+      },
+      {
+        en: "Fixed: dawn/dusk's warm amber hues sat right next to the single orange accent reserved for the tracked target — in production this painted every aircraft and label the same orange as the one thing meant to stand out. Replaced with a sky-colour palette (dawn blush, daytime cyan, twilight violet, night blue) that keeps a wide hue gap from the accent in every direction, and dialed back overall vividness to stay ambient rather than loud.",
+        zh: "修复:黎明/黄昏的暖橙色调和唯一保留给追踪目标的橙色强调色挨得太近——生产环境里把所有飞机和标签都染成了本该用来突出重点的那个橙色。换成一套天空色调色板(黎明淡粉、白天青色、黄昏紫罗兰、夜晚蓝),在各个方向都和强调色保持足够色相距离,整体饱和度也调低,保持氛围感而不刺眼。",
       },
     ],
   },

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -102,6 +102,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
         en: "The sidebar's map-facing border and the floating toolbar's existing glow now pick up a faint hint of the same ambiance too, so the effect doesn't stop dead at the map's edge — both stay a background-only accent well behind the text and icons, so nothing gets harder to read.",
         zh: "侧栏朝向地图那一侧的边框、以及浮动工具栏本身的既有光晕,现在也会带上一点同样的氛围色调,让效果不会在地图边缘戛然而止——两处都只是文字和图标背后的一层背景点缀,不会影响任何内容的可读性。",
       },
+      {
+        en: "The sidebar and toolbar's own surface now blends in a stronger hint of the same weather/time colour too, not just their edge — and a new \"Sidebar & toolbar colour\" setting (Map settings) lets you pick Weather & time (default) or plain Theme colour if you'd rather the chrome stay static.",
+        zh: "侧栏和工具栏本身的底色现在也会融入更明显一点的同款天气/时间色调,不再只是边缘——地图设置里新增了「侧栏与工具栏配色」选项,可以选择「天气与时间」(默认)或「主题色」,想要界面保持纯色不变也可以。",
+      },
     ],
   },
 ];

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -689,7 +689,7 @@ const en = {
     title: "Map settings",
     description: "Fine-tune the layers shown on this airport map.",
     baseMapSection: "Base map",
-    chromeAmbientSection: "Sidebar & toolbar colour",
+    ambientSection: "Ambient colour",
     layersSection: "Display",
     unitsSection: "Units",
     notificationsSection: "Notifications",
@@ -725,13 +725,13 @@ const en = {
       standard: "Clean street map with no terrain shading.",
       terrain: "Hillshade and topographic relief under the base map.",
     },
-    chromeAmbient: {
+    ambient: {
       ambient: "Weather & time",
       theme: "Theme colour",
     },
-    chromeAmbientDescriptions: {
-      ambient: "Sidebar and toolbar pick up a hint of the airport's current weather and time of day.",
-      theme: "Sidebar and toolbar stay a plain, static colour.",
+    ambientDescriptions: {
+      ambient: "The map, aircraft, sidebar, and toolbar all pick up a hint of the airport's current weather and local time of day.",
+      theme: "The map, aircraft, sidebar, and toolbar stay a plain, static colour.",
     },
   },
   notifications: {

--- a/src/config/i18n/en.ts
+++ b/src/config/i18n/en.ts
@@ -689,6 +689,7 @@ const en = {
     title: "Map settings",
     description: "Fine-tune the layers shown on this airport map.",
     baseMapSection: "Base map",
+    chromeAmbientSection: "Sidebar & toolbar colour",
     layersSection: "Display",
     unitsSection: "Units",
     notificationsSection: "Notifications",
@@ -723,6 +724,14 @@ const en = {
     baseLayerDescriptions: {
       standard: "Clean street map with no terrain shading.",
       terrain: "Hillshade and topographic relief under the base map.",
+    },
+    chromeAmbient: {
+      ambient: "Weather & time",
+      theme: "Theme colour",
+    },
+    chromeAmbientDescriptions: {
+      ambient: "Sidebar and toolbar pick up a hint of the airport's current weather and time of day.",
+      theme: "Sidebar and toolbar stay a plain, static colour.",
     },
   },
   notifications: {

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -679,7 +679,7 @@ const zhCN = {
     title: "地图设置",
     description: "微调这个机场地图显示的图层。",
     baseMapSection: "底图",
-    chromeAmbientSection: "侧栏与工具栏配色",
+    ambientSection: "氛围配色",
     layersSection: "显示",
     unitsSection: "单位",
     notificationsSection: "通知",
@@ -715,13 +715,13 @@ const zhCN = {
       standard: "干净的街道底图,无地形渲染。",
       terrain: "在底图下方叠加山体阴影和地势起伏。",
     },
-    chromeAmbient: {
+    ambient: {
       ambient: "天气与时间",
       theme: "主题色",
     },
-    chromeAmbientDescriptions: {
-      ambient: "侧栏和工具栏会带上一点当前机场天气与时间的色调。",
-      theme: "侧栏和工具栏保持纯色主题,不随天气/时间变化。",
+    ambientDescriptions: {
+      ambient: "地图、飞机、侧栏和工具栏都会带上一点机场当地天气与时间的色调。",
+      theme: "地图、飞机、侧栏和工具栏保持纯色主题,不随天气/时间变化。",
     },
   },
   notifications: {

--- a/src/config/i18n/zh-CN.ts
+++ b/src/config/i18n/zh-CN.ts
@@ -679,6 +679,7 @@ const zhCN = {
     title: "地图设置",
     description: "微调这个机场地图显示的图层。",
     baseMapSection: "底图",
+    chromeAmbientSection: "侧栏与工具栏配色",
     layersSection: "显示",
     unitsSection: "单位",
     notificationsSection: "通知",
@@ -713,6 +714,14 @@ const zhCN = {
     baseLayerDescriptions: {
       standard: "干净的街道底图,无地形渲染。",
       terrain: "在底图下方叠加山体阴影和地势起伏。",
+    },
+    chromeAmbient: {
+      ambient: "天气与时间",
+      theme: "主题色",
+    },
+    chromeAmbientDescriptions: {
+      ambient: "侧栏和工具栏会带上一点当前机场天气与时间的色调。",
+      theme: "侧栏和工具栏保持纯色主题,不随天气/时间变化。",
     },
   },
   notifications: {

--- a/src/features/aircraft/canvas/aircraftAmbientModel.test.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.test.ts
@@ -9,8 +9,12 @@ import {
   simplifiedLightBearingDeg,
 } from "./aircraftAmbientModel";
 
+// UTC-based construction (not the local-time Date constructor) so these
+// tests are deterministic regardless of the machine's own timezone — the
+// whole point of resolveLocalHour is to derive time from longitude instead
+// of the runtime's local clock.
 const dateMs = (hour: number, minute = 0) =>
-  new Date(2026, 0, 15, hour, minute, 0, 0).getTime();
+  Date.UTC(2026, 0, 15, hour, minute, 0, 0);
 
 // --- resolveWeatherMood ----------------------------------------------------
 
@@ -58,6 +62,30 @@ const dateMs = (hour: number, minute = 0) =>
   assert.equal(resolveTimeOfDayBucket(dateMs(19, 59)), "dusk");
   assert.equal(resolveTimeOfDayBucket(dateMs(20)), "night");
   assert.equal(resolveTimeOfDayBucket(dateMs(23, 59)), "night");
+}
+
+// --- longitude-derived local time (the actual bug fix) ---------------------
+// Time-of-day must follow the LOCATION (via longitude), not the machine
+// running the code. UTC 00:00 is night at lon=0, but broad daylight on the
+// other side of the world — the exact bug a device-local clock would get
+// wrong for an airport far from the viewer.
+
+{
+  const utcMidnight = dateMs(0);
+  assert.equal(resolveTimeOfDayBucket(utcMidnight, 0), "night");
+  // lon=150 (~East Asia, UTC+10): local hour = 0 + 10 = 10 -> day.
+  assert.equal(resolveTimeOfDayBucket(utcMidnight, 150), "day");
+  // lon=-120 (~US Pacific, UTC-8): local hour = 0 - 8 = 16 -> day.
+  assert.equal(resolveTimeOfDayBucket(utcMidnight, -120), "day");
+
+  const utcNoon = dateMs(12);
+  assert.equal(resolveTimeOfDayBucket(utcNoon, 0), "day");
+  // lon=180: local hour = 12 + 12 = 24 -> wraps to 0 -> night.
+  assert.equal(resolveTimeOfDayBucket(utcNoon, 180), "night");
+
+  assert.equal(simplifiedLightBearingDeg(utcMidnight, 0), 90, "clamped before dawn at lon 0");
+  // lon=150: local hour 10 (mid-morning) -> partway from dawn (90) to dusk (270).
+  assert.equal(simplifiedLightBearingDeg(utcMidnight, 150), 150, "local mid-morning at lon 150");
 }
 
 // --- relativeLightAngleDeg + lightBucketForRelativeAngle -------------------

--- a/src/features/aircraft/canvas/aircraftAmbientModel.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.ts
@@ -5,9 +5,22 @@
 // mapping and hysteresis math are unit-testable without a browser.
 //
 // This is a distinct, narrower thing than a real day/night terminator: the
-// light bearing here is a linear East->West sweep over the browser's local
+// light bearing here is a linear East->West sweep over the LOCATION's local
 // clock, not a solar-position calculation. That's an explicit, user-approved
 // simplification for this ambient glyph-shading effect only.
+//
+// "Location's local clock" — not the browser's. Every time-of-day input here
+// takes a longitude and derives local time from UTC + a coarse 15deg-per-hour
+// offset (no timezone/DST database, another deliberate simplification). Using
+// the viewer's own device timezone was a real bug: an airport on the other
+// side of the world would render "night" colours just because the viewer's
+// clock said so, regardless of what time it actually was there.
+function resolveLocalHour(nowMs: number, lonDeg: number): number {
+  const date = new Date(nowMs);
+  const utcHour = date.getUTCHours() + date.getUTCMinutes() / 60;
+  const offsetHours = lonDeg / 15;
+  return (((utcHour + offsetHours) % 24) + 24) % 24;
+}
 
 export type WeatherMood = "clear" | "overcast" | "severe";
 
@@ -39,14 +52,14 @@ const DAWN_BEARING_DEG = 90;
 const DUSK_BEARING_DEG = 270;
 
 // Simplified light source bearing: sweeps linearly from due-east at dawn to
-// due-west at dusk using the browser's local clock, clamping outside that
-// window. Not solar-accurate (no latitude/season/declination) — that
-// precision belongs to a real day/night terminator overlay, a separate,
-// deferred feature. This is intentionally just "does the sun feel like it's
-// behind me or ahead of me right now".
-export function simplifiedLightBearingDeg(nowMs: number): number {
-  const date = new Date(nowMs);
-  const hour = date.getHours() + date.getMinutes() / 60;
+// due-west at dusk using the LOCATION's local clock (derived from longitude —
+// see resolveLocalHour above), clamping outside that window. Not
+// solar-accurate (no latitude/season/declination) — that precision belongs
+// to a real day/night terminator overlay, a separate, deferred feature. This
+// is intentionally just "does the sun feel like it's behind me or ahead of
+// me right now, at this location".
+export function simplifiedLightBearingDeg(nowMs: number, lonDeg = 0): number {
+  const hour = resolveLocalHour(nowMs, lonDeg);
   if (hour <= DAWN_HOUR) return DAWN_BEARING_DEG;
   if (hour >= DUSK_HOUR) return DUSK_BEARING_DEG;
   const t = (hour - DAWN_HOUR) / (DUSK_HOUR - DAWN_HOUR);
@@ -59,9 +72,9 @@ export type TimeOfDay = "dawn" | "day" | "dusk" | "night";
 // the light-direction bearing above (that one drives the highlight/shadow
 // mask; this one drives hue, so aircraft actually read as "morning gold" /
 // "midday neutral" / "sunset amber" / "night blue" at a glance, layered with
-// the weather mood in AircraftCanvasLayer's colour table). Local clock hours,
-// same simplification stance as simplifiedLightBearingDeg — not tied to
-// actual sunrise/sunset for the map's location.
+// the weather mood in AircraftCanvasLayer's colour table). Location-local
+// hours (see resolveLocalHour), same simplification stance as
+// simplifiedLightBearingDeg — not tied to actual sunrise/sunset times.
 const TIME_OF_DAY_BOUNDARIES: Array<[number, TimeOfDay]> = [
   [5, "night"],
   [8, "dawn"],
@@ -70,9 +83,8 @@ const TIME_OF_DAY_BOUNDARIES: Array<[number, TimeOfDay]> = [
   [24, "night"],
 ];
 
-export function resolveTimeOfDayBucket(nowMs: number): TimeOfDay {
-  const date = new Date(nowMs);
-  const hour = date.getHours() + date.getMinutes() / 60;
+export function resolveTimeOfDayBucket(nowMs: number, lonDeg = 0): TimeOfDay {
+  const hour = resolveLocalHour(nowMs, lonDeg);
   for (const [beforeHour, bucket] of TIME_OF_DAY_BOUNDARIES) {
     if (hour < beforeHour) return bucket;
   }

--- a/src/features/aircraft/canvas/aircraftAmbientModel.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.ts
@@ -201,6 +201,23 @@ export function resolveAmbientChromeEdgeColor(
   return `oklch(${lightness} ${chroma} ${hue} / ${alpha})`;
 }
 
+// Chrome surface tint: an opaque colour meant to be `color-mix()`ed into the
+// toolbar/sidebar's own surface token at a modest, fixed percentage (the
+// call site controls "how much", this controls "which colour") — a
+// stronger, more literal reading of "match the map's colour" than the edge
+// accent above, which only glows at the rim. Deliberately reuses the map
+// wash's own tuning (resolveAmbientOverlayColor) rather than a third table:
+// it's already a theme-aware, mood-scaled tint built for blending OVER a
+// surface, which is exactly this job too — same "sky colour" family reads
+// as one coordinated system instead of the chrome inventing its own look.
+export function resolveAmbientChromeSurfaceTint(
+  mood: WeatherMood,
+  timeOfDay: TimeOfDay,
+  dark: boolean,
+): string {
+  return resolveAmbientOverlayColor(mood, timeOfDay, dark).color;
+}
+
 function normalizeDeg(deg: number): number {
   return ((deg % 360) + 360) % 360;
 }

--- a/src/features/aircraft/canvas/aircraftAmbientModel.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.ts
@@ -155,6 +155,52 @@ export function resolveAmbientOverlayColor(
   };
 }
 
+// Chrome edge accent: feeds the existing --app-floating-edge-shadow token
+// (Toolbar.tsx's map-kit halo) and a matching sidebar-edge glow, so the
+// floating toolbar and the sidebar's map-facing border pick up a hint of
+// the same ambiance. This is deliberately the most restrained consumer of
+// the hue table — it sits as a low-lightness "coloured shadow" behind
+// chrome that already has to stay legible, not a wash over content. Both
+// call sites additionally apply their own ~45% opacity multiplier on top
+// (matching the existing toolbar halo), so the effective alpha ends up
+// noticeably fainter than the numbers below alone suggest.
+const CHROME_EDGE_CHROMA: Record<WeatherMood, number> = {
+  clear: 0.07,
+  overcast: 0.045,
+  severe: 0.025,
+};
+const CHROME_EDGE_LIGHTNESS: Record<WeatherMood, number> = {
+  clear: 0.32,
+  overcast: 0.26,
+  severe: 0.2,
+};
+// Dark theme reads a colour glow at a similar strength to its pre-existing
+// near-black halo (32% alpha); light theme stays as subtle as its
+// pre-existing near-black shadow (7.5% alpha) — a colour cast that loud
+// against a light background would compete with legibility.
+const CHROME_EDGE_ALPHA_DARK: Record<WeatherMood, number> = {
+  clear: 0.3,
+  overcast: 0.36,
+  severe: 0.42,
+};
+const CHROME_EDGE_ALPHA_LIGHT: Record<WeatherMood, number> = {
+  clear: 0.12,
+  overcast: 0.16,
+  severe: 0.2,
+};
+
+export function resolveAmbientChromeEdgeColor(
+  mood: WeatherMood,
+  timeOfDay: TimeOfDay,
+  dark: boolean,
+): string {
+  const hue = TIME_OF_DAY_HUE[timeOfDay];
+  const chroma = CHROME_EDGE_CHROMA[mood];
+  const lightness = CHROME_EDGE_LIGHTNESS[mood];
+  const alpha = dark ? CHROME_EDGE_ALPHA_DARK[mood] : CHROME_EDGE_ALPHA_LIGHT[mood];
+  return `oklch(${lightness} ${chroma} ${hue} / ${alpha})`;
+}
+
 function normalizeDeg(deg: number): number {
   return ((deg % 360) + 360) % 360;
 }

--- a/src/features/aircraft/canvas/aircraftAmbientModel.ts
+++ b/src/features/aircraft/canvas/aircraftAmbientModel.ts
@@ -79,6 +79,82 @@ export function resolveTimeOfDayBucket(nowMs: number): TimeOfDay {
   return "night";
 }
 
+// Shared hue-per-time-of-day table for every ambient colour derived from
+// TimeOfDay (aircraft rest colour AND the map-level wash below) so both read
+// as the same "sky colour" progression instead of two uncoordinated palettes.
+//
+// Hue MUST stay clear of --atc-signal-accent (oklch(0.66 0.16 50), the single
+// reserved orange for focal/tracked targets) — an earlier pass used warm hues
+// near 35-55 for dawn/dusk and, in production, painted the ENTIRE map (every
+// aircraft + label) the same orange as the one thing that's supposed to stand
+// out, destroying the whole "one accent colour" hierarchy. This palette keeps
+// a >=60deg hue gap from 50 in every direction: dawn blush -> daytime cyan ->
+// twilight violet -> night blue.
+export const TIME_OF_DAY_HUE: Record<TimeOfDay, number> = {
+  dawn: 350, // soft rose/blush sunrise sky
+  day: 180, // cool daytime cyan-sky
+  dusk: 290, // twilight violet
+  night: 240, // night blue
+};
+
+// Map-level ambient wash: a colour tint over the base map imagery only (see
+// AmbientWashLayer.tsx — it renders in a pane just above the tile layer and
+// below every annotation/aircraft pane), so the whole viewport picks up the
+// same time-of-day/weather atmosphere instead of leaving it confined to the
+// tiny aircraft glyphs. A first pass here used much lower chroma/alpha on the
+// theory that a full-viewport wash needs less than a 20px glyph — verified by
+// compositing over a representative terrain colour, that came out within a
+// few RGB units across every combination and read as flatly invisible, the
+// same mistake the aircraft tint made before ITS chroma got raised. These
+// values are tuned so adjacent combinations differ by double-digit RGB units
+// once composited (checked numerically, not just by eye), while staying a
+// wash rather than a solid colour cast — severe weather still tops out well
+// under 50% alpha.
+const OVERLAY_MOOD_CHROMA: Record<WeatherMood, number> = {
+  clear: 0.09,
+  overcast: 0.06,
+  severe: 0.035,
+};
+const OVERLAY_LIGHTNESS_DARK: Record<WeatherMood, number> = {
+  clear: 0.36,
+  overcast: 0.3,
+  severe: 0.24,
+};
+const OVERLAY_LIGHTNESS_LIGHT: Record<WeatherMood, number> = {
+  clear: 0.86,
+  overcast: 0.8,
+  severe: 0.72,
+};
+// Overcast/severe read as heavier (more atmosphere-in-the-way), not just a
+// hue change — mirrors how the aircraft mood chroma already dims for worse
+// weather, applied here as opacity since this wash's chroma stays modest.
+const OVERLAY_MOOD_ALPHA: Record<WeatherMood, number> = {
+  clear: 0.24,
+  overcast: 0.32,
+  severe: 0.42,
+};
+
+export interface AmbientOverlayColor {
+  /** Opaque oklch() colour string — pass as fillColor, not as a CSS background alone. */
+  color: string;
+  /** Separate 0-1 alpha — kept apart from `color` so callers can't accidentally double-apply alpha. */
+  opacity: number;
+}
+
+export function resolveAmbientOverlayColor(
+  mood: WeatherMood,
+  timeOfDay: TimeOfDay,
+  dark: boolean,
+): AmbientOverlayColor {
+  const hue = TIME_OF_DAY_HUE[timeOfDay];
+  const chroma = OVERLAY_MOOD_CHROMA[mood];
+  const lightness = dark ? OVERLAY_LIGHTNESS_DARK[mood] : OVERLAY_LIGHTNESS_LIGHT[mood];
+  return {
+    color: `oklch(${lightness} ${chroma} ${hue})`,
+    opacity: OVERLAY_MOOD_ALPHA[mood],
+  };
+}
+
 function normalizeDeg(deg: number): number {
   return ((deg % 360) + 360) % 360;
 }

--- a/src/features/aircraft/canvas/aircraftCanvasDraw.ts
+++ b/src/features/aircraft/canvas/aircraftCanvasDraw.ts
@@ -12,6 +12,7 @@
 // above — it doesn't change the glyph's shape, rotation, or the "flat" spec.
 
 import type { AircraftDrawDescriptor } from "./aircraftCanvasModel";
+import type { TimeOfDay } from "./aircraftAmbientModel";
 import { getAircraftSprite } from "./aircraftSpriteCache";
 import { getLightMask } from "./aircraftLightMask";
 
@@ -72,9 +73,10 @@ function applyLightMask(
   ctx: CanvasRenderingContext2D,
   lightBucket: number | null | undefined,
   sizePx: number,
+  timeOfDay: TimeOfDay,
 ) {
   if (lightBucket == null) return;
-  const mask = getLightMask(lightBucket);
+  const mask = getLightMask(lightBucket, timeOfDay);
   if (!mask) return;
   ctx.save();
   ctx.globalCompositeOperation = "source-atop";
@@ -92,6 +94,7 @@ export function drawAircraftGlyph(
   palette: AircraftCanvasPalette,
   dpr: number,
   lightBucket: number | null = null,
+  timeOfDay: TimeOfDay = "day",
 ) {
   const color = colorFor(d, palette);
   ctx.save();
@@ -127,7 +130,7 @@ export function drawAircraftGlyph(
     // Sprite already carries the baked drop-shadow — plain drawImage, no shadow.
     const s = sprite.sizeCss * scale;
     ctx.drawImage(sprite.canvas, -s / 2, -s / 2, s, s);
-    applyLightMask(ctx, lightBucket, s);
+    applyLightMask(ctx, lightBucket, s, timeOfDay);
   } else {
     // Arrow fallback (no silhouette, or sprite still loading). Gets the same
     // ambient mask so there's no flat-colour -> gradient pop the moment the
@@ -141,7 +144,7 @@ export function drawAircraftGlyph(
     // state applies to any subsequent draw, and would otherwise blur-shadow
     // the mask rectangle itself).
     ctx.shadowBlur = 0;
-    applyLightMask(ctx, lightBucket, AIRCRAFT_GLYPH_BASE_PX * scale);
+    applyLightMask(ctx, lightBucket, AIRCRAFT_GLYPH_BASE_PX * scale, timeOfDay);
   }
   ctx.restore();
 }

--- a/src/features/aircraft/canvas/aircraftLightMask.ts
+++ b/src/features/aircraft/canvas/aircraftLightMask.ts
@@ -2,24 +2,45 @@
 //
 // Unlike aircraftSpriteCache.ts (keyed by icon/colour/size/dpr, one bake per
 // visually-distinct aircraft), these masks depend on NOTHING but the light
-// bucket (0-3: front/right/back/left) — there are only ever 4 of them, baked
-// once on first use and kept forever. They are composited on top of an
-// already-drawn glyph with `source-atop`, so the gradient is clipped to
-// whatever was just drawn without needing to know the aircraft's silhouette
-// shape at all.
+// bucket (0-3: front/right/back/left) and the time-of-day colour temperature
+// (4 buckets) — there are only ever 16 of them, baked once on first use and
+// kept forever. They are composited on top of an already-drawn glyph with
+// `source-atop`, so the gradient is clipped to whatever was just drawn
+// without needing to know the aircraft's silhouette shape at all.
 //
 // Direction convention: the mask is drawn AFTER the canvas has already been
 // translated to the aircraft's centre and rotated by its heading, so "up"
 // (-Y) is the nose. Bucket angle 0 = light from the nose, 90 = from the
 // right, 180 = from the tail, 270 = from the left.
+//
+// Highlight/shadow COLOUR (not just direction) now varies by time-of-day too
+// — the classic warm-highlight/cool-shadow look real daylight has at dawn/
+// dusk, a near-neutral look at midday, and a cool moonlit look at night.
+// This is layered on top of the separately-tinted base fill colour
+// (AircraftCanvasLayer's mood x time-of-day palette), not a replacement
+// for it.
+
+import type { TimeOfDay } from "./aircraftAmbientModel";
 
 const MASK_SIZE_PX = 48;
-const HIGHLIGHT_COLOR = "rgba(255,255,255,0.26)";
-const SHADOW_COLOR = "rgba(0,0,0,0.20)";
 
-const masks = new Map<number, HTMLCanvasElement>();
+const TIME_OF_DAY_MASK_COLORS: Record<
+  TimeOfDay,
+  { highlight: string; shadow: string }
+> = {
+  dawn: { highlight: "rgba(255,214,170,0.30)", shadow: "rgba(70,60,120,0.22)" },
+  day: { highlight: "rgba(255,255,255,0.26)", shadow: "rgba(0,0,0,0.20)" },
+  dusk: { highlight: "rgba(255,178,120,0.32)", shadow: "rgba(55,48,110,0.24)" },
+  night: { highlight: "rgba(190,210,255,0.22)", shadow: "rgba(5,5,25,0.30)" },
+};
 
-function buildLightMask(bucketAngleDeg: number): HTMLCanvasElement {
+const masks = new Map<string, HTMLCanvasElement>();
+
+function buildLightMask(
+  bucketAngleDeg: number,
+  highlightColor: string,
+  shadowColor: string,
+): HTMLCanvasElement {
   const canvas = document.createElement("canvas");
   canvas.width = MASK_SIZE_PX;
   canvas.height = MASK_SIZE_PX;
@@ -38,22 +59,28 @@ function buildLightMask(bucketAngleDeg: number): HTMLCanvasElement {
     center - dx * radius,
     center - dy * radius,
   );
-  gradient.addColorStop(0, HIGHLIGHT_COLOR);
+  gradient.addColorStop(0, highlightColor);
   gradient.addColorStop(0.5, "rgba(255,255,255,0)");
-  gradient.addColorStop(1, SHADOW_COLOR);
+  gradient.addColorStop(1, shadowColor);
 
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, MASK_SIZE_PX, MASK_SIZE_PX);
   return canvas;
 }
 
-/** Lazily bakes and caches the gradient mask for a light bucket (0-3). */
-export function getLightMask(bucket: number, bucketCount = 4): HTMLCanvasElement | null {
+/** Lazily bakes and caches the gradient mask for a (light bucket, time-of-day) pair. */
+export function getLightMask(
+  bucket: number,
+  timeOfDay: TimeOfDay = "day",
+  bucketCount = 4,
+): HTMLCanvasElement | null {
   if (typeof document === "undefined") return null;
-  const cached = masks.get(bucket);
+  const key = `${bucket}:${timeOfDay}`;
+  const cached = masks.get(key);
   if (cached) return cached;
   const bucketAngleDeg = bucket * (360 / bucketCount);
-  const mask = buildLightMask(bucketAngleDeg);
-  masks.set(bucket, mask);
+  const colors = TIME_OF_DAY_MASK_COLORS[timeOfDay];
+  const mask = buildLightMask(bucketAngleDeg, colors.highlight, colors.shadow);
+  masks.set(key, mask);
   return mask;
 }

--- a/src/features/airport/map-settings/mapSettingsModel.test.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.test.ts
@@ -6,13 +6,13 @@ import {
   MAP_MODE_IDS,
   buildCustomMapSettings,
   buildMapSettingsFromLayerState,
-  buildMapSettingsWithChromeAmbientMode,
+  buildMapSettingsWithAmbientMode,
   getAlternateMapSettingsDevice,
-  getChromeAmbientModeOptions,
-  isKnownChromeAmbientMode,
+  getAmbientModeOptions,
+  isKnownAmbientMode,
   mapSettingsToExplorerLayers,
   mergeMapSettings,
-  normalizeChromeAmbientMode,
+  normalizeAmbientMode,
   normalizeMapSettings,
   normalizeMapSettingsDevice,
   resolveMapSettingsDeviceForClientDeviceProfile,
@@ -404,31 +404,31 @@ import {
 }
 
 {
-  assert.equal(isKnownChromeAmbientMode("theme"), true);
-  assert.equal(isKnownChromeAmbientMode("ambient"), true);
-  assert.equal(isKnownChromeAmbientMode("bogus"), false);
-  assert.equal(normalizeChromeAmbientMode("theme"), "theme");
+  assert.equal(isKnownAmbientMode("theme"), true);
+  assert.equal(isKnownAmbientMode("ambient"), true);
+  assert.equal(isKnownAmbientMode("bogus"), false);
+  assert.equal(normalizeAmbientMode("theme"), "theme");
   assert.equal(
-    normalizeChromeAmbientMode("bogus"),
+    normalizeAmbientMode("bogus"),
     "ambient",
     "unknown values fall back to the ambient default",
   );
   assert.equal(
-    normalizeMapSettings({}).chromeAmbientMode,
+    normalizeMapSettings({}).ambientMode,
     "ambient",
     "default settings should default to the ambient chrome mode",
   );
-  const optionIds = getChromeAmbientModeOptions().map((option) => option.id);
+  const optionIds = getAmbientModeOptions().map((option) => option.id);
   assert.deepEqual(optionIds.slice().sort(), ["ambient", "theme"]);
 }
 
 {
-  const withTheme = buildMapSettingsWithChromeAmbientMode({
+  const withTheme = buildMapSettingsWithAmbientMode({
     settings: normalizeMapSettings({}),
-    chromeAmbientMode: "theme",
+    ambientMode: "theme",
     now: "2026-07-06T12:00:00.000Z",
   });
-  assert.equal(withTheme.chromeAmbientMode, "theme");
+  assert.equal(withTheme.ambientMode, "theme");
   assert.equal(withTheme.updatedAt, "2026-07-06T12:00:00.000Z");
 
   const merged = mergeMapSettings({
@@ -436,7 +436,7 @@ import {
     updates: { layerOverrides: { [MAP_LAYER_KEYS.AIRSPACES]: true } },
   });
   assert.equal(
-    merged.chromeAmbientMode,
+    merged.ambientMode,
     "theme",
     "unrelated setting updates should preserve the chosen chrome ambient mode",
   );

--- a/src/features/airport/map-settings/mapSettingsModel.test.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.test.ts
@@ -6,9 +6,13 @@ import {
   MAP_MODE_IDS,
   buildCustomMapSettings,
   buildMapSettingsFromLayerState,
+  buildMapSettingsWithChromeAmbientMode,
   getAlternateMapSettingsDevice,
+  getChromeAmbientModeOptions,
+  isKnownChromeAmbientMode,
   mapSettingsToExplorerLayers,
   mergeMapSettings,
+  normalizeChromeAmbientMode,
   normalizeMapSettings,
   normalizeMapSettingsDevice,
   resolveMapSettingsDeviceForClientDeviceProfile,
@@ -396,6 +400,45 @@ import {
     first,
     layerChange,
     "real layer changes should still mark map settings dirty",
+  );
+}
+
+{
+  assert.equal(isKnownChromeAmbientMode("theme"), true);
+  assert.equal(isKnownChromeAmbientMode("ambient"), true);
+  assert.equal(isKnownChromeAmbientMode("bogus"), false);
+  assert.equal(normalizeChromeAmbientMode("theme"), "theme");
+  assert.equal(
+    normalizeChromeAmbientMode("bogus"),
+    "ambient",
+    "unknown values fall back to the ambient default",
+  );
+  assert.equal(
+    normalizeMapSettings({}).chromeAmbientMode,
+    "ambient",
+    "default settings should default to the ambient chrome mode",
+  );
+  const optionIds = getChromeAmbientModeOptions().map((option) => option.id);
+  assert.deepEqual(optionIds.slice().sort(), ["ambient", "theme"]);
+}
+
+{
+  const withTheme = buildMapSettingsWithChromeAmbientMode({
+    settings: normalizeMapSettings({}),
+    chromeAmbientMode: "theme",
+    now: "2026-07-06T12:00:00.000Z",
+  });
+  assert.equal(withTheme.chromeAmbientMode, "theme");
+  assert.equal(withTheme.updatedAt, "2026-07-06T12:00:00.000Z");
+
+  const merged = mergeMapSettings({
+    settings: withTheme,
+    updates: { layerOverrides: { [MAP_LAYER_KEYS.AIRSPACES]: true } },
+  });
+  assert.equal(
+    merged.chromeAmbientMode,
+    "theme",
+    "unrelated setting updates should preserve the chosen chrome ambient mode",
   );
 }
 

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -81,49 +81,50 @@ export function getMapBaseLayerOptions() {
   return MAP_BASE_LAYER_OPTIONS;
 }
 
-// Whether the sidebar + floating toolbar's colour follows the static theme
-// (the pre-ambient look) or picks up the current weather/time ambiance
-// (see aircraftAmbientModel.ts's chrome-tint resolvers). Scoped to just
-// those two surfaces — the map wash and aircraft tint are a separate,
-// always-on system this setting does not touch.
-const CHROME_AMBIENT_MODE_IDS = Object.freeze({
+// Whether the whole ambient system — map wash, aircraft weather/time tint +
+// light-mask colour, sidebar panel, and floating toolbar — follows the
+// static pre-ambient theme, or picks up the airport's current weather and
+// local time of day (see aircraftAmbientModel.ts's resolvers). One switch
+// for all of it, so the map never ends up in an inconsistent state (e.g. a
+// tinted map with plain aircraft).
+const AMBIENT_MODE_IDS = Object.freeze({
   THEME: "theme",
   AMBIENT: "ambient",
 });
 
-export const DEFAULT_CHROME_AMBIENT_MODE = CHROME_AMBIENT_MODE_IDS.AMBIENT;
+export const DEFAULT_AMBIENT_MODE = AMBIENT_MODE_IDS.AMBIENT;
 
-const CHROME_AMBIENT_MODE_OPTIONS = [
+const AMBIENT_MODE_OPTIONS = [
   {
-    id: CHROME_AMBIENT_MODE_IDS.AMBIENT,
-    labelKey: "mapSettings.chromeAmbient.ambient",
-    descriptionKey: "mapSettings.chromeAmbientDescriptions.ambient",
+    id: AMBIENT_MODE_IDS.AMBIENT,
+    labelKey: "mapSettings.ambient.ambient",
+    descriptionKey: "mapSettings.ambientDescriptions.ambient",
     iconKey: "sunMoon",
   },
   {
-    id: CHROME_AMBIENT_MODE_IDS.THEME,
-    labelKey: "mapSettings.chromeAmbient.theme",
-    descriptionKey: "mapSettings.chromeAmbientDescriptions.theme",
+    id: AMBIENT_MODE_IDS.THEME,
+    labelKey: "mapSettings.ambient.theme",
+    descriptionKey: "mapSettings.ambientDescriptions.theme",
     iconKey: "palette",
   },
 ] as const;
 
-const CHROME_AMBIENT_MODE_ID_SET: Set<string> = new Set(
-  Object.values(CHROME_AMBIENT_MODE_IDS),
+const AMBIENT_MODE_ID_SET: Set<string> = new Set(
+  Object.values(AMBIENT_MODE_IDS),
 );
 
-export function isKnownChromeAmbientMode(value: unknown) {
-  return typeof value === "string" && CHROME_AMBIENT_MODE_ID_SET.has(value);
+export function isKnownAmbientMode(value: unknown) {
+  return typeof value === "string" && AMBIENT_MODE_ID_SET.has(value);
 }
 
-export function normalizeChromeAmbientMode(value: unknown) {
-  return isKnownChromeAmbientMode(value)
+export function normalizeAmbientMode(value: unknown) {
+  return isKnownAmbientMode(value)
     ? (value as string)
-    : DEFAULT_CHROME_AMBIENT_MODE;
+    : DEFAULT_AMBIENT_MODE;
 }
 
-export function getChromeAmbientModeOptions() {
-  return CHROME_AMBIENT_MODE_OPTIONS;
+export function getAmbientModeOptions() {
+  return AMBIENT_MODE_OPTIONS;
 }
 
 export const DEFAULT_MAP_SETTINGS: MapSettingsRecord = Object.freeze({
@@ -131,7 +132,7 @@ export const DEFAULT_MAP_SETTINGS: MapSettingsRecord = Object.freeze({
   baseMode: MAP_MODE_IDS.CUSTOM,
   layerOverrides: Object.freeze({}),
   baseLayer: DEFAULT_MAP_BASE_LAYER,
-  chromeAmbientMode: DEFAULT_CHROME_AMBIENT_MODE,
+  ambientMode: DEFAULT_AMBIENT_MODE,
   audioEnabled: false,
   hasSelectedMode: false,
   updatedAt: "",
@@ -236,8 +237,8 @@ export function normalizeMapSettings(
     baseMode,
     layerOverrides: normalizeMapLayerOverrides(settings?.layerOverrides),
     baseLayer: normalizeMapBaseLayer(settings?.baseLayer ?? settings?.base_layer),
-    chromeAmbientMode: normalizeChromeAmbientMode(
-      settings?.chromeAmbientMode ?? settings?.chrome_ambient_mode,
+    ambientMode: normalizeAmbientMode(
+      settings?.ambientMode ?? settings?.ambient_mode,
     ),
     audioEnabled: settings?.audioEnabled === true,
     hasSelectedMode:
@@ -349,13 +350,13 @@ export function mergeMapSettings({
             updateRecord.baseLayer ?? updateRecord.base_layer,
           )
         : normalized.baseLayer,
-    chromeAmbientMode:
-      hasOwnSetting(updateRecord, "chromeAmbientMode") ||
-      hasOwnSetting(updateRecord, "chrome_ambient_mode")
-        ? normalizeChromeAmbientMode(
-            updateRecord.chromeAmbientMode ?? updateRecord.chrome_ambient_mode,
+    ambientMode:
+      hasOwnSetting(updateRecord, "ambientMode") ||
+      hasOwnSetting(updateRecord, "ambient_mode")
+        ? normalizeAmbientMode(
+            updateRecord.ambientMode ?? updateRecord.ambient_mode,
           )
-        : normalized.chromeAmbientMode,
+        : normalized.ambientMode,
     audioEnabled: hasOwnSetting(updateRecord, "audioEnabled")
       ? updateRecord.audioEnabled === true
       : normalized.audioEnabled,
@@ -390,15 +391,15 @@ export function buildMapSettingsWithBaseLayer({
 // Build a settings record with a swapped chrome ambient mode, preserving the
 // rest of the user's selections. Used by the Ambient chrome switcher in the
 // settings sheet.
-export function buildMapSettingsWithChromeAmbientMode({
+export function buildMapSettingsWithAmbientMode({
   settings = DEFAULT_MAP_SETTINGS,
-  chromeAmbientMode = DEFAULT_CHROME_AMBIENT_MODE,
+  ambientMode = DEFAULT_AMBIENT_MODE,
   now = new Date().toISOString(),
 }: MapSettingsOptions = {}) {
   return mergeMapSettings({
     settings,
     updates: {
-      chromeAmbientMode: normalizeChromeAmbientMode(chromeAmbientMode),
+      ambientMode: normalizeAmbientMode(ambientMode),
       updatedAt: now,
     },
   });

--- a/src/features/airport/map-settings/mapSettingsModel.ts
+++ b/src/features/airport/map-settings/mapSettingsModel.ts
@@ -81,11 +81,57 @@ export function getMapBaseLayerOptions() {
   return MAP_BASE_LAYER_OPTIONS;
 }
 
+// Whether the sidebar + floating toolbar's colour follows the static theme
+// (the pre-ambient look) or picks up the current weather/time ambiance
+// (see aircraftAmbientModel.ts's chrome-tint resolvers). Scoped to just
+// those two surfaces — the map wash and aircraft tint are a separate,
+// always-on system this setting does not touch.
+const CHROME_AMBIENT_MODE_IDS = Object.freeze({
+  THEME: "theme",
+  AMBIENT: "ambient",
+});
+
+export const DEFAULT_CHROME_AMBIENT_MODE = CHROME_AMBIENT_MODE_IDS.AMBIENT;
+
+const CHROME_AMBIENT_MODE_OPTIONS = [
+  {
+    id: CHROME_AMBIENT_MODE_IDS.AMBIENT,
+    labelKey: "mapSettings.chromeAmbient.ambient",
+    descriptionKey: "mapSettings.chromeAmbientDescriptions.ambient",
+    iconKey: "sunMoon",
+  },
+  {
+    id: CHROME_AMBIENT_MODE_IDS.THEME,
+    labelKey: "mapSettings.chromeAmbient.theme",
+    descriptionKey: "mapSettings.chromeAmbientDescriptions.theme",
+    iconKey: "palette",
+  },
+] as const;
+
+const CHROME_AMBIENT_MODE_ID_SET: Set<string> = new Set(
+  Object.values(CHROME_AMBIENT_MODE_IDS),
+);
+
+export function isKnownChromeAmbientMode(value: unknown) {
+  return typeof value === "string" && CHROME_AMBIENT_MODE_ID_SET.has(value);
+}
+
+export function normalizeChromeAmbientMode(value: unknown) {
+  return isKnownChromeAmbientMode(value)
+    ? (value as string)
+    : DEFAULT_CHROME_AMBIENT_MODE;
+}
+
+export function getChromeAmbientModeOptions() {
+  return CHROME_AMBIENT_MODE_OPTIONS;
+}
+
 export const DEFAULT_MAP_SETTINGS: MapSettingsRecord = Object.freeze({
   selectedMode: MAP_MODE_IDS.CUSTOM,
   baseMode: MAP_MODE_IDS.CUSTOM,
   layerOverrides: Object.freeze({}),
   baseLayer: DEFAULT_MAP_BASE_LAYER,
+  chromeAmbientMode: DEFAULT_CHROME_AMBIENT_MODE,
   audioEnabled: false,
   hasSelectedMode: false,
   updatedAt: "",
@@ -190,6 +236,9 @@ export function normalizeMapSettings(
     baseMode,
     layerOverrides: normalizeMapLayerOverrides(settings?.layerOverrides),
     baseLayer: normalizeMapBaseLayer(settings?.baseLayer ?? settings?.base_layer),
+    chromeAmbientMode: normalizeChromeAmbientMode(
+      settings?.chromeAmbientMode ?? settings?.chrome_ambient_mode,
+    ),
     audioEnabled: settings?.audioEnabled === true,
     hasSelectedMode:
       settings?.hasSelectedMode === true || settings?.has_selected_mode === true,
@@ -300,6 +349,13 @@ export function mergeMapSettings({
             updateRecord.baseLayer ?? updateRecord.base_layer,
           )
         : normalized.baseLayer,
+    chromeAmbientMode:
+      hasOwnSetting(updateRecord, "chromeAmbientMode") ||
+      hasOwnSetting(updateRecord, "chrome_ambient_mode")
+        ? normalizeChromeAmbientMode(
+            updateRecord.chromeAmbientMode ?? updateRecord.chrome_ambient_mode,
+          )
+        : normalized.chromeAmbientMode,
     audioEnabled: hasOwnSetting(updateRecord, "audioEnabled")
       ? updateRecord.audioEnabled === true
       : normalized.audioEnabled,
@@ -328,6 +384,23 @@ export function buildMapSettingsWithBaseLayer({
   return mergeMapSettings({
     settings,
     updates: { baseLayer: normalizeMapBaseLayer(baseLayer), updatedAt: now },
+  });
+}
+
+// Build a settings record with a swapped chrome ambient mode, preserving the
+// rest of the user's selections. Used by the Ambient chrome switcher in the
+// settings sheet.
+export function buildMapSettingsWithChromeAmbientMode({
+  settings = DEFAULT_MAP_SETTINGS,
+  chromeAmbientMode = DEFAULT_CHROME_AMBIENT_MODE,
+  now = new Date().toISOString(),
+}: MapSettingsOptions = {}) {
+  return mergeMapSettings({
+    settings,
+    updates: {
+      chromeAmbientMode: normalizeChromeAmbientMode(chromeAmbientMode),
+      updatedAt: now,
+    },
   });
 }
 

--- a/src/hooks/useSimplifiedLightBearing.ts
+++ b/src/hooks/useSimplifiedLightBearing.ts
@@ -7,10 +7,10 @@ import {
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
-function resolveAmbientTimeSignal(nowMs: number) {
+function resolveAmbientTimeSignal(nowMs: number, lonDeg: number) {
   return {
-    lightBearingDeg: simplifiedLightBearingDeg(nowMs),
-    timeOfDay: resolveTimeOfDayBucket(nowMs),
+    lightBearingDeg: simplifiedLightBearingDeg(nowMs, lonDeg),
+    timeOfDay: resolveTimeOfDayBucket(nowMs, lonDeg),
   };
 }
 
@@ -18,23 +18,32 @@ function resolveAmbientTimeSignal(nowMs: number) {
  * Tracks the two time-derived ambient signals the aircraft canvas layer
  * uses: the simplified (non-astronomical) light bearing for the highlight/
  * shadow mask, and the time-of-day colour-temperature bucket for the
- * weather-mood palette. Both only drift over hours, so one slow interval
- * refreshes them together — this deliberately does NOT hook into the
- * per-frame motion loop; a state update here just lets the next natural
- * redraw pick up the new values.
+ * weather-mood palette. Both are LOCATION-local (derived from `lonDeg`, not
+ * the viewer's own device clock — see aircraftAmbientModel's resolveLocalHour)
+ * so an airport the other side of the world doesn't render "night" colours
+ * just because the viewer's own clock says so.
+ *
+ * Both only drift over hours, so one slow interval refreshes them together —
+ * this deliberately does NOT hook into the per-frame motion loop; a state
+ * update here just lets the next natural redraw pick up the new values. A
+ * `lonDeg` change (e.g. navigating to a different airport) recomputes
+ * immediately rather than waiting for the next interval tick.
  */
-export function useSimplifiedLightBearing(): {
+export function useSimplifiedLightBearing(lonDeg = 0): {
   lightBearingDeg: number;
   timeOfDay: TimeOfDay;
 } {
-  const [signal, setSignal] = useState(() => resolveAmbientTimeSignal(Date.now()));
+  const [signal, setSignal] = useState(() =>
+    resolveAmbientTimeSignal(Date.now(), lonDeg),
+  );
 
   useEffect(() => {
+    setSignal(resolveAmbientTimeSignal(Date.now(), lonDeg));
     const timer = window.setInterval(() => {
-      setSignal(resolveAmbientTimeSignal(Date.now()));
+      setSignal(resolveAmbientTimeSignal(Date.now(), lonDeg));
     }, REFRESH_INTERVAL_MS);
     return () => window.clearInterval(timer);
-  }, []);
+  }, [lonDeg]);
 
   return signal;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -3809,13 +3809,20 @@ body {
        pinned exactly this as the scroll jank: GPU VizCompositorThread saturated
        + ~86% of frames dropped while the main thread sat ~87% idle. An opaque
        tint keeps the frosted material read with zero per-frame GPU cost. */
+    /* The base frost tint blends in a hint of --app-ambient-chrome-tint (set
+       by AirportExplorer's "Sidebar & toolbar colour" setting) so the panel
+       matches the floating toolbar's own ambient tint (Toolbar.tsx). The
+       self-referencing fallback (var(--app-ambient-chrome-tint,
+       var(--app-frost-tint))) makes this a no-op wherever the variable isn't
+       set — the "theme" setting, or pages that share this wrapper class but
+       never compute the tint (e.g. flight). */
     background:
         radial-gradient(
             120% 70% at 18% 0%,
             color-mix(in oklab, white 32%, transparent),
             transparent 46%
         ),
-        var(--app-frost-tint);
+        color-mix(in oklab, var(--app-ambient-chrome-tint, var(--app-frost-tint)) 16%, var(--app-frost-tint));
     border-right: 1px solid var(--app-frost-border);
     box-shadow:
         inset -1px 0 0 color-mix(in oklab, white 40%, transparent),
@@ -3871,11 +3878,15 @@ body {
         inset 0 1px 0 color-mix(in oklab, var(--atc-text) 12%, transparent),
         inset 0 0 0 1px color-mix(in oklab, var(--atc-text) 7%, transparent);
     /* Opaque dark frosted tint — NO backdrop-filter (see the light rule above:
-       a scrolling sidebar can't carry a live blur without GPU-compositor jank). */
+       a scrolling sidebar can't carry a live blur without GPU-compositor jank).
+       Each stop blends in --app-ambient-chrome-tint (see the light rule's
+       comment above for the self-referencing-fallback no-op mechanism); this
+       block hardcodes its own colours instead of --app-frost-tint, so the
+       fallback here is the literal stop colour rather than that token. */
     background: linear-gradient(
         180deg,
-        oklch(0.215 0.003 100),
-        oklch(0.135 0.003 100)
+        color-mix(in oklab, var(--app-ambient-chrome-tint, oklch(0.215 0.003 100)) 16%, oklch(0.215 0.003 100)),
+        color-mix(in oklab, var(--app-ambient-chrome-tint, oklch(0.135 0.003 100)) 16%, oklch(0.135 0.003 100))
     );
     border-right: 1px solid color-mix(in oklab, var(--atc-text) 9%, transparent);
     box-shadow:


### PR DESCRIPTION
## 做了什么

你截图指出的问题完全说中了要害:v3.2.3 的黎明(hue 55)/黄昏(hue 35)色相和 `--atc-signal-accent`(唯一保留给追踪/焦点目标的橙色,`oklch(0.66 0.16 50)`)只差 5-15°,生产环境黄昏时段整张地图的飞机 + 标签全部变成和"本该突出的那个橙色"一样的颜色,把"全局单一强调色"这条设计红线直接破了,看起来又乱又刺眼。

换成一套色相轮,确保和强调色(hue 50)在任意方向都保持 ≥60° 的距离:黎明淡粉(350)、白天青色(180)、黄昏紫罗兰(290)、夜晚蓝(240,不变)。同时把整体饱和度也调低了一档(clear 0.13→0.09、overcast 0.07→0.05、severe 0.035→0.025),让它读起来是"氛围"而不是"刺眼的一大片颜色"。

## Validation

- local test — `pnpm test` 130 文件全过;`changelog.test.ts` 版本同步;typecheck 无新增错误
- local browser — 做了两组验证:
  1. 色卡网格里加了一行**真实的追踪目标橙色**作为参照,和下面 12 种 mood×时段组合并排对比,确认现在清楚区分,不再混淆
  2. 真实 KBOS 地图(当前本地时间正好是黄昏时段)确认渲染出的是柔和的暮色紫,机场徽标和"NEAR"标签的橙色完全不受影响、依然醒目

Release: v3.2.4(patch,修正色相与强调色冲突的真实缺陷)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)