### PR TITLE
fix(dev): don't default FlightAware access on without a configured secret service

### DIFF
--- a/services/data-service/run-local.sh
+++ b/services/data-service/run-local.sh
@@ -45,8 +45,17 @@ done
 
 echo "starting adsbao-data-service on :$PORT (OPENAIP=$([ -n "${OPENAIP_API_KEY:-}" ] && echo set || echo MISSING), DB=$([ -n "${DATABASE_URL:-}" ] && echo set || echo MISSING))"
 
+# Only default INTERNAL_ACCESS_ENABLED on when a FlightAware secret-service URL
+# is actually configured. Defaulting it to true unconditionally used to make
+# /api/feature-flags report flightAwareEnabled: true with no secret service
+# behind it — the Go layer degrades gracefully (no crash), but the frontend
+# believes a path is available that structurally isn't. An explicit
+# INTERNAL_ACCESS_ENABLED / FLIGHTAWARE_ACCESS_ENABLED in .env.local still wins.
+DEFAULT_INTERNAL_ACCESS_ENABLED="false"
+[ -n "${FLIGHTAWARE_SERVICE_BASE_URL:-}" ] && DEFAULT_INTERNAL_ACCESS_ENABLED="true"
+
 cd "$SCRIPT_DIR"
 PORT="$PORT" \
-INTERNAL_ACCESS_ENABLED="${INTERNAL_ACCESS_ENABLED:-${FLIGHTAWARE_ACCESS_ENABLED:-true}}" \
+INTERNAL_ACCESS_ENABLED="${INTERNAL_ACCESS_ENABLED:-${FLIGHTAWARE_ACCESS_ENABLED:-$DEFAULT_INTERNAL_ACCESS_ENABLED}}" \
 ADSBAO_REALTIME_AUTH_SECRET="${ADSBAO_REALTIME_AUTH_SECRET:-local-dev-secret}" \
   exec go run ./cmd/adsbao-data-service


### PR DESCRIPTION
## Summary
- `run-local.sh` unconditionally defaulted `INTERNAL_ACCESS_ENABLED=true`, so `/api/feature-flags` reported `flightAwareEnabled: true` locally even with no `FLIGHTAWARE_SERVICE_BASE_URL` configured and the secret service not running.
- The Go layer already degrades gracefully in that state (no crash, clean fallbacks), but the frontend believed a path was available that structurally wasn't.
- Now the default only flips on when `FLIGHTAWARE_SERVICE_BASE_URL` is actually set. An explicit `INTERNAL_ACCESS_ENABLED` / `FLIGHTAWARE_ACCESS_ENABLED` in `.env.local` still wins.
- Also confirmed the classic local "502" symptom is a cold-start race: starting the frontend and data-service at the same moment leaves a ~2s window where Vite's proxy target isn't listening yet — not a code bug, just needs the data-service's `/health` to answer before hitting the frontend on a fresh restart.

## Test plan
- [x] Restarted data-service alone, confirmed `/api/feature-flags` now reports `flightAwareEnabled: false` with `.env.local` unchanged (no `FLIGHTAWARE_SERVICE_BASE_URL`).
- [x] Restarted frontend against it, loaded `/airport/KBOS` — no console errors, no 502s, weather/aircraft render normally on adsbdb.
- [x] `bash -n run-local.sh` syntax check.

Validation: local browser — checked http://localhost:3000/airport/KBOS after a sequenced (health-checked) restart of both services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)