### PR TITLE
fix(data-service): stop airport surface fallbacks after cancellation

### DIFF
--- a/services/data-service/internal/api/webapi/airport_surface.go
+++ b/services/data-service/internal/api/webapi/airport_surface.go
@@ -122,7 +122,7 @@ func (c *airportSurfaceCache) set(key string, payload map[string]any) {
 }
 
 func airportSurfaceContextDone(ctx context.Context) bool {
-	return ctx != nil && ctx.Err() != nil
+	return ctx != nil && ctx.Err() == context.Canceled
 }
 
 func (h *Handler) airportSurfaceMap(ctx context.Context, ident string, lat, lon float64, runwayMap map[string]any, scope string) map[string]any {

--- a/services/data-service/internal/api/webapi/airport_surface.go
+++ b/services/data-service/internal/api/webapi/airport_surface.go
@@ -26,11 +26,11 @@ const (
 	// the flat-bbox pavement query, so they get more headroom.
 	airportSurfaceStructuresRequestTimeout = 12 * time.Second
 	airportSurfaceOSMMapRequestTimeout     = 12 * time.Second
-	airportSurfaceBBoxPaddingMeters    = 400
-	airportSurfaceCenterRadiusMeters   = 1200
-	airportSurfaceFallbackRadiusMeters = 4500
-	maxAirportSurfaceFeatures          = 1400
-	maxAirportSurfaceBuildings         = 600
+	airportSurfaceBBoxPaddingMeters        = 400
+	airportSurfaceCenterRadiusMeters       = 1200
+	airportSurfaceFallbackRadiusMeters     = 4500
+	maxAirportSurfaceFeatures              = 1400
+	maxAirportSurfaceBuildings             = 600
 )
 
 const (
@@ -121,10 +121,14 @@ func (c *airportSurfaceCache) set(key string, payload map[string]any) {
 	}
 }
 
+func airportSurfaceContextDone(ctx context.Context) bool {
+	return ctx != nil && ctx.Err() != nil
+}
+
 func (h *Handler) airportSurfaceMap(ctx context.Context, ident string, lat, lon float64, runwayMap map[string]any, scope string) map[string]any {
 	airport := normalizeAirportIdent(ident)
 	normalizedScope := normalizeAirportSurfaceScope(scope)
-	if airport == "" || h == nil || h.overpassBaseURL == "" || !finite(lat) || !finite(lon) {
+	if airport == "" || h == nil || h.overpassBaseURL == "" || !finite(lat) || !finite(lon) || airportSurfaceContextDone(ctx) {
 		return nil
 	}
 	cacheKey := airportSurfaceCacheKey(airport, normalizedScope)
@@ -143,10 +147,16 @@ func (h *Handler) airportSurfaceMap(ctx context.Context, ident string, lat, lon 
 		buildAirportSurfaceOverpassQuery(bbox, normalizedScope),
 		normalizedScope,
 	)
+	if surfaceMap == nil && airportSurfaceContextDone(ctx) {
+		return nil
+	}
 	if surfaceMap == nil {
 		if centerBBox, ok := expandedBBoxAroundPoint(lat, lon, airportSurfaceCenterRadiusMeters); ok {
 			surfaceMap = h.airportSurfaceMapFromOSMMap(ctx, airport, centerBBox, normalizedScope)
 		}
+	}
+	if surfaceMap == nil && airportSurfaceContextDone(ctx) {
+		return nil
 	}
 	if surfaceMap == nil {
 		surfaceMap = h.airportSurfaceMapFromOSMMap(ctx, airport, bbox, normalizedScope)
@@ -199,6 +209,9 @@ func (h *Handler) fetchAirportSurfacePayload(
 	}
 	var payload map[string]any
 	status, err := h.fetchAirportSurfaceJSON(ctx, requestURL.String(), query, timeout, &payload)
+	if airportSurfaceContextDone(ctx) {
+		return nil, false
+	}
 	if err != nil || status < 200 || status >= 300 {
 		log.Printf("airport surface fetch failed airport=%s mode=%s status=%d error=%v", airport, mode, status, err)
 		return nil, false
@@ -249,6 +262,9 @@ func (h *Handler) airportSurfaceMapFromOSMMap(ctx context.Context, airport strin
 }
 
 func (h *Handler) fetchAirportSurfaceOSMMap(ctx context.Context, airport string, bbox airportSurfaceBBox, scope string) (*airportSurfaceOSMMap, bool) {
+	if airportSurfaceContextDone(ctx) {
+		return nil, false
+	}
 	requestURL, err := url.Parse(defaultAirportSurfaceOSMMapBaseURL)
 	if err != nil {
 		log.Printf("airport surface osm url parse failed airport=%s scope=%s error=%v", airport, scope, err)
@@ -271,11 +287,17 @@ func (h *Handler) fetchAirportSurfaceOSMMap(ctx context.Context, airport string,
 	req.Header.Set("User-Agent", "ADSBao data-service/1.0 (+https://adsbao.dev)")
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
+		if airportSurfaceContextDone(ctx) {
+			return nil, false
+		}
 		log.Printf("airport surface osm fetch failed airport=%s scope=%s status=0 error=%v", airport, scope, err)
 		return nil, false
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, aircraftJSONMaxBytes))
+	if airportSurfaceContextDone(ctx) {
+		return nil, false
+	}
 	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		log.Printf("airport surface osm fetch failed airport=%s scope=%s status=%d error=%v", airport, scope, resp.StatusCode, err)
 		return nil, false

--- a/services/data-service/internal/api/webapi/airport_surface_cancellation_test.go
+++ b/services/data-service/internal/api/webapi/airport_surface_cancellation_test.go
@@ -1,0 +1,76 @@
+package webapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+type airportSurfaceCancelOnReadBody struct {
+	cancel context.CancelFunc
+}
+
+func (body *airportSurfaceCancelOnReadBody) Read([]byte) (int, error) {
+	body.cancel()
+	return 0, context.Canceled
+}
+
+func (body *airportSurfaceCancelOnReadBody) Close() error {
+	return nil
+}
+
+func TestAirportSurfaceCancellationStopsFallbacks(t *testing.T) {
+	for _, scope := range []string{
+		airportSurfaceScopePavement,
+		airportSurfaceScopeStructures,
+	} {
+		t.Run(scope, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			overpassHits := 0
+			osmHits := 0
+			handler := New(Options{
+				HTTPClient: &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						switch req.URL.Host {
+						case "overpass.invalid":
+							overpassHits++
+							return &http.Response{
+								StatusCode: http.StatusOK,
+								Header:     http.Header{"Content-Type": []string{"application/json"}},
+								Body:       &airportSurfaceCancelOnReadBody{cancel: cancel},
+								Request:    req,
+							}, nil
+						case "api.openstreetmap.org":
+							osmHits++
+							return nil, context.Canceled
+						default:
+							t.Fatalf("unexpected upstream host %q", req.URL.Host)
+							return nil, context.Canceled
+						}
+					}),
+				},
+				OverpassBaseURL: "https://overpass.invalid/api/interpreter",
+			})
+
+			surfaceMap := handler.airportSurfaceMap(
+				ctx,
+				"KPHL",
+				39.8744,
+				-75.2424,
+				nil,
+				scope,
+			)
+			if surfaceMap != nil {
+				t.Fatalf("expected no surface map after cancellation, got %#v", surfaceMap)
+			}
+			if overpassHits != 1 {
+				t.Fatalf("overpass hits = %d", overpassHits)
+			}
+			if osmHits != 0 {
+				t.Fatalf("OSM fallback should not run after cancellation, hits=%d", osmHits)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- stop airport surface loading immediately when the client request is cancelled
- suppress expected `context canceled` failure logs from Overpass and OSM calls
- preserve normal logging and fallback behavior for service-owned upstream timeouts
- add pavement and structures regression coverage reproducing the `status=200 error=context canceled` path

## Test coverage

The new regression test returns an HTTP 200 Overpass response whose body read cancels the parent request context. It verifies that:

- the Overpass request is attempted once
- no OpenStreetMap fallback request is issued
- no surface map is returned after cancellation
- both `pavement` and `structures` scopes follow the same behavior

Closes #616