### PR TITLE
fix(map): only label nearby airports with a real ICAO or IATA code (v3.2.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adsbao",
   "private": true,
-  "version": "3.2.5",
+  "version": "3.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config/changelog.ts
+++ b/src/config/changelog.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_TOTAL_COUNT = 67;
 
 export const CHANGELOG_RECENT: ChangelogEntry[] = [
   {
-    version: "v3.2.5",
+    version: "v3.2.6",
     kind: "feat",
     title: {
       en: "Aircraft blend into the weather and light",
@@ -117,6 +117,10 @@ export const CHANGELOG_RECENT: ChangelogEntry[] = [
       {
         en: "Turned up the vividness across the board after feedback that the colour difference and light-direction shading still weren't obvious enough at real map scale: the aircraft highlight/shadow gradient, the aircraft weather/time tint, and the map wash are all noticeably stronger now, verified pixel-by-pixel so it's a deliberate boost rather than a guess.",
         zh: "根据「颜色区别和光影还不够明显」的反馈,整体调高了鲜艳度:飞机的高光/阴影渐变、飞机的天气/时间色调、地图遮罩现在都明显更强了——逐像素核对过具体数值,不是凭感觉调的。",
+      },
+      {
+        en: "Decluttered the airport map: nearby fields carrying only an FAA local code (no ICAO and no IATA) — the \"6B6 / 8MA4 / NH14\"-style labels — are no longer drawn. Only airports with a real ICAO or IATA identifier get a badge now.",
+        zh: "地图机场标注瘦身:附近那些只有 FAA 本地码、既没有 ICAO 也没有 IATA 的小场(如「6B6 / 8MA4 / NH14」这类)不再标注,只有拥有真实 ICAO 或 IATA 代码的机场才显示徽标。",
       },
     ],
   },

--- a/src/features/airport/map/airportMapModel.test.ts
+++ b/src/features/airport/map/airportMapModel.test.ts
@@ -162,3 +162,16 @@ assert.deepEqual(
     showRunwayBadges: false,
   },
 );
+
+// FAA-local-code fields (no ICAO and no IATA) are dropped from the label layer,
+// while IATA-only and ICAO-only airports are kept.
+const mixedCodeAirports = [
+  { icao: "KBED", lat: 42.47, lon: -71.29 },
+  { icao: "", iata: "LWM", lat: 42.72, lon: -71.12 },
+  { icao: "", iata: "", code: "6B6", localCode: "6B6", lat: 42.46, lon: -71.52 },
+  { icao: "", iata: "", code: "NH14", localCode: "NH14", lat: 42.9, lon: -71.4 },
+];
+assert.deepEqual(
+  resolveNearbyAirportLayerDisplay({ nearbyAirports: mixedCodeAirports }).airports,
+  [mixedCodeAirports[0], mixedCodeAirports[1]],
+);

--- a/src/features/airport/map/airportMapModel.ts
+++ b/src/features/airport/map/airportMapModel.ts
@@ -1,4 +1,5 @@
 import { getDistanceNm } from "../../../utils/aircraftTrafficIntent";
+import { cleanAirportCode } from "../../../utils/airport";
 import { airportGroundTrafficHideRadiusNmForZoom } from "./airportMapZoomFeatures";
 
 type AirportMapCoordinate = {
@@ -64,10 +65,18 @@ export const getMapOverlayTheme = (theme: unknown) =>
         attributionColor: "var(--map-attribution)",
       };
 
+// Only label airports that carry a real ICAO or IATA code. OpenAIP also returns
+// small FAA-local-code fields (e.g. "NH14", "6B6", "8MA4") whose only identifier
+// is a local id; those clutter the map without being useful spotting targets.
+export const airportHasStandardCode = (airport: AirportMapCoordinate) =>
+  Boolean(cleanAirportCode(airport?.icao) || cleanAirportCode(airport?.iata));
+
 export const resolveNearbyAirportLayerDisplay = ({
   nearbyAirports = [],
 }: NearbyAirportLayerDisplayOptions = {}) => ({
-  airports: Array.isArray(nearbyAirports) ? nearbyAirports : [],
+  airports: (Array.isArray(nearbyAirports) ? nearbyAirports : []).filter(
+    airportHasStandardCode,
+  ),
   showAirportBadges: true,
   showRunwayBadges: false,
 });


### PR DESCRIPTION
## What

Nearby airports on the map were labelled even when they had **no ICAO and no IATA** — only an FAA local code. Around KBOS/60NM that meant 65 of 90 nearby "airports" showed up as `6B6 / 8MA4 / NH14 / 2B2 / 04MA`-style badges, cluttering the map.

## Why it happened

OpenAIP's nearby feed returns these local-only fields with `icaoCode` set to the literal string `"<NIL>"`, and the label helper `airportDisplayCode = icao || code || iata` falls back to `code` (which resolves to the local id). Neither the backend nor the frontend filtered on "has a real ICAO/IATA".

## Change

Filter the **nearby-airport label layer** in `resolveNearbyAirportLayerDisplay` to keep only airports whose `icao` or `iata` is a real code. Reuses `cleanAirportCode`, which already treats `<NIL>` / `NIL` / `NULL` as empty.

- Display-only: ground-traffic suppression still uses the full nearby list, so low/ground traffic near unlabelled fields stays hidden exactly as before.
- Around KBOS/60NM the labelled set drops from **90 → 25** (all real K-prefixed ICAO airports).

## Validation

- **Local test** — added a case to `airportMapModel.test.ts` (local-code fields dropped; ICAO-only and IATA-only kept); ran the file, passes.
- **Local browser** — KBOS airport map now shows only real ICAO airports (KMHT/KASH/KLWM/KBED/KBVY/KOWD/KGHG/KSFZ/KTAN/KPYM…), zero local-code labels. Verified the raw `/api/proxy/airports/nearby` response: 90 total, 25 with real ICAO/IATA, 65 local-only now hidden.

Version: patch bump `3.2.5 → 3.2.6` (package.json + changelog rolling entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)